### PR TITLE
Fix julia memset runtime err

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -2862,6 +2862,7 @@ public:
                         /*pointerIntSame*/ true);
         llvm_unreachable("bad msi");
       }
+      return;
     }
   known:;
 


### PR DESCRIPTION
@swilliamson7 this is a fix for that memset assertion error that shouldn't have happened, we were discussing yesterday