### PR TITLE
fix ConstantExpr handling in CreateAugmentedPrimal

### DIFF
--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -2412,22 +2412,21 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
   Function *NewF = Function::Create(
       FTy, nf->getLinkage(), "augmented_" + todiff->getName(), nf->getParent());
 
-  unsigned ii = 0, jj = 0;
+  unsigned attrIndex = 0;
   auto i = nf->arg_begin(), j = NewF->arg_begin();
-  for (; i != nf->arg_end();) {
+  while (i != nf->arg_end()) {
     VMap[i] = j;
-    if (nf->hasParamAttribute(ii, Attribute::NoCapture)) {
-      NewF->addParamAttr(jj, Attribute::NoCapture);
+    if (nf->hasParamAttribute(attrIndex, Attribute::NoCapture)) {
+      NewF->addParamAttr(attrIndex, Attribute::NoCapture);
     }
-    if (nf->hasParamAttribute(ii, Attribute::NoAlias)) {
-      NewF->addParamAttr(jj, Attribute::NoAlias);
+    if (nf->hasParamAttribute(attrIndex, Attribute::NoAlias)) {
+      NewF->addParamAttr(attrIndex, Attribute::NoAlias);
     }
 
     j->setName(i->getName());
     ++j;
-    ++jj;
     ++i;
-    ++ii;
+    ++attrIndex;
   }
 
   SmallVector<ReturnInst *, 4> Returns;
@@ -2617,9 +2616,10 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
         if (auto ggep = dyn_cast<GetElementPtrInst>(gep)) {
           ggep->setIsInBounds(true);
         }
-        if (isa<ConstantData>(invertedRetPs[ri]))
+        if (isa<ConstantExpr>(invertedRetPs[ri]) ||
+            isa<ConstantData>(invertedRetPs[ri])) {
           ib.CreateStore(invertedRetPs[ri], gep);
-        else {
+        } else {
           assert(VMap[invertedRetPs[ri]]);
           ib.CreateStore(VMap[invertedRetPs[ri]], gep);
         }

--- a/enzyme/test/Enzyme/ReverseMode/constexpr.ll
+++ b/enzyme/test/Enzyme/ReverseMode/constexpr.ll
@@ -1,0 +1,26 @@
+; RUN: %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -mem2reg -instsimplify -simplifycfg -S | FileCheck %s
+
+@_ZTId = external dso_local constant i8*
+
+define i8* @_ZNK4implIdE4typeEv()  {
+  ret i8* bitcast (i8** @_ZTId to i8*)
+}
+
+declare void @_Z17__enzyme_virtualreverse(i8*)
+
+define void @_Z18wrapper_1body_intsv()  {
+  call void @_Z17__enzyme_virtualreverse(i8* bitcast (i8* ()* @_ZNK4implIdE4typeEv to i8*))
+  ret void
+}
+
+; CHECK: define internal { i8*, i8*, i8* } @augmented__ZNK4implIdE4typeEv() #1 {
+; CHECK-NEXT:   %1 = alloca { i8*, i8*, i8* }, align 8
+; CHECK-NEXT:   %2 = getelementptr inbounds { i8*, i8*, i8* }, { i8*, i8*, i8* }* %1, i32 0, i32 0
+; CHECK-NEXT:   store i8* null, i8** %2, align 8
+; CHECK-NEXT:   %3 = getelementptr inbounds { i8*, i8*, i8* }, { i8*, i8*, i8* }* %1, i32 0, i32 1
+; CHECK-NEXT:   store i8* bitcast (i8** @_ZTId to i8*), i8** %3, align 8
+; CHECK-NEXT:   %4 = getelementptr inbounds { i8*, i8*, i8* }, { i8*, i8*, i8* }* %1, i32 0, i32 2
+; CHECK-NEXT:   store i8* bitcast (i8** @_ZTId_shadow to i8*), i8** %4, align 8
+; CHECK-NEXT:   %5 = load { i8*, i8*, i8* }, { i8*, i8*, i8* }* %1, align 8
+; CHECK-NEXT:   ret { i8*, i8*, i8* } %5
+; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ReverseMode/constexpr.ll
+++ b/enzyme/test/Enzyme/ReverseMode/constexpr.ll
@@ -13,14 +13,14 @@ define void @_Z18wrapper_1body_intsv()  {
   ret void
 }
 
-; CHECK: define internal { i8*, i8*, i8* } @augmented__ZNK4implIdE4typeEv() #1 {
-; CHECK-NEXT:   %1 = alloca { i8*, i8*, i8* }, align 8
+; CHECK: define internal { i8*, i8*, i8* } @augmented__ZNK4implIdE4typeEv()
+; CHECK-NEXT:   %1 = alloca { i8*, i8*, i8* }
 ; CHECK-NEXT:   %2 = getelementptr inbounds { i8*, i8*, i8* }, { i8*, i8*, i8* }* %1, i32 0, i32 0
-; CHECK-NEXT:   store i8* null, i8** %2, align 8
+; CHECK-NEXT:   store i8* null, i8** %2
 ; CHECK-NEXT:   %3 = getelementptr inbounds { i8*, i8*, i8* }, { i8*, i8*, i8* }* %1, i32 0, i32 1
-; CHECK-NEXT:   store i8* bitcast (i8** @_ZTId to i8*), i8** %3, align 8
+; CHECK-NEXT:   store i8* bitcast (i8** @_ZTId to i8*), i8** %3
 ; CHECK-NEXT:   %4 = getelementptr inbounds { i8*, i8*, i8* }, { i8*, i8*, i8* }* %1, i32 0, i32 2
-; CHECK-NEXT:   store i8* bitcast (i8** @_ZTId_shadow to i8*), i8** %4, align 8
-; CHECK-NEXT:   %5 = load { i8*, i8*, i8* }, { i8*, i8*, i8* }* %1, align 8
+; CHECK-NEXT:   store i8* bitcast (i8** @_ZTId_shadow to i8*), i8** %4
+; CHECK-NEXT:   %5 = load { i8*, i8*, i8* }, { i8*, i8*, i8* }* %1
 ; CHECK-NEXT:   ret { i8*, i8*, i8* } %5
 ; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ReverseMode/constexpr.ll
+++ b/enzyme/test/Enzyme/ReverseMode/constexpr.ll
@@ -1,4 +1,4 @@
-; RUN: %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -mem2reg -instsimplify -simplifycfg -S | FileCheck %s
+; RUN: %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -mem2reg -S | FileCheck %s
 
 @_ZTId = external dso_local constant i8*
 


### PR DESCRIPTION
llvm's copyFunctionInto won't add constantexpr to the vmap, since It can be shared, similar to constantData.

fixes #721