### PR TITLE
Extract handleArguments

### DIFF
--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -23,6 +23,8 @@
 // the function passed as the first argument.
 //
 //===----------------------------------------------------------------------===//
+#include <optional>
+
 #include "SCEV/ScalarEvolution.h"
 #include "SCEV/ScalarEvolutionExpander.h"
 
@@ -492,11 +494,11 @@ castToDiffeFunctionArgType(IRBuilder<> &Builder, llvm::CallInst *CI,
   return Builder.CreateBitCast(value, destType);
 }
 
-static Optional<StringRef> getMetadataName(llvm::Value *res);
+static std::optional<StringRef> getMetadataName(llvm::Value *res);
 
 // if all phi arms are (recursively) based on the same metaString, use that
-static Optional<StringRef> recursePhiReads(PHINode *val) {
-  Optional<StringRef> finalMetadata;
+static std::optional<StringRef> recursePhiReads(PHINode *val) {
+  std::optional<StringRef> finalMetadata;
   SmallVector<PHINode *, 1> todo = {val};
   SmallSet<PHINode *, 1> done;
   while (todo.size()) {
@@ -510,12 +512,12 @@ static Optional<StringRef> recursePhiReads(PHINode *val) {
       if (auto phi = dyn_cast<PHINode>(newVal)) {
         todo.push_back(phi);
       } else {
-        Optional<StringRef> metaString = getMetadataName(newVal);
+        std::optional<StringRef> metaString = getMetadataName(newVal);
         if (metaString) {
           if (!finalMetadata) {
             finalMetadata = metaString;
           } else if (finalMetadata != metaString) {
-            return None;
+            return std::nullopt;
           }
         }
       }
@@ -524,7 +526,7 @@ static Optional<StringRef> recursePhiReads(PHINode *val) {
   return finalMetadata;
 }
 
-static Optional<StringRef> getMetadataName(llvm::Value *res) {
+static std::optional<StringRef> getMetadataName(llvm::Value *res) {
   if (auto av = dyn_cast<MetadataAsValue>(res)) {
     return cast<MDString>(av->getMetadata())->getString();
   } else if ((isa<LoadInst>(res) || isa<CastInst>(res)) &&
@@ -557,7 +559,7 @@ static Optional<StringRef> getMetadataName(llvm::Value *res) {
     if (isa<PHINode>(res)) {
       return recursePhiReads(cast<PHINode>(res));
     }
-    return Optional<StringRef>();
+    return std::nullopt;
   }
 }
 
@@ -699,7 +701,7 @@ public:
     // initializeLowerAutodiffIntrinsicPass(*PassRegistry::getPassRegistry());
   }
 
-  Optional<Function *> parseFunctionParameter(CallInst *CI) {
+  std::optional<Function *> parseFunctionParameter(CallInst *CI) {
     Value *fn = CI->getArgOperand(0);
 
     // determine function to differentiate
@@ -713,19 +715,19 @@ public:
       EmitFailure("NoFunctionToDifferentiate", CI->getDebugLoc(), CI,
                   "failed to find fn to differentiate", *CI, " - found - ",
                   *fn);
-      return None;
+      return std::nullopt;
     }
     if (cast<Function>(fn)->empty()) {
       EmitFailure("EmptyFunctionToDifferentiate", CI->getDebugLoc(), CI,
                   "failed to find fn to differentiate", *CI, " - found - ",
                   *fn);
-      return None;
+      return std::nullopt;
     }
 
     return cast<Function>(fn);
   }
 
-  Optional<unsigned> parseWidthParameter(CallInst *CI) {
+  static std::optional<unsigned> parseWidthParameter(CallInst *CI) {
     unsigned width = 1;
 
 #if LLVM_VERSION_MAJOR >= 14
@@ -743,7 +745,7 @@ public:
             EmitFailure("IllegalVectorWidth", CI->getDebugLoc(), CI,
                         "vector width declared more than once",
                         *CI->getArgOperand(i), " in", *CI);
-            return None;
+            return std::nullopt;
           }
 
 #if LLVM_VERSION_MAJOR >= 14
@@ -755,7 +757,7 @@ public:
             EmitFailure("MissingVectorWidth", CI->getDebugLoc(), CI,
                         "constant integer followong enzyme_width is missing",
                         *CI->getArgOperand(i), " in", *CI);
-            return None;
+            return std::nullopt;
           }
 
           Value *width_arg = CI->getArgOperand(i + 1);
@@ -766,19 +768,472 @@ public:
             EmitFailure("IllegalVectorWidth", CI->getDebugLoc(), CI,
                         "enzyme_width must be a constant integer",
                         *CI->getArgOperand(i), " in", *CI);
-            return None;
+            return std::nullopt;
           }
 
           if (!found) {
             EmitFailure("IllegalVectorWidth", CI->getDebugLoc(), CI,
                         "illegal enzyme vector argument width ",
                         *CI->getArgOperand(i), " in", *CI);
-            return None;
+            return std::nullopt;
           }
         }
       }
     }
     return width;
+  }
+
+  struct Options {
+    Value *differet;
+    Value *tape;
+    unsigned width;
+    int allocatedTapeSize;
+    bool freeMemory;
+    bool returnUsed;
+    bool tapeIsPointer;
+    bool differentialReturn;
+    DIFFE_TYPE retType;
+  };
+
+  static std::optional<Options> handleArguments(
+      IRBuilder<> &Builder, CallInst *CI, Function *fn, DerivativeMode mode,
+      bool sizeOnly, std::vector<DIFFE_TYPE> &constants,
+      SmallVectorImpl<Value *> &args, std::map<int, Type *> &byVal) {
+    std::map<unsigned, Value *> batchOffset;
+    FunctionType *FT = fn->getFunctionType();
+
+    Value *differet = nullptr;
+    Value *tape = nullptr;
+    unsigned width = 1;
+    int allocatedTapeSize = -1;
+    bool freeMemory = true;
+    bool tapeIsPointer = false;
+    unsigned truei = 0;
+    unsigned byRefSize = 0;
+
+    DIFFE_TYPE retType = whatType(fn->getReturnType(), mode);
+
+    bool returnUsed =
+        !fn->getReturnType()->isVoidTy() && !fn->getReturnType()->isEmptyTy();
+
+    bool differentialReturn = (mode == DerivativeMode::ReverseModeCombined ||
+                               mode == DerivativeMode::ReverseModeGradient) &&
+                              (retType == DIFFE_TYPE::OUT_DIFF);
+
+    bool sret = CI->hasStructRetAttr() ||
+                fn->hasParamAttribute(0, Attribute::StructRet);
+
+    // find and handle enzyme_width
+    if (auto parsedWidth = parseWidthParameter(CI)) {
+      width = parsedWidth.value();
+    } else {
+      return std::nullopt;
+    }
+
+    // handle different argument order for struct return.
+    if (fn->hasParamAttribute(0, Attribute::StructRet)) {
+      Type *fnsrety = cast<PointerType>(FT->getParamType(0));
+
+      truei = 1;
+
+      const DataLayout &DL = CI->getParent()->getModule()->getDataLayout();
+      Type *Ty = fnsrety->getPointerElementType();
+#if LLVM_VERSION_MAJOR >= 11
+      AllocaInst *primal = new AllocaInst(Ty, DL.getAllocaAddrSpace(), nullptr,
+                                          DL.getPrefTypeAlign(Ty));
+#else
+      AllocaInst *primal = new AllocaInst(Ty, DL.getAllocaAddrSpace(), nullptr);
+#endif
+
+      primal->insertBefore(CI);
+
+      Value *shadow;
+      switch (mode) {
+      case DerivativeMode::ForwardModeSplit:
+      case DerivativeMode::ForwardMode: {
+        Value *sretPt = CI->getArgOperand(0);
+        if (width > 1) {
+          PointerType *pty = cast<PointerType>(sretPt->getType());
+          if (auto sty = dyn_cast<StructType>(pty->getPointerElementType())) {
+            Value *acc = UndefValue::get(
+                ArrayType::get(PointerType::get(sty->getElementType(0),
+                                                pty->getAddressSpace()),
+                               width));
+            for (size_t i = 0; i < width; ++i) {
+#if LLVM_VERSION_MAJOR > 7
+              Value *elem = Builder.CreateStructGEP(
+                  sretPt->getType()->getPointerElementType(), sretPt, i);
+#else
+              Value *elem = Builder.CreateStructGEP(sretPt, i);
+#endif
+              acc = Builder.CreateInsertValue(acc, elem, i);
+            }
+            shadow = acc;
+          } else {
+            EmitFailure(
+                "IllegalReturnType", CI->getDebugLoc(), CI,
+                "Return type of __enzyme_autodiff has to be a struct with",
+                width, "elements of the same type.");
+            return std::nullopt;
+          }
+        } else {
+          shadow = sretPt;
+        }
+        break;
+      }
+      case DerivativeMode::ReverseModePrimal:
+      case DerivativeMode::ReverseModeCombined:
+      case DerivativeMode::ReverseModeGradient: {
+        shadow = CI->getArgOperand(1);
+        sret = true;
+        break;
+      }
+      }
+
+      args.push_back(primal);
+      args.push_back(shadow);
+      constants.push_back(DIFFE_TYPE::DUP_ARG);
+    }
+
+#if LLVM_VERSION_MAJOR >= 14
+    for (unsigned i = 1 + sret; i < CI->arg_size(); ++i)
+#else
+    for (unsigned i = 1 + sret; i < CI->getNumArgOperands(); ++i)
+#endif
+    {
+      Value *res = CI->getArgOperand(i);
+      std::optional<DIFFE_TYPE> opt_ty;
+      std::optional<StringRef> metaString = getMetadataName(res);
+
+      // handle metadata
+      if (metaString.has_value() && metaString.value().startswith("enzyme_")) {
+        if (*metaString == "enzyme_byref") {
+          ++i;
+          if (!isa<ConstantInt>(CI->getArgOperand(i))) {
+            EmitFailure("IllegalAllocatedSize", CI->getDebugLoc(), CI,
+                        "illegal enzyme byref size ", *CI->getArgOperand(i),
+                        "in", *CI);
+            return std::nullopt;
+          }
+          byRefSize = cast<ConstantInt>(CI->getArgOperand(i))->getZExtValue();
+          assert(byRefSize > 0);
+          continue;
+        }
+        if (*metaString == "enzyme_dup") {
+          opt_ty = DIFFE_TYPE::DUP_ARG;
+        } else if (*metaString == "enzyme_dupv") {
+          opt_ty = DIFFE_TYPE::DUP_ARG;
+          ++i;
+          Value *offset_arg = CI->getArgOperand(i);
+          if (offset_arg->getType()->isIntegerTy()) {
+            batchOffset[i + 1] = offset_arg;
+          } else {
+            EmitFailure("IllegalVectorOffset", CI->getDebugLoc(), CI,
+                        "enzyme_batch must be followd by an integer "
+                        "offset.",
+                        *CI->getArgOperand(i), " in", *CI);
+            return std::nullopt;
+          }
+          continue;
+        } else if (*metaString == "enzyme_dupnoneedv") {
+          opt_ty = DIFFE_TYPE::DUP_NONEED;
+          ++i;
+          Value *offset_arg = CI->getArgOperand(i);
+          if (offset_arg->getType()->isIntegerTy()) {
+            batchOffset[i + 1] = offset_arg;
+          } else {
+            EmitFailure("IllegalVectorOffset", CI->getDebugLoc(), CI,
+                        "enzyme_batch must be followd by an integer "
+                        "offset.",
+                        *CI->getArgOperand(i), " in", *CI);
+            return std::nullopt;
+          }
+          continue;
+        } else if (*metaString == "enzyme_dupnoneed") {
+          opt_ty = DIFFE_TYPE::DUP_NONEED;
+        } else if (*metaString == "enzyme_dupnoneedv") {
+          opt_ty = DIFFE_TYPE::DUP_NONEED;
+          ++i;
+          Value *offset_arg = CI->getArgOperand(i);
+          if (offset_arg->getType()->isIntegerTy()) {
+            batchOffset[i + 1] = offset_arg;
+          } else {
+            EmitFailure("IllegalVectorOffset", CI->getDebugLoc(), CI,
+                        "enzyme_batch must be followd by an integer "
+                        "offset.",
+                        *CI->getArgOperand(i), " in", *CI);
+            return std::nullopt;
+          }
+          continue;
+        } else if (*metaString == "enzyme_out") {
+          opt_ty = DIFFE_TYPE::OUT_DIFF;
+        } else if (*metaString == "enzyme_const") {
+          opt_ty = DIFFE_TYPE::CONSTANT;
+        } else if (*metaString == "enzyme_noret") {
+          returnUsed = false;
+          continue;
+        } else if (*metaString == "enzyme_allocated") {
+          assert(!sizeOnly);
+          ++i;
+          if (!isa<ConstantInt>(CI->getArgOperand(i))) {
+            EmitFailure("IllegalAllocatedSize", CI->getDebugLoc(), CI,
+                        "illegal enzyme allocated size ", *CI->getArgOperand(i),
+                        "in", *CI);
+            return std::nullopt;
+          }
+          allocatedTapeSize =
+              cast<ConstantInt>(CI->getArgOperand(i))->getZExtValue();
+          continue;
+        } else if (*metaString == "enzyme_tape") {
+          assert(!sizeOnly);
+          ++i;
+          tape = CI->getArgOperand(i);
+          tapeIsPointer = true;
+          continue;
+        } else if (*metaString == "enzyme_nofree") {
+          assert(!sizeOnly);
+          freeMemory = false;
+          continue;
+        } else if (*metaString == "enzyme_width") {
+          ++i;
+          continue;
+        } else {
+          EmitFailure("IllegalDiffeType", CI->getDebugLoc(), CI,
+                      "illegal enzyme metadata classification ", *CI,
+                      *metaString);
+          return std::nullopt;
+        }
+        if (sizeOnly) {
+          assert(opt_ty);
+          constants.push_back(*opt_ty);
+          truei++;
+          continue;
+        }
+        ++i;
+        res = CI->getArgOperand(i);
+      }
+
+      if (byRefSize) {
+        Type *subTy = res->getType()->getPointerElementType();
+        auto &DL = fn->getParent()->getDataLayout();
+        auto BitSize = DL.getTypeSizeInBits(subTy);
+        if (BitSize / 8 != byRefSize) {
+          EmitFailure("IllegalByRefSize", CI->getDebugLoc(), CI,
+                      "illegal enzyme pointer type size ", *res, " expected ",
+                      byRefSize, " (bytes) actual size ", BitSize,
+                      " (bits) in ", *CI);
+        }
+#if LLVM_VERSION_MAJOR > 7
+        res = Builder.CreateLoad(subTy, res);
+#else
+        res = Builder.CreateLoad(res);
+#endif
+        byRefSize = 0;
+      }
+
+      if (truei >= FT->getNumParams()) {
+        if (!isa<MetadataAsValue>(res) &&
+            (mode == DerivativeMode::ReverseModeGradient ||
+             mode == DerivativeMode::ForwardModeSplit)) {
+          if (differentialReturn && differet == nullptr) {
+            differet = res;
+            if (CI->paramHasAttr(i, Attribute::ByVal)) {
+#if LLVM_VERSION_MAJOR > 7
+              differet = Builder.CreateLoad(
+                  differet->getType()->getPointerElementType(), differet);
+#else
+              differet = Builder.CreateLoad(differet);
+#endif
+            }
+            if (differet->getType() != fn->getReturnType())
+              if (auto ST0 = dyn_cast<StructType>(differet->getType()))
+                if (auto ST1 = dyn_cast<StructType>(fn->getReturnType()))
+                  if (ST0->isLayoutIdentical(ST1)) {
+                    IRBuilder<> B(&Builder.GetInsertBlock()
+                                       ->getParent()
+                                       ->getEntryBlock()
+                                       .front());
+                    auto AI = B.CreateAlloca(ST1);
+                    Builder.CreateStore(differet,
+                                        Builder.CreatePointerCast(
+                                            AI, PointerType::getUnqual(ST0)));
+#if LLVM_VERSION_MAJOR > 7
+                    differet = Builder.CreateLoad(ST1, AI);
+#else
+                    differet = Builder.CreateLoad(AI);
+#endif
+                  }
+
+            if (differet->getType() != fn->getReturnType()) {
+              EmitFailure("BadDiffRet", CI->getDebugLoc(), CI,
+                          "Bad DiffRet type ", *differet, " expected ",
+                          *fn->getReturnType());
+              return std::nullopt;
+            }
+            continue;
+          } else if (tape == nullptr) {
+            tape = res;
+            if (CI->paramHasAttr(i, Attribute::ByVal)) {
+#if LLVM_VERSION_MAJOR > 7
+              tape = Builder.CreateLoad(
+                  tape->getType()->getPointerElementType(), tape);
+#else
+              tape = Builder.CreateLoad(tape);
+#endif
+            }
+            continue;
+          }
+        }
+        EmitFailure("TooManyArgs", CI->getDebugLoc(), CI,
+                    "Had too many arguments to __enzyme_autodiff", *CI,
+                    " - extra arg - ", *res);
+        return std::nullopt;
+      }
+      assert(truei < FT->getNumParams());
+
+      auto PTy = FT->getParamType(truei);
+      DIFFE_TYPE ty = opt_ty ? *opt_ty : whatType(PTy, mode);
+
+      constants.push_back(ty);
+
+      assert(truei < FT->getNumParams());
+      // cast primal
+      if (PTy != res->getType()) {
+        if (auto ptr = dyn_cast<PointerType>(res->getType())) {
+          if (auto PT = dyn_cast<PointerType>(PTy)) {
+            if (ptr->getAddressSpace() != PT->getAddressSpace()) {
+              res = Builder.CreateAddrSpaceCast(
+                  res, PointerType::get(ptr->getPointerElementType(),
+                                        PT->getAddressSpace()));
+              assert(res);
+              assert(PTy);
+              assert(FT);
+              llvm::errs() << "Warning cast(1) __enzyme_autodiff argument " << i
+                           << " " << *res << "|" << *res->getType()
+                           << " to argument " << truei << " " << *PTy << "\n"
+                           << "orig: " << *FT << "\n";
+            }
+          }
+        }
+        if (res->getType()->canLosslesslyBitCastTo(PTy)) {
+          res = Builder.CreateBitCast(res, PTy);
+        }
+        if (res->getType() != PTy && res->getType()->isIntegerTy() &&
+            PTy->isIntegerTy(1)) {
+          res = Builder.CreateTrunc(res, PTy);
+        }
+        if (res->getType() != PTy) {
+          auto loc = CI->getDebugLoc();
+          if (auto arg = dyn_cast<Instruction>(res)) {
+            loc = arg->getDebugLoc();
+          }
+          EmitFailure("IllegalArgCast", loc, CI,
+                      "Cannot cast __enzyme_autodiff primal argument ", i,
+                      ", found ", *res, ", type ", *res->getType(),
+                      " - to arg ", truei, " ", *PTy);
+          return std::nullopt;
+        }
+      }
+#if LLVM_VERSION_MAJOR >= 9
+      if (CI->isByValArgument(i)) {
+        byVal[args.size()] = CI->getParamByValType(i);
+      }
+#endif
+      args.push_back(res);
+      if (ty == DIFFE_TYPE::DUP_ARG || ty == DIFFE_TYPE::DUP_NONEED) {
+        ++i;
+
+        Value *res = nullptr;
+        bool batch = batchOffset.count(i - 1) != 0;
+
+        for (unsigned v = 0; v < width; ++v) {
+#if LLVM_VERSION_MAJOR >= 14
+          if (i >= CI->arg_size())
+#else
+          if (i >= CI->getNumArgOperands())
+#endif
+          {
+            EmitFailure("MissingArgShadow", CI->getDebugLoc(), CI,
+                        "__enzyme_autodiff missing argument shadow at index ",
+                        i, ", need shadow of type ", *PTy,
+                        " to shadow primal argument ", *args.back(),
+                        " at call ", *CI);
+            return std::nullopt;
+          }
+
+          // cast diffe
+          Value *element = CI->getArgOperand(i);
+          if (batch) {
+            if (auto elementPtrTy = dyn_cast<PointerType>(element->getType())) {
+              element = Builder.CreateBitCast(
+                  element, PointerType::get(Type::getInt8Ty(CI->getContext()),
+                                            elementPtrTy->getAddressSpace()));
+#if LLVM_VERSION_MAJOR >= 7
+              element = Builder.CreateGEP(
+                  Type::getInt8Ty(CI->getContext()), element,
+                  Builder.CreateMul(
+                      batchOffset[i - 1],
+                      ConstantInt::get(batchOffset[i - 1]->getType(), v)));
+#else
+              element = Builder.CreateGEP(
+#if LLVM_VERSION_MAJOR >= 14
+                  elementPtrTy,
+#endif
+                  element,
+                  Builder.CreateMul(
+                      batchOffset[i - 1],
+                      ConstantInt::get(batchOffset[i - 1]->getType(), v)));
+#endif
+              element = Builder.CreateBitCast(element, elementPtrTy);
+            } else {
+              EmitFailure(
+                  "NonPointerBatch", CI->getDebugLoc(), CI,
+                  "Batched argument at index ", i,
+                  " must be of pointer type, found: ", *element->getType());
+              return std::nullopt;
+            }
+          }
+          if (PTy != element->getType()) {
+            element = castToDiffeFunctionArgType(Builder, CI, FT, PTy, i, mode,
+                                                 element, truei);
+            if (!element) {
+              return std::nullopt;
+            }
+          }
+
+          if (width > 1) {
+            res =
+                res ? Builder.CreateInsertValue(res, element, {v})
+                    : Builder.CreateInsertValue(UndefValue::get(ArrayType::get(
+                                                    element->getType(), width)),
+                                                element, {v});
+
+            if (v < width - 1 && !batch) {
+              ++i;
+            }
+
+          } else {
+            res = element;
+          }
+        }
+
+        args.push_back(res);
+      }
+
+      ++truei;
+    }
+    if (truei < FT->getNumParams()) {
+      auto numParams = FT->getNumParams();
+      EmitFailure(
+          "EnzymeInsufficientArgs", CI->getDebugLoc(), CI,
+          "Insufficient number of args passed to derivative call required ",
+          numParams, " primal args, found ", truei);
+      return std::nullopt;
+    }
+
+    return std::optional<Options>({differet, tape, width, allocatedTapeSize,
+                                   freeMemory, returnUsed, tapeIsPointer,
+                                   differentialReturn, retType});
   }
 
   static FnTypeInfo
@@ -829,9 +1284,8 @@ public:
     SmallVector<BATCH_TYPE, 4> arg_types;
     IRBuilder<> Builder(CI);
     Function *F;
-    auto parsedFunction = parseFunctionParameter(CI);
-    if (parsedFunction.hasValue()) {
-      F = parsedFunction.getValue();
+    if (auto parsedFunction = parseFunctionParameter(CI)) {
+      F = parsedFunction.value();
     } else {
       return false;
     }
@@ -840,9 +1294,8 @@ public:
     FunctionType *FT = F->getFunctionType();
 
     // find and handle enzyme_width
-    auto parsedWidth = parseWidthParameter(CI);
-    if (parsedWidth.hasValue()) {
-      width = parsedWidth.getValue();
+    if (auto parsedWidth = parseWidthParameter(CI)) {
+      width = parsedWidth.value();
     } else {
       return false;
     }
@@ -877,10 +1330,10 @@ public:
       auto PTy = FT->getParamType(truei);
 
       BATCH_TYPE ty = width == 1 ? BATCH_TYPE::SCALAR : BATCH_TYPE::VECTOR;
-      Optional<StringRef> metaString = getMetadataName(res);
+      std::optional<StringRef> metaString = getMetadataName(res);
 
       // handle metadata
-      if (metaString && metaString.getValue().startswith("enzyme_")) {
+      if (metaString.has_value() && metaString.value().startswith("enzyme_")) {
         if (*metaString == "enzyme_scalar") {
           ty = BATCH_TYPE::SCALAR;
         } else if (*metaString == "enzyme_vector") {
@@ -1007,9 +1460,8 @@ public:
 
     // determine function to differentiate
     Function *fn;
-    auto parsedFunction = parseFunctionParameter(CI);
-    if (parsedFunction.hasValue()) {
-      fn = parsedFunction.getValue();
+    if (auto parsedFunction = parseFunctionParameter(CI)) {
+      fn = parsedFunction.value();
     } else {
       return false;
     }
@@ -1018,89 +1470,6 @@ public:
     assert(fn);
 
     IRBuilder<> Builder(CI);
-    unsigned truei = 0;
-    unsigned width = 1;
-    std::map<unsigned, Value *> batchOffset;
-    bool returnUsed =
-        !fn->getReturnType()->isVoidTy() && !fn->getReturnType()->isEmptyTy();
-
-    // find and handle enzyme_width
-    auto parsedWidth = parseWidthParameter(CI);
-    if (parsedWidth.hasValue()) {
-      width = parsedWidth.getValue();
-    } else {
-      return false;
-    }
-
-    std::vector<DIFFE_TYPE> constants;
-    SmallVector<Value *, 2> args;
-
-    // handle different argument order for struct return.
-    bool sret = CI->hasStructRetAttr() ||
-                fn->hasParamAttribute(0, Attribute::StructRet);
-    if (fn->hasParamAttribute(0, Attribute::StructRet)) {
-      Type *fnsrety = cast<PointerType>(FT->getParamType(0));
-
-      truei = 1;
-
-      const DataLayout &DL = CI->getParent()->getModule()->getDataLayout();
-      Type *Ty = fnsrety->getPointerElementType();
-#if LLVM_VERSION_MAJOR >= 11
-      AllocaInst *primal = new AllocaInst(Ty, DL.getAllocaAddrSpace(), nullptr,
-                                          DL.getPrefTypeAlign(Ty));
-#else
-      AllocaInst *primal = new AllocaInst(Ty, DL.getAllocaAddrSpace(), nullptr);
-#endif
-
-      primal->insertBefore(CI);
-
-      Value *shadow;
-      switch (mode) {
-      case DerivativeMode::ForwardModeSplit:
-      case DerivativeMode::ForwardMode: {
-        Value *sretPt = CI->getArgOperand(0);
-        if (width > 1) {
-          PointerType *pty = cast<PointerType>(sretPt->getType());
-          if (auto sty = dyn_cast<StructType>(pty->getPointerElementType())) {
-            Value *acc = UndefValue::get(
-                ArrayType::get(PointerType::get(sty->getElementType(0),
-                                                pty->getAddressSpace()),
-                               width));
-            for (size_t i = 0; i < width; ++i) {
-#if LLVM_VERSION_MAJOR > 7
-              Value *elem = Builder.CreateStructGEP(
-                  sretPt->getType()->getPointerElementType(), sretPt, i);
-#else
-              Value *elem = Builder.CreateStructGEP(sretPt, i);
-#endif
-              acc = Builder.CreateInsertValue(acc, elem, i);
-            }
-            shadow = acc;
-          } else {
-            EmitFailure(
-                "IllegalReturnType", CI->getDebugLoc(), CI,
-                "Return type of __enzyme_autodiff has to be a struct with",
-                width, "elements of the same type.");
-            return false;
-          }
-        } else {
-          shadow = sretPt;
-        }
-        break;
-      }
-      case DerivativeMode::ReverseModePrimal:
-      case DerivativeMode::ReverseModeCombined:
-      case DerivativeMode::ReverseModeGradient: {
-        shadow = CI->getArgOperand(1);
-        sret = true;
-        break;
-      }
-      }
-
-      args.push_back(primal);
-      args.push_back(shadow);
-      constants.push_back(DIFFE_TYPE::DUP_ARG);
-    }
 
     if (EnzymePrint)
       llvm::errs() << "prefn:\n" << *fn << "\n";
@@ -1113,356 +1482,26 @@ public:
     bool AtomicAdd = Arch == Triple::nvptx || Arch == Triple::nvptx64 ||
                      Arch == Triple::amdgcn;
 
-    bool freeMemory = true;
-
-    DIFFE_TYPE retType = whatType(fn->getReturnType(), mode);
-
-    bool differentialReturn = (mode == DerivativeMode::ReverseModeCombined ||
-                               mode == DerivativeMode::ReverseModeGradient) &&
-                              (retType == DIFFE_TYPE::OUT_DIFF);
-
     std::map<int, Type *> byVal;
-    llvm::Value *differet = nullptr;
-    llvm::Value *tape = nullptr;
-    bool tapeIsPointer = false;
-    int allocatedTapeSize = -1;
-    unsigned byRefSize = 0;
+    std::vector<DIFFE_TYPE> constants;
+    SmallVector<Value *, 2> args;
 
-#if LLVM_VERSION_MAJOR >= 14
-    for (unsigned i = 1 + sret; i < CI->arg_size(); ++i)
-#else
-    for (unsigned i = 1 + sret; i < CI->getNumArgOperands(); ++i)
-#endif
-    {
-      Value *res = CI->getArgOperand(i);
-      Optional<DIFFE_TYPE> opt_ty;
-      Optional<StringRef> metaString = getMetadataName(res);
+    auto options = handleArguments(Builder, CI, fn, mode, sizeOnly, constants,
+                                   args, byVal);
 
-      // handle metadata
-      if (metaString && metaString.getValue().startswith("enzyme_")) {
-        if (*metaString == "enzyme_byref") {
-          ++i;
-          if (!isa<ConstantInt>(CI->getArgOperand(i))) {
-            EmitFailure("IllegalAllocatedSize", CI->getDebugLoc(), CI,
-                        "illegal enzyme byref size ", *CI->getArgOperand(i),
-                        "in", *CI);
-            return false;
-          }
-          byRefSize = cast<ConstantInt>(CI->getArgOperand(i))->getZExtValue();
-          assert(byRefSize > 0);
-          continue;
-        }
-        if (*metaString == "enzyme_dup") {
-          opt_ty = DIFFE_TYPE::DUP_ARG;
-        } else if (*metaString == "enzyme_dupv") {
-          opt_ty = DIFFE_TYPE::DUP_ARG;
-          ++i;
-          Value *offset_arg = CI->getArgOperand(i);
-          if (offset_arg->getType()->isIntegerTy()) {
-            batchOffset[i + 1] = offset_arg;
-          } else {
-            EmitFailure("IllegalVectorOffset", CI->getDebugLoc(), CI,
-                        "enzyme_batch must be followd by an integer "
-                        "offset.",
-                        *CI->getArgOperand(i), " in", *CI);
-            return false;
-          }
-          continue;
-        } else if (*metaString == "enzyme_dupnoneedv") {
-          opt_ty = DIFFE_TYPE::DUP_NONEED;
-          ++i;
-          Value *offset_arg = CI->getArgOperand(i);
-          if (offset_arg->getType()->isIntegerTy()) {
-            batchOffset[i + 1] = offset_arg;
-          } else {
-            EmitFailure("IllegalVectorOffset", CI->getDebugLoc(), CI,
-                        "enzyme_batch must be followd by an integer "
-                        "offset.",
-                        *CI->getArgOperand(i), " in", *CI);
-            return false;
-          }
-          continue;
-        } else if (*metaString == "enzyme_dupnoneed") {
-          opt_ty = DIFFE_TYPE::DUP_NONEED;
-        } else if (*metaString == "enzyme_dupnoneedv") {
-          opt_ty = DIFFE_TYPE::DUP_NONEED;
-          ++i;
-          Value *offset_arg = CI->getArgOperand(i);
-          if (offset_arg->getType()->isIntegerTy()) {
-            batchOffset[i + 1] = offset_arg;
-          } else {
-            EmitFailure("IllegalVectorOffset", CI->getDebugLoc(), CI,
-                        "enzyme_batch must be followd by an integer "
-                        "offset.",
-                        *CI->getArgOperand(i), " in", *CI);
-            return false;
-          }
-          continue;
-        } else if (*metaString == "enzyme_out") {
-          opt_ty = DIFFE_TYPE::OUT_DIFF;
-        } else if (*metaString == "enzyme_const") {
-          opt_ty = DIFFE_TYPE::CONSTANT;
-        } else if (*metaString == "enzyme_noret") {
-          returnUsed = false;
-          continue;
-        } else if (*metaString == "enzyme_allocated") {
-          assert(!sizeOnly);
-          ++i;
-          if (!isa<ConstantInt>(CI->getArgOperand(i))) {
-            EmitFailure("IllegalAllocatedSize", CI->getDebugLoc(), CI,
-                        "illegal enzyme allocated size ", *CI->getArgOperand(i),
-                        "in", *CI);
-            return false;
-          }
-          allocatedTapeSize =
-              cast<ConstantInt>(CI->getArgOperand(i))->getZExtValue();
-          continue;
-        } else if (*metaString == "enzyme_tape") {
-          assert(!sizeOnly);
-          ++i;
-          tape = CI->getArgOperand(i);
-          tapeIsPointer = true;
-          continue;
-        } else if (*metaString == "enzyme_nofree") {
-          assert(!sizeOnly);
-          freeMemory = false;
-          continue;
-        } else if (*metaString == "enzyme_width") {
-          ++i;
-          continue;
-        } else {
-          EmitFailure("IllegalDiffeType", CI->getDebugLoc(), CI,
-                      "illegal enzyme metadata classification ", *CI,
-                      *metaString);
-          return false;
-        }
-        if (sizeOnly) {
-          assert(opt_ty);
-          constants.push_back(*opt_ty);
-          truei++;
-          continue;
-        }
-        ++i;
-        res = CI->getArgOperand(i);
-      }
-
-      if (byRefSize) {
-        Type *subTy = res->getType()->getPointerElementType();
-        auto &DL = fn->getParent()->getDataLayout();
-        auto BitSize = DL.getTypeSizeInBits(subTy);
-        if (BitSize / 8 != byRefSize) {
-          EmitFailure("IllegalByRefSize", CI->getDebugLoc(), CI,
-                      "illegal enzyme pointer type size ", *res, " expected ",
-                      byRefSize, " (bytes) actual size ", BitSize,
-                      " (bits) in ", *CI);
-        }
-#if LLVM_VERSION_MAJOR > 7
-        res = Builder.CreateLoad(subTy, res);
-#else
-        res = Builder.CreateLoad(res);
-#endif
-        byRefSize = 0;
-      }
-
-      if (truei >= FT->getNumParams()) {
-        if (!isa<MetadataAsValue>(res) &&
-            (mode == DerivativeMode::ReverseModeGradient ||
-             mode == DerivativeMode::ForwardModeSplit)) {
-          if (differentialReturn && differet == nullptr) {
-            differet = res;
-            if (CI->paramHasAttr(i, Attribute::ByVal)) {
-#if LLVM_VERSION_MAJOR > 7
-              differet = Builder.CreateLoad(
-                  differet->getType()->getPointerElementType(), differet);
-#else
-              differet = Builder.CreateLoad(differet);
-#endif
-            }
-            if (differet->getType() != fn->getReturnType())
-              if (auto ST0 = dyn_cast<StructType>(differet->getType()))
-                if (auto ST1 = dyn_cast<StructType>(fn->getReturnType()))
-                  if (ST0->isLayoutIdentical(ST1)) {
-                    IRBuilder<> B(&Builder.GetInsertBlock()
-                                       ->getParent()
-                                       ->getEntryBlock()
-                                       .front());
-                    auto AI = B.CreateAlloca(ST1);
-                    Builder.CreateStore(differet,
-                                        Builder.CreatePointerCast(
-                                            AI, PointerType::getUnqual(ST0)));
-#if LLVM_VERSION_MAJOR > 7
-                    differet = Builder.CreateLoad(ST1, AI);
-#else
-                    differet = Builder.CreateLoad(AI);
-#endif
-                  }
-
-            if (differet->getType() != fn->getReturnType()) {
-              EmitFailure("BadDiffRet", CI->getDebugLoc(), CI,
-                          "Bad DiffRet type ", *differet, " expected ",
-                          *fn->getReturnType());
-              return false;
-            }
-            continue;
-          } else if (tape == nullptr) {
-            tape = res;
-            if (CI->paramHasAttr(i, Attribute::ByVal)) {
-#if LLVM_VERSION_MAJOR > 7
-              tape = Builder.CreateLoad(
-                  tape->getType()->getPointerElementType(), tape);
-#else
-              tape = Builder.CreateLoad(tape);
-#endif
-            }
-            continue;
-          }
-        }
-        EmitFailure("TooManyArgs", CI->getDebugLoc(), CI,
-                    "Had too many arguments to __enzyme_autodiff", *CI,
-                    " - extra arg - ", *res);
-        return false;
-      }
-      assert(truei < FT->getNumParams());
-
-      auto PTy = FT->getParamType(truei);
-      DIFFE_TYPE ty = opt_ty ? *opt_ty : whatType(PTy, mode);
-
-      constants.push_back(ty);
-
-      assert(truei < FT->getNumParams());
-      // cast primal
-      if (PTy != res->getType()) {
-        if (auto ptr = dyn_cast<PointerType>(res->getType())) {
-          if (auto PT = dyn_cast<PointerType>(PTy)) {
-            if (ptr->getAddressSpace() != PT->getAddressSpace()) {
-              res = Builder.CreateAddrSpaceCast(
-                  res, PointerType::get(ptr->getPointerElementType(),
-                                        PT->getAddressSpace()));
-              assert(res);
-              assert(PTy);
-              assert(FT);
-              llvm::errs() << "Warning cast(1) __enzyme_autodiff argument " << i
-                           << " " << *res << "|" << *res->getType()
-                           << " to argument " << truei << " " << *PTy << "\n"
-                           << "orig: " << *FT << "\n";
-            }
-          }
-        }
-        if (res->getType()->canLosslesslyBitCastTo(PTy)) {
-          res = Builder.CreateBitCast(res, PTy);
-        }
-        if (res->getType() != PTy && res->getType()->isIntegerTy() &&
-            PTy->isIntegerTy(1)) {
-          res = Builder.CreateTrunc(res, PTy);
-        }
-        if (res->getType() != PTy) {
-          auto loc = CI->getDebugLoc();
-          if (auto arg = dyn_cast<Instruction>(res)) {
-            loc = arg->getDebugLoc();
-          }
-          EmitFailure("IllegalArgCast", loc, CI,
-                      "Cannot cast __enzyme_autodiff primal argument ", i,
-                      ", found ", *res, ", type ", *res->getType(),
-                      " - to arg ", truei, " ", *PTy);
-          return false;
-        }
-      }
-#if LLVM_VERSION_MAJOR >= 9
-      if (CI->isByValArgument(i)) {
-        byVal[args.size()] = CI->getParamByValType(i);
-      }
-#endif
-      args.push_back(res);
-      if (ty == DIFFE_TYPE::DUP_ARG || ty == DIFFE_TYPE::DUP_NONEED) {
-        ++i;
-
-        Value *res = nullptr;
-        bool batch = batchOffset.count(i - 1) != 0;
-
-        for (unsigned v = 0; v < width; ++v) {
-#if LLVM_VERSION_MAJOR >= 14
-          if (i >= CI->arg_size())
-#else
-          if (i >= CI->getNumArgOperands())
-#endif
-          {
-            EmitFailure("MissingArgShadow", CI->getDebugLoc(), CI,
-                        "__enzyme_autodiff missing argument shadow at index ",
-                        i, ", need shadow of type ", *PTy,
-                        " to shadow primal argument ", *args.back(),
-                        " at call ", *CI);
-            return false;
-          }
-
-          // cast diffe
-          Value *element = CI->getArgOperand(i);
-          if (batch) {
-            if (auto elementPtrTy = dyn_cast<PointerType>(element->getType())) {
-              element = Builder.CreateBitCast(
-                  element, PointerType::get(Type::getInt8Ty(CI->getContext()),
-                                            elementPtrTy->getAddressSpace()));
-#if LLVM_VERSION_MAJOR >= 7
-              element = Builder.CreateGEP(
-                  Type::getInt8Ty(CI->getContext()), element,
-                  Builder.CreateMul(
-                      batchOffset[i - 1],
-                      ConstantInt::get(batchOffset[i - 1]->getType(), v)));
-#else
-              element = Builder.CreateGEP(
-#if LLVM_VERSION_MAJOR >= 14
-                  elementPtrTy,
-#endif
-                  element,
-                  Builder.CreateMul(
-                      batchOffset[i - 1],
-                      ConstantInt::get(batchOffset[i - 1]->getType(), v)));
-#endif
-              element = Builder.CreateBitCast(element, elementPtrTy);
-            } else {
-              EmitFailure(
-                  "NonPointerBatch", CI->getDebugLoc(), CI,
-                  "Batched argument at index ", i,
-                  " must be of pointer type, found: ", *element->getType());
-              return false;
-            }
-          }
-          if (PTy != element->getType()) {
-            element = castToDiffeFunctionArgType(Builder, CI, FT, PTy, i, mode,
-                                                 element, truei);
-            if (!element) {
-              return false;
-            }
-          }
-
-          if (width > 1) {
-            res =
-                res ? Builder.CreateInsertValue(res, element, {v})
-                    : Builder.CreateInsertValue(UndefValue::get(ArrayType::get(
-                                                    element->getType(), width)),
-                                                element, {v});
-
-            if (v < width - 1 && !batch) {
-              ++i;
-            }
-
-          } else {
-            res = element;
-          }
-        }
-
-        args.push_back(res);
-      }
-
-      ++truei;
-    }
-    if (truei < FT->getNumParams()) {
-      auto numParams = FT->getNumParams();
-      EmitFailure(
-          "EnzymeInsufficientArgs", CI->getDebugLoc(), CI,
-          "Insufficient number of args passed to derivative call required ",
-          numParams, " primal args, found ", truei);
+    if (!options.has_value()) {
       return false;
     }
+
+    auto differet = options->differet;
+    auto tape = options->tape;
+    auto width = options->width;
+    auto allocatedTapeSize = options->allocatedTapeSize;
+    auto freeMemory = options->freeMemory;
+    auto returnUsed = options->returnUsed;
+    auto tapeIsPointer = options->tapeIsPointer;
+    auto differentialReturn = options->differentialReturn;
+    auto retType = options->retType;
 
     TypeAnalysis TA(Logic.PPC.FAM);
     std::vector<bool> overwritten_args;
@@ -1807,9 +1846,8 @@ public:
   bool HandleProbProg(CallInst *CI, ProbProgMode mode) {
     IRBuilder<> Builder(CI);
     Function *F;
-    auto parsedFunction = parseFunctionParameter(CI);
-    if (parsedFunction.hasValue()) {
-      F = parsedFunction.getValue();
+    if (auto parsedFunction = parseFunctionParameter(CI)) {
+      F = parsedFunction.value();
     } else {
       return false;
     }
@@ -1828,10 +1866,10 @@ public:
 #endif
     {
       Value *res = CI->getArgOperand(i);
-      Optional<StringRef> metaString = getMetadataName(res);
+      std::optional<StringRef> metaString = getMetadataName(res);
 
       // handle metadata
-      if (metaString && metaString.getValue().startswith("enzyme_")) {
+      if (metaString && metaString.value().startswith("enzyme_")) {
         if (*metaString == "enzyme_interface") {
           ++i;
           dynamic_interface = CI->getArgOperand(i);


### PR DESCRIPTION
for future reuse in prob prog. Diff looks a bit wild event though I only extracted that one function.

Also replace some instance of llvm::Optional with std::optional.
https://discourse.llvm.org/t/deprecating-llvm-optional-x-hasvalue-getvalue-getvalueor/63716/38