### PR TITLE
Enable error propagation in MLIR AD

### DIFF
--- a/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.h
+++ b/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.h
@@ -72,6 +72,7 @@ public:
   void eraseIfUnused(Operation *op, bool erase = true, bool check = true) {
     // TODO
   }
+  bool isConstantOperation(mlir::Operation *op) const;
   bool isConstantValue(mlir::Value v) const;
   mlir::Value invertPointerM(mlir::Value v, OpBuilder &Builder2);
   void setDiffe(mlir::Value val, mlir::Value toset, OpBuilder &BuilderM);

--- a/enzyme/test/MLIR/invalid.mlir
+++ b/enzyme/test/MLIR/invalid.mlir
@@ -1,0 +1,15 @@
+// RUN: %eopt --enzyme --verify-diagnostics %s
+
+module {
+  func.func @unsupported(%x : f64) -> f64 {
+    // We are not going to differentiate nested funcs, at least for a while.
+    // expected-error @below {{could not compute the adjoint for this operation}}
+    func.func private @foo()
+    %c = arith.constant 42.0 : f64
+    return %c : f64
+  }
+  func.func @diff(%x : f64, %dx : f64) -> f64 {
+    %r = enzyme.fwddiff @unsupported(%x, %dx) { activity=[#enzyme<activity enzyme_dup>] } : (f64, f64) -> (f64)
+    return %r : f64
+  }
+}


### PR DESCRIPTION
This enables error propagation in MLIR Enzyme flow and approximates
activity analysis by only treating provable constants as inactive.