### PR TITLE
Bugfixes around scf.for + memref.subview implementation

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/ArithAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/ArithAutoDiffOpInterfaceImpl.cpp
@@ -92,19 +92,6 @@ void addToGradient(Value oldGradient, Value addedGradient, OpBuilder &builder,
   gutils->mapInvertPointer(oldGradient, gradient, builder);
 }
 
-void defaultClearGradient(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) {
-  Value result = op->getOpResult(0);
-  if (gutils->invertedPointersGlobal.contains(result)) {
-    FloatType floatType = result.getType().cast<FloatType>();
-    APFloat apf(floatType.getFloatSemantics(), 0);
-
-    Value gradient =
-        builder.create<arith::ConstantFloatOp>(op->getLoc(), apf, floatType);
-    gutils->mapInvertPointer(result, gradient, builder);
-  }
-}
-
 struct AddFOpInterfaceReverse
     : public ReverseAutoDiffOpInterface::ExternalModel<AddFOpInterfaceReverse,
                                                        arith::AddFOp> {

--- a/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogic.h
+++ b/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogic.h
@@ -127,7 +127,8 @@ public:
   void handlePredecessors(Block *oBB, Block *newBB, Block *reverseBB,
                           MGradientUtilsReverse *gutils,
                           void (*buildReturnOp)(OpBuilder &, Location,
-                                                SmallVector<mlir::Value>));
+                                                SmallVector<mlir::Value>),
+                          bool parentRegion);
   void visitChildren(Block *oBB, Block *reverseBB,
                      MGradientUtilsReverse *gutils);
   void visitChild(Operation *op, OpBuilder &builder,

--- a/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogicReverse.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogicReverse.cpp
@@ -42,9 +42,9 @@ MEnzymeLogic::getDominatorToposort(MGradientUtilsReverse *gutils,
 
 void MEnzymeLogic::mapInvertArguments(Block *oBB, Block *reverseBB,
                                       MGradientUtilsReverse *gutils) {
+  OpBuilder builder(reverseBB, reverseBB->begin());
   for (int i = 0; i < (int)gutils->mapBlockArguments[oBB].size(); i++) {
     auto x = gutils->mapBlockArguments[oBB][i];
-    OpBuilder builder(reverseBB, reverseBB->begin());
     if (auto iface = x.second.getType().dyn_cast<AutoDiffTypeInterface>()) {
       Value added = reverseBB->getArgument(i);
       if (gutils->hasInvertPointer(x.second)) {

--- a/enzyme/Enzyme/MLIR/Interfaces/GradientUtilsReverse.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/GradientUtilsReverse.cpp
@@ -359,8 +359,20 @@ MGradientUtilsReverse *MGradientUtilsReverse::CreateFromClone(
     DIFFE_TYPE retType, bool diffeReturnArg, ArrayRef<DIFFE_TYPE> constant_args,
     ReturnType returnValue, mlir::Type additionalArg,
     SymbolTableCollection &symbolTable_) {
+  std::string prefix;
 
-  std::string prefix = "diffe";
+  switch (mode_) {
+  case DerivativeMode::ForwardMode:
+  case DerivativeMode::ForwardModeSplit:
+    assert(false);
+    break;
+  case DerivativeMode::ReverseModeCombined:
+  case DerivativeMode::ReverseModeGradient:
+    prefix = "diffe";
+    break;
+  case DerivativeMode::ReverseModePrimal:
+    llvm_unreachable("invalid DerivativeMode: ReverseModePrimal\n");
+  }
 
   if (width > 1)
     prefix += std::to_string(width);

--- a/enzyme/Enzyme/MLIR/Interfaces/GradientUtilsReverse.h
+++ b/enzyme/Enzyme/MLIR/Interfaces/GradientUtilsReverse.h
@@ -37,7 +37,6 @@ public:
   MEnzymeLogic &Logic;
   bool AtomicAdd;
   DerivativeMode mode;
-  BlockAndValueMapping invertedPointers;
   BlockAndValueMapping invertedPointersGlobal;
   BlockAndValueMapping invertedPointersShadow;
   BlockAndValueMapping shadowValues;

--- a/enzyme/test/MLIR/CMakeLists.txt
+++ b/enzyme/test/MLIR/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(ReverseMode)
+
 # Run regression and unit tests
 add_lit_testsuite(check-enzymemlir "Running MLIR regression tests"
     ${CMAKE_CURRENT_BINARY_DIR}

--- a/enzyme/test/MLIR/ReverseMode/CMakeLists.txt
+++ b/enzyme/test/MLIR/ReverseMode/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Run regression and unit tests
+add_lit_testsuite(check-enzymemlir-reverse "Running MLIR reverse mode tests"
+    ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS enzymemlir-opt
+    ARGS -v
+)
+
+set_target_properties(check-enzymemlir-reverse PROPERTIES FOLDER "Tests")

--- a/enzyme/test/MLIR/ReverseMode/bbarg-order.mlir
+++ b/enzyme/test/MLIR/ReverseMode/bbarg-order.mlir
@@ -1,0 +1,33 @@
+// RUN: %eopt --enzyme %s | FileCheck %s
+
+module {
+  func.func @bbargs(%x: f64) -> f64 {
+    %cst1 = arith.constant 1.000000e+00 : f64
+    %2 = arith.addf %x, %cst1 : f64
+    cf.br ^bb1(%2 : f64)
+  ^bb1(%1 : f64):
+    %cst = arith.constant 0.000000e+00 : f64
+    %flag = arith.cmpf ult, %1, %cst : f64
+    cf.cond_br %flag, ^bb1(%1 : f64), ^bb2(%1 : f64)
+  ^bb2(%ret : f64):
+    return %ret : f64
+  }
+
+  func.func @diff(%x: f64, %dres: f64) -> f64 {
+    %r = enzyme.autodiff @bbargs(%x, %dres) { activity=[#enzyme<activity enzyme_out>] } : (f64, f64) -> f64
+    return %r : f64
+  }
+}
+
+// CHECK:    func.func @diff(%[[arg0:.+]]: f64, %[[arg1:.+]]: f64) -> f64 {
+// CHECK-NEXT:    %[[i0:.+]] = call @diffebbargs(%[[arg0]], %[[arg1]]) : (f64, f64) -> f64
+// CHECK-NEXT:    return %[[i0:.+]]
+// CHECK:    func.func private @diffebbargs(%[[arg0:.+]]: f64, %[[arg1:.+]]: f64) -> f64 {
+
+// There should be exactly one block with two f64 args, and their values should be accumulated
+// in the shadow.
+// CHECK:    ^[[BBMULTI:.+]](%[[fst:.+]]: f64, %[[snd:.+]]: f64):
+// CHECK-NEXT:    "enzyme.set"(%[[shadow:.+]], %[[fst]])
+// CHECK-NEXT:    %[[before:.+]] = "enzyme.get"(%[[shadow]])
+// CHECK-NEXT:    %[[after:.+]] = arith.addf %[[snd]], %[[before]]
+// CHECK-NEXT:    "enzyme.set"(%[[shadow]], %[[after]])

--- a/enzyme/test/MLIR/ReverseMode/pow.mlir
+++ b/enzyme/test/MLIR/ReverseMode/pow.mlir
@@ -1,0 +1,47 @@
+// RUN: %eopt --enzyme %s | FileCheck %s
+
+module {
+  func.func @ppow(%x: f64) -> f64 {
+    %cst = arith.constant 1.000000e+00 : f64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %n = arith.constant 10 : index
+    %r = scf.for %iv = %c0 to %n step %c1 iter_args(%r_it = %cst) -> f64 {
+      %r_next = arith.mulf %r_it, %x : f64
+      scf.yield %r_next : f64
+    }
+    return %r : f64
+  }
+
+  func.func @dppow(%x: f64, %dr: f64) -> f64 {
+    %r = enzyme.autodiff @ppow(%x, %dr) { activity=[#enzyme<activity enzyme_out>] } : (f64, f64) -> f64
+    return %r : f64
+  }
+}
+
+// CHECK:    func.func private @diffeppow(%[[x:.+]]: f64, %[[dr:.+]]: f64) -> f64
+
+// Make sure the right values are being cached in the primal
+// CHECK:        %[[one:.+]] = arith.constant 1.0
+// CHECK:        scf.for %[[iv:.+]] = %c0 to %c10 step %c1 iter_args(%[[r_it:.+]] = %[[one]])
+// CHECK-NEXT:       "enzyme.push"(%[[xcache:.+]], %[[x]])
+// CHECK-NEXT:       "enzyme.push"(%[[rcache:.+]], %[[r_it]])
+
+// Ensure the right value is yielded in the adjoint
+// CHECK:        "enzyme.set"(%[[rshadow:.+]], %[[dr]])
+// CHECK:        %[[dr:.+]] = "enzyme.get"(%[[rshadow]])
+// CHECK:        scf.for %[[iv:.+]] = %[[lb:.+]] to %[[ub:.+]] step %[[step:.+]] iter_args(%[[dr_it:.+]] = %[[dr]])
+// CHECK-NEXT:       "enzyme.set"(%[[rshadow:.+]], %[[dr_it]])
+// CHECK-NEXT:       %[[dr_it:.+]] = "enzyme.get"(%[[rshadow]])
+// CHECK-NEXT:       %[[x:.+]] = "enzyme.pop"(%[[xcache]])
+// CHECK-NEXT:       %[[dr_next:.+]] = arith.mulf %[[dr_it]], %[[x]]
+// CHECK-NEXT:       "enzyme.set"(%[[rshadow:.+]], %[[dr_next]])
+// CHECK-NEXT:       %[[r_cached:.+]] = "enzyme.pop"(%[[rcache]])
+// CHECK-NEXT:       %[[dx_next:.+]] = arith.mulf %[[dr_it]], %[[r_cached]]
+// CHECK-NEXT:       %[[dx0:.+]] = "enzyme.get"(%[[xshadow:.+]]) :
+// CHECK-NEXT:       %[[dx1:.+]] = arith.addf %[[dx0]], %[[dx_next]]
+// CHECK-NEXT:       "enzyme.set"(%[[xshadow]], %[[dx1]])
+// CHECK-NEXT:       %[[dr_next:.+]] = "enzyme.get"(%[[rshadow]])
+// CHECK-NEXT:       scf.yield %[[dr_next]]
+// CHECK:        %[[final:.+]] = "enzyme.get"(%[[xshadow]])
+// CHECK-NEXT:   return %[[final]]


### PR DESCRIPTION
Per the weekly Enzyme-MLIR meeting today, this PR should include all the fixes that are currently in the [reverse mode fork](https://github.com/EnzymeAD/Enzyme-MLIR-Reverse).

Specifically:
- Bugfixes/cleanup around the internal differential value mapping
- Bugfix around `scf.for`
- Reverse mode implementation for `memref.subview`

@umatin Feel free to let me know if I missed anything.