### PR TITLE
try new option enzyme_nocache

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -3892,11 +3892,12 @@ public:
     if (Mode == DerivativeMode::ReverseModePrimal ||
         Mode == DerivativeMode::ReverseModeCombined) {
       if (called) {
+        std::vector<bool> nocache_args(overwritten_args.size(), false);
         subdata = &gutils->Logic.CreateAugmentedPrimal(
             RequestContext(&call, &BuilderZ), cast<Function>(called),
             subretType, argsInverted, TR.analyzer.interprocedural,
             /*return is used*/ false,
-            /*shadowReturnUsed*/ false, nextTypeInfo, overwritten_args, false,
+            /*shadowReturnUsed*/ false, nextTypeInfo, overwritten_args, nocache_args, false,
             gutils->getWidth(),
             /*AtomicAdd*/ true,
             /*OpenMP*/ true);
@@ -6849,12 +6850,13 @@ public:
       FunctionType *FT = nullptr;
 
       if (called) {
+        std::vector<bool> nocache_args(overwritten_args.size(), false);
         newcalled = gutils->Logic.CreateForwardDiff(
             RequestContext(&call, &BuilderZ), cast<Function>(called),
             subretType, argsInverted, TR.analyzer.interprocedural,
             /*returnValue*/ subretused, Mode,
             ((DiffeGradientUtils *)gutils)->FreeMemory, gutils->getWidth(),
-            tape ? tape->getType() : nullptr, nextTypeInfo, overwritten_args,
+            tape ? tape->getType() : nullptr, nextTypeInfo, overwritten_args, nocache_args,
             /*augmented*/ subdata);
         FT = cast<Function>(newcalled)->getFunctionType();
       } else {
@@ -7253,11 +7255,12 @@ public:
       } else {
         if (Mode == DerivativeMode::ReverseModePrimal ||
             Mode == DerivativeMode::ReverseModeCombined) {
+          std::vector<bool> nocache_args(overwritten_args.size(), false);
           subdata = &gutils->Logic.CreateAugmentedPrimal(
               RequestContext(&call, &BuilderZ), cast<Function>(called),
               subretType, argsInverted, TR.analyzer.interprocedural,
               /*return is used*/ subretused, shadowReturnUsed, nextTypeInfo,
-              overwritten_args, false, gutils->getWidth(), gutils->AtomicAdd);
+              overwritten_args, nocache_args, false, gutils->getWidth(), gutils->AtomicAdd);
           if (Mode == DerivativeMode::ReverseModePrimal) {
             assert(augmentedReturn);
             auto subaugmentations =

--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -550,10 +550,11 @@ LLVMValueRef EnzymeCreateForwardDiff(
   SmallVector<DIFFE_TYPE, 4> nconstant_args((DIFFE_TYPE *)constant_args,
                                             (DIFFE_TYPE *)constant_args +
                                                 constant_args_size);
-  std::vector<bool> overwritten_args;
+  std::vector<bool> overwritten_args, nocache_args;
   assert(overwritten_args_size == cast<Function>(unwrap(todiff))->arg_size());
   for (uint64_t i = 0; i < overwritten_args_size; i++) {
     overwritten_args.push_back(_overwritten_args[i]);
+    nocache_args.push_back(false);
   }
   return wrap(eunwrap(Logic).CreateForwardDiff(
       RequestContext(cast_or_null<Instruction>(unwrap(request_req)),
@@ -561,7 +562,7 @@ LLVMValueRef EnzymeCreateForwardDiff(
       cast<Function>(unwrap(todiff)), (DIFFE_TYPE)retType, nconstant_args,
       eunwrap(TA), returnValue, (DerivativeMode)mode, freeMemory, width,
       unwrap(additionalArg), eunwrap(typeInfo, cast<Function>(unwrap(todiff))),
-      overwritten_args, eunwrap(augmented)));
+      overwritten_args, nocache_args, eunwrap(augmented)));
 }
 LLVMValueRef EnzymeCreatePrimalAndGradient(
     EnzymeLogicRef Logic, LLVMValueRef request_req, LLVMBuilderRef request_ip,
@@ -610,17 +611,18 @@ EnzymeAugmentedReturnPtr EnzymeCreateAugmentedPrimal(
   SmallVector<DIFFE_TYPE, 4> nconstant_args((DIFFE_TYPE *)constant_args,
                                             (DIFFE_TYPE *)constant_args +
                                                 constant_args_size);
-  std::vector<bool> overwritten_args;
+  std::vector<bool> overwritten_args, nocache_args;
   assert(overwritten_args_size == cast<Function>(unwrap(todiff))->arg_size());
   for (uint64_t i = 0; i < overwritten_args_size; i++) {
     overwritten_args.push_back(_overwritten_args[i]);
+    nocache_args.push_back(false);
   }
   return ewrap(eunwrap(Logic).CreateAugmentedPrimal(
       RequestContext(cast_or_null<Instruction>(unwrap(request_req)),
                      unwrap(request_ip)),
       cast<Function>(unwrap(todiff)), (DIFFE_TYPE)retType, nconstant_args,
       eunwrap(TA), returnUsed, shadowReturnUsed,
-      eunwrap(typeInfo, cast<Function>(unwrap(todiff))), overwritten_args,
+      eunwrap(typeInfo, cast<Function>(unwrap(todiff))), overwritten_args, nocache_args,
       forceAnonymousTape, width, AtomicAdd));
 }
 

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -682,17 +682,15 @@ public:
 
 #if LLVM_VERSION_MAJOR > 16
   static std::optional<Options>
-  handleArguments(IRBuilder<> &Builder, CallInst *CI, Function *fn,
-                  DerivativeMode mode, bool sizeOnly,
-                  std::vector<DIFFE_TYPE> &constants,
-                  SmallVectorImpl<Value *> &args, std::map<int, Type *> &byVal)
 #else
   static Optional<Options>
+#endif
   handleArguments(IRBuilder<> &Builder, CallInst *CI, Function *fn,
                   DerivativeMode mode, bool sizeOnly,
                   std::vector<DIFFE_TYPE> &constants,
+                  std::vector<bool>& overwritten_args,
+                  std::vector<bool>& nocache_args,
                   SmallVectorImpl<Value *> &args, std::map<int, Type *> &byVal)
-#endif
   {
     FunctionType *FT = fn->getFunctionType();
 
@@ -712,6 +710,16 @@ public:
     unsigned byRefSize = 0;
     bool primalReturn = false;
     StringSet<> ActiveRandomVariables;
+    bool no_overwrite = false;
+    bool no_cache = false;
+    // set default values of overwritten_args and nocache_args
+    // these can be overridden with enzyme_noowr and and enzyme_nocache
+    overwritten_args.clear();
+    nocache_args.clear();
+    for (auto &a : fn->args()) {
+      overwritten_args.push_back(mode != DerivativeMode::ReverseModeCombined);
+      nocache_args.push_back(false);
+    }
 
     DIFFE_TYPE retType = whatType(fn->getReturnType(), mode);
 
@@ -851,6 +859,12 @@ public:
           byRefSize = cast<ConstantInt>(CI->getArgOperand(i))->getZExtValue();
           assert(byRefSize > 0);
           continue;
+        } else if (*metaString == "enzyme_noowr") {
+          no_overwrite = true;
+          continue;
+        } else if (*metaString == "enzyme_nocache") {
+          no_cache = true;
+          continue;
         }
         if (*metaString == "enzyme_dup") {
           opt_ty = DIFFE_TYPE::DUP_ARG;
@@ -970,6 +984,14 @@ public:
         if (sizeOnly) {
           assert(opt_ty);
           constants.push_back(*opt_ty);
+          if (no_overwrite)
+              overwritten_args.at(truei) = false;
+          no_overwrite = false;
+          if (no_cache) {
+              overwritten_args.at(truei) = false;
+              nocache_args.at(truei) = true;
+          }
+          no_cache = false;
           truei++;
           continue;
         }
@@ -1201,6 +1223,14 @@ public:
         args.push_back(res);
       }
 
+      if (no_overwrite)
+        overwritten_args.at(truei) = false;
+      no_overwrite = false;
+      if (no_cache) {
+        overwritten_args.at(truei) = false;
+        nocache_args.at(truei) = true;
+      }
+      no_cache = false;
       ++truei;
     }
     if (truei < FT->getNumParams()) {
@@ -1219,13 +1249,10 @@ public:
   }
 
   static FnTypeInfo
-  populate_overwritten_args(TypeAnalysis &TA, llvm::Function *fn,
-                            DerivativeMode mode,
-                            std::vector<bool> &overwritten_args) {
+  compute_type_args(TypeAnalysis &TA, llvm::Function *fn,
+                    DerivativeMode mode) {
     FnTypeInfo type_args(fn);
     for (auto &a : type_args.Function->args()) {
-      overwritten_args.push_back(
-          !(mode == DerivativeMode::ReverseModeCombined));
       TypeTree dt;
       if (a.getType()->isFPOrFPVectorTy()) {
         dt = ConcreteType(a.getType()->getScalarType());
@@ -1450,6 +1477,8 @@ public:
   bool HandleAutoDiff(Instruction *CI, CallingConv::ID CallingConv, Value *ret,
                       Type *retElemType, SmallVectorImpl<Value *> &args,
                       const std::map<int, Type *> &byVal,
+                      std::vector<bool>& overwritten_args,
+                      std::vector<bool>& nocache_args,
                       const std::vector<DIFFE_TYPE> &constants, Function *fn,
                       DerivativeMode mode, Options &options, bool sizeOnly,
                       SmallVectorImpl<CallInst *> &calls) {
@@ -1469,9 +1498,7 @@ public:
                      Arch == Triple::amdgcn;
 
     TypeAnalysis TA(Logic.PPC.FAM);
-    std::vector<bool> overwritten_args;
-    FnTypeInfo type_args =
-        populate_overwritten_args(TA, fn, mode, overwritten_args);
+    FnTypeInfo type_args = compute_type_args(TA, fn, mode);
 
     IRBuilder Builder(CI);
     RequestContext context(CI, &Builder);
@@ -1485,7 +1512,7 @@ public:
       newFunc = Logic.CreateForwardDiff(
           context, fn, retType, constants, TA,
           /*should return*/ primalReturn, mode, freeMemory, width,
-          /*addedType*/ nullptr, type_args, overwritten_args,
+          /*addedType*/ nullptr, type_args, overwritten_args, nocache_args,
           /*augmented*/ nullptr);
       break;
     case DerivativeMode::ForwardModeSplit: {
@@ -1493,7 +1520,8 @@ public:
       aug = &Logic.CreateAugmentedPrimal(
           context, fn, retType, constants, TA,
           /*returnUsed*/ false, /*shadowReturnUsed*/ false, type_args,
-          overwritten_args, forceAnonymousTape, width, /*atomicAdd*/ AtomicAdd);
+          overwritten_args, nocache_args,
+          forceAnonymousTape, width, /*atomicAdd*/ AtomicAdd);
       auto &DL = fn->getParent()->getDataLayout();
       if (!forceAnonymousTape) {
         assert(!aug->tapeType);
@@ -1529,7 +1557,7 @@ public:
       newFunc = Logic.CreateForwardDiff(
           context, fn, retType, constants, TA,
           /*should return*/ primalReturn, mode, freeMemory, width,
-          /*addedType*/ tapeType, type_args, overwritten_args, aug);
+          /*addedType*/ tapeType, type_args, overwritten_args, nocache_args, aug);
       break;
     }
     case DerivativeMode::ReverseModeCombined:
@@ -1563,7 +1591,7 @@ public:
                                              retType == DIFFE_TYPE::DUP_NONEED);
       aug = &Logic.CreateAugmentedPrimal(
           context, fn, retType, constants, TA, returnUsed, shadowReturnUsed,
-          type_args, overwritten_args, forceAnonymousTape, width,
+          type_args, overwritten_args, nocache_args, forceAnonymousTape, width,
           /*atomicAdd*/ AtomicAdd);
       auto &DL = fn->getParent()->getDataLayout();
       if (!forceAnonymousTape) {
@@ -1606,6 +1634,7 @@ public:
                               .retType = retType,
                               .constant_args = constants,
                               .overwritten_args = overwritten_args,
+                              .nocache_args = nocache_args,
                               .returnUsed = false,
                               .shadowReturnUsed = false,
                               .mode = mode,
@@ -1768,9 +1797,11 @@ public:
 
     std::map<int, Type *> byVal;
     std::vector<DIFFE_TYPE> constants;
+    std::vector<bool> overwritten_args, nocache_args;
     SmallVector<Value *, 2> args;
 
     auto options = handleArguments(Builder, CI, fn, mode, sizeOnly, constants,
+                                   overwritten_args, nocache_args,
                                    args, byVal);
 
     if (!options) {
@@ -1792,11 +1823,13 @@ public:
 
 #if LLVM_VERSION_MAJOR >= 16
     return HandleAutoDiff(CI, CI->getCallingConv(), ret, retElemType, args,
-                          byVal, constants, fn, mode, options.value(), sizeOnly,
+                          byVal, overwritten_args, nocache_args,
+                          constants, fn, mode, options.value(), sizeOnly,
                           calls);
 #else
     return HandleAutoDiff(CI, CI->getCallingConv(), ret, retElemType, args,
-                          byVal, constants, fn, mode, options.getValue(),
+                          byVal, overwritten_args, nocache_args,
+                          constants, fn, mode, options.getValue(),
                           sizeOnly, calls);
 #endif
   }
@@ -1811,12 +1844,14 @@ public:
     assert(F);
 
     std::vector<DIFFE_TYPE> constants;
+    std::vector<bool> overwritten_args, nocache_args;
     std::map<int, Type *> byVal;
     SmallVector<Value *, 4> args;
 
     auto diffeMode = DerivativeMode::ReverseModeCombined;
 
     auto opt = handleArguments(Builder, CI, F, diffeMode, false, constants,
+                               overwritten_args, nocache_args,
                                args, byVal);
 
     SmallVector<Value *, 6> dargs = SmallVector(args);
@@ -1927,11 +1962,13 @@ public:
 #if LLVM_VERSION_MAJOR >= 16
     bool status =
         HandleAutoDiff(CI, CI->getCallingConv(), ret, retElemType, dargs, byVal,
+                       overwritten_args, nocache_args,
                        constants, newFunc, DerivativeMode::ReverseModeCombined,
                        opt.value(), false, calls);
 #else
     bool status =
         HandleAutoDiff(CI, CI->getCallingConv(), ret, retElemType, dargs, byVal,
+                       overwritten_args, nocache_args,
                        constants, newFunc, DerivativeMode::ReverseModeCombined,
                        opt.getValue(), false, calls);
 #endif

--- a/enzyme/test/Integration/ReverseMode/nocache_containers.cpp
+++ b/enzyme/test/Integration/ReverseMode/nocache_containers.cpp
@@ -1,0 +1,145 @@
+// This should work on LLVM 7, 8, 9, however in CI the version of clang installed on Ubuntu 18.04 cannot load
+// a clang plugin properly without segfaulting on exit. This is fine on Ubuntu 20.04 or later LLVM versions...
+// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O0 %s -S -emit-llvm -o - %loadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %loadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %loadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %loadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O0 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 10 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O0 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O0 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-inline=1 -S | %lli - ; fi
+
+#include <vector>
+#include <list>
+#include <forward_list>
+#include "test_utils.h"
+
+template<typename RT, typename... Args> RT __enzyme_fwddiff(Args...);
+template<typename RT, typename... Args> RT __enzyme_autodiff(Args...);
+template<typename RT, typename... Args> RT __enzyme_augmentfwd(Args...);
+template<typename RT, typename... Args> RT __enzyme_reverse(Args...);
+
+// example that layers enzyme_nocache over enzyme_dup
+// in the case of std::(forward_)list:
+// the contents must be cached since the list cannot be traversed in reverse otherwise
+
+template<typename T>
+void f(T& y, T& x) {
+    auto xi = x.begin();
+    auto yi = y.begin();
+    for (; xi != x.end(); ++xi, ++yi)
+        *yi = *xi * *xi;
+}
+
+template<typename T>
+__attribute__((noinline)) void* f_aug(T& y, T& y_b, T& x, T& x_b) {
+    return __enzyme_augmentfwd<void*>(f<T>, enzyme_nocache, &y, &y_b,
+                                            enzyme_nocache, &x, &x_b);
+}
+
+template<typename T>
+__attribute__((noinline)) void f_rev(T& y, T& y_b, T& x, T& x_b, void* tape) {
+    __enzyme_reverse<void*>(f<T>, enzyme_nocache, &y, &y_b,
+                                  enzyme_nocache, &x, &x_b,
+                                  tape);
+}
+
+template<typename T>
+void test_f() {
+    size_t n = 7;
+    T x(n, 0.0), x_b(n, 0.0), y(n, 0.0), y_b(n, 1.0);
+    size_t i = 0;
+    for (auto& xi: x)
+        xi = i++;
+
+    void* tape = f_aug<T>(y, y_b, x, x_b);
+    printf("tape: %p\n", tape);
+    f_rev<T>(y, y_b, x, x_b, tape);
+
+    i = 0;
+    auto xi = x.begin();
+    auto yi = y.begin();
+    auto xi_b = x_b.begin();
+    auto yi_b = y_b.begin();
+    for (; xi != x.end(); ++xi, ++xi_b, ++yi, ++yi_b, ++i) {
+        APPROX_EQ(*xi,     i, 1e-10);
+        APPROX_EQ(*xi_b, 2*i, 1e-10);
+        APPROX_EQ(*yi,   i*i, 1e-10);
+        APPROX_EQ(*yi_b,   0, 1e-10);
+    }
+}
+
+// example that layers enzyme_nocache over enzyme_const
+// without enzyme_nocache, the contents of c are cached on the tape
+// with enzyme_nocache - at least in the case of std::vector - there is no caching
+
+template<typename T>
+void g(T& y, T& x, T& c) {
+    auto xi = x.begin();
+    auto yi = y.begin();
+    auto ci = c.begin();
+    for (; xi != x.end(); ++xi, ++yi, ++ci)
+        *yi = *ci * *xi * *xi;
+}
+
+template<typename T>
+__attribute__((noinline)) void* g_aug(T& y, T& y_b, T& x, T& x_b, T& c) {
+    return __enzyme_augmentfwd<void*>(g<T>, enzyme_nocache, &y, &y_b,
+                                            enzyme_nocache, &x, &x_b,
+                                            enzyme_nocache, enzyme_const, &c);
+}
+
+template<typename T>
+__attribute__((noinline)) void g_rev(T& y, T& y_b, T& x, T& x_b, T& c, void* tape) {
+    __enzyme_reverse<void*>(g<T>, enzyme_nocache, &y, &y_b,
+                                  enzyme_nocache, &x, &x_b,
+                                  enzyme_nocache, enzyme_const, &c,
+                                  tape);
+}
+
+template<typename T>
+void test_g() {
+    size_t n = 7;
+    T x(n, 0.0), x_b(n, 0.0), y(n, 0.0), y_b(n, 1.0), c(n, 0.0);
+    size_t i = 0;
+    for (auto& xi: x)
+        xi = i++;
+    for (auto& ci: c)
+        ci = i++;
+
+    void* tape = g_aug<T>(y, y_b, x, x_b, c);
+    printf("tape: %p\n", tape);
+    g_rev<T>(y, y_b, x, x_b, c, tape);
+
+    i = 0;
+    auto xi = x.begin();
+    auto xi_b = x_b.begin();
+    auto yi = y.begin();
+    auto yi_b = y_b.begin();
+    auto ci = c.begin();
+    for (; xi != x.end(); ++xi, ++xi_b, ++yi, ++yi_b, ++ci, ++i) {
+        APPROX_EQ(*xi,         i, 1e-10);
+        APPROX_EQ(*xi_b, *ci*2*i, 1e-10);
+        APPROX_EQ(*yi,   *ci*i*i, 1e-10);
+        APPROX_EQ(*yi_b,       0, 1e-10);
+    }
+}
+
+int main()
+{
+    test_f<std::vector<double>>();
+    test_f<std::list<double>>();
+    test_f<std::forward_list<double>>();
+    test_g<std::vector<double>>();
+    // that the following are broken on -O0 is not the fault of the enzyme_nocache implementation
+    test_g<std::list<double>>();
+    test_g<std::forward_list<double>>();
+}

--- a/enzyme/test/Integration/ReverseMode/test_utils.h
+++ b/enzyme/test/Integration/ReverseMode/test_utils.h
@@ -7,8 +7,8 @@ extern
 #ifdef __cplusplus
 "C"
 #endif
-int enzyme_allocated, enzyme_const, enzyme_dup, enzyme_dupnoneed, enzyme_out,
-    enzyme_tape;
+int enzyme_allocated, enzyme_const, enzyme_dup, enzyme_dupnoneed,
+    enzyme_nocache, enzyme_out, enzyme_tape;
 
 /*
 #ifdef __cplusplus


### PR DESCRIPTION
Initial versions of Enzyme had an option for globally nuking the caching mechanism (for extra performance, I suppose). Since this is clearly not very useful, I propose adding an option to allow the user to control this on a per-argument basis.
What does "nocache" mean?
The definition is not precise, and any user would have to try their code with it and see if it still works. The basic idea is that it is a promise between the __enzyme_augmentfwd and __enzyme_reverse that the given argument will not be modified, hence much of the caching can be skipped.
What does it mean "argument will not be modified"?
This is also not precisely defined, but in general it means that all loads emanating from the given argument can skip caching. The implementation in `compute_nocache` is quite flexible and allows for easy tweaking of the handling of specific instruction. For example, I currently said that all of the argument of a phi must be 'nocache' in order for the phi itself to be 'nocache'. This allows the linked list examples to work (they still get some caching because this is the only way they can work).

@wsmoses Please let me know if you think this kind of performance-minded option is viable in enzyme.