### PR TITLE
fix a control flow bug

### DIFF
--- a/enzyme/Enzyme/CacheUtility.cpp
+++ b/enzyme/Enzyme/CacheUtility.cpp
@@ -459,11 +459,7 @@ llvm::AllocaInst *CacheUtility::getDynamicLoopLimit(llvm::Loop *L,
     auto Limit = B.CreatePHI(found.var->getType(), 1);
 
     for (BasicBlock *Pred : predecessors(ExitBlock)) {
-      if (LI.getLoopFor(Pred) == L) {
-        Limit->addIncoming(found.var, Pred);
-      } else {
-        Limit->addIncoming(UndefValue::get(found.var->getType()), Pred);
-      }
+      Limit->addIncoming(found.var, Pred);
     }
 
     storeInstructionInCache(lctx, Limit, LimitVar);

--- a/enzyme/test/Integration/ReverseMode/controlflow.c
+++ b/enzyme/test/Integration/ReverseMode/controlflow.c
@@ -1,0 +1,43 @@
+// RUN: if [ %llvmver -eq 15 ]; then %clang -std=c11 -O0 -fno-unroll-loops -fno-tree-vectorize %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
+
+
+void f(double x[2])
+{
+   double t;
+A:
+   t    = 4*__builtin_cos(x[0] + x[1]);
+   x[0] = 3*__builtin_sin(2*x[0] + x[1]);
+   x[1] = t;
+   if (x[0]*x[0] < x[1])
+      return;
+   else if (x[0] > 0)
+      goto A;
+   else
+      goto B;
+
+B:
+   t    = 4*__builtin_sin(2*x[0] + x[1]);
+   x[0] = 4*__builtin_cos(x[0] + 2*x[1]);
+   x[1] = t;
+   if (x[0]*x[0] < x[1])
+      return;
+   else if (x[0] > 0)
+      goto A;
+   else
+      goto B;
+}
+
+extern void* __enzyme_augmentfwd(void*, double*, double*);
+extern void __enzyme_reverse(void*, double*, double*, void*);
+
+int main()
+{
+   double x[2], x_b[2];
+   x[0] = 0.9;
+   x[1] = 0.7;
+   x_b[0] = 1;
+   x_b[1] = 2;
+
+   void* tape = __enzyme_augmentfwd((void*)f, x, x_b);
+   __enzyme_reverse((void*)f, x, x_b, tape);
+}


### PR DESCRIPTION
@wsmoses I am trying to fix some bugs in Enzyme. There are at least two bugs in `__enzyme_reverse` in play here:
1. `getDynamicLoopLimit` creates an undefined value if the loop induction variable does not belong to the immediate predecessor. Here, if `f` is exited via `B`, then `A`'s loop induction variable is the one that becomes undefined in the block of code called `return.loopexit`. I see nothing wrong with "fixing" this the way I did here.
2. The previous bug occurs in the forward portion of `__enzyme_reverse`. There is also a bug in the reverse portion, whereby `A`'s induction variable (iv ac) is simply reading junk from an uninitialized alloca. The code responsible for making this decision is `ComputeIndexOfChunk`. However, I could not infer what your intentions were with this part of the code, so I have not tried to fix it.

The executable crashes with -O0, but higher optimizations may mask the junk values.