### PR TITLE
Ring of springs integration test using modulo

### DIFF
--- a/enzyme/Enzyme/FunctionUtils.cpp
+++ b/enzyme/Enzyme/FunctionUtils.cpp
@@ -1047,6 +1047,7 @@ static void SimplifyMPIQueries(Function &NewF, FunctionAnalysisManager &FAM) {
     B.SetInsertPoint(res);
 
     if (auto PT = dyn_cast<PointerType>(storePointer->getType())) {
+      (void)PT;
 #if LLVM_VERSION_MAJOR < 17
 #if LLVM_VERSION_MAJOR >= 15
       if (PT->getContext().supportsTypedPointers()) {
@@ -4659,7 +4660,8 @@ std::optional<std::string> fixSparse_inner(Instruction *cur, llvm::Function &F,
             legal = false;
           auto L = LI.getLoopFor(PN->getParent());
           if (legal && L && L->getLoopPreheader() &&
-              L->getCanonicalInductionVariable()) {
+              L->getCanonicalInductionVariable() &&
+              L->getHeader() == PN->getParent()) {
             auto ph_idx = PN->getBasicBlockIndex(L->getLoopPreheader());
             if (isa<ConstantInt>(PN->getIncomingValue(ph_idx))) {
               lhsOps[ph_idx] =

--- a/enzyme/test/Integration/Sparse/ringspring.cpp
+++ b/enzyme/test/Integration/Sparse/ringspring.cpp
@@ -1,0 +1,116 @@
+// This should work on LLVM 7, 8, 9, however in CI the version of clang installed on Ubuntu 18.04 cannot load
+// a clang plugin properly without segfaulting on exit. This is fine on Ubuntu 20.04 or later LLVM versions...
+// RUN: if [ %llvmver -ge 12 ]; then %clang++ -fno-exceptions -std=c++11 -O1 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-auto-sparsity=1 | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang++ -fno-exceptions -std=c++11 -O2 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-auto-sparsity=1  | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang++ -fno-exceptions -std=c++11 -O3 %s -S -emit-llvm -o - %loadClangEnzyme  -mllvm -enzyme-auto-sparsity=1 | %lli - ; fi
+// TODO: if [ %llvmver -ge 12 ]; then %clang++ -fno-exceptions -std=c++11 -O1 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-auto-sparsity=1 -S | %lli - ; fi
+// TODO: if [ %llvmver -ge 12 ]; then %clang++ -fno-exceptions -std=c++11 -O2 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-auto-sparsity=1 -S | %lli - ; fi
+// TODO: if [ %llvmver -ge 12 ]; then %clang++ -fno-exceptions -std=c++11 -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme -mllvm -enzyme-auto-sparsity=1 -S | %lli - ; fi
+
+#include <stdio.h>
+#include <assert.h>
+#include <vector>
+
+#include<math.h>
+
+struct triple {
+    size_t row;
+    size_t col;
+    double val;
+    triple(triple&&) = default;
+    triple(size_t row, size_t col, double val) : row(row), col(col), val(val) {}
+};
+
+extern int enzyme_dup;
+extern int enzyme_dupnoneed;
+extern int enzyme_out;
+extern int enzyme_const;
+
+extern void __enzyme_autodiff(void *, ...);
+
+extern void __enzyme_fwddiff(void *, ...);
+
+extern double* __enzyme_todense(void *, ...) noexcept;
+
+
+/// Compute energy
+double f(size_t N, double* input) {
+    double out = 0;
+    __builtin_assume(!((N-1) == 0));
+    for (size_t i=0; i<N; i++) {
+        //double sub = input[i] - input[i+1]; 
+        // out += sub * sub;
+        double sub = input[(i + 1) % N] - input[i % N]; 
+        out += (sqrt(sub) + 1)*(sqrt(sub) + 1);
+    }
+    return out;
+}
+
+/// Perform dinput += gradient(f)
+void grad_f(size_t N, double* input, double* dinput) {
+    __enzyme_autodiff((void*)f, enzyme_const, N, enzyme_dup, input, dinput);
+}
+
+
+void ident_store(double , int64_t idx, size_t i) {
+    assert(0 && "should never load");
+}
+
+__attribute__((always_inline))
+double ident_load(int64_t idx, size_t i, size_t N) {
+    idx /= sizeof(double);
+    return (double)(idx == i);// ? 1.0 : 0.0;
+}
+
+__attribute__((enzyme_sparse_accumulate))
+void inner_store(int64_t row, int64_t col, double val, std::vector<triple> &triplets) {
+    printf("row=%d col=%d val=%f\n", row, col, val);
+    assert(abs(val) > 0.00001);
+    triplets.emplace_back(row, col, val);
+}
+
+__attribute__((always_inline))
+void sparse_store(double val, int64_t idx, size_t i, size_t N, std::vector<triple> &triplets) {
+    if (val == 0.0) return;
+    idx /= sizeof(double);
+    inner_store(i, idx, val, triplets);
+}
+
+__attribute__((always_inline))
+double sparse_load(int64_t idx, size_t i, size_t N, std::vector<triple> &triplets) {
+    return 0.0;
+}
+
+__attribute__((noinline))
+std::vector<triple> hess_f(size_t N, double* input) {
+    std::vector<triple> triplets;
+    __builtin_assume(N > 0);
+    for (size_t i=0; i<N; i++) {
+        __builtin_assume(i < 100000000);
+        double* d_input = __enzyme_todense((void*)ident_load, (void*)ident_store, i, N);
+        double* d_dinput = __enzyme_todense((void*)sparse_load, (void*)sparse_store, i, N, &triplets);
+
+       __enzyme_fwddiff((void*)grad_f, 
+                            enzyme_const, N,
+                            enzyme_dup, input, d_input,
+                            enzyme_dupnoneed, (double*)0x1, d_dinput);
+
+    }
+    return triplets;
+}
+
+int main() {
+  size_t N = 8;
+  double x[N];
+  for (int i=0; i<N; i++) x[i] = (i + 1) * (i + 1);
+
+  auto res = hess_f(N, &x[0]);
+
+
+  printf("%ld\n", res.size());
+
+  for (auto & tup : res)
+      printf("%ld, %ld = %f\n", tup.row, tup.col, tup.val);
+
+  return 0;
+}


### PR DESCRIPTION
This PR is a slight change to the simplified springs example that changes the topology of the springs so that is a ring of 1D springs rather than a line of springs. Executing this code produced the following result on my machine:
```row=0 col=7 val=nan
Assertion failed: (abs(val) > 0.00001), function inner_store, file new_sparse.cpp, line 68.
[1]    24375 abort      ./new_sparse.out
```
