### PR TITLE
Fix devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 // available ubuntu versions: [18, 20, 22]
-// available llvm versions: [7, 8, 9, 10, 11, 12, 13, 14, 15]
+// available llvm versions: [7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
 {
     "name": "Enzyme",
     "image": "ghcr.io/enzymead/enzyme-dev-docker/ubuntu-20-llvm-12:latest",
@@ -7,7 +7,7 @@
         "source=enzyme-bashhistory,target=/commandhistory,type=volume",
         "source=enzyme-extensions,target=/home/vscode/.vscode-server/extensions,type=volume",
         "source=enzyme-extensions-insiders,target=/home/vscode/.vscode-server-insiders/extensions,type=volume",
-        "source=enzyme-build,target=${containerWorkspaceFolder}/enzyme/build,type=volume"
+        "source=enzyme-build,target=${containerWorkspaceFolder}/build,type=volume"
     ],
     "capAdd": ["SYS_PTRACE"],
     "securityOpt": ["seccomp=unconfined"],


### PR DESCRIPTION
Bazel BUILD file prevents docker from mounting the build directory. Changed location of build directory.
