### PR TITLE
Addr11

### DIFF
--- a/enzyme/BCLoad/CMakeLists.txt
+++ b/enzyme/BCLoad/CMakeLists.txt
@@ -39,8 +39,8 @@ ExternalProject_Add(openblas
 set_target_properties(openblas PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
 ExternalProject_Add(fblas
-    GIT_REPOSITORY https://github.com/UCSantaCruzComputationalGenomicsLab/clapack
-    GIT_TAG 8bac8d5cd7aa8506b11cdb2cfa2ce8a2e03048f3
+    GIT_REPOSITORY https://github.com/EnzymeAD/clapack
+    GIT_TAG 42603bf49ac2b27a7c00c53f92fa648748476510
     PREFIX fblas
     BUILD_IN_SOURCE 1
     INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/openblas/install

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -2525,6 +2525,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
         tapeMemory = CreateAllocation(
             ib, tapeType, ConstantInt::get(i64, 1), "tapemem", &malloccall,
             EnzymeZeroCache ? &zero : nullptr, /*isDefault*/ true);
+        tapeMemory = GetAddressableFromAllocation(ib, tapeMemory);
         memory = malloccall;
       } else {
         memory = ConstantPointerNull::get(

--- a/enzyme/Enzyme/FunctionUtils.cpp
+++ b/enzyme/Enzyme/FunctionUtils.cpp
@@ -472,6 +472,8 @@ UpgradeAllocasToMallocs(Function *NewF, DerivativeMode mode,
                                           MDNode::get(CI->getContext(), {}));
     }
 
+    rep = GetAddressableFromAllocation(B, rep);
+
     auto PT0 = cast<PointerType>(rep->getType());
     auto PT1 = cast<PointerType>(AI->getType());
     if (PT0->getAddressSpace() != PT1->getAddressSpace()) {

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -92,6 +92,8 @@ llvm::Value *CreateAllocation(llvm::IRBuilder<> &B, llvm::Type *T,
                               bool isDefault = false);
 llvm::CallInst *CreateDealloc(llvm::IRBuilder<> &B, llvm::Value *ToFree);
 
+llvm::Value *GetAddressableFromAllocation(llvm::IRBuilder <>&B, llvm::Value* gVal);
+
 llvm::Value *CreateReAllocation(llvm::IRBuilder<> &B, llvm::Value *prev,
                                 llvm::Type *T, llvm::Value *OuterCount,
                                 llvm::Value *InnerCount, llvm::Twine Name = "",


### PR DESCRIPTION
@vchuravy my quick "does decaying matter" attempt for https://github.com/EnzymeAD/Enzyme.jl/issues/488


```
after simplification :
; Function Attrs: mustprogress willreturn
define void @preprocess_julia_objective__1857_inner.1({} addrspace(10)* nocapture nonnull readonly align 16 dereferenceable(40) %0, {} addrspace(10)* nocapture nofree nonnull writeonly align 8 dereferenceable(8) %1, {} addrspace(10)* nocapture nonnull readonly align 16 dereferenceable(40) %2) local_unnamed_addr #7 !dbg !85 {
entry:
  %3 = call {}*** @julia.get_pgcstack() #8
  %4 = bitcast {} addrspace(10)* %2 to double addrspace(13)* addrspace(10)*
  %5 = addrspacecast double addrspace(13)* addrspace(10)* %4 to double addrspace(13)* addrspace(11)*
  %6 = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %5, align 16
  %7 = bitcast {} addrspace(10)* %0 to double addrspace(13)* addrspace(10)*
  %8 = addrspacecast double addrspace(13)* addrspace(10)* %7 to double addrspace(13)* addrspace(11)*
  %9 = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %8, align 16
  %10 = bitcast {} addrspace(10)* %1 to double addrspace(10)*
  br label %L2.i, !dbg !86

L2.i:                                             ; preds = %idxend.i, %entry
  %iv = phi i64 [ %iv.next, %idxend.i ], [ 0, %entry ]
  %iv.next = add nuw nsw i64 %iv, 1, !dbg !88
  %11 = call noalias nonnull {} addrspace(10)* @ijl_alloc_array_1d({} addrspace(10)* noundef addrspacecast ({}* inttoptr (i64 140701160744064 to {}*) to {} addrspace(10)*), i64 noundef 3) #8, !dbg !88
  %12 = bitcast {} addrspace(10)* %11 to { i8 addrspace(13)*, i64, i16, i16, i32 } addrspace(10)*, !dbg !94
  %13 = addrspacecast { i8 addrspace(13)*, i64, i16, i16, i32 } addrspace(10)* %12 to { i8 addrspace(13)*, i64, i16, i16, i32 } addrspace(11)*, !dbg !94
  %14 = getelementptr inbounds { i8 addrspace(13)*, i64, i16, i16, i32 }, { i8 addrspace(13)*, i64, i16, i16, i32 } addrspace(11)* %13, i64 0, i32 1, !dbg !94
  %15 = load i64, i64 addrspace(11)* %14, align 8, !dbg !94, !tbaa !31, !range !36
  %.not.not = icmp eq i64 %15, 0, !dbg !100
  br i1 %.not.not, label %oob.i, label %idxend.i, !dbg !104

oob.i:                                            ; preds = %L2.i
  %.phi.trans.insert = bitcast {} addrspace(10)* %11 to double addrspace(13)* addrspace(10)*
  %.phi.trans.insert8 = addrspacecast double addrspace(13)* addrspace(10)* %.phi.trans.insert to double addrspace(13)* addrspace(11)*
  %.pre = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %.phi.trans.insert8, align 8, !dbg !105, !tbaa !52
  %16 = load double, double addrspace(13)* %6, align 8, !dbg !107, !tbaa !56
  %17 = load double, double addrspace(13)* %9, align 8, !dbg !108, !tbaa !56
  %18 = fmul double %16, %17, !dbg !109
  store double %18, double addrspace(13)* %.pre, align 8, !dbg !105, !tbaa !56
  %19 = alloca i64, align 8, !dbg !110
  store i64 1, i64* %19, align 8, !dbg !110
  %20 = addrspacecast {} addrspace(10)* %11 to {} addrspace(12)*, !dbg !110
  call void @ijl_bounds_error_ints({} addrspace(12)* %20, i64* noundef nonnull align 8 %19, i64 noundef 1) #9, !dbg !110
  unreachable, !dbg !110

idxend.i:                                         ; preds = %L2.i
  %21 = bitcast {} addrspace(10)* %11 to double addrspace(13)* addrspace(10)*
  %22 = addrspacecast double addrspace(13)* addrspace(10)* %21 to double addrspace(13)* addrspace(11)*
  %23 = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %22, align 8, !tbaa !52, !nonnull !4
  %24 = bitcast double addrspace(13)* %23 to i8 addrspace(13)*, !dbg !112
  %25 = shl nuw i64 %15, 3, !dbg !112
  call void @llvm.memset.p13i8.i64(i8 addrspace(13)* noundef nonnull align 8 %24, i8 noundef 0, i64 %25, i1 noundef false) #8, !dbg !113
  %26 = load double, double addrspace(13)* %6, align 8, !dbg !107, !tbaa !56
  %27 = load double, double addrspace(13)* %9, align 8, !dbg !108, !tbaa !56
  %28 = fmul double %26, %27, !dbg !109
  store double %28, double addrspace(13)* %23, align 8, !dbg !105, !tbaa !56
  store double %28, double addrspace(10)* %10, align 8, !dbg !115, !tbaa !74
  %.not5 = icmp eq i64 %iv.next, 1000, !dbg !117
  %29 = add nuw nsw i64 %iv.next, 1, !dbg !120
  br i1 %.not5, label %julia_objective__1857_inner.exit, label %L2.i, !dbg !121

julia_objective__1857_inner.exit:                 ; preds = %idxend.i
  ret void, !dbg !122
}

; Function Attrs: mustprogress willreturn
define internal void @diffejulia_objective__1857_inner.1({} addrspace(10)* nocapture nonnull readonly align 16 dereferenceable(40) %0, {} addrspace(10)* nocapture %"'", {} addrspace(10)* nocapture nofree nonnull writeonly align 8 dereferenceable(8) %1, {} addrspace(10)* nocapture %"'1", {} addrspace(10)* nocapture nonnull readonly align 16 dereferenceable(40) %2) local_unnamed_addr #7 !dbg !123 {
entry:
  %"iv'ac" = alloca i64, align 8
  %_cache = alloca {} addrspace(10)* addrspace(10)*, align 8
  %"'de" = alloca double, align 8
  store double 0.000000e+00, double* %"'de", align 8
  %_cache11 = alloca double*, align 8
  %"'de14" = alloca double, align 8
  store double 0.000000e+00, double* %"'de14", align 8
  %_cache17 = alloca i64*, align 8
  %3 = call {}*** @julia.get_pgcstack()
  %4 = bitcast {} addrspace(10)* %2 to double addrspace(13)* addrspace(10)*
  %5 = addrspacecast double addrspace(13)* addrspace(10)* %4 to double addrspace(13)* addrspace(11)*
  %6 = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %5, align 16
  %"'ipc" = bitcast {} addrspace(10)* %"'" to double addrspace(13)* addrspace(10)*
  %7 = bitcast {} addrspace(10)* %0 to double addrspace(13)* addrspace(10)*
  %"'ipc4" = addrspacecast double addrspace(13)* addrspace(10)* %"'ipc" to double addrspace(13)* addrspace(11)*
  %8 = addrspacecast double addrspace(13)* addrspace(10)* %7 to double addrspace(13)* addrspace(11)*
  %"'ipl" = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %"'ipc4", align 16
  %9 = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %8, align 16
  %"'ipc7" = bitcast {} addrspace(10)* %"'1" to double addrspace(10)*
  %10 = bitcast {} addrspace(10)* %1 to double addrspace(10)*
  %11 = bitcast {}*** %3 to {}**, !dbg !124
  %12 = getelementptr inbounds {}*, {}** %11, i64 -12, !dbg !124
  %13 = getelementptr inbounds {}*, {}** %12, i64 14, !dbg !124
  %14 = bitcast {}** %13 to i8**, !dbg !124
  %15 = load i8*, i8** %14, align 8, !dbg !124
  %16 = call noalias nonnull dereferenceable(8000) dereferenceable_or_null(8000) {} addrspace(10)* @jl_gc_alloc_typed(i8* %15, i64 8000, {} addrspace(10)* addrspacecast ({}* inttoptr (i64 140691990391120 to {}*) to {} addrspace(10)*)), !dbg !124
  %17 = bitcast {} addrspace(10)* %16 to i8 addrspace(10)*, !dbg !124, !enzyme_formemset !4
  call void @llvm.memset.p10i8.i64(i8 addrspace(10)* %17, i8 0, i64 8000, i1 false), !dbg !124
  %_malloccache = bitcast {} addrspace(10)* %16 to {} addrspace(10)* addrspace(10)*, !dbg !124
  store {} addrspace(10)* addrspace(10)* %_malloccache, {} addrspace(10)* addrspace(10)** %_cache, align 8, !dbg !124, !invariant.group !126
  %18 = call noalias nonnull dereferenceable(8000) dereferenceable_or_null(8000) i8* @malloc(i64 8000), !dbg !124
  call void @llvm.memset.p0i8.i64(i8* %18, i8 0, i64 8000, i1 false), !dbg !124
  %_malloccache12 = bitcast i8* %18 to double*, !dbg !124
  store double* %_malloccache12, double** %_cache11, align 8, !dbg !124, !invariant.group !127
  %19 = call noalias nonnull dereferenceable(8000) dereferenceable_or_null(8000) i8* @malloc(i64 8000), !dbg !124
  call void @llvm.memset.p0i8.i64(i8* %19, i8 0, i64 8000, i1 false), !dbg !124
  %_malloccache18 = bitcast i8* %19 to i64*, !dbg !124
  store i64* %_malloccache18, i64** %_cache17, align 8, !dbg !124, !invariant.group !128
  br label %L2.i, !dbg !124

L2.i:                                             ; preds = %idxend.i, %entry
  %iv = phi i64 [ %iv.next, %idxend.i ], [ 0, %entry ]
  %iv.next = add nuw nsw i64 %iv, 1, !dbg !129
  %20 = call noalias nonnull {} addrspace(10)* @ijl_alloc_array_1d({} addrspace(10)* noundef addrspacecast ({}* inttoptr (i64 140701160744064 to {}*) to {} addrspace(10)*), i64 noundef 3) #8, !dbg !129
  %21 = call {} addrspace(10)* @ijl_alloc_array_1d({} addrspace(10)* addrspacecast ({}* inttoptr (i64 140701160744064 to {}*) to {} addrspace(10)*), i64 3), !dbg !129
  %22 = load {} addrspace(10)* addrspace(10)*, {} addrspace(10)* addrspace(10)** %_cache, align 8, !dbg !129, !dereferenceable !135, !invariant.group !126
  %23 = addrspacecast {} addrspace(10)* addrspace(10)* %22 to {} addrspace(10)* addrspace(11)*, !dbg !129
  %24 = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)* addrspace(11)* %23, i64 %iv, !dbg !129
  store {} addrspace(10)* %21, {} addrspace(10)* addrspace(11)* %24, align 8, !dbg !129, !invariant.group !136
  %25 = bitcast {} addrspace(10)* addrspace(10)* %22 to {} addrspace(10)*, !dbg !129
  call void ({} addrspace(10)*, ...) @julia.write_barrier({} addrspace(10)* %25, {} addrspace(10)* %21), !dbg !129
  %26 = bitcast {} addrspace(10)* %21 to i8 addrspace(13)* addrspace(10)*, !dbg !129
  %27 = load i8 addrspace(13)*, i8 addrspace(13)* addrspace(10)* %26, align 8, !dbg !129
  call void @llvm.memset.p13i8.i64(i8 addrspace(13)* align 1 %27, i8 0, i64 24, i1 false), !dbg !129
  %28 = bitcast {} addrspace(10)* %20 to { i8 addrspace(13)*, i64, i16, i16, i32 } addrspace(10)*, !dbg !137
  %29 = addrspacecast { i8 addrspace(13)*, i64, i16, i16, i32 } addrspace(10)* %28 to { i8 addrspace(13)*, i64, i16, i16, i32 } addrspace(11)*, !dbg !137
  %30 = getelementptr inbounds { i8 addrspace(13)*, i64, i16, i16, i32 }, { i8 addrspace(13)*, i64, i16, i16, i32 } addrspace(11)* %29, i64 0, i32 1, !dbg !137
  %31 = load i64, i64 addrspace(11)* %30, align 8, !dbg !137, !tbaa !31, !range !36
  %.not.not = icmp eq i64 %31, 0, !dbg !143
  br i1 %.not.not, label %oob.i, label %idxend.i, !dbg !147

oob.i:                                            ; preds = %L2.i
  %.phi.trans.insert = bitcast {} addrspace(10)* %20 to double addrspace(13)* addrspace(10)*
  %.phi.trans.insert8 = addrspacecast double addrspace(13)* addrspace(10)* %.phi.trans.insert to double addrspace(13)* addrspace(11)*
  %.pre = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %.phi.trans.insert8, align 8, !dbg !148, !tbaa !52
  %32 = load double, double addrspace(13)* %6, align 8, !dbg !150, !tbaa !56
  %33 = load double, double addrspace(13)* %9, align 8, !dbg !151, !tbaa !56
  %34 = fmul double %32, %33, !dbg !152
  store double %34, double addrspace(13)* %.pre, align 8, !dbg !148, !tbaa !56
  %35 = alloca i64, align 8, !dbg !153
  store i64 1, i64* %35, align 8, !dbg !153
  %36 = addrspacecast {} addrspace(10)* %20 to {} addrspace(12)*, !dbg !153
  call void @ijl_bounds_error_ints({} addrspace(12)* %36, i64* noundef nonnull align 8 %35, i64 noundef 1) #9, !dbg !153
  unreachable

idxend.i:                                         ; preds = %L2.i
  %"'ipc8" = bitcast {} addrspace(10)* %21 to double addrspace(13)* addrspace(10)*
  %37 = bitcast {} addrspace(10)* %20 to double addrspace(13)* addrspace(10)*
  %"'ipc9" = addrspacecast double addrspace(13)* addrspace(10)* %"'ipc8" to double addrspace(13)* addrspace(11)*
  %38 = addrspacecast double addrspace(13)* addrspace(10)* %37 to double addrspace(13)* addrspace(11)*
  %"'ipl20" = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %"'ipc9", align 8, !tbaa !52, !nonnull !4
  %39 = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %38, align 8, !tbaa !52, !nonnull !4
  %"'ipc15" = bitcast double addrspace(13)* %"'ipl20" to i8 addrspace(13)*, !dbg !155
  %40 = bitcast double addrspace(13)* %39 to i8 addrspace(13)*, !dbg !155
  %41 = shl nuw i64 %31, 3, !dbg !155
  call void @llvm.memset.p13i8.i64(i8 addrspace(13)* noundef nonnull align 8 %40, i8 noundef 0, i64 %41, i1 noundef false) #8, !dbg !156
  %42 = load double, double addrspace(13)* %6, align 8, !dbg !150, !tbaa !56
  %43 = load double, double addrspace(13)* %9, align 8, !dbg !151, !tbaa !56
  %44 = fmul double %42, %43, !dbg !152
  store double %44, double addrspace(13)* %39, align 8, !dbg !148, !tbaa !56, !alias.scope !158, !noalias !161
  %45 = load i64*, i64** %_cache17, align 8, !dbg !163, !dereferenceable !135, !invariant.group !128
  %46 = getelementptr inbounds i64, i64* %45, i64 %iv, !dbg !163
  store i64 %41, i64* %46, align 8, !dbg !163, !invariant.group !165
  %47 = load double*, double** %_cache11, align 8, !dbg !163, !dereferenceable !135, !invariant.group !127
  %48 = getelementptr inbounds double, double* %47, i64 %iv, !dbg !163
  store double %42, double* %48, align 8, !dbg !163, !tbaa !56, !invariant.group !166
  store double %44, double addrspace(10)* %10, align 8, !dbg !163, !tbaa !74, !alias.scope !158, !noalias !161
  %.not5 = icmp eq i64 %iv.next, 1000, !dbg !167
  br i1 %.not5, label %julia_objective__1857_inner.exit, label %L2.i, !dbg !170

julia_objective__1857_inner.exit:                 ; preds = %idxend.i
  br label %invertjulia_objective__1857_inner.exit, !dbg !171

invertentry:                                      ; preds = %invertL2.i
  %49 = load i64, i64* %"iv'ac", align 8
  %forfree = load {} addrspace(10)* addrspace(10)*, {} addrspace(10)* addrspace(10)** %_cache, align 8, !dereferenceable !135, !invariant.group !126
  %50 = load i64, i64* %"iv'ac", align 8
  %forfree13 = load double*, double** %_cache11, align 8, !dereferenceable !135, !invariant.group !127
  %51 = bitcast double* %forfree13 to i8*
  call void @free(i8* nonnull %51), !dbg !171
  %52 = load i64, i64* %"iv'ac", align 8
  %forfree19 = load i64*, i64** %_cache17, align 8, !dereferenceable !135, !invariant.group !128
  %53 = bitcast i64* %forfree19 to i8*
  call void @free(i8* nonnull %53), !dbg !171
  ret void

invertL2.i:                                       ; preds = %invertidxend.i
  %54 = load i64, i64* %"iv'ac", align 8
  %55 = load {} addrspace(10)* addrspace(10)*, {} addrspace(10)* addrspace(10)** %_cache, align 8, !dereferenceable !135, !invariant.group !126
  %56 = addrspacecast {} addrspace(10)* addrspace(10)* %55 to {} addrspace(10)* addrspace(11)*
  %57 = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)* addrspace(11)* %56, i64 %54
  %58 = load {} addrspace(10)*, {} addrspace(10)* addrspace(11)* %57, align 8, !invariant.group !136
  %59 = load i64, i64* %"iv'ac", align 8
  %60 = icmp eq i64 %59, 0
  %61 = xor i1 %60, true
  br i1 %60, label %invertentry, label %incinvertL2.i

incinvertL2.i:                                    ; preds = %invertL2.i
  %62 = load i64, i64* %"iv'ac", align 8
  %63 = add nsw i64 %62, -1
  store i64 %63, i64* %"iv'ac", align 8
  br label %invertidxend.i

invertidxend.i:                                   ; preds = %mergeinvertL2.i_julia_objective__1857_inner.exit, %incinvertL2.i
  %64 = load double, double addrspace(10)* %"'ipc7", align 8
  store double 0.000000e+00, double addrspace(10)* %"'ipc7", align 8, !dbg !163, !tbaa !74, !alias.scope !161, !noalias !158
  %65 = load double, double* %"'de", align 8
  %66 = fadd fast double %65, %64
  store double %66, double* %"'de", align 8
  %67 = load i64, i64* %"iv'ac", align 8
  %68 = load {} addrspace(10)* addrspace(10)*, {} addrspace(10)* addrspace(10)** %_cache, align 8, !dereferenceable !135, !invariant.group !126
  %69 = addrspacecast {} addrspace(10)* addrspace(10)* %68 to {} addrspace(10)* addrspace(11)*
  %70 = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)* addrspace(11)* %69, i64 %67
  %71 = load {} addrspace(10)*, {} addrspace(10)* addrspace(11)* %70, align 8, !invariant.group !136
  %"'ipc8_unwrap" = bitcast {} addrspace(10)* %71 to double addrspace(13)* addrspace(10)*
  %"'ipc9_unwrap" = addrspacecast double addrspace(13)* addrspace(10)* %"'ipc8_unwrap" to double addrspace(13)* addrspace(11)*
  %"'il_phi3_unwrap" = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %"'ipc9_unwrap", align 8, !tbaa !52
  %72 = load double, double addrspace(13)* %"'il_phi3_unwrap", align 8
  store double 0.000000e+00, double addrspace(13)* %"'il_phi3_unwrap", align 8, !dbg !148, !tbaa !56, !alias.scope !161, !noalias !158
  %73 = load double, double* %"'de", align 8
  %74 = fadd fast double %73, %72
  store double %74, double* %"'de", align 8
  %75 = load double, double* %"'de", align 8
  %76 = load i64, i64* %"iv'ac", align 8
  %77 = load double*, double** %_cache11, align 8, !dereferenceable !135, !invariant.group !127
  %78 = getelementptr inbounds double, double* %77, i64 %76
  %79 = load double, double* %78, align 8, !dbg !150, !tbaa !56, !invariant.group !166
  %m1diffe = fmul fast double %75, %79
  store double 0.000000e+00, double* %"'de", align 8
  %80 = load double, double* %"'de14", align 8
  %81 = fadd fast double %80, %m1diffe
  store double %81, double* %"'de14", align 8
  %82 = load double, double* %"'de14", align 8
  store double 0.000000e+00, double* %"'de14", align 8
  %83 = load double, double addrspace(13)* %"'ipl", align 8, !dbg !151, !tbaa !56, !alias.scope !161, !noalias !158
  %84 = fadd fast double %83, %82
  store double %84, double addrspace(13)* %"'ipl", align 8, !dbg !151, !tbaa !56, !alias.scope !161, !noalias !158
  %85 = load i64, i64* %"iv'ac", align 8, !dbg !156
  %86 = load i64*, i64** %_cache17, align 8, !dbg !156, !dereferenceable !135, !invariant.group !128
  %87 = getelementptr inbounds i64, i64* %86, i64 %85, !dbg !156
  %88 = load i64, i64* %87, align 8, !dbg !156, !invariant.group !165
  %89 = load i64, i64* %"iv'ac", align 8, !dbg !156
  %"'ipc15_unwrap" = bitcast double addrspace(13)* %"'il_phi3_unwrap" to i8 addrspace(13)*, !dbg !156
  call void @llvm.memset.p13i8.i64(i8 addrspace(13)* noundef nonnull align 8 %"'ipc15_unwrap", i8 noundef 0, i64 %88, i1 noundef false) #8, !dbg !156
  br label %invertL2.i

invertjulia_objective__1857_inner.exit:           ; preds = %julia_objective__1857_inner.exit
  br label %mergeinvertL2.i_julia_objective__1857_inner.exit

mergeinvertL2.i_julia_objective__1857_inner.exit: ; preds = %invertjulia_objective__1857_inner.exit
  store i64 999, i64* %"iv'ac", align 8
  br label %invertidxend.i
}


signal (11): Segmentation fault
in expression starting at /home/wmoses/git/Enzyme.jl/s.jl:22
page_metadata at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gc.h:450 [inlined]
gc_setmark_pool at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gc.c:827 [inlined]
gc_setmark at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gc.c:834 [inlined]
gc_mark_loop at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gc.c:2771
_jl_gc_collect at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gc.c:3097
ijl_gc_collect at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gc.c:3326
maybe_collect at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gc.c:903 [inlined]
jl_gc_pool_alloc_inner at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gc.c:1247 [inlined]
jl_gc_pool_alloc_noinline at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gc.c:1306 [inlined]
jl_gc_alloc_ at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/julia_internal.h:369 [inlined]
jl_gc_alloc at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gc.c:3371
_new_array_ at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/array.c:134 [inlined]
_new_array at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/array.c:198 [inlined]
ijl_alloc_array_1d at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/array.c:436
unknown function (ip: 0x7ff79fc391fe)
macro expansion at /home/wmoses/git/Enzyme.jl/src/compiler.jl:6119 [inlined]
enzyme_call at /home/wmoses/git/Enzyme.jl/src/compiler.jl:5850
unknown function (ip: 0x7ff5851492fa)
_jl_invoke at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gf.c:2367 [inlined]
ijl_apply_generic at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gf.c:2549
jl_apply at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/julia.h:1838 [inlined]
do_apply at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/builtins.c:730
CombinedAdjointThunk at /home/wmoses/git/Enzyme.jl/src/compiler.jl:5827
_jl_invoke at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gf.c:2367 [inlined]
ijl_apply_generic at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gf.c:2549
jl_apply at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/julia.h:1838 [inlined]
do_apply at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/builtins.c:730
autodiff at /home/wmoses/git/Enzyme.jl/src/Enzyme.jl:317
_jl_invoke at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gf.c:2367 [inlined]
ijl_apply_generic at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gf.c:2549
jl_apply at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/julia.h:1838 [inlined]
do_apply at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/builtins.c:730
autodiff at /home/wmoses/git/Enzyme.jl/src/Enzyme.jl:348
_jl_invoke at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gf.c:2367 [inlined]
ijl_apply_generic at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gf.c:2549
top-level scope at /home/wmoses/git/Enzyme.jl/s.jl:25
jl_toplevel_eval_flex at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/toplevel.c:897
jl_toplevel_eval_flex at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/toplevel.c:850
ijl_toplevel_eval_in at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/toplevel.c:965
eval at ./boot.jl:368 [inlined]
include_string at ./loading.jl:1428
_jl_invoke at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gf.c:2367 [inlined]
ijl_apply_generic at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gf.c:2549
_include at ./loading.jl:1488
include at ./Base.jl:419
jfptr_include_32221.clone_1 at /home/wmoses/git/Enzyme.jl/julia-1.8.1/lib/julia/sys.so (unknown line)
_jl_invoke at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gf.c:2367 [inlined]
ijl_apply_generic at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gf.c:2549
exec_options at ./client.jl:303
_start at ./client.jl:522
jfptr__start_61720.clone_1 at /home/wmoses/git/Enzyme.jl/julia-1.8.1/lib/julia/sys.so (unknown line)
_jl_invoke at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gf.c:2367 [inlined]
ijl_apply_generic at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/gf.c:2549
jl_apply at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/julia.h:1838 [inlined]
true_main at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/jlapi.c:575
jl_repl_entrypoint at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/src/jlapi.c:719
main at /cache/build/default-amdci5-0/julialang/julia-release-1-dot-8/cli/loader_exe.c:59
unknown function (ip: 0x7ff79fe72d8f)
__libc_start_main at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
unknown function (ip: 0x401098)
Allocations: 30712021 (Pool: 30670154; Big: 41867); GC: 35
Segmentation fault (core dumped)
```