### PR TITLE
Update rust

### DIFF
--- a/.packaging/rust/Cargo.toml
+++ b/.packaging/rust/Cargo.toml
@@ -28,7 +28,7 @@ path = "src/bin/run.rs"
 
 [dependencies]
 clap = { version = "3.1", features = ["default", "derive"] }
-bindgen = { version = "0.58", default-features = false }
+bindgen = { version = "0.59", default-features = false }
 dirs = { version = "3.0", default-features = false }
 curl = "0.4"
 tar = { version = "0.4", default-features = false }

--- a/.packaging/rust/src/code/generate_api.rs
+++ b/.packaging/rust/src/code/generate_api.rs
@@ -28,6 +28,28 @@ pub fn generate_bindings(args: Cli) -> Result<(), String> {
             "-I{}",
             utils::get_llvm_header_path(rust_repo).display()
         )])
+        .allowlist_type("CConcreteType")
+        .rustified_enum("CConcreteType")
+        .allowlist_type("CDerivativeMode")
+        .rustified_enum("CDerivativeMode")
+        .allowlist_type("CDIFFE_TYPE")
+        .rustified_enum("CDIFFE_TYPE")
+        .allowlist_type("CTypeTreeRef")
+        .allowlist_type("EnzymeTypeAnalysisRef")
+        .allowlist_function("EnzymeNewTypeTree")
+        .allowlist_function("EnzymeFreeTypeTree")
+        // Next two are for debugging / printning type information
+        .allowlist_function("EnzymeSetCLBool")
+        .allowlist_function("EnzymeSetCLInteger")
+        .allowlist_function("CreateTypeAnalysis")
+        .allowlist_function("ClearTypeAnalysis")
+        .allowlist_function("FreeTypeAnalysis")
+        .allowlist_function("CreateEnzymeLogic")
+        .allowlist_function("ClearEnzymeLogic")
+        .allowlist_function("FreeEnzymeLogic")
+        .allowlist_function("EnzymeCreateForwardDiff")
+        .allowlist_function("EnzymeCreatePrimalAndGradient")
+        .allowlist_function("EnzymeCreateAugmentedPrimal")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))

--- a/.packaging/rust/src/code/version_manager.rs
+++ b/.packaging/rust/src/code/version_manager.rs
@@ -3,7 +3,7 @@ use super::utils;
 use crate::Cli;
 use std::{fs::File, path::PathBuf};
 
-pub const ENZYME_VER: &str = "0.0.27";
+pub const ENZYME_VER: &str = "0.0.29";
 pub const RUSTC_VER: &str = "1.59.0";
 
 pub fn get_rust_compilation_checkfile_path(args: &Cli) -> PathBuf {

--- a/.packaging/rust/src/code/version_manager.rs
+++ b/.packaging/rust/src/code/version_manager.rs
@@ -3,7 +3,7 @@ use super::utils;
 use crate::Cli;
 use std::{fs::File, path::PathBuf};
 
-pub const ENZYME_VER: &str = "0.0.29";
+pub const ENZYME_VER: &str = "0.0.30";
 pub const RUSTC_VER: &str = "1.60.0";
 
 pub fn get_rust_compilation_checkfile_path(args: &Cli) -> PathBuf {

--- a/.packaging/rust/src/code/version_manager.rs
+++ b/.packaging/rust/src/code/version_manager.rs
@@ -4,7 +4,7 @@ use crate::Cli;
 use std::{fs::File, path::PathBuf};
 
 pub const ENZYME_VER: &str = "0.0.29";
-pub const RUSTC_VER: &str = "1.59.0";
+pub const RUSTC_VER: &str = "1.60.0";
 
 pub fn get_rust_compilation_checkfile_path(args: &Cli) -> PathBuf {
     utils::get_local_rust_repo_path(args.rust.clone()).join("finished-building.txt")


### PR DESCRIPTION
- Updating Enzyme version
- Re-introducing specific bindings. C Enums aren't handled nicely by default so it's worth to maintain the allowlist.