### PR TITLE
Adding instructions for expm1f / expm1l

### DIFF
--- a/enzyme/Enzyme/InstructionDerivatives.td
+++ b/enzyme/Enzyme/InstructionDerivatives.td
@@ -370,7 +370,7 @@ def : CallPattern<(Op $x),
                   [ReadNone, NoUnwind]
                   >;
 def : CallPattern<(Op $x),
-                  ["expm1"],
+                  ["expm1", "expm1f", "expm1l"],
                   [(FMul (Intrinsic<"exp"> $x), (DiffeRet))],
                   (ForwardFromSummedReverse),
                   [ReadNone, NoUnwind]

--- a/enzyme/test/Enzyme/ReverseMode/expm1f.ll
+++ b/enzyme/test/Enzyme/ReverseMode/expm1f.ll
@@ -1,0 +1,29 @@
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme-preopt=false -enzyme -mem2reg -simplifycfg -instsimplify -adce -S | FileCheck %s; fi
+; RUN: %opt < %s %newLoadEnzyme -enzyme-preopt=false -passes="enzyme,function(mem2reg,%simplifycfg,instsimplify,adce)" -S | FileCheck %s
+
+; Function Attrs: nounwind readnone uwtable
+define float @tester(float %x) {
+entry:
+  %0 = tail call fast float @expm1f(float %x)
+  ret float %0
+}
+
+define float @test_derivative(float %x) {
+entry:
+  %0 = tail call float (float (float)*, ...) @__enzyme_autodiff(float (float)* nonnull @tester, float %x)
+  ret float %0
+}
+
+; Function Attrs: nounwind readnone speculatable
+declare float @expm1f(float)
+
+; Function Attrs: nounwind
+declare float @__enzyme_autodiff(float (float)*, ...)
+
+; CHECK: define internal { float } @diffetester(float %x, float %differeturn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %[[i0:.+]] = call fast float @llvm.exp.f32(float %x)
+; CHECK-NEXT:   %[[i1:.+]] = fmul fast float %[[i0]], %differeturn
+; CHECK-NEXT:   %[[i2:.+]] = insertvalue { float } {{(undef|poison)}}, float %[[i1]], 0
+; CHECK-NEXT:   ret { float } %[[i2]]
+; CHECK-NEXT: }


### PR DESCRIPTION
This pull request adds instructions in InstructionDerivatives.td for the single-precision and long double versions of expm1 in the standard math library of C++. It also adds a test for expm1f to the reverse mode test directory.