### PR TITLE
check hasVal() before getVal()

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -9508,6 +9508,7 @@ public:
           Value *dcall = nullptr;
           assert(returnIdx);
           assert(augmentcall);
+          assert(returnIdx.hasValue());
           dcall = (returnIdx.getValue() < 0)
                       ? augmentcall
                       : BuilderZ.CreateExtractValue(


### PR DESCRIPTION
Apparently this isn't always true.
TODO: find reason for it being None in the first place.