### PR TITLE
New PM clang

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm: ["7", "8", "9", "10", "11", "12", "13"] #, "14"]
+        llvm: ["7", "8", "9", "10", "11", "12", "13", "14", "15"]
         build: ["Release"] # "RelWithDebInfo"
         os: [ubuntu-20.04]
     
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm: ["7", "8", "9", "10", "11", "12", "13"] #, "14"]
+        llvm: ["7", "8", "9", "10", "11", "12", "13", "14", "15"]
         build: ["Release"] # "RelWithDebInfo"
     
     timeout-minutes: 45 

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -2568,10 +2568,11 @@ AnalysisKey EnzymeNewPM::Key;
 #include "llvm/Transforms/Scalar/LoopDeletion.h"
 #include "llvm/Transforms/Scalar/LoopRotation.h"
 #include "llvm/Transforms/Scalar/LoopUnrollPass.h"
+#include "llvm/Transforms/Scalar/SROA.h"
+
 #if LLVM_VERSION_MAJOR >= 12
 #include "llvm/Transforms/Scalar/LowerConstantIntrinsics.h"
 #include "llvm/Transforms/Scalar/LowerMatrixIntrinsics.h"
-#include "llvm/Transforms/Scalar/SROA.h"
 namespace llvm {
 extern cl::opt<bool> EnableMatrix;
 #if LLVM_VERSION_MAJOR <= 14

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -2562,9 +2562,40 @@ AnalysisKey EnzymeNewPM::Key;
 #ifdef ENZYME_RUNPASS
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Transforms/IPO/GlobalOpt.h"
+#include "llvm/Transforms/Scalar/EarlyCSE.h"
+#include "llvm/Transforms/Scalar/Float2Int.h"
 #include "llvm/Transforms/Scalar/GVN.h"
 #include "llvm/Transforms/Scalar/LoopDeletion.h"
+#include "llvm/Transforms/Scalar/LoopRotation.h"
+#include "llvm/Transforms/Scalar/LoopUnrollPass.h"
+#if LLVM_VERSION_MAJOR >= 12
+#include "llvm/Transforms/Scalar/LowerConstantIntrinsics.h"
+#include "llvm/Transforms/Scalar/LowerMatrixIntrinsics.h"
 #include "llvm/Transforms/Scalar/SROA.h"
+namespace llvm {
+extern cl::opt<bool> EnableMatrix;
+#if LLVM_VERSION_MAJOR <= 14
+extern cl::opt<bool> EnableFunctionSpecialization;
+extern cl::opt<bool> RunPartialInlining;
+#endif
+} // namespace llvm
+#if LLVM_VERSION_MAJOR <= 14
+#include "llvm/Transforms/IPO/CalledValuePropagation.h"
+#include "llvm/Transforms/IPO/DeadArgumentElimination.h"
+#include "llvm/Transforms/IPO/SCCP.h"
+#include "llvm/Transforms/InstCombine/InstCombine.h"
+#include "llvm/Transforms/Scalar/SimplifyCFG.h"
+#if LLVM_VERSION_MAJOR >= 12
+#include "llvm/Transforms/Coroutines/CoroCleanup.h"
+#endif
+#include "llvm/Transforms/IPO/FunctionAttrs.h"
+#include "llvm/Transforms/IPO/GlobalDCE.h"
+#include "llvm/Transforms/IPO/PartialInlining.h"
+#if LLVM_VERSION_MAJOR <= 12
+#include "llvm/Transforms/Utils/Mem2Reg.h"
+#endif
+#endif
+#endif
 #endif
 
 extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
@@ -2575,13 +2606,141 @@ llvmGetPassPluginInfo() {
 #if LLVM_VERSION_MAJOR < 14
             using OptimizationLevel = llvm::PassBuilder::OptimizationLevel;
 #endif
+
 #if LLVM_VERSION_MAJOR >= 12
-            auto loadPass = [](ModulePassManager &MPM, OptimizationLevel)
+            auto prePass = [&](ModulePassManager &MPM, OptimizationLevel Level)
 #else
-            auto loadPass = [](ModulePassManager &MPM)
+            auto prePass = [&](ModulePassManager &MPM)
+#endif
+            {
+
+#if LLVM_VERSION_MAJOR < 12
+              llvm_unreachable(
+                  "New Pass manager pipeline unsupported at version <= 11");
+#else
+#if LLVM_VERSION_MAJOR < 15
+    ////// End of Module simplification
+    // Specialize functions with IPSCCP.
+#if LLVM_VERSION_MAJOR >= 13
+              if (EnableFunctionSpecialization &&
+                  Level == OptimizationLevel::O3)
+                MPM.addPass(FunctionSpecializationPass());
+#endif
+
+              // Interprocedural constant propagation now that basic cleanup has
+              // occurred and prior to optimizing globals.
+              // FIXME: This position in the pipeline hasn't been carefully
+              // considered in years, it should be re-analyzed.
+              MPM.addPass(IPSCCPPass());
+
+              // Attach metadata to indirect call sites indicating the set of
+              // functions they may target at run-time. This should follow
+              // IPSCCP.
+              MPM.addPass(CalledValuePropagationPass());
+
+              // Optimize globals to try and fold them into constants.
+              MPM.addPass(GlobalOptPass());
+
+              // Promote any localized globals to SSA registers.
+              // FIXME: Should this instead by a run of SROA?
+              // FIXME: We should probably run instcombine and simplifycfg
+              // afterward to delete control flows that are dead once globals
+              // have been folded to constants.
+              MPM.addPass(createModuleToFunctionPassAdaptor(PromotePass()));
+
+              // Remove any dead arguments exposed by cleanups and constant
+              // folding globals.
+              MPM.addPass(DeadArgumentEliminationPass());
+
+              // Create a small function pass pipeline to cleanup after all the
+              // global optimizations.
+              FunctionPassManager GlobalCleanupPM;
+              GlobalCleanupPM.addPass(InstCombinePass());
+
+#if LLVM_VERSION_MAJOR >= 14
+              GlobalCleanupPM.addPass(SimplifyCFGPass(
+                  SimplifyCFGOptions().convertSwitchRangeToICmp(true)));
+#else
+              GlobalCleanupPM.addPass(SimplifyCFGPass(SimplifyCFGOptions()));
+#endif
+              MPM.addPass(createModuleToFunctionPassAdaptor(
+                  std::move(GlobalCleanupPM)));
+
+              bool EnableModuleInliner = false;
+              ThinOrFullLTOPhase Phase = ThinOrFullLTOPhase::None;
+#if LLVM_VERSION >= 13
+              if (EnableModuleInliner)
+                MPM.addPass(PB.buildModuleInlinerPipeline(Level, Phase));
+              else
+#endif
+                MPM.addPass(PB.buildInlinerPipeline(Level, Phase));
+
+              FunctionPassManager CoroCleanupPM;
+              CoroCleanupPM.addPass(CoroCleanupPass());
+              MPM.addPass(
+                  createModuleToFunctionPassAdaptor(std::move(CoroCleanupPM)));
+
+              ////// Finished Module simplification, starting ModuleOptimization
+              //
+              // Optimize globals now that the module is fully simplified.
+              MPM.addPass(GlobalOptPass());
+              MPM.addPass(GlobalDCEPass());
+
+              // Run partial inlining pass to partially inline functions that
+              // have large bodies.
+              if (RunPartialInlining)
+                MPM.addPass(PartialInlinerPass());
+
+              // Do RPO function attribute inference across the module to
+              // forward-propagate attributes where applicable.
+              // FIXME: Is this really an optimization rather than a
+              // canonicalization?
+              MPM.addPass(ReversePostOrderFunctionAttrsPass());
+#endif
+              FunctionPassManager OptimizePM;
+              OptimizePM.addPass(Float2IntPass());
+              OptimizePM.addPass(LowerConstantIntrinsicsPass());
+
+              if (EnableMatrix) {
+                OptimizePM.addPass(LowerMatrixIntrinsicsPass());
+                OptimizePM.addPass(EarlyCSEPass());
+              }
+
+              LoopPassManager LPM;
+              bool LTOPreLink = false;
+      // First rotate loops that may have been un-rotated by prior passes.
+      // Disable header duplication at -Oz.
+#if LLVM_VERSION_MAJOR >= 11
+              LPM.addPass(
+                  LoopRotatePass(Level != OptimizationLevel::Oz, LTOPreLink));
+#endif
+              // Some loops may have become dead by now. Try to delete them.
+              // FIXME: see discussion in https://reviews.llvm.org/D112851,
+              //        this may need to be revisited once we run GVN before
+              //        loop deletion in the simplification pipeline.
+              LPM.addPass(LoopDeletionPass());
+
+              LPM.addPass(llvm::LoopFullUnrollPass());
+              OptimizePM.addPass(
+                  createFunctionToLoopPassAdaptor(std::move(LPM)));
+
+              MPM.addPass(
+                  createModuleToFunctionPassAdaptor(std::move(OptimizePM)));
+#endif
+            };
+
+#if LLVM_VERSION_MAJOR >= 12
+            auto loadPass = [&](ModulePassManager &MPM, OptimizationLevel Level)
+#else
+            auto loadPass = [&](ModulePassManager &MPM)
 #endif
             {
               MPM.addPass(PreserveNVVMNewPM(/*Begin*/ true));
+#if LLVM_VERSION_MAJOR >= 12
+              prePass(MPM, Level);
+#else
+              prePass(MPM);
+#endif
               FunctionPassManager OptimizerPM;
               FunctionPassManager OptimizerPM2;
 #if LLVM_VERSION_MAJOR >= 14
@@ -2613,7 +2772,9 @@ llvmGetPassPluginInfo() {
               MPM.addPass(GlobalOptPass());
             };
 // TODO need for perf reasons to move Enzyme pass to the pre vectorization.
-#if LLVM_VERSION_MAJOR >= 12
+#if LLVM_VERSION_MAJOR >= 15
+            PB.registerOptimizerEarlyEPCallback(loadPass);
+#elif LLVM_VERSION_MAJOR >= 12
             PB.registerPipelineEarlySimplificationEPCallback(loadPass);
 #else
             PB.registerPipelineStartEPCallback(loadPass);

--- a/enzyme/test/Integration/ForwardMode/customfwd.c
+++ b/enzyme/test/Integration/ForwardMode/customfwd.c
@@ -9,13 +9,13 @@
 // RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
 // RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
 // RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O0 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
 // RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O0 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
 
 #include "test_utils.h"
 

--- a/enzyme/test/Integration/ReverseMode/customalloc.c
+++ b/enzyme/test/Integration/ReverseMode/customalloc.c
@@ -10,13 +10,13 @@
 // RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
 // RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
 // RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O0 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
 // RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O0 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
 
 #include <stdio.h>
 #include <math.h>

--- a/enzyme/test/Integration/ReverseMode/customcombined.c
+++ b/enzyme/test/Integration/ReverseMode/customcombined.c
@@ -9,13 +9,13 @@
 // RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
 // RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
 // RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O0 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
 // RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O0 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
 
 #include "test_utils.h"
 

--- a/enzyme/test/Integration/ReverseMode/customlog1p.c
+++ b/enzyme/test/Integration/ReverseMode/customlog1p.c
@@ -9,13 +9,13 @@
 // RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
 // RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
 // RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O0 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
 // RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O0 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
 
 #include <stdio.h>
 #include <math.h>

--- a/enzyme/test/Integration/ReverseMode/err_too_few_args.c
+++ b/enzyme/test/Integration/ReverseMode/err_too_few_args.c
@@ -3,9 +3,9 @@
 // RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -g -O2 %s -S -emit-llvm -o -  %loadClangEnzyme -Xclang -verify; fi
 // RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -g -O3 %s -S -emit-llvm -o -  %loadClangEnzyme -Xclang -verify; fi
 // RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O0 %s -S -emit-llvm -o -  %newLoadClangEnzyme -Xclang -verify; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -g -O1 %s -S -emit-llvm -o -  %newLoadClangEnzyme -Xclang -verify; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -g -O2 %s -S -emit-llvm -o -  %newLoadClangEnzyme -Xclang -verify; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -g -O3 %s -S -emit-llvm -o -  %newLoadClangEnzyme -Xclang -verify; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O1 %s -S -emit-llvm -o -  %newLoadClangEnzyme -Xclang -verify; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O2 %s -S -emit-llvm -o -  %newLoadClangEnzyme -Xclang -verify; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O3 %s -S -emit-llvm -o -  %newLoadClangEnzyme -Xclang -verify; fi
 
 extern void __enzyme_autodiff(void*);
 

--- a/enzyme/test/Integration/ReverseMode/warn_cache.c
+++ b/enzyme/test/Integration/ReverseMode/warn_cache.c
@@ -9,14 +9,14 @@
 // RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -g0 -O3 %s -S -emit-llvm -o /dev/null %loadClangEnzyme -Xclang -verify -Rpass=enzyme -mllvm -enzyme-postopt=0; fi
 
 // RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O0 %s -S -emit-llvm -o /dev/null %newLoadClangEnzyme -Xclang -verify -Rpass=enzyme -mllvm -enzyme-postopt=0; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -g -O1 %s -S -emit-llvm -o /dev/null %newLoadClangEnzyme -Xclang -verify -Rpass=enzyme -mllvm -enzyme-postopt=0; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -g -O2 %s -S -emit-llvm -o /dev/null %newLoadClangEnzyme -Xclang -verify -Rpass=enzyme -mllvm -enzyme-postopt=0; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -g -O3 %s -S -emit-llvm -o /dev/null %newLoadClangEnzyme -Xclang -verify -Rpass=enzyme -mllvm -enzyme-postopt=0; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O1 %s -S -emit-llvm -o /dev/null %newLoadClangEnzyme -Xclang -verify -Rpass=enzyme -mllvm -enzyme-postopt=0; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O2 %s -S -emit-llvm -o /dev/null %newLoadClangEnzyme -Xclang -verify -Rpass=enzyme -mllvm -enzyme-postopt=0; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O3 %s -S -emit-llvm -o /dev/null %newLoadClangEnzyme -Xclang -verify -Rpass=enzyme -mllvm -enzyme-postopt=0; fi
 
 // RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g0 -O0 %s -S -emit-llvm -o /dev/null %newLoadClangEnzyme -Xclang -verify -Rpass=enzyme -mllvm -enzyme-postopt=0; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -g0 -O1 %s -S -emit-llvm -o /dev/null %newLoadClangEnzyme -Xclang -verify -Rpass=enzyme -mllvm -enzyme-postopt=0; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -g0 -O2 %s -S -emit-llvm -o /dev/null %newLoadClangEnzyme -Xclang -verify -Rpass=enzyme -mllvm -enzyme-postopt=0; fi
-// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -g0 -O3 %s -S -emit-llvm -o /dev/null %newLoadClangEnzyme -Xclang -verify -Rpass=enzyme -mllvm -enzyme-postopt=0; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g0 -O1 %s -S -emit-llvm -o /dev/null %newLoadClangEnzyme -Xclang -verify -Rpass=enzyme -mllvm -enzyme-postopt=0; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g0 -O2 %s -S -emit-llvm -o /dev/null %newLoadClangEnzyme -Xclang -verify -Rpass=enzyme -mllvm -enzyme-postopt=0; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g0 -O3 %s -S -emit-llvm -o /dev/null %newLoadClangEnzyme -Xclang -verify -Rpass=enzyme -mllvm -enzyme-postopt=0; fi
 
 extern void __enzyme_autodiff(void*, ...);
 


### PR DESCRIPTION
The new pass manager pipeline has fewer available plugin points to inject an optimization pass (enzyme) at its previous location (right before vectorization). This means that existing optimizations will not run before Enzyme on the new pm.

Support for better plugin points has been improving over time (aka adding new plugin injection points). Unfortunately, they aren't available on all LLVM versions. This remedies this, by forcibly running the passes that would've occured in the pipeline before vectorization and after the point Enzyme can be injected in the New PM. As new LLVM's have more plugin point options, this manual list diminishes over LLVM version time.