### PR TITLE
Fix string usage

### DIFF
--- a/enzyme/Enzyme/ActivityAnalysis.h
+++ b/enzyme/Enzyme/ActivityAnalysis.h
@@ -48,6 +48,7 @@
 
 #include "llvm/Support/CommandLine.h"
 
+#include "llvm/ADT/StringMap.h"
 #include "llvm/IR/InstVisitor.h"
 
 #include "TypeAnalysis/TypeAnalysis.h"
@@ -64,7 +65,7 @@ class PreProcessCache;
 
 // A map of MPI comm allocators (otherwise inactive) to the
 // argument of the Comm* they allocate into.
-extern const std::map<std::string, size_t> MPIInactiveCommAllocators;
+extern const llvm::StringMap<size_t> MPIInactiveCommAllocators;
 
 /// Helper class to analyze the differential activity
 class ActivityAnalyzer {

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -133,8 +133,7 @@ public:
     if (!I.getType()->isVoidTy() && !I.getType()->isTokenTy() &&
         isa<Instruction>(iload)) {
       IRBuilder<> BuilderZ(cast<Instruction>(iload));
-      pn = BuilderZ.CreatePHI(I.getType(), 1,
-                              (I.getName() + "_replacementA").str());
+      pn = BuilderZ.CreatePHI(I.getType(), 1, I.getName() + "_replacementA");
       gutils->fictiousPHIs[pn] = &I;
       gutils->replaceAWithB(iload, pn);
     }
@@ -7983,7 +7982,7 @@ public:
     // Adjoint of MPI_Comm_split / MPI_Graph_create (which allocates a comm in a
     // pointer) is to free the created comm at the corresponding place in the
     // reverse pass
-    auto commFound = MPIInactiveCommAllocators.find(funcName.str());
+    auto commFound = MPIInactiveCommAllocators.find(funcName);
     if (commFound != MPIInactiveCommAllocators.end()) {
       if (Mode == DerivativeMode::ReverseModeGradient ||
           Mode == DerivativeMode::ReverseModeCombined) {
@@ -8972,8 +8971,8 @@ public:
           cachereplace = gutils->cacheForReverse(
               BuilderZ, cachereplace, getIndex(&call, CacheType::Self));
         } else {
-          auto pn = BuilderZ.CreatePHI(
-              call.getType(), 1, (call.getName() + "_replacementC").str());
+          auto pn = BuilderZ.CreatePHI(call.getType(), 1,
+                                       call.getName() + "_replacementC");
           gutils->fictiousPHIs[pn] = &call;
           cachereplace = pn;
         }
@@ -9302,7 +9301,7 @@ public:
         gutils->getReturnDiffeType(&call, &subretused, &shadowReturnUsed);
 
     if (Mode == DerivativeMode::ForwardMode) {
-      auto found = customFwdCallHandlers.find(funcName.str());
+      auto found = customFwdCallHandlers.find(funcName);
       if (found != customFwdCallHandlers.end()) {
         Value *invertedReturn = nullptr;
         auto ifound = gutils->invertedPointers.find(&call);
@@ -9359,7 +9358,7 @@ public:
     if (Mode == DerivativeMode::ReverseModePrimal ||
         Mode == DerivativeMode::ReverseModeCombined ||
         Mode == DerivativeMode::ReverseModeGradient) {
-      auto found = customCallHandlers.find(funcName.str());
+      auto found = customCallHandlers.find(funcName);
       if (found != customCallHandlers.end()) {
         IRBuilder<> Builder2(call.getParent());
         if (Mode == DerivativeMode::ReverseModeGradient ||
@@ -9527,7 +9526,7 @@ public:
     if ((funcName.startswith("MPI_") || funcName.startswith("PMPI_")) &&
         (!gutils->isConstantInstruction(&call) || funcName == "MPI_Barrier" ||
          funcName == "MPI_Comm_free" || funcName == "MPI_Comm_disconnect" ||
-         MPIInactiveCommAllocators.find(funcName.str()) !=
+         MPIInactiveCommAllocators.find(funcName) !=
              MPIInactiveCommAllocators.end())) {
       handleMPI(call, called, funcName);
       return;
@@ -11094,7 +11093,7 @@ public:
               }
             }
             placeholder->setName("");
-            if (shadowHandlers.find(funcName.str()) != shadowHandlers.end()) {
+            if (shadowHandlers.find(funcName) != shadowHandlers.end()) {
               bb.SetInsertPoint(placeholder);
 
               if (Mode == DerivativeMode::ReverseModeCombined ||
@@ -11103,8 +11102,7 @@ public:
                   (Mode == DerivativeMode::ReverseModeGradient &&
                    backwardsShadow)) {
                 anti = applyChainRule(call.getType(), bb, [&]() {
-                  return shadowHandlers[funcName.str()](bb, &call, args,
-                                                        gutils);
+                  return shadowHandlers[funcName](bb, &call, args, gutils);
                 });
                 if (anti->getType() != placeholder->getType()) {
                   llvm::errs() << "orig: " << call << "\n";
@@ -11613,8 +11611,8 @@ public:
         if (!primalNeededInReverse) {
           if (Mode == DerivativeMode::ReverseModeGradient ||
               Mode == DerivativeMode::ForwardModeSplit) {
-            auto pn = BuilderZ.CreatePHI(
-                call.getType(), 1, (call.getName() + "_replacementJ").str());
+            auto pn = BuilderZ.CreatePHI(call.getType(), 1,
+                                         call.getName() + "_replacementJ");
             gutils->fictiousPHIs[pn] = &call;
             gutils->replaceAWithB(newCall, pn);
             gutils->erase(newCall);
@@ -11654,7 +11652,7 @@ public:
         // try to find the shadow pointer will use the shadow of null rather
         // than the true shadow of this
         auto pn = BuilderZ.CreatePHI(call.getType(), 1,
-                                     (call.getName() + "_replacementB").str());
+                                     call.getName() + "_replacementB");
         gutils->fictiousPHIs[pn] = &call;
         gutils->replaceAWithB(newCall, pn);
         gutils->erase(newCall);

--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -313,17 +313,16 @@ void EnzymeGradientUtilsReplaceAWithB(GradientUtils *G, LLVMValueRef A,
 
 void EnzymeRegisterAllocationHandler(char *Name, CustomShadowAlloc AHandle,
                                      CustomShadowFree FHandle) {
-  shadowHandlers[std::string(Name)] =
-      [=](IRBuilder<> &B, CallInst *CI, ArrayRef<Value *> Args,
-          GradientUtils *gutils) -> llvm::Value * {
+  shadowHandlers[Name] = [=](IRBuilder<> &B, CallInst *CI,
+                             ArrayRef<Value *> Args,
+                             GradientUtils *gutils) -> llvm::Value * {
     SmallVector<LLVMValueRef, 3> refs;
     for (auto a : Args)
       refs.push_back(wrap(a));
     return unwrap(
         AHandle(wrap(&B), wrap(CI), Args.size(), refs.data(), gutils));
   };
-  shadowErasers[std::string(Name)] = [=](IRBuilder<> &B,
-                                         Value *ToFree) -> llvm::CallInst * {
+  shadowErasers[Name] = [=](IRBuilder<> &B, Value *ToFree) -> llvm::CallInst * {
     return cast_or_null<CallInst>(unwrap(FHandle(wrap(&B), wrap(ToFree))));
   };
 }
@@ -331,7 +330,7 @@ void EnzymeRegisterAllocationHandler(char *Name, CustomShadowAlloc AHandle,
 void EnzymeRegisterCallHandler(char *Name,
                                CustomAugmentedFunctionForward FwdHandle,
                                CustomFunctionReverse RevHandle) {
-  auto &pair = customCallHandlers[std::string(Name)];
+  auto &pair = customCallHandlers[Name];
   pair.first = [=](IRBuilder<> &B, CallInst *CI, GradientUtils &gutils,
                    Value *&normalReturn, Value *&shadowReturn,
                    Value *&tape) -> bool {
@@ -352,7 +351,7 @@ void EnzymeRegisterCallHandler(char *Name,
 }
 
 void EnzymeRegisterFwdCallHandler(char *Name, CustomFunctionForward FwdHandle) {
-  auto &pair = customFwdCallHandlers[std::string(Name)];
+  auto &pair = customFwdCallHandlers[Name];
   pair = [=](IRBuilder<> &B, CallInst *CI, GradientUtils &gutils,
              Value *&normalReturn, Value *&shadowReturn) -> bool {
     LLVMValueRef normalR = wrap(normalReturn);

--- a/enzyme/Enzyme/CacheUtility.cpp
+++ b/enzyme/Enzyme/CacheUtility.cpp
@@ -118,19 +118,19 @@ void CacheUtility::replaceAWithB(Value *A, Value *B, bool storeInCache) {
 
 // Create a new canonical induction variable of Type Ty for Loop L
 // Return the variable and the increment instruction
-std::pair<PHINode *, Instruction *> InsertNewCanonicalIV(Loop *L, Type *Ty,
-                                                         std::string name) {
+std::pair<PHINode *, Instruction *>
+InsertNewCanonicalIV(Loop *L, Type *Ty, const llvm::Twine &Name) {
   assert(L);
   assert(Ty);
 
   BasicBlock *Header = L->getHeader();
   assert(Header);
   IRBuilder<> B(&Header->front());
-  PHINode *CanonicalIV = B.CreatePHI(Ty, 1, name);
+  PHINode *CanonicalIV = B.CreatePHI(Ty, 1, Name);
 
   B.SetInsertPoint(Header->getFirstNonPHIOrDbg());
   Instruction *Inc = cast<Instruction>(
-      B.CreateAdd(CanonicalIV, ConstantInt::get(Ty, 1), name + ".next",
+      B.CreateAdd(CanonicalIV, ConstantInt::get(Ty, 1), Name + ".next",
                   /*NUW*/ true, /*NSW*/ true));
 
   for (BasicBlock *Pred : predecessors(Header)) {

--- a/enzyme/Enzyme/CacheUtility.h
+++ b/enzyme/Enzyme/CacheUtility.h
@@ -419,7 +419,8 @@ protected:
 // Create a new canonical induction variable of Type Ty for Loop L
 // Return the variable and the increment instruction
 std::pair<llvm::PHINode *, llvm::Instruction *>
-InsertNewCanonicalIV(llvm::Loop *L, llvm::Type *Ty, std::string name = "iv");
+InsertNewCanonicalIV(llvm::Loop *L, llvm::Type *Ty,
+                     const llvm::Twine &Name = "iv");
 
 // Attempt to rewrite all phinode's in the loop in terms of the
 // induction variable

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -652,8 +652,6 @@ public:
 
     // handle different argument order for struct return.
     if (fn->hasParamAttribute(0, Attribute::StructRet)) {
-      Type *fnsrety = cast<PointerType>(FT->getParamType(0));
-
       truei = 1;
 
       const DataLayout &DL = CI->getParent()->getModule()->getDataLayout();
@@ -661,6 +659,7 @@ public:
 #if LLVM_VERSION_MAJOR >= 12
       Ty = fn->getParamAttribute(0, Attribute::StructRet).getValueAsType();
 #else
+      Type *fnsrety = cast<PointerType>(FT->getParamType(0));
       Ty = fnsrety->getPointerElementType();
 #endif
 #if LLVM_VERSION_MAJOR >= 11

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -2040,7 +2040,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
       SmallVector<Value *, 3> fwdargs;
       int act_idx = 0;
       while (arg != NewF->arg_end()) {
-        arg->setName("arg" + std::to_string(act_idx));
+        arg->setName("arg" + Twine(act_idx));
         fwdargs.push_back(arg);
         switch (constant_args[act_idx]) {
         case DIFFE_TYPE::OUT_DIFF:
@@ -2048,7 +2048,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
         case DIFFE_TYPE::DUP_ARG:
         case DIFFE_TYPE::DUP_NONEED:
           arg++;
-          arg->setName("arg" + std::to_string(act_idx) + "'");
+          arg->setName("arg" + Twine(act_idx) + "'");
           fwdargs.push_back(arg);
           break;
         case DIFFE_TYPE::CONSTANT:
@@ -2112,7 +2112,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
       size_t realidx = 0;
       for (size_t i = 0; i < foundcalled->arg_size(); i++) {
         if (!foundcalled->hasParamAttribute(i, Attribute::StructRet)) {
-          arg->setName("arg" + std::to_string(realidx));
+          arg->setName("arg" + Twine(realidx));
           realidx++;
           argVs.push_back(arg);
           ++arg;
@@ -2167,7 +2167,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
           SmallVector<Value *, 3> argVs;
           size_t realidx = 0;
           for (auto &a : NewF->args()) {
-            a.setName("arg" + std::to_string(realidx));
+            a.setName("arg" + Twine(realidx));
             realidx++;
             argVs.push_back(&a);
           }
@@ -2232,7 +2232,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
           SmallVector<Value *, 3> argVs;
           size_t realidx = 0;
           for (auto &a : NewF->args()) {
-            a.setName("arg" + std::to_string(realidx));
+            a.setName("arg" + Twine(realidx));
             realidx++;
             argVs.push_back(&a);
           }
@@ -3551,7 +3551,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
 
       size_t argnum = 0;
       for (Argument &Arg : NewF->args()) {
-        Arg.setName("arg" + std::to_string(argnum));
+        Arg.setName("arg" + Twine(argnum));
         ++argnum;
       }
 
@@ -3722,7 +3722,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
       SmallVector<Value *, 3> revargs;
       size_t act_idx = 0;
       while (act_idx != key.constant_args.size()) {
-        arg->setName("arg" + std::to_string(act_idx));
+        arg->setName("arg" + Twine(act_idx));
         revargs.push_back(arg);
         switch (key.constant_args[act_idx]) {
         case DIFFE_TYPE::OUT_DIFF:
@@ -3730,7 +3730,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
         case DIFFE_TYPE::DUP_ARG:
         case DIFFE_TYPE::DUP_NONEED:
           arg++;
-          arg->setName("arg" + std::to_string(act_idx) + "'");
+          arg->setName("arg" + Twine(act_idx) + "'");
           revargs.push_back(arg);
           break;
         case DIFFE_TYPE::CONSTANT:
@@ -3745,7 +3745,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
       size_t pa = 0;
       while (arg != NewF->arg_end()) {
         revargs.push_back(arg);
-        arg->setName("postarg" + std::to_string(pa));
+        arg->setName("postarg" + Twine(pa));
         pa++;
         arg++;
       }
@@ -3828,7 +3828,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
             Arg.removeAttr(Attribute::Returned);
           if (Arg.hasAttribute(Attribute::StructRet))
             Arg.removeAttr(Attribute::StructRet);
-          Arg.setName("arg" + std::to_string(argnum));
+          Arg.setName("arg" + Twine(argnum));
           ++argnum;
         }
 
@@ -4888,7 +4888,7 @@ llvm::Function *EnzymeLogic::CreateBatch(Function *tobatch, unsigned width,
           cast<ExtractValueInst>(Builder2.CreateExtractValue(
               arg, {j},
               "unwrap" + (orig_arg->hasName()
-                              ? "." + orig_arg->getName() + std::to_string(j)
+                              ? "." + orig_arg->getName() + Twine(j)
                               : "")));
       if (j == 0) {
         placeholder->replaceAllUsesWith(argVecElem);
@@ -4940,8 +4940,7 @@ llvm::Function *EnzymeLogic::CreateBatch(Function *tobatch, unsigned width,
           PHINode *placeholder = Builder2.CreatePHI(I.getType(), 0);
           vectorizedValues[&I].push_back(placeholder);
           if (I.hasName())
-            placeholder->setName("placeholder." + I.getName() +
-                                 std::to_string(i));
+            placeholder->setName("placeholder." + I.getName() + Twine(i));
         }
       }
     }

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -2896,9 +2896,9 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
   for (auto user : fnusers) {
     if (removeStruct) {
       IRBuilder<> B(user);
-      user->setName("");
       SmallVector<Value *, 4> args(user->arg_begin(), user->arg_end());
       auto rep = B.CreateCall(NewF, args);
+      rep->takeName(user);
       rep->copyIRFlags(user);
       rep->setAttributes(user->getAttributes());
       rep->setCallingConv(user->getCallingConv());

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -64,6 +64,8 @@
 
 #include "llvm/Support/AMDGPUMetadata.h"
 
+#include "llvm/ADT/StringSet.h"
+
 #include "DiffeGradientUtils.h"
 #include "FunctionUtils.h"
 #include "GradientUtils.h"
@@ -2894,7 +2896,6 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
   for (auto user : fnusers) {
     if (removeStruct) {
       IRBuilder<> B(user);
-      auto n = user->getName().str();
       user->setName("");
       SmallVector<Value *, 4> args(user->arg_begin(), user->arg_end());
       auto rep = B.CreateCall(NewF, args);
@@ -5050,7 +5051,7 @@ llvm::Function *EnzymeLogic::CreateNoFree(Function *F) {
   if (isAllocationFunction(F->getName(), TLI))
     return F;
 
-  std::set<std::string> NoFrees = {
+  StringSet<> NoFrees = {
       "memchr",
       "_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EPKcRKS3_",
       "_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_"
@@ -5110,7 +5111,7 @@ llvm::Function *EnzymeLogic::CreateNoFree(Function *F) {
       "_ZNSt3__19addressofIcEEPT_RS1_",
       "_ZNSt3__19addressofIKcEEPT_RS2_"};
 
-  if (F->getName().startswith("_ZNSolsE") || NoFrees.count(F->getName().str()))
+  if (F->getName().startswith("_ZNSolsE") || NoFrees.count(F->getName()))
     return F;
 
   switch (F->getIntrinsicID()) {

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -7435,8 +7435,7 @@ void GradientUtils::branchToCorrespondingTarget(
               Value *val = cond2;
               if (i == 1)
                 val = BuilderM.CreateNot(val, "bnot1_");
-              val = BuilderM.CreateAnd(val, otherBranch,
-                                       "andVal" + std::to_string(i));
+              val = BuilderM.CreateAnd(val, otherBranch, "andVal" + Twine(i));
               if (&*BuilderM.GetInsertPoint() == found->second) {
                 if (found->second->getNextNode())
                   BuilderM.SetInsertPoint(found->second->getNextNode());

--- a/enzyme/Enzyme/GradientUtils.h
+++ b/enzyme/Enzyme/GradientUtils.h
@@ -47,6 +47,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
 
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/DebugInfoMetadata.h"
@@ -72,24 +73,20 @@
 #include "llvm-c/Core.h"
 
 class GradientUtils;
-extern std::map<std::string,
-                std::function<llvm::Value *(
-                    llvm::IRBuilder<> &, llvm::CallInst *,
-                    llvm::ArrayRef<llvm::Value *>, GradientUtils *)>>
+extern llvm::StringMap<std::function<llvm::Value *(
+    llvm::IRBuilder<> &, llvm::CallInst *, llvm::ArrayRef<llvm::Value *>,
+    GradientUtils *)>>
     shadowHandlers;
 
 class DiffeGradientUtils;
-extern std::map<
-    std::string,
-    std::pair<std::function<bool(llvm::IRBuilder<> &, llvm::CallInst *,
-                                 GradientUtils &, llvm::Value *&,
-                                 llvm::Value *&, llvm::Value *&)>,
-              std::function<void(llvm::IRBuilder<> &, llvm::CallInst *,
-                                 DiffeGradientUtils &, llvm::Value *)>>>
+extern llvm::StringMap<std::pair<
+    std::function<bool(llvm::IRBuilder<> &, llvm::CallInst *, GradientUtils &,
+                       llvm::Value *&, llvm::Value *&, llvm::Value *&)>,
+    std::function<void(llvm::IRBuilder<> &, llvm::CallInst *,
+                       DiffeGradientUtils &, llvm::Value *)>>>
     customCallHandlers;
 
-extern std::map<
-    std::string,
+extern llvm::StringMap<
     std::function<bool(llvm::IRBuilder<> &, llvm::CallInst *, GradientUtils &,
                        llvm::Value *&, llvm::Value *&)>>
     customFwdCallHandlers;

--- a/enzyme/Enzyme/InstructionBatcher.cpp
+++ b/enzyme/Enzyme/InstructionBatcher.cpp
@@ -140,7 +140,7 @@ void InstructionBatcher::visitInstruction(llvm::Instruction &inst) {
     RemapInstruction(new_inst, vmap, RF_NoModuleLevelChanges);
 
     if (!inst.getType()->isVoidTy() && inst.hasName())
-      new_inst->setName(inst.getName() + std::to_string(i));
+      new_inst->setName(inst.getName() + Twine(i));
   }
 }
 
@@ -271,8 +271,7 @@ void InstructionBatcher::visitCallInst(llvm::CallInst &call) {
       Instruction *placeholder = dyn_cast<Instruction>(placeholders[i]);
       ExtractValueInst *ret = ExtractValueInst::Create(
           new_call, {i},
-          "unwrap" +
-              (call.hasName() ? "." + call.getName() + std::to_string(i) : ""));
+          "unwrap" + (call.hasName() ? "." + call.getName() + Twine(i) : ""));
       ReplaceInstWithInst(placeholder, ret);
       vectorizedValues[&call][i] = ret;
     }

--- a/enzyme/Enzyme/LibraryFuncs.h
+++ b/enzyme/Enzyme/LibraryFuncs.h
@@ -23,6 +23,7 @@
 #ifndef LIBRARYFUNCS_H_
 #define LIBRARYFUNCS_H_
 
+#include "llvm/ADT/StringMap.h"
 #include "llvm/Analysis/AliasAnalysis.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/IR/IRBuilder.h"
@@ -30,13 +31,12 @@
 #include "llvm/IR/Instructions.h"
 
 class GradientUtils;
-extern std::map<std::string,
-                std::function<llvm::Value *(
-                    llvm::IRBuilder<> &, llvm::CallInst *,
-                    llvm::ArrayRef<llvm::Value *>, GradientUtils *)>>
+extern llvm::StringMap<std::function<llvm::Value *(
+    llvm::IRBuilder<> &, llvm::CallInst *, llvm::ArrayRef<llvm::Value *>,
+    GradientUtils *)>>
     shadowHandlers;
-extern std::map<std::string, std::function<llvm::CallInst *(llvm::IRBuilder<> &,
-                                                            llvm::Value *)>>
+extern llvm::StringMap<
+    std::function<llvm::CallInst *(llvm::IRBuilder<> &, llvm::Value *)>>
     shadowErasers;
 
 /// Return whether a given function is a known C/C++ memory allocation function
@@ -54,7 +54,7 @@ static inline bool isAllocationFunction(const llvm::StringRef name,
   if (name == "julia.gc_alloc_obj" || name == "jl_gc_alloc_typed" ||
       name == "ijl_gc_alloc_typed")
     return true;
-  if (shadowHandlers.find(name.str()) != shadowHandlers.end())
+  if (shadowHandlers.find(name) != shadowHandlers.end())
     return true;
 
   using namespace llvm;

--- a/enzyme/Enzyme/PreserveNVVM.cpp
+++ b/enzyme/Enzyme/PreserveNVVM.cpp
@@ -28,6 +28,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
 
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/IR/Constants.h"
@@ -286,7 +287,7 @@ bool preserveLinkage(bool Begin, Function &F) {
 
 bool preserveNVVM(bool Begin, Function &F) {
   bool changed = false;
-  std::map<std::string, std::pair<std::string, std::string>> Implements;
+  StringMap<std::pair<std::string, std::string>> Implements;
   for (std::string T : {"", "f"}) {
     // sincos, sinpi, cospi, sincospi, cyl_bessel_i1
     for (std::string name :
@@ -316,7 +317,7 @@ bool preserveNVVM(bool Begin, Function &F) {
       Implements[nvname] = std::make_pair(mathname, llname);
     }
   }
-  auto found = Implements.find(F.getName().str());
+  auto found = Implements.find(F.getName());
   if (found != Implements.end()) {
     changed = true;
     if (Begin) {

--- a/enzyme/Enzyme/PreserveNVVM.cpp
+++ b/enzyme/Enzyme/PreserveNVVM.cpp
@@ -195,7 +195,7 @@ handleCustomDerivative(llvm::Module &M, llvm::GlobalVariable &g,
               realidx = 0;
               for (size_t i = 0; i < F->arg_size(); i++) {
                 if (!F->hasParamAttribute(i, Attribute::StructRet)) {
-                  arg->setName("arg" + std::to_string(realidx));
+                  arg->setName("arg" + Twine(realidx));
                   if (!byref.count(realidx))
                     argVs.push_back(arg);
                   else {

--- a/enzyme/Enzyme/TypeAnalysis/RustDebugInfo.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/RustDebugInfo.cpp
@@ -36,7 +36,7 @@ using namespace llvm;
 TypeTree parseDIType(DIType &Type, Instruction &I, DataLayout &DL);
 
 TypeTree parseDIType(DIBasicType &Type, Instruction &I, DataLayout &DL) {
-  std::string TypeName = Type.getName().str();
+  auto TypeName = Type.getName();
   TypeTree Result;
   if (TypeName == "f64") {
     Result = TypeTree(Type::getDoubleTy(I.getContext())).Only(0, &I);

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.h
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.h
@@ -31,6 +31,7 @@
 #include <llvm/Config/llvm-config.h>
 
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/StringMap.h"
 
 #include "llvm/Analysis/TargetLibraryInfo.h"
 
@@ -53,7 +54,7 @@
 
 #include "TypeTree.h"
 
-extern const std::map<std::string, llvm::Intrinsic::ID> LIBM_FUNCTIONS;
+extern const llvm::StringMap<llvm::Intrinsic::ID> LIBM_FUNCTIONS;
 
 static inline bool isMemFreeLibMFunction(llvm::StringRef str,
                                          llvm::Intrinsic::ID *ID = nullptr) {
@@ -365,11 +366,11 @@ public:
   llvm::FunctionAnalysisManager &FAM;
   TypeAnalysis(llvm::FunctionAnalysisManager &FAM) : FAM(FAM) {}
   /// Map of custom function call handlers
-  std::map<std::string,
-           std::function<bool(int /*direction*/, TypeTree & /*returnTree*/,
-                              llvm::ArrayRef<TypeTree> /*argTrees*/,
-                              llvm::ArrayRef<std::set<int64_t>> /*knownValues*/,
-                              llvm::CallInst * /*call*/, TypeAnalyzer *)>>
+  llvm::StringMap<
+      std::function<bool(int /*direction*/, TypeTree & /*returnTree*/,
+                         llvm::ArrayRef<TypeTree> /*argTrees*/,
+                         llvm::ArrayRef<std::set<int64_t>> /*knownValues*/,
+                         llvm::CallInst * /*call*/, TypeAnalyzer *)>>
       CustomRules;
 
   /// Map of possible query states to TypeAnalyzer intermediate results

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -47,6 +47,7 @@
 #include "llvm/Support/CommandLine.h"
 
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/StringMap.h"
 
 #include "llvm/IR/Dominators.h"
 
@@ -115,10 +116,9 @@ llvm::Value *CreateReAllocation(llvm::IRBuilder<> &B, llvm::Value *prev,
 llvm::PointerType *getDefaultAnonymousTapeType(llvm::LLVMContext &C);
 
 class GradientUtils;
-extern std::map<std::string,
-                std::function<llvm::Value *(
-                    llvm::IRBuilder<> &, llvm::CallInst *,
-                    llvm::ArrayRef<llvm::Value *>, GradientUtils *)>>
+extern llvm::StringMap<std::function<llvm::Value *(
+    llvm::IRBuilder<> &, llvm::CallInst *, llvm::ArrayRef<llvm::Value *>,
+    GradientUtils *)>>
     shadowHandlers;
 
 template <typename... Args>


### PR DESCRIPTION
`std::map<std::string, T> `--> `StringMap<T>`
`std::set<std::string>` --> `StringSet<>`

Additionally replace `std::string` in function signatures with `StringRef` and avoid materialising `std::strings` where possible