### PR TITLE
fix #607 for -O0 builds

### DIFF
--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -103,6 +103,7 @@ const char *KnownInactiveFunctionsStartingWith[] = {
     "_ZNSi6ignore",
     // std::ios_base
     "_ZNSt8ios_base",
+    "_ZNKSt9basic_ios",
     "_ZNSt9basic_ios",
     "_ZStorSt13_Ios_OpenmodeS_",
     // std::local


### PR DESCRIPTION
Referring to the first, getLine example under -O0 builds.
O3 builds still cause a segfault.
