### PR TITLE
Additional C++ IO support

### DIFF
--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -86,6 +86,7 @@ const char *KnownInactiveFunctionsStartingWith[] = {
     "_ZNSt7__cxx1112basic_string",
     "_ZNSt7__cxx1118basic_string",
     "_ZNKSt7__cxx1112basic_string",
+    "_ZN9__gnu_cxx12__to_xstringINSt7__cxx1112basic_string",
     // filebuf
     "_ZNSt12__basic_file",
     "_ZNSt15basic_streambufIcSt11char_traits",
@@ -98,6 +99,7 @@ const char *KnownInactiveFunctionsStartingWith[] = {
     // ostream generic <<
     "_ZNSo5writeEPKcl",
     "_ZNSt19basic_ostringstreamIcSt11char_traits",
+    "_ZStrsIcSt11char_traitsIcESaIcEERSt13basic_istream",
     "_ZStlsIcSt11char_traitsIcESaIcEERSt13basic_ostream",
     "_ZNSt7__cxx1119basic_ostringstreamIcSt11char_traits",
     "_ZNKSt7__cxx1119basic_ostringstreamIcSt11char_traits",


### PR DESCRIPTION
The `@_ZN9__gnu_cxx12__to_xstringINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEcEET_PFiPT0_mPKS8_P13__va_list_tagEmSB_z`
one seems strange to me, but based on my libstdc++ usage probably ok. 

How about generally getting (slowly) rid of this list by calling 
`std::string llvm::demangle(const std::string &MangledName)`
in `llvm/Demangle/Demangle.h` for every function missing a definition?
If it succeeds we can still match the beginning, but using the demangled name 
it should end up in a shorter comparison list and we should miss less functions. 
I didn't run into a single fn which I couldn't demangle with llvm-c++filt, so I guess it's valid to still panic then.