### PR TITLE
Use structured bindings to unwrap pairs

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -631,10 +631,10 @@ public:
       // everything it requires.
       std::map<UsageKey, bool> Seen;
       bool primalNeededInReverse = false;
-      for (auto pair : gutils->knownRecomputeHeuristic)
-        if (!pair.second) {
-          Seen[UsageKey(pair.first, ValueType::Primal)] = false;
-          if (pair.first == &I)
+      for (auto &&[value, knownHeuristic] : gutils->knownRecomputeHeuristic)
+        if (!knownHeuristic) {
+          Seen[UsageKey(value, ValueType::Primal)] = false;
+          if (value == &I)
             primalNeededInReverse = true;
         }
       primalNeededInReverse |= is_value_needed_in_reverse<ValueType::Primal>(
@@ -1072,13 +1072,13 @@ public:
 
       bool backwardsShadow = false;
       bool forwardsShadow = true;
-      for (auto pair : gutils->backwardsOnlyShadows) {
-        if (pair.second.stores.count(&I)) {
+      for (auto &&[val, rematerializer] : gutils->backwardsOnlyShadows) {
+        if (rematerializer.stores.count(&I)) {
           backwardsShadow = true;
-          forwardsShadow = pair.second.primalInitialize;
-          if (auto inst = dyn_cast<Instruction>(pair.first))
-            if (!forwardsShadow && pair.second.LI &&
-                pair.second.LI->contains(inst->getParent()))
+          forwardsShadow = rematerializer.primalInitialize;
+          if (auto inst = dyn_cast<Instruction>(val))
+            if (!forwardsShadow && rematerializer.LI &&
+                rematerializer.LI->contains(inst->getParent()))
               backwardsShadow = false;
         }
       }
@@ -2695,13 +2695,13 @@ public:
 
     bool backwardsShadow = false;
     bool forwardsShadow = true;
-    for (auto pair : gutils->backwardsOnlyShadows) {
-      if (pair.second.stores.count(&MS)) {
+    for (auto &&[val, rematerializer] : gutils->backwardsOnlyShadows) {
+      if (rematerializer.stores.count(&MS)) {
         backwardsShadow = true;
-        forwardsShadow = pair.second.primalInitialize;
-        if (auto inst = dyn_cast<Instruction>(pair.first))
-          if (!forwardsShadow && pair.second.LI &&
-              pair.second.LI->contains(inst->getParent()))
+        forwardsShadow = rematerializer.primalInitialize;
+        if (auto inst = dyn_cast<Instruction>(val))
+          if (!forwardsShadow && rematerializer.LI &&
+              rematerializer.LI->contains(inst->getParent()))
             backwardsShadow = false;
       }
     }
@@ -2943,13 +2943,13 @@ public:
 
     bool backwardsShadow = false;
     bool forwardsShadow = true;
-    for (auto pair : gutils->backwardsOnlyShadows) {
-      if (pair.second.stores.count(&MTI)) {
+    for (auto &&[val, rematerializer] : gutils->backwardsOnlyShadows) {
+      if (rematerializer.stores.count(&MTI)) {
         backwardsShadow = true;
-        forwardsShadow = pair.second.primalInitialize;
-        if (auto inst = dyn_cast<Instruction>(pair.first))
-          if (!forwardsShadow && pair.second.LI &&
-              pair.second.LI->contains(inst->getParent()))
+        forwardsShadow = rematerializer.primalInitialize;
+        if (auto inst = dyn_cast<Instruction>(val))
+          if (!forwardsShadow && rematerializer.LI &&
+              rematerializer.LI->contains(inst->getParent()))
             backwardsShadow = false;
       }
     }
@@ -8563,9 +8563,9 @@ public:
           primalNeededInReverse = !gutils->knownRecomputeHeuristic[orig];
         } else {
           std::map<UsageKey, bool> Seen;
-          for (auto pair : gutils->knownRecomputeHeuristic)
-            if (!pair.second)
-              Seen[UsageKey(pair.first, ValueType::Primal)] = false;
+          for (auto &&[value, knownHeuristic] : gutils->knownRecomputeHeuristic)
+            if (!knownHeuristic)
+              Seen[UsageKey(value, ValueType::Primal)] = false;
           primalNeededInReverse = is_value_needed_in_reverse<ValueType::Primal>(
               gutils, orig, Mode, Seen, oldUnreachable);
         }
@@ -9009,8 +9009,8 @@ public:
 
         if (!shouldCache && !lrc) {
           std::map<UsageKey, bool> Seen;
-          for (auto pair : gutils->knownRecomputeHeuristic)
-            Seen[UsageKey(pair.first, ValueType::Primal)] = false;
+          for (auto &&[value, knownHeuristic] : gutils->knownRecomputeHeuristic)
+            Seen[UsageKey(value, ValueType::Primal)] = false;
           bool primalNeededInReverse =
               is_value_needed_in_reverse<ValueType::Primal>(
                   gutils, orig, Mode, Seen, oldUnreachable);
@@ -9746,13 +9746,13 @@ public:
         if (funcName == "julia.write_barrier") {
           bool backwardsShadow = false;
           bool forwardsShadow = true;
-          for (auto pair : gutils->backwardsOnlyShadows) {
-            if (pair.second.stores.count(orig)) {
+          for (auto &&[val, rematerializer] : gutils->backwardsOnlyShadows) {
+            if (rematerializer.stores.count(orig)) {
               backwardsShadow = true;
-              forwardsShadow = pair.second.primalInitialize;
-              if (auto inst = dyn_cast<Instruction>(pair.first))
-                if (!forwardsShadow && pair.second.LI &&
-                    pair.second.LI->contains(inst->getParent()))
+              forwardsShadow = rematerializer.primalInitialize;
+              if (auto inst = dyn_cast<Instruction>(val))
+                if (!forwardsShadow && rematerializer.LI &&
+                    rematerializer.LI->contains(inst->getParent()))
                   backwardsShadow = false;
               break;
             }
@@ -10418,9 +10418,9 @@ public:
         return;
 
       std::map<UsageKey, bool> Seen;
-      for (auto pair : gutils->knownRecomputeHeuristic)
-        if (!pair.second)
-          Seen[UsageKey(pair.first, ValueType::Primal)] = false;
+      for (auto &&[value, knownHeuristic] : gutils->knownRecomputeHeuristic)
+        if (!knownHeuristic)
+          Seen[UsageKey(value, ValueType::Primal)] = false;
       bool primalNeededInReverse =
           Mode == DerivativeMode::ForwardMode
               ? false
@@ -10868,9 +10868,10 @@ public:
           } else {
             assert(Mode == DerivativeMode::ReverseModeCombined);
             std::map<UsageKey, bool> Seen;
-            for (auto pair : gutils->knownRecomputeHeuristic)
-              if (!pair.second)
-                Seen[UsageKey(pair.first, ValueType::Primal)] = false;
+            for (auto &&[value, knownHeuristic] :
+                 gutils->knownRecomputeHeuristic)
+              if (!knownHeuristic)
+                Seen[UsageKey(value, ValueType::Primal)] = false;
             bool primalNeededInReverse =
                 is_value_needed_in_reverse<ValueType::Primal>(
                     gutils, rmat.first, Mode, Seen, oldUnreachable);

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -92,8 +92,8 @@ public:
         dretAlloca(dretAlloca) {
 
     assert(TR.getFunction() == gutils->oldFunc);
-    for (auto &pair : TR.analyzer.analysis) {
-      if (auto in = dyn_cast<Instruction>(pair.first)) {
+    for (auto &&[value, type_tree] : TR.analyzer.analysis) {
+      if (auto in = dyn_cast<Instruction>(value)) {
         if (in->getParent()->getParent() != gutils->oldFunc) {
           llvm::errs() << "inf: " << *in->getParent()->getParent() << "\n";
           llvm::errs() << "gutils->oldFunc: " << *gutils->oldFunc << "\n";

--- a/enzyme/Enzyme/CacheUtility.cpp
+++ b/enzyme/Enzyme/CacheUtility.cpp
@@ -492,9 +492,8 @@ bool CacheUtility::getContext(BasicBlock *BB, LoopContext &loopContext,
   loopContexts[L].offset = nullptr;
   loopContexts[L].allocLimit = nullptr;
   // A precisely matching canonical IV shouldve been run during preprocessing.
-  auto pair = FindCanonicalIV(L, Type::getInt64Ty(BB->getContext()));
-  PHINode *CanonicalIV = pair.first;
-  auto incVar = pair.second;
+  auto &&[CanonicalIV, incVar] =
+      FindCanonicalIV(L, Type::getInt64Ty(BB->getContext()));
   assert(CanonicalIV);
   loopContexts[L].var = CanonicalIV;
   loopContexts[L].incvar = incVar;

--- a/enzyme/Enzyme/DifferentialUseAnalysis.h
+++ b/enzyme/Enzyme/DifferentialUseAnalysis.h
@@ -666,10 +666,9 @@ struct Node {
 typedef std::map<Node, std::set<Node>> Graph;
 
 static inline void dump(Graph &G) {
-  for (auto &pair : G) {
-    llvm::errs() << "[" << *pair.first.V << ", " << (int)pair.first.outgoing
-                 << "]\n";
-    for (auto N : pair.second) {
+  for (auto &&[node, nodes] : G) {
+    llvm::errs() << "[" << *node.V << ", " << (int)node.outgoing << "]\n";
+    for (auto N : nodes) {
       llvm::errs() << "\t[" << *N.V << ", " << (int)N.outgoing << "]\n";
     }
   }
@@ -802,12 +801,12 @@ static inline void minCut(const DataLayout &DL, LoopInfo &OrigLI,
 
   // Print all edges that are from a reachable vertex to
   // non-reachable vertex in the original graph
-  for (auto &pair : Orig) {
-    if (parent.find(pair.first) != parent.end())
-      for (auto N : pair.second) {
+  for (auto &[node, nodes] : Orig) {
+    if (parent.find(node) != parent.end())
+      for (auto N : nodes) {
         if (parent.find(N) == parent.end()) {
-          assert(pair.first.outgoing == 0 && N.outgoing == 1);
-          assert(pair.first.V == N.V);
+          assert(node.outgoing == 0 && N.outgoing == 1);
+          assert(node.V == N.V);
           MinReq.insert(N.V);
         }
       }

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -2427,8 +2427,8 @@ public:
       changed = true;
     }
 
-    for (const auto &pair : Logic.PPC.cache)
-      pair.second->eraseFromParent();
+    for (auto &&[cached_func, orig_func] : Logic.PPC.cache)
+      orig_func->eraseFromParent();
     Logic.clear();
 
     if (changed && Logic.PostOpt) {

--- a/enzyme/Enzyme/GradientUtils.h
+++ b/enzyme/Enzyme/GradientUtils.h
@@ -1211,9 +1211,9 @@ public:
 #if LLVM_VERSION_MAJOR <= 6
     OrigPDT.recalculate(*oldFunc_);
 #endif
-    for (auto pair : invertedPointers_) {
-      invertedPointers.insert(std::make_pair(
-          (const Value *)pair.first, InvertedPointerVH(this, pair.second)));
+    for (auto &&[orig_ptr, new_ptr] : invertedPointers_) {
+      invertedPointers.insert(std::make_pair((const Value *)orig_ptr,
+                                             InvertedPointerVH(this, new_ptr)));
     }
     originalToNewFn.insert(originalToNewFn_.begin(), originalToNewFn_.end());
     for (BasicBlock &oBB : *oldFunc) {


### PR DESCRIPTION
Make our code more readable by actually giving the pair elements a name.