### PR TITLE
Nice error message for undifferentiable functions

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -3896,8 +3896,9 @@ public:
         Mode == DerivativeMode::ReverseModeCombined) {
       if (called) {
         subdata = &gutils->Logic.CreateAugmentedPrimal(
-            cast<Function>(called), subretType, argsInverted,
-            TR.analyzer.interprocedural, /*return is used*/ false,
+            RequestContext(&call, &BuilderZ), cast<Function>(called),
+            subretType, argsInverted, TR.analyzer.interprocedural,
+            /*return is used*/ false,
             /*shadowReturnUsed*/ false, nextTypeInfo, overwritten_args, false,
             gutils->getWidth(),
             /*AtomicAdd*/ true,
@@ -4096,6 +4097,7 @@ public:
         }
 
         newcalled = gutils->Logic.CreatePrimalAndGradient(
+            RequestContext(&call, &Builder2),
             (ReverseCacheKey){.todiff = cast<Function>(called),
                               .retType = subretType,
                               .constant_args = argsInverted,
@@ -6851,8 +6853,9 @@ public:
 
       if (called) {
         newcalled = gutils->Logic.CreateForwardDiff(
-            cast<Function>(called), subretType, argsInverted,
-            TR.analyzer.interprocedural, /*returnValue*/ subretused, Mode,
+            RequestContext(&call, &BuilderZ), cast<Function>(called),
+            subretType, argsInverted, TR.analyzer.interprocedural,
+            /*returnValue*/ subretused, Mode,
             ((DiffeGradientUtils *)gutils)->FreeMemory, gutils->getWidth(),
             tape ? tape->getType() : nullptr, nextTypeInfo, overwritten_args,
             /*augmented*/ subdata);
@@ -7254,10 +7257,10 @@ public:
         if (Mode == DerivativeMode::ReverseModePrimal ||
             Mode == DerivativeMode::ReverseModeCombined) {
           subdata = &gutils->Logic.CreateAugmentedPrimal(
-              cast<Function>(called), subretType, argsInverted,
-              TR.analyzer.interprocedural, /*return is used*/ subretused,
-              shadowReturnUsed, nextTypeInfo, overwritten_args, false,
-              gutils->getWidth(), gutils->AtomicAdd);
+              RequestContext(&call, &BuilderZ), cast<Function>(called),
+              subretType, argsInverted, TR.analyzer.interprocedural,
+              /*return is used*/ subretused, shadowReturnUsed, nextTypeInfo,
+              overwritten_args, false, gutils->getWidth(), gutils->AtomicAdd);
           if (Mode == DerivativeMode::ReverseModePrimal) {
             assert(augmentedReturn);
             auto subaugmentations =
@@ -7639,6 +7642,7 @@ public:
       }
 
       newcalled = gutils->Logic.CreatePrimalAndGradient(
+          RequestContext(&call, &Builder2),
           (ReverseCacheKey){.todiff = cast<Function>(called),
                             .retType = subretType,
                             .constant_args = argsInverted,
@@ -10066,7 +10070,8 @@ public:
         auto callval = call.getCalledOperand();
         if (!isa<Constant>(callval))
           callval = gutils->getNewFromOriginal(callval);
-        newCall->setCalledOperand(gutils->Logic.CreateNoFree(callval));
+        newCall->setCalledOperand(gutils->Logic.CreateNoFree(
+            RequestContext(&call, &BuilderZ), callval));
       }
       if (gutils->knownRecomputeHeuristic.find(&call) !=
           gutils->knownRecomputeHeuristic.end()) {

--- a/enzyme/Enzyme/CApi.h
+++ b/enzyme/Enzyme/CApi.h
@@ -119,6 +119,8 @@ typedef enum {
                      // but don't need the forward
 } CDIFFE_TYPE;
 
+typedef enum { BT_SCALAR = 0, BT_VECTOR = 1 } CBATCH_TYPE;
+
 typedef enum {
   DEM_ForwardMode = 0,
   DEM_ReverseModePrimal = 1,
@@ -131,40 +133,6 @@ typedef enum {
   DEM_Trace = 0,
   DEM_Condition = 1,
 } CProbProgMode;
-
-LLVMValueRef EnzymeCreateForwardDiff(
-    EnzymeLogicRef, LLVMValueRef todiff, CDIFFE_TYPE retType,
-    CDIFFE_TYPE *constant_args, size_t constant_args_size,
-    EnzymeTypeAnalysisRef TA, uint8_t returnValue, CDerivativeMode mode,
-    uint8_t freeMemory, unsigned width, LLVMTypeRef additionalArg,
-    struct CFnTypeInfo typeInfo, uint8_t *_uncacheable_args,
-    size_t uncacheable_args_size, EnzymeAugmentedReturnPtr augmented);
-
-LLVMValueRef EnzymeCreatePrimalAndGradient(
-    EnzymeLogicRef, LLVMValueRef todiff, CDIFFE_TYPE retType,
-    CDIFFE_TYPE *constant_args, size_t constant_args_size,
-    EnzymeTypeAnalysisRef TA, uint8_t returnValue, uint8_t dretUsed,
-    CDerivativeMode mode, unsigned width, uint8_t freeMemory,
-    LLVMTypeRef additionalArg, uint8_t forceAnonymousTape,
-    struct CFnTypeInfo typeInfo, uint8_t *_uncacheable_args,
-    size_t uncacheable_args_size, EnzymeAugmentedReturnPtr augmented,
-    uint8_t AtomicAdd);
-
-EnzymeAugmentedReturnPtr EnzymeCreateAugmentedPrimal(
-    EnzymeLogicRef, LLVMValueRef todiff, CDIFFE_TYPE retType,
-    CDIFFE_TYPE *constant_args, size_t constant_args_size,
-    EnzymeTypeAnalysisRef TA, uint8_t returnUsed, uint8_t shadowReturnUsed,
-    struct CFnTypeInfo typeInfo, uint8_t *_uncacheable_args,
-    size_t uncacheable_args_size, uint8_t forceAnonymousTape, unsigned width,
-    uint8_t AtomicAdd);
-
-LLVMValueRef CreateTrace(
-    EnzymeLogicRef Logic, LLVMValueRef totrace, LLVMValueRef *sample_functions,
-    size_t sample_functions_size, LLVMValueRef *observe_functions,
-    size_t observe_functions_size, LLVMValueRef *generative_functions,
-    size_t generative_functions_size, const char *active_random_variables[],
-    size_t active_random_variables_size, CProbProgMode mode, uint8_t autodiff,
-    EnzymeTraceInterfaceRef interface);
 
 typedef uint8_t (*CustomRuleType)(int /*direction*/, CTypeTreeRef /*return*/,
                                   CTypeTreeRef * /*args*/,

--- a/enzyme/Enzyme/DiffeGradientUtils.cpp
+++ b/enzyme/Enzyme/DiffeGradientUtils.cpp
@@ -83,7 +83,6 @@ DiffeGradientUtils *DiffeGradientUtils::CreateFromClone(
     TargetLibraryInfo &TLI, TypeAnalysis &TA, FnTypeInfo &oldTypeInfo,
     DIFFE_TYPE retType, bool diffeReturnArg, ArrayRef<DIFFE_TYPE> constant_args,
     ReturnType returnValue, Type *additionalArg, bool omp) {
-  assert(!todiff->empty());
   Function *oldFunc = todiff;
   assert(mode == DerivativeMode::ReverseModeGradient ||
          mode == DerivativeMode::ReverseModeCombined ||
@@ -149,7 +148,8 @@ DiffeGradientUtils *DiffeGradientUtils::CreateFromClone(
   }
 
   TypeResults TR = TA.analyzeFunction(typeInfo);
-  assert(TR.getFunction() == oldFunc);
+  if (!oldFunc->empty())
+    assert(TR.getFunction() == oldFunc);
 
   auto res = new DiffeGradientUtils(Logic, newFunc, oldFunc, TLI, TA, TR,
                                     invertedPointers, constant_values,

--- a/enzyme/Enzyme/DiffeGradientUtils.cpp
+++ b/enzyme/Enzyme/DiffeGradientUtils.cpp
@@ -62,6 +62,8 @@ DiffeGradientUtils::DiffeGradientUtils(
     : GradientUtils(Logic, newFunc_, oldFunc_, TLI, TA, TR, invertedPointers_,
                     constantvalues_, returnvals_, ActiveReturn, constant_values,
                     origToNew_, mode, width, omp) {
+  if (oldFunc_->empty())
+    return;
   assert(reverseBlocks.size() == 0);
   if (mode == DerivativeMode::ForwardMode ||
       mode == DerivativeMode::ForwardModeSplit) {

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -2279,16 +2279,17 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
       CustomErrorHandler(ss.str().c_str(), wrap(toshow),
                          ErrorType::NoDerivative, nullptr, wrap(todiff),
                          wrap(context.ip));
+      auto newFunc = gutils->newFunc;
+      delete gutils;
+      return insert_or_assign<AugmentedCacheKey, AugmentedReturn>(
+                 AugmentedCachedFunctions, tup,
+                 AugmentedReturn(newFunc, nullptr, {}, returnMapping, {}, {},
+                                 constant_args))
+          ->second;
     }
     if (context.req) {
       EmitFailure("NoDerivative", context.req->getDebugLoc(), context.req,
                   ss.str());
-
-      if (llvm::verifyFunction(*gutils->newFunc, &llvm::errs())) {
-        llvm::errs() << *gutils->oldFunc << "\n";
-        llvm::errs() << *gutils->newFunc << "\n";
-        report_fatal_error("function failed verification (r5)");
-      }
       auto newFunc = gutils->newFunc;
       delete gutils;
       return insert_or_assign<AugmentedCacheKey, AugmentedReturn>(
@@ -3938,14 +3939,11 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
       CustomErrorHandler(ss.str().c_str(), wrap(toshow),
                          ErrorType::NoDerivative, nullptr, wrap(key.todiff),
                          wrap(context.ip));
+      auto newFunc = gutils->newFunc;
+      delete gutils;
+      return newFunc;
     }
     if (context.req) {
-
-      if (llvm::verifyFunction(*gutils->newFunc, &llvm::errs())) {
-        llvm::errs() << *gutils->oldFunc << "\n";
-        llvm::errs() << *gutils->newFunc << "\n";
-        report_fatal_error("function failed verification (r4)");
-      }
       EmitFailure("NoDerivative", context.req->getDebugLoc(), context.req,
                   ss.str());
       auto newFunc = gutils->newFunc;
@@ -4566,6 +4564,9 @@ Function *EnzymeLogic::CreateForwardDiff(
       CustomErrorHandler(ss.str().c_str(), wrap(toshow),
                          ErrorType::NoDerivative, nullptr, wrap(todiff),
                          wrap(context.ip));
+      auto newFunc = gutils->newFunc;
+      delete gutils;
+      return newFunc;
     }
     if (context.req) {
       EmitFailure("NoDerivative", context.req->getDebugLoc(), context.req,
@@ -4817,6 +4818,7 @@ llvm::Function *EnzymeLogic::CreateBatch(RequestContext context,
       CustomErrorHandler(ss.str().c_str(), wrap(toshow),
                          ErrorType::NoDerivative, nullptr, wrap(tobatch),
                          wrap(context.ip));
+      return NewF;
     }
     if (context.req) {
       EmitFailure("NoDerivative", context.req->getDebugLoc(), context.req,
@@ -5112,6 +5114,10 @@ EnzymeLogic::CreateTrace(RequestContext context, llvm::Function *totrace,
       CustomErrorHandler(ss.str().c_str(), wrap(toshow),
                          ErrorType::NoDerivative, nullptr, wrap(totrace),
                          wrap(context.ip));
+      auto newFunc = tutils->newFunc;
+      delete tracer;
+      delete tutils;
+      return newFunc;
     }
     if (context.req) {
       EmitFailure("NoDerivative", context.req->getDebugLoc(), context.req,
@@ -5173,6 +5179,7 @@ llvm::Value *EnzymeLogic::CreateNoFree(RequestContext context,
     CustomErrorHandler(ss.str().c_str(), wrap(context.req),
                        ErrorType::NoDerivative, nullptr, wrap(todiff),
                        wrap(context.ip));
+    return todiff;
   }
 
   if (context.req) {
@@ -5296,6 +5303,7 @@ llvm::Function *EnzymeLogic::CreateNoFree(RequestContext context, Function *F) {
       CustomErrorHandler(ss.str().c_str(), wrap(context.req),
                          ErrorType::NoDerivative, nullptr, wrap(F),
                          wrap(context.ip));
+      return F;
     }
     if (context.req) {
       EmitFailure("IllegalNoFree", context.req->getDebugLoc(), context.req,

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -1918,10 +1918,11 @@ void restoreCache(
 
 //! return structtype if recursive function
 const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
-    Function *todiff, DIFFE_TYPE retType, ArrayRef<DIFFE_TYPE> constant_args,
-    TypeAnalysis &TA, bool returnUsed, bool shadowReturnUsed,
-    const FnTypeInfo &oldTypeInfo_, const std::vector<bool> _overwritten_args,
-    bool forceAnonymousTape, unsigned width, bool AtomicAdd, bool omp) {
+    RequestContext context, Function *todiff, DIFFE_TYPE retType,
+    ArrayRef<DIFFE_TYPE> constant_args, TypeAnalysis &TA, bool returnUsed,
+    bool shadowReturnUsed, const FnTypeInfo &oldTypeInfo_,
+    const std::vector<bool> _overwritten_args, bool forceAnonymousTape,
+    unsigned width, bool AtomicAdd, bool omp) {
   if (returnUsed)
     assert(!todiff->getReturnType()->isEmptyTy() &&
            !todiff->getReturnType()->isVoidTy());
@@ -1999,9 +2000,9 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
       }
 
       auto &aug = CreateAugmentedPrimal(
-          todiff, retType, next_constant_args, TA, returnUsed, shadowReturnUsed,
-          oldTypeInfo_, _overwritten_args, forceAnonymousTape, width, AtomicAdd,
-          omp);
+          context, todiff, retType, next_constant_args, TA, returnUsed,
+          shadowReturnUsed, oldTypeInfo_, _overwritten_args, forceAnonymousTape,
+          width, AtomicAdd, omp);
 
       FunctionType *FTy =
           FunctionType::get(aug.fn->getReturnType(), dupargs,
@@ -2253,26 +2254,53 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
         ->second; // dyn_cast<StructType>(st->getElementType(0)));
   }
 
-  if (todiff->empty()) {
-    if (todiff->empty() && CustomErrorHandler) {
-      std::string s;
-      llvm::raw_string_ostream ss(s);
-      ss << "No augmented forward pass found for " + todiff->getName() << "\n";
-      ss << *todiff << "\n";
-      CustomErrorHandler(ss.str().c_str(), wrap(todiff),
-                         ErrorType::NoDerivative, nullptr, nullptr, nullptr);
-    }
-    llvm::errs() << "mod: " << *todiff->getParent() << "\n";
-    llvm::errs() << *todiff << "\n";
-    assert(0 && "attempting to differentiate function without definition");
-    llvm_unreachable("attempting to differentiate function without definition");
-  }
   std::map<AugmentedStruct, int> returnMapping;
 
   GradientUtils *gutils = GradientUtils::CreateFromClone(
       *this, width, todiff, TLI, TA, oldTypeInfo, retType, constant_args,
       /*returnUsed*/ returnUsed, /*shadowReturnUsed*/ shadowReturnUsed,
       returnMapping, omp);
+
+  if (todiff->empty()) {
+    std::string s;
+    llvm::raw_string_ostream ss(s);
+    ss << "No augmented forward pass found for " + todiff->getName() << "\n";
+    llvm::Value *toshow = todiff;
+    if (context.req) {
+      toshow = context.req;
+      ss << " at context: " << *context.req;
+    } else {
+      ss << *todiff << "\n";
+    }
+    (IRBuilder<>(gutils->inversionAllocs)).CreateUnreachable();
+    DeleteDeadBlock(gutils->inversionAllocs);
+    clearFunctionAttributes(gutils->newFunc);
+    if (CustomErrorHandler) {
+      CustomErrorHandler(ss.str().c_str(), wrap(toshow),
+                         ErrorType::NoDerivative, nullptr, wrap(todiff),
+                         wrap(context.ip));
+    }
+    if (context.req) {
+      EmitFailure("NoDerivative", context.req->getDebugLoc(), context.req,
+                  ss.str());
+
+      if (llvm::verifyFunction(*gutils->newFunc, &llvm::errs())) {
+        llvm::errs() << *gutils->oldFunc << "\n";
+        llvm::errs() << *gutils->newFunc << "\n";
+        report_fatal_error("function failed verification (r5)");
+      }
+      auto newFunc = gutils->newFunc;
+      delete gutils;
+      return insert_or_assign<AugmentedCacheKey, AugmentedReturn>(
+                 AugmentedCachedFunctions, tup,
+                 AugmentedReturn(newFunc, nullptr, {}, returnMapping, {}, {},
+                                 constant_args))
+          ->second;
+    }
+    llvm::errs() << "mod: " << *todiff->getParent() << "\n";
+    llvm::errs() << *todiff << "\n";
+    llvm_unreachable("attempting to differentiate function without definition");
+  }
   gutils->AtomicAdd = AtomicAdd;
   const SmallPtrSet<BasicBlock *, 4> guaranteedUnreachable =
       getGuaranteedUnreachable(gutils->oldFunc);
@@ -2915,7 +2943,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
     auto GV = pair.first;
     GV->setName("_tmp");
     auto R = gutils->GetOrCreateShadowFunction(
-        *this, TLI, TA, todiff, pair.second, width, gutils->AtomicAdd);
+        context, *this, TLI, TA, todiff, pair.second, width, gutils->AtomicAdd);
     SmallVector<std::pair<ConstantExpr *, bool>, 1> users;
     GV->replaceAllUsesWith(ConstantExpr::getPointerCast(R, GV->getType()));
     GV->eraseFromParent();
@@ -3462,7 +3490,7 @@ void createInvertedTerminator(DiffeGradientUtils *gutils,
 }
 
 Function *EnzymeLogic::CreatePrimalAndGradient(
-    const ReverseCacheKey &&key, TypeAnalysis &TA,
+    RequestContext context, const ReverseCacheKey &&key, TypeAnalysis &TA,
     const AugmentedReturn *augmenteddata, bool omp) {
 
   assert(key.mode == DerivativeMode::ReverseModeCombined ||
@@ -3536,8 +3564,9 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
       IRBuilder<> bb(BB);
 
       auto &aug = CreateAugmentedPrimal(
-          key.todiff, key.retType, key.constant_args, TA, key.returnUsed,
-          key.shadowReturnUsed, key.typeInfo, key.overwritten_args,
+          context, key.todiff, key.retType, key.constant_args, TA,
+          key.returnUsed, key.shadowReturnUsed, key.typeInfo,
+          key.overwritten_args,
           /*forceAnonymousTape*/ false, key.width, key.AtomicAdd, omp);
 
       SmallVector<Value *, 4> fwdargs;
@@ -3578,6 +3607,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
       }
 
       auto revfn = CreatePrimalAndGradient(
+          context,
           (ReverseCacheKey){.todiff = key.todiff,
                             .retType = key.retType,
                             .constant_args = key.constant_args,
@@ -3658,6 +3688,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
       }
 
       auto revfn = CreatePrimalAndGradient(
+          context,
           (ReverseCacheKey){.todiff = key.todiff,
                             .retType = key.retType,
                             .constant_args = next_constant_args,
@@ -3872,21 +3903,6 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
     assert(augmenteddata->constant_args == key.constant_args);
   }
 
-  if (key.todiff->empty()) {
-    std::string s;
-    llvm::raw_string_ostream ss(s);
-    ss << "No reverse pass found for " + key.todiff->getName() << "\n";
-    ss << *key.todiff << "\n";
-    if (CustomErrorHandler) {
-      CustomErrorHandler(ss.str().c_str(), wrap(key.todiff),
-                         ErrorType::NoDerivative, nullptr, nullptr, nullptr);
-      return nullptr;
-    } else {
-      llvm_unreachable(ss.str().c_str());
-    }
-  }
-  assert(!key.todiff->empty());
-
   ReturnType retVal =
       key.returnUsed ? (key.shadowReturnUsed ? ReturnType::ArgsWithTwoReturns
                                              : ReturnType::ArgsWithReturn)
@@ -3903,6 +3919,43 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
   gutils->FreeMemory = key.freeMemory;
   insert_or_assign2<ReverseCacheKey, Function *>(ReverseCachedFunctions, key,
                                                  gutils->newFunc);
+
+  if (key.todiff->empty()) {
+    std::string s;
+    llvm::raw_string_ostream ss(s);
+    ss << "No reverse pass found for " + key.todiff->getName() << "\n";
+    llvm::Value *toshow = key.todiff;
+    if (context.req) {
+      toshow = context.req;
+      ss << " at context: " << *context.req;
+    } else {
+      ss << *key.todiff << "\n";
+    }
+    BasicBlock *entry = &gutils->newFunc->getEntryBlock();
+    cleanupInversionAllocs(gutils, entry);
+    clearFunctionAttributes(gutils->newFunc);
+    if (CustomErrorHandler) {
+      CustomErrorHandler(ss.str().c_str(), wrap(toshow),
+                         ErrorType::NoDerivative, nullptr, wrap(key.todiff),
+                         wrap(context.ip));
+    }
+    if (context.req) {
+
+      if (llvm::verifyFunction(*gutils->newFunc, &llvm::errs())) {
+        llvm::errs() << *gutils->oldFunc << "\n";
+        llvm::errs() << *gutils->newFunc << "\n";
+        report_fatal_error("function failed verification (r4)");
+      }
+      EmitFailure("NoDerivative", context.req->getDebugLoc(), context.req,
+                  ss.str());
+      auto newFunc = gutils->newFunc;
+      delete gutils;
+      return newFunc;
+    }
+    llvm::errs() << "mod: " << *key.todiff->getParent() << "\n";
+    llvm::errs() << *key.todiff << "\n";
+    llvm_unreachable("attempting to differentiate function without definition");
+  }
 
   if (augmenteddata && !augmenteddata->isComplete) {
     auto nf = gutils->newFunc;
@@ -4293,9 +4346,10 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
 }
 
 Function *EnzymeLogic::CreateForwardDiff(
-    Function *todiff, DIFFE_TYPE retType, ArrayRef<DIFFE_TYPE> constant_args,
-    TypeAnalysis &TA, bool returnUsed, DerivativeMode mode, bool freeMemory,
-    unsigned width, llvm::Type *additionalArg, const FnTypeInfo &oldTypeInfo_,
+    RequestContext context, Function *todiff, DIFFE_TYPE retType,
+    ArrayRef<DIFFE_TYPE> constant_args, TypeAnalysis &TA, bool returnUsed,
+    DerivativeMode mode, bool freeMemory, unsigned width,
+    llvm::Type *additionalArg, const FnTypeInfo &oldTypeInfo_,
     const std::vector<bool> _overwritten_args,
     const AugmentedReturn *augmenteddata, bool omp) {
   assert(retType != DIFFE_TYPE::OUT_DIFF);
@@ -4478,17 +4532,6 @@ Function *EnzymeLogic::CreateForwardDiff(
     EmitWarning("NoCustom", *todiff,
                 "Cannot use provided custom derivative pass");
   }
-  if (todiff->empty() && CustomErrorHandler) {
-    std::string s;
-    llvm::raw_string_ostream ss(s);
-    ss << "No forward derivative found for " + todiff->getName() << "\n";
-    ss << *todiff << "\n";
-    CustomErrorHandler(s.c_str(), wrap(todiff), ErrorType::NoDerivative,
-                       nullptr, nullptr, nullptr);
-  }
-  if (todiff->empty())
-    llvm::errs() << *todiff << "\n";
-  assert(!todiff->empty());
 
   bool retActive = retType != DIFFE_TYPE::CONSTANT;
 
@@ -4505,6 +4548,42 @@ Function *EnzymeLogic::CreateForwardDiff(
   insert_or_assign2<ForwardCacheKey, Function *>(ForwardCachedFunctions, tup,
                                                  gutils->newFunc);
 
+  if (todiff->empty()) {
+    std::string s;
+    llvm::raw_string_ostream ss(s);
+    ss << "No forward mode derivative found for " + todiff->getName() << "\n";
+    llvm::Value *toshow = todiff;
+    if (context.req) {
+      toshow = context.req;
+      ss << " at context: " << *context.req;
+    } else {
+      ss << *todiff << "\n";
+    }
+    BasicBlock *entry = &gutils->newFunc->getEntryBlock();
+    cleanupInversionAllocs(gutils, entry);
+    clearFunctionAttributes(gutils->newFunc);
+    if (CustomErrorHandler) {
+      CustomErrorHandler(ss.str().c_str(), wrap(toshow),
+                         ErrorType::NoDerivative, nullptr, wrap(todiff),
+                         wrap(context.ip));
+    }
+    if (context.req) {
+      EmitFailure("NoDerivative", context.req->getDebugLoc(), context.req,
+                  ss.str());
+
+      if (llvm::verifyFunction(*gutils->newFunc, &llvm::errs())) {
+        llvm::errs() << *gutils->oldFunc << "\n";
+        llvm::errs() << *gutils->newFunc << "\n";
+        report_fatal_error("function failed verification (r6)");
+      }
+      auto newFunc = gutils->newFunc;
+      delete gutils;
+      return newFunc;
+    }
+    llvm::errs() << "mod: " << *todiff->getParent() << "\n";
+    llvm::errs() << *todiff << "\n";
+    llvm_unreachable("attempting to differentiate function without definition");
+  }
   gutils->FreeMemory = freeMemory;
 
   const SmallPtrSet<BasicBlock *, 4> guaranteedUnreachable =
@@ -4692,7 +4771,8 @@ Function *EnzymeLogic::CreateForwardDiff(
   return nf;
 }
 
-llvm::Function *EnzymeLogic::CreateBatch(Function *tobatch, unsigned width,
+llvm::Function *EnzymeLogic::CreateBatch(RequestContext context,
+                                         Function *tobatch, unsigned width,
                                          ArrayRef<BATCH_TYPE> arg_types,
                                          BATCH_TYPE ret_type) {
 
@@ -4721,6 +4801,32 @@ llvm::Function *EnzymeLogic::CreateBatch(Function *tobatch, unsigned width,
   Function *NewF =
       Function::Create(FTy, tobatch->getLinkage(),
                        "batch_" + tobatch->getName(), tobatch->getParent());
+
+  if (tobatch->empty()) {
+    std::string s;
+    llvm::raw_string_ostream ss(s);
+    ss << "No batch mode found for " + tobatch->getName() << "\n";
+    llvm::Value *toshow = tobatch;
+    if (context.req) {
+      toshow = context.req;
+      ss << " at context: " << *context.req;
+    } else {
+      ss << *tobatch << "\n";
+    }
+    if (CustomErrorHandler) {
+      CustomErrorHandler(ss.str().c_str(), wrap(toshow),
+                         ErrorType::NoDerivative, nullptr, wrap(tobatch),
+                         wrap(context.ip));
+    }
+    if (context.req) {
+      EmitFailure("NoDerivative", context.req->getDebugLoc(), context.req,
+                  ss.str());
+      return NewF;
+    }
+    llvm::errs() << "mod: " << *tobatch->getParent() << "\n";
+    llvm::errs() << *tobatch << "\n";
+    llvm_unreachable("attempting to batch function without definition");
+  }
 
   NewF->setLinkage(Function::LinkageTypes::InternalLinkage);
 
@@ -4949,11 +5055,13 @@ llvm::Function *EnzymeLogic::CreateBatch(Function *tobatch, unsigned width,
   return BatchCachedFunctions[tup] = NewF;
 };
 
-llvm::Function *EnzymeLogic::CreateTrace(
-    llvm::Function *totrace, const SmallPtrSetImpl<Function *> &sampleFunctions,
-    const SmallPtrSetImpl<Function *> &observeFunctions,
-    const StringSet<> &ActiveRandomVariables, ProbProgMode mode, bool autodiff,
-    TraceInterface *interface) {
+llvm::Function *
+EnzymeLogic::CreateTrace(RequestContext context, llvm::Function *totrace,
+                         const SmallPtrSetImpl<Function *> &sampleFunctions,
+                         const SmallPtrSetImpl<Function *> &observeFunctions,
+                         const StringSet<> &ActiveRandomVariables,
+                         ProbProgMode mode, bool autodiff,
+                         TraceInterface *interface) {
   TraceCacheKey tup(totrace, mode, autodiff, interface);
   if (TraceCachedFunctions.find(tup) != TraceCachedFunctions.end()) {
     return TraceCachedFunctions.find(tup)->second;
@@ -4989,6 +5097,35 @@ llvm::Function *EnzymeLogic::CreateTrace(
       new TraceGenerator(*this, tutils, autodiff, originalToNewFn,
                          GenerativeFunctions, ActiveRandomVariables);
 
+  if (totrace->empty()) {
+    std::string s;
+    llvm::raw_string_ostream ss(s);
+    ss << "No tracer found for " + totrace->getName() << "\n";
+    llvm::Value *toshow = totrace;
+    if (context.req) {
+      toshow = context.req;
+      ss << " at context: " << *context.req;
+    } else {
+      ss << *totrace << "\n";
+    }
+    if (CustomErrorHandler) {
+      CustomErrorHandler(ss.str().c_str(), wrap(toshow),
+                         ErrorType::NoDerivative, nullptr, wrap(totrace),
+                         wrap(context.ip));
+    }
+    if (context.req) {
+      EmitFailure("NoDerivative", context.req->getDebugLoc(), context.req,
+                  ss.str());
+      auto newFunc = tutils->newFunc;
+      delete tracer;
+      delete tutils;
+      return newFunc;
+    }
+    llvm::errs() << "mod: " << *totrace->getParent() << "\n";
+    llvm::errs() << *totrace << "\n";
+    llvm_unreachable("attempting to trace function without definition");
+  }
+
   tracer->visit(totrace);
 
   if (verifyFunction(*tutils->newFunc, &errs())) {
@@ -5015,13 +5152,14 @@ llvm::Function *EnzymeLogic::CreateTrace(
   return TraceCachedFunctions[tup] = NewF;
 }
 
-llvm::Value *EnzymeLogic::CreateNoFree(llvm::Value *todiff) {
+llvm::Value *EnzymeLogic::CreateNoFree(RequestContext context,
+                                       llvm::Value *todiff) {
   if (auto F = dyn_cast<Function>(todiff))
-    return CreateNoFree(F);
+    return CreateNoFree(context, F);
   if (auto castinst = dyn_cast<ConstantExpr>(todiff))
     if (castinst->isCast()) {
       llvm::Constant *reps[] = {
-          cast<llvm::Constant>(CreateNoFree(castinst->getOperand(0)))};
+          cast<llvm::Constant>(CreateNoFree(context, castinst->getOperand(0)))};
       return castinst->getWithOperands(reps);
     }
   if (CustomErrorHandler) {
@@ -5029,14 +5167,23 @@ llvm::Value *EnzymeLogic::CreateNoFree(llvm::Value *todiff) {
     llvm::raw_string_ostream ss(s);
     ss << "No create nofree of unknown value\n";
     ss << *todiff << "\n";
-    CustomErrorHandler(ss.str().c_str(), wrap(todiff), ErrorType::NoDerivative,
-                       nullptr, nullptr, nullptr);
+    if (context.req) {
+      ss << " at context: " << *context.req;
+    }
+    CustomErrorHandler(ss.str().c_str(), wrap(context.req),
+                       ErrorType::NoDerivative, nullptr, wrap(todiff),
+                       wrap(context.ip));
   }
 
+  if (context.req) {
+    EmitFailure("IllegalNoFree", context.req->getDebugLoc(), context.req,
+                "Cannot create nofree of instruction-created value: ", *todiff);
+    return todiff;
+  }
   if (auto arg = dyn_cast<Instruction>(todiff)) {
     auto loc = arg->getDebugLoc();
     EmitFailure("IllegalNoFree", loc, arg,
-                "Cannot create nofree of instruction-created value: ", *arg);
+                "Cannot create nofree of instruction-created value: ", *todiff);
     return todiff;
   }
 
@@ -5044,7 +5191,7 @@ llvm::Value *EnzymeLogic::CreateNoFree(llvm::Value *todiff) {
   llvm_unreachable("unhandled, create no free");
 }
 
-llvm::Function *EnzymeLogic::CreateNoFree(Function *F) {
+llvm::Function *EnzymeLogic::CreateNoFree(RequestContext context, Function *F) {
   if (NoFreeCachedFunctions.find(F) != NoFreeCachedFunctions.end()) {
     return NoFreeCachedFunctions.find(F)->second;
   }
@@ -5141,9 +5288,19 @@ llvm::Function *EnzymeLogic::CreateNoFree(Function *F) {
       std::string s;
       llvm::raw_string_ostream ss(s);
       ss << "No create nofree of empty function " << F->getName() << "\n";
-      ss << *F << "\n";
-      CustomErrorHandler(ss.str().c_str(), wrap(F), ErrorType::NoDerivative,
-                         nullptr, nullptr, nullptr);
+      if (context.req) {
+        ss << " at context: " << *context.req;
+      } else {
+        ss << *F << "\n";
+      }
+      CustomErrorHandler(ss.str().c_str(), wrap(context.req),
+                         ErrorType::NoDerivative, nullptr, wrap(F),
+                         wrap(context.ip));
+    }
+    if (context.req) {
+      EmitFailure("IllegalNoFree", context.req->getDebugLoc(), context.req,
+                  "Cannot create nofree of empty function: ", *F);
+      return F;
     }
     llvm::errs() << " unhandled, create no free of empty function: " << *F
                  << "\n";
@@ -5202,11 +5359,11 @@ llvm::Function *EnzymeLogic::CreateNoFree(Function *F) {
       else {
         if (auto CI = dyn_cast<CallInst>(&I)) {
           auto callval = CI->getCalledOperand();
-          CI->setCalledOperand(CreateNoFree(callval));
+          CI->setCalledOperand(CreateNoFree(context, callval));
         }
         if (auto CI = dyn_cast<InvokeInst>(&I)) {
           auto callval = CI->getCalledOperand();
-          CI->setCalledOperand(CreateNoFree(callval));
+          CI->setCalledOperand(CreateNoFree(context, callval));
         }
       }
     }

--- a/enzyme/Enzyme/FunctionUtils.cpp
+++ b/enzyme/Enzyme/FunctionUtils.cpp
@@ -1325,16 +1325,18 @@ Function *PreProcessCache::preprocessForClone(Function *F,
 
   SmallVector<ReturnInst *, 4> Returns;
 
+  if (!F->empty()) {
 #if LLVM_VERSION_MAJOR >= 13
-  CloneFunctionInto(
-      NewF, F, VMap,
-      /*ModuleLevelChanges*/ CloneFunctionChangeType::LocalChangesOnly, Returns,
-      "", nullptr);
+    CloneFunctionInto(
+        NewF, F, VMap,
+        /*ModuleLevelChanges*/ CloneFunctionChangeType::LocalChangesOnly,
+        Returns, "", nullptr);
 #else
-  CloneFunctionInto(NewF, F, VMap,
-                    /*ModuleLevelChanges*/ F->getSubprogram() != nullptr,
-                    Returns, "", nullptr);
+    CloneFunctionInto(NewF, F, VMap,
+                      /*ModuleLevelChanges*/ F->getSubprogram() != nullptr,
+                      Returns, "", nullptr);
 #endif
+  }
   CloneOrigin[NewF] = F;
   NewF->setAttributes(F->getAttributes());
   if (EnzymeNoAlias)
@@ -2113,13 +2115,15 @@ Function *PreProcessCache::CloneFunctionWithReturns(
       VMap[&I] = &*DestI++;        // Add mapping to VMap
     }
   SmallVector<ReturnInst *, 4> Returns;
+  if (!F->empty()) {
 #if LLVM_VERSION_MAJOR >= 13
-  CloneFunctionInto(NewF, F, VMap, CloneFunctionChangeType::LocalChangesOnly,
-                    Returns, "", nullptr);
+    CloneFunctionInto(NewF, F, VMap, CloneFunctionChangeType::LocalChangesOnly,
+                      Returns, "", nullptr);
 #else
-  CloneFunctionInto(NewF, F, VMap, F->getSubprogram() != nullptr, Returns, "",
-                    nullptr);
+    CloneFunctionInto(NewF, F, VMap, F->getSubprogram() != nullptr, Returns, "",
+                      nullptr);
 #endif
+  }
   if (NewF->empty()) {
     auto entry = BasicBlock::Create(NewF->getContext(), "entry", NewF);
     IRBuilder<> B(entry);

--- a/enzyme/Enzyme/FunctionUtils.h
+++ b/enzyme/Enzyme/FunctionUtils.h
@@ -173,6 +173,8 @@ getLatches(const llvm::Loop *L,
 static inline llvm::SmallPtrSet<llvm::BasicBlock *, 4>
 getGuaranteedUnreachable(llvm::Function *F) {
   llvm::SmallPtrSet<llvm::BasicBlock *, 4> knownUnreachables;
+  if (F->empty())
+    return knownUnreachables;
   std::deque<llvm::BasicBlock *> todo;
   for (auto &BB : *F) {
     todo.push_back(&BB);

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -195,6 +195,8 @@ GradientUtils::GradientUtils(
                                : Logic.PPC.getAAResultsFromFunction(oldFunc_)),
       TA(TA_), TR(TR_), omp(omp), width(width), ArgDiffeTypes(ArgDiffeTypes_),
       overwritten_args_map_ptr(nullptr) {
+  if (oldFunc_->empty())
+    return;
   if (oldFunc_->getSubprogram()) {
     assert(originalToNewFn_.hasMD());
   }

--- a/enzyme/Enzyme/GradientUtils.h
+++ b/enzyme/Enzyme/GradientUtils.h
@@ -485,13 +485,17 @@ public:
   llvm::Value *invertPointerM(llvm::Value *val, llvm::IRBuilder<> &BuilderM,
                               bool nullShadow = false);
 
-  static llvm::Constant *GetOrCreateShadowConstant(
-      EnzymeLogic &Logic, llvm::TargetLibraryInfo &TLI, TypeAnalysis &TA,
-      llvm::Constant *F, DerivativeMode mode, unsigned width, bool AtomicAdd);
+  static llvm::Constant *
+  GetOrCreateShadowConstant(RequestContext context, EnzymeLogic &Logic,
+                            llvm::TargetLibraryInfo &TLI, TypeAnalysis &TA,
+                            llvm::Constant *F, DerivativeMode mode,
+                            unsigned width, bool AtomicAdd);
 
-  static llvm::Constant *GetOrCreateShadowFunction(
-      EnzymeLogic &Logic, llvm::TargetLibraryInfo &TLI, TypeAnalysis &TA,
-      llvm::Function *F, DerivativeMode mode, unsigned width, bool AtomicAdd);
+  static llvm::Constant *
+  GetOrCreateShadowFunction(RequestContext context, EnzymeLogic &Logic,
+                            llvm::TargetLibraryInfo &TLI, TypeAnalysis &TA,
+                            llvm::Function *F, DerivativeMode mode,
+                            unsigned width, bool AtomicAdd);
 
   void branchToCorrespondingTarget(
       llvm::BasicBlock *ctx, llvm::IRBuilder<> &BuilderM,

--- a/enzyme/Enzyme/InstructionBatcher.cpp
+++ b/enzyme/Enzyme/InstructionBatcher.cpp
@@ -260,7 +260,8 @@ void InstructionBatcher::visitCallInst(llvm::CallInst &call) {
                             ? BATCH_TYPE::SCALAR
                             : BATCH_TYPE::VECTOR;
 
-  Function *new_func = Logic.CreateBatch(orig_func, width, arg_types, ret_type);
+  Function *new_func = Logic.CreateBatch(RequestContext(&call, &Builder2),
+                                         orig_func, width, arg_types, ret_type);
   CallInst *new_call = Builder2.CreateCall(new_func->getFunctionType(),
                                            new_func, args, call.getName());
 

--- a/enzyme/Enzyme/TraceGenerator.cpp
+++ b/enzyme/Enzyme/TraceGenerator.cpp
@@ -332,8 +332,9 @@ void TraceGenerator::handleArbitraryCall(CallInst &call, CallInst *new_call) {
   assert(called);
 
   Function *samplefn = Logic.CreateTrace(
-      called, tutils->sampleFunctions, tutils->observeFunctions,
-      activeRandomVariables, mode, autodiff, tutils->interface);
+      RequestContext(&call, &Builder), called, tutils->sampleFunctions,
+      tutils->observeFunctions, activeRandomVariables, mode, autodiff,
+      tutils->interface);
 
   Instruction *replacement;
   switch (mode) {

--- a/enzyme/Enzyme/TraceUtils.cpp
+++ b/enzyme/Enzyme/TraceUtils.cpp
@@ -114,14 +114,16 @@ TraceUtils::FromClone(ProbProgMode mode,
   }
 
   SmallVector<ReturnInst *, 4> Returns;
+  if (!oldFunc->empty()) {
 #if LLVM_VERSION_MAJOR >= 13
-  CloneFunctionInto(newFunc, oldFunc, originalToNewFn,
-                    CloneFunctionChangeType::LocalChangesOnly, Returns, "",
-                    nullptr);
+    CloneFunctionInto(newFunc, oldFunc, originalToNewFn,
+                      CloneFunctionChangeType::LocalChangesOnly, Returns, "",
+                      nullptr);
 #else
-  CloneFunctionInto(newFunc, oldFunc, originalToNewFn, true, Returns, "",
-                    nullptr);
+    CloneFunctionInto(newFunc, oldFunc, originalToNewFn, true, Returns, "",
+                      nullptr);
 #endif
+  }
   if (newFunc->empty()) {
     auto entry = BasicBlock::Create(newFunc->getContext(), "entry", newFunc);
     IRBuilder<> B(entry);

--- a/enzyme/Enzyme/TraceUtils.cpp
+++ b/enzyme/Enzyme/TraceUtils.cpp
@@ -122,6 +122,11 @@ TraceUtils::FromClone(ProbProgMode mode,
   CloneFunctionInto(newFunc, oldFunc, originalToNewFn, true, Returns, "",
                     nullptr);
 #endif
+  if (newFunc->empty()) {
+    auto entry = BasicBlock::Create(newFunc->getContext(), "entry", newFunc);
+    IRBuilder<> B(entry);
+    B.CreateUnreachable();
+  }
 
   newFunc->setLinkage(Function::LinkageTypes::InternalLinkage);
 

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -5296,7 +5296,6 @@ TypeResults TypeAnalysis::analyzeFunction(const FnTypeInfo &fn) {
   assert(fn.KnownValues.size() ==
          fn.Function->getFunctionType()->getNumParams());
   assert(fn.Function);
-  assert(!fn.Function->empty());
   auto found = analyzedFunctions.find(fn);
   if (found != analyzedFunctions.end()) {
     auto &analysis = *found->second;
@@ -5309,6 +5308,8 @@ TypeResults TypeAnalysis::analyzeFunction(const FnTypeInfo &fn) {
 
     return TypeResults(analysis);
   }
+  if (fn.Function->empty())
+    return TypeResults(*(TypeAnalyzer *)nullptr);
 
   auto res = analyzedFunctions.emplace(fn, new TypeAnalyzer(fn, *this));
   auto &analysis = *res.first->second;

--- a/enzyme/test/Integration/ForwardMode/err_empty.c
+++ b/enzyme/test/Integration/ForwardMode/err_empty.c
@@ -1,0 +1,20 @@
+// RUN: %clang -std=c11 -g -O0 %s -S -emit-llvm -o -  %loadClangEnzyme -Xclang -verify
+// RUN: %clang -std=c11 -g -O1 %s -S -emit-llvm -o -  %loadClangEnzyme -Xclang -verify
+// RUN: %clang -std=c11 -g -O2 %s -S -emit-llvm -o -  %loadClangEnzyme -Xclang -verify
+// RUN: %clang -std=c11 -g -O3 %s -S -emit-llvm -o -  %loadClangEnzyme -Xclang -verify
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O0 %s -S -emit-llvm -o -  %newLoadClangEnzyme -Xclang -verify; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O1 %s -S -emit-llvm -o -  %newLoadClangEnzyme -Xclang -verify; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O2 %s -S -emit-llvm -o -  %newLoadClangEnzyme -Xclang -verify; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O3 %s -S -emit-llvm -o -  %newLoadClangEnzyme -Xclang -verify; fi
+
+extern double __enzyme_fwddiff(void*, double, double);
+
+double unknown(double in);
+
+double g(double in) {
+    return unknown(in); // expected-error {{Enzyme: No forward mode derivative found for unknown}}
+}
+
+double square(double x, double dx) {
+    return __enzyme_fwddiff((void*)g, x, dx);
+}

--- a/enzyme/test/Integration/ReverseMode/err_empty.c
+++ b/enzyme/test/Integration/ReverseMode/err_empty.c
@@ -12,7 +12,7 @@ extern double __enzyme_autodiff(void*, double);
 double unknown(double in);
 
 double g(double in) {
-    return unknown(unknown(in)); // expected-error {{Enzyme: No reverse pass found for unknown}}  expected-error {{Enzyme: No augmented forward pass found for unknown}} expected-error {{Enzyme: No reverse pass found for unknown at context}}
+    return unknown(unknown(in)); // expected-error {{Enzyme: No reverse pass found for unknown}}  expected-error {{Enzyme: No augmented forward pass found for unknown}} expected-error {{Enzyme: No reverse pass found for unknown}}
 }
 
 double square(double x) {

--- a/enzyme/test/Integration/ReverseMode/err_empty.c
+++ b/enzyme/test/Integration/ReverseMode/err_empty.c
@@ -1,0 +1,20 @@
+// RUN: %clang -std=c11 -g -O0 %s -S -emit-llvm -o -  %loadClangEnzyme -Xclang -verify
+// RUN: %clang -std=c11 -g -O1 %s -S -emit-llvm -o -  %loadClangEnzyme -Xclang -verify
+// RUN: %clang -std=c11 -g -O2 %s -S -emit-llvm -o -  %loadClangEnzyme -Xclang -verify
+// RUN: %clang -std=c11 -g -O3 %s -S -emit-llvm -o -  %loadClangEnzyme -Xclang -verify
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O0 %s -S -emit-llvm -o -  %newLoadClangEnzyme -Xclang -verify; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O1 %s -S -emit-llvm -o -  %newLoadClangEnzyme -Xclang -verify; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O2 %s -S -emit-llvm -o -  %newLoadClangEnzyme -Xclang -verify; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O3 %s -S -emit-llvm -o -  %newLoadClangEnzyme -Xclang -verify; fi
+
+extern double __enzyme_autodiff(void*, double);
+
+double unknown(double in);
+
+double g(double in) {
+    return unknown(unknown(in)); // expected-error {{Enzyme: No reverse pass found for unknown}}  expected-error {{Enzyme: No augmented forward pass found for unknown}} expected-error {{Enzyme: No reverse pass found for unknown at context}}
+}
+
+double square(double x) {
+    return __enzyme_autodiff((void*)g, x);
+}


### PR DESCRIPTION
Also exposed batch in the CAPI and added some docs while at it.

This also notably means that:
1) the compiler won't crash if there's a non differentiable function it doesn't know about
2) it provides nice error messages at the source line location/backtrace of the call that caused it
3) it does so for all errors/functions at once (rather than doing one crash at a time)