### PR TITLE
MLIR: Rename ForwardModeAdjoint to ForwardModeTangent

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/ArithAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/ArithAutoDiffOpInterfaceImpl.cpp
@@ -25,7 +25,7 @@ namespace {
 struct MulFOpInterface
     : public AutoDiffOpInterface::ExternalModel<MulFOpInterface,
                                                 arith::MulFOp> {
-  LogicalResult createForwardModeAdjoint(Operation *op, OpBuilder &builder,
+  LogicalResult createForwardModeTangent(Operation *op, OpBuilder &builder,
                                          MGradientUtils *gutils) const {
     // Derivative of r = a * b -> dr = a * db + da * b
     auto mulOp = cast<arith::MulFOp>(op);
@@ -53,7 +53,7 @@ struct MulFOpInterface
 struct AddFOpInterface
     : public AutoDiffOpInterface::ExternalModel<AddFOpInterface,
                                                 arith::AddFOp> {
-  LogicalResult createForwardModeAdjoint(Operation *op, OpBuilder &builder,
+  LogicalResult createForwardModeTangent(Operation *op, OpBuilder &builder,
                                          MGradientUtils *gutils) const {
     // Derivative of r = a + b -> dr = da + db
     auto addOp = cast<arith::AddFOp>(op);

--- a/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
@@ -25,7 +25,7 @@ using namespace mlir::enzyme;
 namespace {
 struct LoadOpInterface
     : public AutoDiffOpInterface::ExternalModel<LoadOpInterface, LLVM::LoadOp> {
-  LogicalResult createForwardModeAdjoint(Operation *op, OpBuilder &builder,
+  LogicalResult createForwardModeTangent(Operation *op, OpBuilder &builder,
                                          MGradientUtils *gutils) const {
     auto loadOp = cast<LLVM::LoadOp>(op);
     if (!gutils->isConstantValue(loadOp)) {
@@ -41,7 +41,7 @@ struct LoadOpInterface
 struct StoreOpInterface
     : public AutoDiffOpInterface::ExternalModel<StoreOpInterface,
                                                 LLVM::StoreOp> {
-  LogicalResult createForwardModeAdjoint(Operation *op, OpBuilder &builder,
+  LogicalResult createForwardModeTangent(Operation *op, OpBuilder &builder,
                                          MGradientUtils *gutils) const {
     auto storeOp = cast<LLVM::StoreOp>(op);
     if (!gutils->isConstantValue(storeOp.getAddr())) {
@@ -57,7 +57,7 @@ struct StoreOpInterface
 struct AllocaOpInterface
     : public AutoDiffOpInterface::ExternalModel<AllocaOpInterface,
                                                 LLVM::AllocaOp> {
-  LogicalResult createForwardModeAdjoint(Operation *op, OpBuilder &builder,
+  LogicalResult createForwardModeTangent(Operation *op, OpBuilder &builder,
                                          MGradientUtils *gutils) const {
     auto allocOp = cast<LLVM::AllocaOp>(op);
     if (!gutils->isConstantValue(allocOp)) {

--- a/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
@@ -26,7 +26,7 @@ namespace {
 struct LoadOpInterface
     : public AutoDiffOpInterface::ExternalModel<LoadOpInterface,
                                                 memref::LoadOp> {
-  LogicalResult createForwardModeAdjoint(Operation *op, OpBuilder &builder,
+  LogicalResult createForwardModeTangent(Operation *op, OpBuilder &builder,
                                          MGradientUtils *gutils) const {
     auto loadOp = cast<memref::LoadOp>(op);
     if (!gutils->isConstantValue(loadOp)) {
@@ -46,7 +46,7 @@ struct LoadOpInterface
 struct StoreOpInterface
     : public AutoDiffOpInterface::ExternalModel<StoreOpInterface,
                                                 memref::StoreOp> {
-  LogicalResult createForwardModeAdjoint(Operation *op, OpBuilder &builder,
+  LogicalResult createForwardModeTangent(Operation *op, OpBuilder &builder,
                                          MGradientUtils *gutils) const {
     auto storeOp = cast<memref::StoreOp>(op);
     if (!gutils->isConstantValue(storeOp.getMemref())) {
@@ -65,7 +65,7 @@ struct StoreOpInterface
 struct AllocOpInterface
     : public AutoDiffOpInterface::ExternalModel<AllocOpInterface,
                                                 memref::AllocOp> {
-  LogicalResult createForwardModeAdjoint(Operation *op, OpBuilder &builder,
+  LogicalResult createForwardModeTangent(Operation *op, OpBuilder &builder,
                                          MGradientUtils *gutils) const {
     auto allocOp = cast<memref::AllocOp>(op);
     if (!gutils->isConstantValue(allocOp)) {

--- a/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
@@ -25,7 +25,7 @@ using namespace mlir::enzyme;
 namespace {
 struct ForOpInterface
     : public AutoDiffOpInterface::ExternalModel<ForOpInterface, scf::ForOp> {
-  LogicalResult createForwardModeAdjoint(Operation *op, OpBuilder &builder,
+  LogicalResult createForwardModeTangent(Operation *op, OpBuilder &builder,
                                          MGradientUtils *gutils) const {
     auto forOp = cast<scf::ForOp>(op);
     auto nFor = cast<scf::ForOp>(gutils->getNewFromOriginal(op));

--- a/enzyme/Enzyme/MLIR/Interfaces/AutoDiffOpInterface.td
+++ b/enzyme/Enzyme/MLIR/Interfaces/AutoDiffOpInterface.td
@@ -26,7 +26,7 @@ def AutoDiffOpInterface : OpInterface<"AutoDiffOpInterface"> {
   let methods = [
     InterfaceMethod<
     /*desc=*/[{
-      Emits a forward-mode adjoint of the given function. All IR manipulation
+      Emits a forward-mode tangent of the given function. All IR manipulation
       must go through the supplied arguments: `builder` is preset to insert new
       IR in the correct location and should be used to construct any new IR;
       `gutils` provides the mapping between main and derivative computation for
@@ -35,7 +35,7 @@ def AutoDiffOpInterface : OpInterface<"AutoDiffOpInterface"> {
       was successful.
     }],
     /*retTy=*/"::mlir::LogicalResult",
-    /*methodName=*/"createForwardModeAdjoint",
+    /*methodName=*/"createForwardModeTangent",
     /*args=*/(ins "::mlir::OpBuilder &":$builder, "::mlir::enzyme::MGradientUtils *":$gutils)
     >
   ];

--- a/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.cpp
@@ -306,7 +306,7 @@ LogicalResult MGradientUtils::visitChild(Operation *op) {
     if (auto iface = dyn_cast<AutoDiffOpInterface>(op)) {
       OpBuilder builder(op->getContext());
       builder.setInsertionPoint(getNewFromOriginal(op));
-      return iface.createForwardModeAdjoint(builder, this);
+      return iface.createForwardModeTangent(builder, this);
     }
   }
   return failure();


### PR DESCRIPTION
To stay in line with prevailing literature, I would suggest to rename `ForwardModeAdjoint` to `ForwardModeTangent` for the nascent MLIR version. `Adjoint` is commonly used to describe the reverse-mode, and hence lends itself to confusion.

Examples in literature, see e.g. "Using Automatic Differentiation for Adjoint CFD Code Development" by Giles et al [1], or section 5.1.2 of the MIT gcm documentation on "Reverse or Adjoint Sensitivity" [2]. The forward mode is more colloquially known as "Tangent"-mode [3,4], which would hence be a more intuitive name in my eyes.

[1] https://people.maths.ox.ac.uk/gilesm/files/NA-05-25.pdf
[2] http://mitgcm.org/sealion/online_documents/node174.html
[3] https://pytorch.org/tutorials/intermediate/forward_ad_usage.html
[4] Chapter 3.1 "Forward Propagation of Tangents" of "Evaluating Derivatives" by Griewank and Walther  (https://epubs.siam.org/doi/book/10.1137/1.9780898717761)