### PR TITLE
[Blas] fix temporary allocation (and deallocation)

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -1673,11 +1673,10 @@ public:
                         .getTypeSizeInBits(SVI.getOperand(opnum)->getType()) +
                     7) /
                    8;
+          Value *toadd = Builder2.CreateExtractElement(loaded, instidx);
           ((DiffeGradientUtils *)gutils)
-              ->addToDiffe(SVI.getOperand(opnum),
-                           Builder2.CreateExtractElement(loaded, instidx),
-                           Builder2, TR.addingType(size, SVI.getOperand(opnum)),
-                           sv);
+              ->addToDiffe(SVI.getOperand(opnum), toadd, Builder2,
+                           TR.addingType(size, SVI.getOperand(opnum)), sv);
         }
         ++instidx;
       }

--- a/enzyme/Enzyme/DiffeGradientUtils.cpp
+++ b/enzyme/Enzyme/DiffeGradientUtils.cpp
@@ -321,6 +321,7 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
 
   Value *ptr = getDifferential(val);
 
+  Value *old;
   if (idxs.size() != 0) {
     SmallVector<Value *, 4> sv = {
         ConstantInt::get(Type::getInt32Ty(val->getContext()), 0)};
@@ -328,8 +329,12 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
       sv.push_back(i);
     ptr = BuilderM.CreateGEP(getShadowType(val->getType()), ptr, sv);
     cast<GetElementPtrInst>(ptr)->setIsInBounds(true);
+    old = BuilderM.CreateLoad(
+        GetElementPtrInst::getIndexedType(getShadowType(val->getType()), sv),
+        ptr);
+  } else {
+    old = BuilderM.CreateLoad(getShadowType(val->getType()), ptr);
   }
-  Value *old = BuilderM.CreateLoad(dif->getType(), ptr);
 
   assert(dif->getType() == old->getType());
   Value *res = nullptr;
@@ -352,7 +357,7 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
                            &TR.analyzer, nullptr, wrap(&BuilderM));
         return addedSelects;
       } else {
-        TR.dump();
+        TR.dump(ss);
         DebugLoc loc;
         if (auto inst = dyn_cast<Instruction>(val))
           EmitFailure("CannotDeduceType", inst->getDebugLoc(), inst, ss.str());
@@ -382,6 +387,7 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
       ss << "oldFunc: " << *oldFunc << "\n";
       ss << "Illegal intermediate when adding to: " << *val
          << " with addingType: " << *addingType << "\n"
+         << " old: " << *old << " dif: " << *dif << "\n"
          << " oldBitSize: " << oldBitSize << " newBitSize: " << newBitSize
          << "\n";
       if (CustomErrorHandler) {

--- a/enzyme/Enzyme/DiffeGradientUtils.cpp
+++ b/enzyme/Enzyme/DiffeGradientUtils.cpp
@@ -381,13 +381,14 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
       llvm::raw_string_ostream ss(s);
       ss << "oldFunc: " << *oldFunc << "\n";
       ss << "Illegal intermediate when adding to: " << *val
-         << " with addingType: " << *addingType << "\n";
+         << " with addingType: " << *addingType << "\n"
+         << " oldBitSize: " << oldBitSize << " newBitSize: " << newBitSize
+         << "\n";
       if (CustomErrorHandler) {
         CustomErrorHandler(ss.str().c_str(), wrap(val), ErrorType::NoType,
                            &TR.analyzer, nullptr, wrap(&BuilderM));
         return addedSelects;
       } else {
-        TR.dump();
         DebugLoc loc;
         if (auto inst = dyn_cast<Instruction>(val))
           EmitFailure("CannotDeduceType", inst->getDebugLoc(), inst, ss.str());

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -932,14 +932,20 @@ getorInsertInnerProd(llvm::IRBuilder<> &B, llvm::Module &M, BlasInfo blas,
 
   {
     IRBuilder<> B1(entry);
-    Value *blasOne =
-        to_blas_callconv(B1, ConstantInt::get(IT, 1), byRef, cublas,
-                         julia_decl ? IT : nullptr, B1, "constant.one");
+    Value *blasOne = to_blas_callconv(B1, ConstantInt::get(IT, 1), byRef,
+                                      cublas, nullptr, B1, "constant.one");
+
+    if (blasOne->getType() != BlasIT)
+      blasOne = B1.CreatePointerCast(blasOne, BlasIT, "intcast.constant.one");
+
     Value *m = load_if_ref(B1, IT, blasm, byRef);
     Value *n = load_if_ref(B1, IT, blasn, byRef);
     Value *size = B1.CreateNUWMul(m, n, "mat.size");
     Value *blasSize = to_blas_callconv(
         B1, size, byRef, cublas, julia_decl ? IT : nullptr, B1, "mat.size");
+
+    if (blasSize->getType() != BlasIT)
+      blasSize = B1.CreatePointerCast(blasSize, BlasIT, "intcast.mat.size");
     B1.CreateCondBr(B1.CreateICmpEQ(size, ConstantInt::get(IT, 0)), end, init);
 
     IRBuilder<> B2(init);

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -932,13 +932,14 @@ getorInsertInnerProd(llvm::IRBuilder<> &B, llvm::Module &M, BlasInfo blas,
 
   {
     IRBuilder<> B1(entry);
-    Value *blasOne = to_blas_callconv(B1, ConstantInt::get(IT, 1), byRef,
-                                      cublas, nullptr, B1, "constant.one");
+    Value *blasOne =
+        to_blas_callconv(B1, ConstantInt::get(IT, 1), byRef, cublas,
+                         julia_decl ? IT : nullptr, B1, "constant.one");
     Value *m = load_if_ref(B1, IT, blasm, byRef);
     Value *n = load_if_ref(B1, IT, blasn, byRef);
     Value *size = B1.CreateNUWMul(m, n, "mat.size");
-    Value *blasSize =
-        to_blas_callconv(B1, size, byRef, cublas, nullptr, B1, "mat.size");
+    Value *blasSize = to_blas_callconv(
+        B1, size, byRef, cublas, julia_decl ? IT : nullptr, B1, "mat.size");
     B1.CreateCondBr(B1.CreateICmpEQ(size, ConstantInt::get(IT, 0)), end, init);
 
     IRBuilder<> B2(init);

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -667,8 +667,8 @@ void callMemcpyStridedLapack(llvm::IRBuilder<> &B, llvm::Module &M,
 
   auto FT = FunctionType::get(Type::getVoidTy(M.getContext()), tys, false);
   auto fn = M.getOrInsertFunction(copy_name, FT);
-  Function *F = cast<Function>(fn.getCallee());
-  attributeKnownFunctions(*F);
+  if (auto F = GetFunctionFromValue(fn.getCallee()))
+    attributeKnownFunctions(*F);
 
   B.CreateCall(fn, args, bundles);
 }
@@ -884,9 +884,9 @@ getorInsertInnerProd(llvm::IRBuilder<> &B, llvm::Module &M, BlasInfo blas,
   std::string dot_name = blas.prefix + blas.floatType + "dot" + blas.suffix;
   auto FDotT =
       FunctionType::get(fpTy, {BlasIT, BlasPT, BlasIT, BlasPT, BlasIT}, false);
-  Function *FDot =
-      cast<Function>(M.getOrInsertFunction(dot_name, FDotT).getCallee());
-  attributeKnownFunctions(*F);
+  auto FDot = M.getOrInsertFunction(dot_name, FDotT);
+  if (auto F = GetFunctionFromValue(FDot.getCallee()))
+    attributeKnownFunctions(*F);
 
   // now add the implementation for the inner_prod call
   F->setLinkage(Function::LinkageTypes::InternalLinkage);
@@ -933,12 +933,12 @@ getorInsertInnerProd(llvm::IRBuilder<> &B, llvm::Module &M, BlasInfo blas,
   {
     IRBuilder<> B1(entry);
     Value *blasOne = to_blas_callconv(B1, ConstantInt::get(IT, 1), byRef,
-                                      cublas, IT, B1, "constant.one");
+                                      cublas, nullptr, B1, "constant.one");
     Value *m = load_if_ref(B1, IT, blasm, byRef);
     Value *n = load_if_ref(B1, IT, blasn, byRef);
     Value *size = B1.CreateNUWMul(m, n, "mat.size");
     Value *blasSize =
-        to_blas_callconv(B1, size, byRef, cublas, IT, B1, "mat.size");
+        to_blas_callconv(B1, size, byRef, cublas, nullptr, B1, "mat.size");
     B1.CreateCondBr(B1.CreateICmpEQ(size, ConstantInt::get(IT, 0)), end, init);
 
     IRBuilder<> B2(init);

--- a/enzyme/test/Enzyme/ReverseMode/blas/gemm_f_c_lacpy_runtime_act.ll
+++ b/enzyme/test/Enzyme/ReverseMode/blas/gemm_f_c_lacpy_runtime_act.ll
@@ -120,15 +120,6 @@ entry:
 ; CHECK-NEXT:   %cache.C = bitcast i8* %malloccall2 to double*
 ; CHECK-NEXT:   store i8 0, i8* %byref.copy.garbage3
 ; CHECK-NEXT:   call void @dlacpy_64_(i8* %byref.copy.garbage3, i8* %m_p, i8* %n_p, i8* %C, i8* %ldc_p, double* %cache.C, i8* %n_p)
-; CHECK-NEXT:   %[[i17:.+]] = bitcast i8* %m_p to i64*
-; CHECK-NEXT:   %[[i18:.+]] = load i64, i64* %[[i17]]
-; CHECK-NEXT:   %[[i19:.+]] = bitcast i8* %n_p to i64*
-; CHECK-NEXT:   %[[i20:.+]] = load i64, i64* %[[i19]]
-; CHECK-NEXT:   %size_AB = mul nuw i64 %[[i18]], %[[i20]]
-; CHECK-NEXT:   %mallocsize5 = mul nuw nsw i64 %size_AB, 8
-; CHECK-NEXT:   %malloccall6 = tail call noalias nonnull i8* @malloc(i64 %mallocsize5)
-; CHECK-NEXT:   %mat_AB = bitcast i8* %malloccall6 to double*
-; CHECK-NEXT:   %[[i21:.+]] = bitcast double* %mat_AB to i8*
 ; CHECK-NEXT:   call void @dgemm_64_(i8* %transa, i8* %transb, i8* %m_p, i8* %n_p, i8* %k_p, i8* %alpha, i8* %A, i8* %lda_p, i8* %B, i8* %ldb_p, i8* %beta, i8* %C, i8* %ldc_p, i64 1, i64 1)
 ; CHECK-NEXT:   %"ptr'ipc" = bitcast i8* %"A'" to double*
 ; CHECK-NEXT:   %ptr = bitcast i8* %A to double*
@@ -145,6 +136,16 @@ entry:
 ; CHECK-NEXT:   br i1 %rt.inactive.alpha, label %invertentry.alpha.done, label %invertentry.alpha.active
 
 ; CHECK: invertentry.alpha.active:                         ; preds = %invertentry
+; CHECK-NEXT:   %[[i17:.+]] = bitcast i8* %m_p to i64*
+; CHECK-NEXT:   %[[i18:.+]] = load i64, i64* %[[i17]]
+; CHECK-NEXT:   %[[i19:.+]] = bitcast i8* %n_p to i64*
+; CHECK-NEXT:   %[[i20:.+]] = load i64, i64* %[[i19]]
+; CHECK-NEXT:   %size_AB = mul nuw i64 %[[i18]], %[[i20]]
+; CHECK-NEXT:   %mallocsize5 = mul nuw nsw i64 %size_AB, 8
+; CHECK-NEXT:   %malloccall6 = tail call noalias nonnull i8* @malloc(i64 %mallocsize5)
+; CHECK-NEXT:   %[[matAB:.+]] = bitcast i8* %malloccall6 to double*
+; CHECK-NEXT:   %[[i21:.+]] = bitcast double* %[[matAB:.+]] to i8*
+
 ; CHECK-NEXT:   store double 1.000000e+00, double* %byref.constant.fp.1.0
 ; CHECK-NEXT:   %fpcast.constant.fp.1.0 = bitcast double* %byref.constant.fp.1.0 to i8*
 ; CHECK-NEXT:   %loaded.trans7 = load i8, i8* %transa
@@ -183,7 +184,7 @@ entry:
 ; CHECK-NEXT:   %iteration.i = phi i64 [ 0, %init.idx.i ], [ %iter.next.i, %for.body.i ]
 ; CHECK-NEXT:   %sum.i = phi{{( fast)?}} double [ 0.000000e+00, %init.idx.i ], [ %[[i57:.+]], %for.body.i ]
 ; CHECK-NEXT:   %A.i.i = getelementptr inbounds double, double* %[[i51]], i64 %Aidx.i
-; CHECK-NEXT:   %B.i.i = getelementptr inbounds double, double* %mat_AB, i64 %Bidx.i
+; CHECK-NEXT:   %B.i.i = getelementptr inbounds double, double* %[[matAB]], i64 %Bidx.i
 ; CHECK-NEXT:   %[[i54:.+]] = bitcast double* %A.i.i to i8*
 ; CHECK-NEXT:   %[[i55:.+]] = bitcast double* %B.i.i to i8*
 ; CHECK-NEXT:   %[[i56:.+]] = call fast double @ddot_64_(i8* %m_p, i8* %[[i54]], i8* %intcast.constant.one.i, i8* %[[i55]], i8* %intcast.constant.one.i)
@@ -202,6 +203,8 @@ entry:
 ; CHECK-NEXT:   %[[i62:.+]] = load double, double* %[[i61]]
 ; CHECK-NEXT:   %[[i63:.+]] = fadd fast double %[[i62]], %res.i
 ; CHECK-NEXT:   store double %[[i63]], double* %[[i61]]
+; CHECK-NEXT:  %[[forfree:.+]] = bitcast double* %[[matAB]] to i8* 
+; CHECK-NEXT:  tail call void @free(i8* nonnull %[[forfree:.+]]) 
 ; CHECK-NEXT:   br label %invertentry.alpha.done
 
 ; CHECK: invertentry.alpha.done:                           ; preds = %__enzyme_inner_prodd_64_.exit, %invertentry

--- a/enzyme/test/Enzyme/ReverseMode/blas/gemv_f_c_split_blascpy.ll
+++ b/enzyme/test/Enzyme/ReverseMode/blas/gemv_f_c_split_blascpy.ll
@@ -100,7 +100,7 @@ entry:
 ; CHECK-NEXT:   %malloccall9 = tail call noalias nonnull i8* @malloc(i64 %mallocsize8)
 ; CHECK-NEXT:   %cache.y = bitcast i8* %malloccall9 to double*
 ; CHECK-NEXT:   store i64 1, i64* %byref.10
-; CHECK-NEXT:   call void @dcopy_64_(i8* %20, i8* %y, i8* %incy_p, double* %cache.y, i64* %byref.10)
+; CHECK-NEXT:   call void @dcopy_64_(i8* %[[r20]], i8* %y, i8* %incy_p, double* %cache.y, i64* %byref.10)
 ; CHECK-NEXT:   %23 = insertvalue { double*, double* } undef, double* %cache.x, 0
 ; CHECK-NEXT:   %24 = insertvalue { double*, double* } %23, double* %cache.y, 1
 ; CHECK-NEXT:   store { double*, double* } %24, { double*, double* }* %0
@@ -148,30 +148,32 @@ entry:
 ; CHECK-NEXT:   store i64 4, i64* %8, align 16
 ; CHECK-NEXT:   store i64 2, i64* %9, align 16
 ; CHECK-NEXT:   store i64 1, i64* %10, align 16
-; CHECK-NEXT:   %11 = bitcast i8* %m_p to i64*
-; CHECK-NEXT:   %12 = load i64, i64* %11
-; CHECK-NEXT:   %13 = bitcast i8* %n_p to i64*
-; CHECK-NEXT:   %14 = load i64, i64* %13
-; CHECK-NEXT:   %loaded.trans = load i8, i8* %malloccall
-; CHECK-DAG:   %[[r15:.+]] = icmp eq i8 %loaded.trans, 78
-; CHECK-DAG:   %[[r16:.+]] = icmp eq i8 %loaded.trans, 110
-; CHECK-NEXT:   %[[r17:.+]] = or i1 %[[r16]], %[[r15]]
-; CHECK-NEXT:   %18 = select i1 %[[r17]], i64 %12, i64 %14
-; CHECK-NEXT:   %mallocsize = mul nuw nsw i64 %18, 8
-; CHECK-NEXT:   %malloccall6 = tail call noalias nonnull i8* @malloc(i64 %mallocsize)
-; CHECK-NEXT:   %mat_Ax = bitcast i8* %malloccall6 to double*
-; CHECK-NEXT:   %19 = bitcast double* %mat_Ax to i8*
 ; CHECK-NEXT:   br label %invertentry
 
 ; CHECK: invertentry:                                      ; preds = %entry
 ; CHECK-NEXT:   %tape.ext.x = extractvalue { double*, double* } %0, 0
-; CHECK-NEXT:   %20 = bitcast double* %tape.ext.x to i8*
+; CHECK-NEXT:   %[[r20:.+]] = bitcast double* %tape.ext.x to i8*
 ; CHECK-NEXT:   %tape.ext.y = extractvalue { double*, double* } %0, 1
-; CHECK-NEXT:   %21 = bitcast double* %tape.ext.y to i8*
+; CHECK-NEXT:   %[[r21:.+]] = bitcast double* %tape.ext.y to i8*
 ; CHECK-NEXT:   %tape.ext.y1 = extractvalue { double*, double* } %0, 1
-; CHECK-NEXT:   %22 = bitcast double* %tape.ext.y1 to i8*
+; CHECK-NEXT:   %[[r22:.+]] = bitcast double* %tape.ext.y1 to i8*
 ; CHECK-NEXT:   store i64 1, i64* %byref.int.one
 ; CHECK-NEXT:   %intcast.int.one = bitcast i64* %byref.int.one to i8*
+
+; CHECK-NEXT:   %[[r11:.+]] = bitcast i8* %m_p to i64*
+; CHECK-NEXT:   %[[r12:.+]] = load i64, i64* %[[r11]]
+; CHECK-NEXT:   %[[r13:.+]] = bitcast i8* %n_p to i64*
+; CHECK-NEXT:   %[[r14:.+]] = load i64, i64* %[[r13]]
+; CHECK-NEXT:   %loaded.trans = load i8, i8* %malloccall
+; CHECK-DAG:   %[[r15:.+]] = icmp eq i8 %loaded.trans, 78
+; CHECK-DAG:   %[[r16:.+]] = icmp eq i8 %loaded.trans, 110
+; CHECK-NEXT:   %[[r17:.+]] = or i1 %[[r16]], %[[r15]]
+; CHECK-NEXT:   %[[r18:.+]] = select i1 %[[r17]], i64 %[[r12]], i64 %[[r14]]
+; CHECK-NEXT:   %mallocsize = mul nuw nsw i64 %[[r18]], 8
+; CHECK-NEXT:   %malloccall6 = tail call noalias nonnull i8* @malloc(i64 %mallocsize)
+; CHECK-NEXT:   %[[matAx:.+]] = bitcast i8* %malloccall6 to double*
+; CHECK-NEXT:   %[[r19:.+]] = bitcast double* %[[matAx]] to i8*
+
 ; CHECK-NEXT:   store double 1.000000e+00, double* %byref.constant.fp.1.0
 ; CHECK-NEXT:   %fpcast.constant.fp.1.0 = bitcast double* %byref.constant.fp.1.0 to i8*
 ; CHECK-NEXT:   store i8 78, i8* %byref.constant.char.N, align 1
@@ -179,7 +181,7 @@ entry:
 ; CHECK-NEXT:   %fpcast.constant.fp.0.0 = bitcast double* %byref.constant.fp.0.0 to i8*
 ; CHECK-NEXT:   store i64 1, i64* %byref.constant.int.1
 ; CHECK-NEXT:   %intcast.constant.int.1 = bitcast i64* %byref.constant.int.1 to i8*
-; CHECK-NEXT:   call void @dgemv_64_(i8* %malloccall, i8* %m_p, i8* %n_p, i8* %fpcast.constant.fp.1.0, i8* %A, i8* %lda_p, i8* %20, i8* %intcast.int.one, i8* %fpcast.constant.fp.0.0, i8* %19, i8* %intcast.constant.int.1, i64 1)
+; CHECK-NEXT:   call void @dgemv_64_(i8* %malloccall, i8* %m_p, i8* %n_p, i8* %fpcast.constant.fp.1.0, i8* %A, i8* %lda_p, i8* %[[r20]], i8* %intcast.int.one, i8* %fpcast.constant.fp.0.0, i8* %[[r19]], i8* %intcast.constant.int.1, i64 1)
 ; CHECK-NEXT:   %ld.row.trans = load i8, i8* %malloccall
 ; CHECK-DAG:    %[[c1:.+]] = icmp eq i8 %ld.row.trans, 110
 ; CHECK-DAG:    %[[c2:.+]] = icmp eq i8 %ld.row.trans, 78
@@ -187,11 +189,15 @@ entry:
 ; CHECK-NEXT:   %[[r34:.+]] = select i1 %[[c3]], i8* %m_p, i8* %n_p
 ; CHECK-NEXT:   store i64 1, i64* %byref.constant.int.17
 ; CHECK-NEXT:   %intcast.constant.int.18 = bitcast i64* %byref.constant.int.17 to i8*
-; CHECK-NEXT:   %[[r35:.+]] = call fast double @ddot_64_(i8* %[[r34]], i8* %"y'", i8* %incy_p, i8* %19, i8* %intcast.constant.int.18)
+; CHECK-NEXT:   %[[r35:.+]] = call fast double @ddot_64_(i8* %[[r34]], i8* %"y'", i8* %incy_p, i8* %[[r19]], i8* %intcast.constant.int.18)
 ; CHECK-NEXT:   %[[r36:.+]] = bitcast i8* %"alpha'" to double*
 ; CHECK-NEXT:   %[[r37:.+]] = load double, double* %[[r36]]
 ; CHECK-NEXT:   %[[r38:.+]] = fadd fast double %[[r37]], %[[r35]]
 ; CHECK-NEXT:   store double %[[r38]], double* %[[r36]]
+
+; CHECK-NEXT:   %[[forfree:.+]] = bitcast double* %22 to i8* 
+; CHECK-NEXT:   tail call void @free(i8* nonnull %[[forfree]])
+
 ; CHECK-NEXT:   %ld.row.trans9 = load i8, i8* %malloccall, align 1
 ; CHECK-DAG:   %[[r39:.+]] = icmp eq i8 %ld.row.trans9, 110
 ; CHECK-DAG:   %[[r40:.+]] = icmp eq i8 %ld.row.trans9, 78

--- a/enzyme/test/Enzyme/ReverseMode/blas/spmv_f_c_lacpy.ll
+++ b/enzyme/test/Enzyme/ReverseMode/blas/spmv_f_c_lacpy.ll
@@ -76,15 +76,6 @@ entry:
 ; CHECK-NEXT:   %cache.y = bitcast i8* %malloccall2 to double*
 ; CHECK-NEXT:   store i64 1, i64* %byref.
 ; CHECK-NEXT:   call void @dcopy_64_(i8* %n_p, i8* %Y, i8* %incy_p, double* %cache.y, i64* %byref.)
-; CHECK-NEXT:   %[[i6:.+]] = bitcast i8* %n_p to i64*
-; CHECK-NEXT:   %[[i7:.+]] = load i64, i64* %[[i6]]
-; CHECK-NEXT:   %[[i8:.+]] = add i64 %[[i7]], 1
-; CHECK-NEXT:   %square_mat_size_y0 = mul i64 %[[i7]], %[[i8]]
-; CHECK-NEXT:   %size_y0 = udiv i64 %square_mat_size_y0, 2
-; CHECK-NEXT:   %mallocsize4 = mul nuw nsw i64 %size_y0, 8
-; CHECK-NEXT:   %malloccall5 = tail call noalias nonnull i8* @malloc(i64 %mallocsize4)
-; CHECK-NEXT:   %mat_y0 = bitcast i8* %malloccall5 to double*
-; CHECK-NEXT:   %[[i9:.+]] = bitcast double* %mat_y0 to i8*
 ; CHECK-NEXT:   call void @dspmv_64_(i8* %uplo, i8* %n_p, i8* %alpha, i8* %AP, i8* %X, i8* %incx_p, i8* %beta, i8* %Y, i8* %incy_p)
 ; CHECK-NEXT:   %"ptr'ipc" = bitcast i8* %"AP'" to double*
 ; CHECK-NEXT:   %ptr = bitcast i8* %AP to double*
@@ -98,6 +89,17 @@ entry:
 ; CHECK-NEXT:   %[[i12:.+]] = bitcast double* %cache.y to i8*
 ; CHECK-NEXT:   store i64 1, i64* %byref.int.one
 ; CHECK-NEXT:   %intcast.int.one = bitcast i64* %byref.int.one to i8*
+
+; CHECK-NEXT:   %[[i6:.+]] = bitcast i8* %n_p to i64*
+; CHECK-NEXT:   %[[i7:.+]] = load i64, i64* %[[i6]]
+; CHECK-NEXT:   %[[i8:.+]] = add i64 %[[i7]], 1
+; CHECK-NEXT:   %square_mat_size_y0 = mul i64 %[[i7]], %[[i8]]
+; CHECK-NEXT:   %size_y0 = udiv i64 %square_mat_size_y0, 2
+; CHECK-NEXT:   %mallocsize4 = mul nuw nsw i64 %size_y0, 8
+; CHECK-NEXT:   %malloccall5 = tail call noalias nonnull i8* @malloc(i64 %mallocsize4)
+; CHECK-NEXT:   %[[mat_y0:.+]] = bitcast i8* %malloccall5 to double*
+; CHECK-NEXT:   %[[i9:.+]] = bitcast double* %[[mat_y0]] to i8*
+
 ; CHECK-NEXT:   store double 1.000000e+00, double* %byref.constant.fp.1.0
 ; CHECK-NEXT:   %fpcast.constant.fp.1.0 = bitcast double* %byref.constant.fp.1.0 to i8*
 ; CHECK-NEXT:   store double 0.000000e+00, double* %byref.constant.fp.0.0
@@ -112,6 +114,8 @@ entry:
 ; CHECK-NEXT:   %[[i15:.+]] = load double, double* %[[i14]]
 ; CHECK-NEXT:   %[[i16:.+]] = fadd fast double %[[i15]], %[[i13]]
 ; CHECK-NEXT:   store double %[[i16]], double* %[[i14]]
+; CHECK-NEXT:   %[[forfree:.+]] = bitcast double* %[[mat_y0]] to i8* 
+; CHECK-NEXT:   tail call void @free(i8* nonnull %[[forfree]])
 ; CHECK-NEXT:   call void @dspr2_64_(i8* %uplo, i8* %n_p, i8* %alpha, i8* %X, i8* %incx_p, i8* %"Y'", i8* %incy_p, i8* %"AP'")
 ; CHECK:   %[[i17:.+]] = load i64, i64* %n
 ; CHECK-NEXT:   %[[i18:.+]] = load i64, i64* %incx

--- a/enzyme/test/Integration/ReverseMode/blas_gemm.c
+++ b/enzyme/test/Integration/ReverseMode/blas_gemm.c
@@ -1,0 +1,75 @@
+// a clang plugin properly without segfaulting on exit. This is fine on Ubuntu 20.04 or later LLVM versions...
+// RUN: %clang -O0 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=1 | %lli -
+// RUN: %clang -O1 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=1 | %lli -
+// RUN: %clang -O2 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=1  | %lli -
+// RUN: %clang -O3 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=1 | %lli -
+// RUN: %clang -O0 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=0 | %lli -
+// RUN: %clang -O1 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=0 | %lli -
+// RUN: %clang -O2 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=0 | %lli -
+// RUN: %clang -O3 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=0 | %lli -
+
+#include "test_utils.h"
+#include "../blas_inline.h"
+
+#include <stdio.h>
+
+extern int enzyme_dup;
+extern int enzyme_dupnoneed;
+extern int enzyme_out;
+extern int enzyme_const;
+
+void __enzyme_autodiff(void*, ...);
+
+const size_t n = 10;
+
+static char N = 'N';
+static int ten = 10;
+static double one = 1.0;
+static double zero = 0.0;
+double simulate(double* A) {
+  double *out = (double*)malloc(sizeof(double)*n*n);
+  dgemm_(&N, &N, &ten, &ten, &ten, &one, A, &ten, A, &ten, &zero, &out[0], &ten);
+  return out[0];//P1(0, 0);
+}
+
+int main(int argc, char **argv) {
+
+    double A[n * n];
+    double Adup[n * n];
+    double Adup_fd[n * n];
+
+    for (int i = 0; i < n; i++) {
+        for (int j = 0; j < n; j++) {
+            A[n*i + j] = j == i ? 0.3 : 0.1;
+            Adup[n*i + j] = 0.0;
+            Adup_fd[n*i + j] = 0.0;
+        }
+    }
+  
+    double delta = 0.001;
+    delta = delta * delta;
+
+    double fx = simulate(A);
+    printf("f(A) = %f\n", fx);
+   
+    __enzyme_autodiff((void *)simulate, enzyme_dup, &A[0], &Adup[0]);
+    
+    for (int i = 0; i < n*n; i++) {
+        printf("dA[%d]=%f\n", i, Adup[i]);
+    }
+    for (int i = 0; i < n*n; i++) {
+        A[i] += delta / 2;
+        double fx2 = simulate(A);
+        A[i] -= delta;
+        double fx3 = simulate(A);
+        A[i] += delta/2;
+        
+        Adup_fd[i] = (fx2 - fx3) / delta;
+
+        printf("dA_fd[%d]=%f\n", i, Adup_fd[i]);
+    
+        APPROX_EQ(Adup[i], Adup_fd[i], 1e-6);
+    }
+
+    return 0;
+}

--- a/enzyme/test/Integration/ReverseMode/blas_gemm.c
+++ b/enzyme/test/Integration/ReverseMode/blas_gemm.c
@@ -1,12 +1,12 @@
 // a clang plugin properly without segfaulting on exit. This is fine on Ubuntu 20.04 or later LLVM versions...
-// RUN: %clang -O0 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=1 | %lli -
-// RUN: %clang -O1 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=1 | %lli -
-// RUN: %clang -O2 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=1  | %lli -
-// RUN: %clang -O3 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=1 | %lli -
-// RUN: %clang -O0 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=0 | %lli -
-// RUN: %clang -O1 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=0 | %lli -
-// RUN: %clang -O2 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=0 | %lli -
-// RUN: %clang -O3 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=0 | %lli -
+// RUN: if [ %llvmver -ge 12 ]; then %clang -O0 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=1 | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -O1 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=1 | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -O2 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=1 | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -O3 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=1 | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -O0 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=0 | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -O1 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=0 | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -O2 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=0 | %lli - ; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -O3 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-lapack-copy=0 | %lli - ; fi
 
 #include "test_utils.h"
 #include "../blas_inline.h"

--- a/enzyme/test/Integration/blas_inline.h
+++ b/enzyme/test/Integration/blas_inline.h
@@ -16,7 +16,7 @@ extern "C" {
 #endif
 
 __attribute__((noinline))
-int xerbla_(const char *srname, integer *info)
+int xerbla_(const char *srname, integer *info, int len)
 {
     static char fmt_9999[] = "(\002 ** On entry to \002,a,\002 parameter num"
 	    "ber \002,i2,\002 had \002,\002an illegal value\002)";
@@ -28,7 +28,7 @@ int xerbla_(const char *srname, integer *info)
     return 0;
 }
 __attribute__((noinline))
-logical lsame_(const char *ca, const char *cb)
+logical lsame_(char *ca, char *cb, int, int)
 {
     /* System generated locals */
     logical ret_val;
@@ -216,7 +216,7 @@ logical disnan_(doublereal *din)
 
 __attribute__((noinline))
 
-/* Subroutine */ int dlacpy_(char *uplo, integer *m, integer *n, doublereal *
+/* Subroutine */ void dlacpy_(char *uplo, integer *m, integer *n, const doublereal *
 	a, integer *lda, doublereal *b, integer *ldb)
 {
     /* System generated locals */
@@ -289,7 +289,7 @@ __attribute__((noinline))
     b -= b_offset;
 
     /* Function Body */
-    if (lsame_(uplo, "U")) {
+    if (lsame_(uplo, (char*)"U", 1, 1)) {
 	i__1 = *n;
 	for (j = 1; j <= i__1; ++j) {
 	    i__2 = min(j,*m);
@@ -299,7 +299,7 @@ __attribute__((noinline))
 	    }
 /* L20: */
 	}
-    } else if (lsame_(uplo, "L")) {
+    } else if (lsame_(uplo, (char*)"L", 1, 1)) {
 	i__1 = *n;
 	for (j = 1; j <= i__1; ++j) {
 	    i__2 = *m;
@@ -320,7 +320,7 @@ __attribute__((noinline))
 /* L60: */
 	}
     }
-    return 0;
+    return;
 
 /*     End of DLACPY */
 
@@ -439,19 +439,19 @@ __attribute__((noinline))
     /* Function Body */
     *info = 0;
 
-    if (lsame_(type__, "G")) {
+    if (lsame_(type__, (char*)"G", 1, 1)) {
 	itype = 0;
-    } else if (lsame_(type__, "L")) {
+    } else if (lsame_(type__, (char*)"L", 1, 1)) {
 	itype = 1;
-    } else if (lsame_(type__, "U")) {
+    } else if (lsame_(type__, (char*)"U", 1, 1)) {
 	itype = 2;
-    } else if (lsame_(type__, "H")) {
+    } else if (lsame_(type__, (char*)"H", 1, 1)) {
 	itype = 3;
-    } else if (lsame_(type__, "B")) {
+    } else if (lsame_(type__, (char*)"B", 1, 1)) {
 	itype = 4;
-    } else if (lsame_(type__, "Q")) {
+    } else if (lsame_(type__, (char*)"Q", 1, 1)) {
 	itype = 5;
-    } else if (lsame_(type__, "Z")) {
+    } else if (lsame_(type__, (char*)"Z", 1, 1)) {
 	itype = 6;
     } else {
 	itype = -1;
@@ -489,7 +489,7 @@ __attribute__((noinline))
 
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla_("DLASCL", &i__1);
+	xerbla_("DLASCL", &i__1, 0);
 	return 0;
     }
 
@@ -764,9 +764,9 @@ L60:
 } /* ddot_ */
 
 __attribute__((noinline))
-/* Subroutine */ int dgemm_(char *transa, char *transb, integer *m, integer *
-	n, integer *k, doublereal *alpha, doublereal *a, integer *lda, 
-	doublereal *b, integer *ldb, doublereal *beta, doublereal *c, integer 
+/* Subroutine */ int dgemm_(const char *transa, const char *transb, const integer *m, const integer *
+	n, const integer *k, const doublereal *alpha, const doublereal *a, const integer *lda, 
+	const doublereal *b, const integer *ldb, const doublereal *beta, doublereal *c, const integer 
 	*ldc)
 {
 
@@ -949,8 +949,8 @@ __attribute__((noinline))
 #define B(I,J) b[(I)-1 + ((J)-1)* ( *ldb)]
 #define C(I,J) c[(I)-1 + ((J)-1)* ( *ldc)]
 
-    nota = lsame_(transa, "N");
-    notb = lsame_(transb, "N");
+    nota = lsame_((char*)transa, (char*)"N", 1, 1);
+    notb = lsame_((char*)transb, (char*)"N", 1, 1);
     if (nota) {
 	nrowa = *m;
 	ncola = *k;
@@ -967,10 +967,10 @@ __attribute__((noinline))
 /*     Test the input parameters. */
 
     info = 0;
-    if (! nota && ! lsame_(transa, "C") && ! lsame_(transa, "T")) {
+    if (! nota && ! lsame_((char*)transa, (char*)"C", 1, 1) && ! lsame_((char*)transa, (char*)"T", 1, 1)) {
 	info = 1;
-    } else if (! notb && ! lsame_(transb, "C") && ! lsame_(transb, 
-	    "T")) {
+    } else if (! notb && ! lsame_((char*)transb, (char*)"C", 1, 1) && ! lsame_((char*)transb, 
+	    (char*)"T", 1, 1)) {
 	info = 2;
     } else if (*m < 0) {
 	info = 3;
@@ -986,7 +986,7 @@ __attribute__((noinline))
 	info = 13;
     }
     if (info != 0) {
-	xerbla_("DGEMM ", &info);
+	xerbla_("DGEMM ", &info, 0);
 	return 0;
     }
 
@@ -1144,11 +1144,16 @@ __attribute__((noinline))
     }
 
     return 0;
-
+#undef A
+#undef B
+#undef C
 /*     End of DGEMM . */
 
 } /* dgemm_ */
 
+#undef max
+#undef min
+#undef abs
 #ifdef __cplusplus
 }
 #endif

--- a/enzyme/test/Integration/blas_inline.h
+++ b/enzyme/test/Integration/blas_inline.h
@@ -1,0 +1,1154 @@
+#include <stdio.h>
+#include <assert.h>
+
+typedef int32_t integer;
+typedef double doublereal;
+typedef bool logical;
+
+#define abs(x) ((x) >= 0 ? (x) : -(x))
+#define min(a,b) ((a) <= (b) ? (a) : (b))
+#define max(a,b) ((a) >= (b) ? (a) : (b))
+#define TRUE_ true
+#define FALSE_ false
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+__attribute__((noinline))
+int xerbla_(const char *srname, integer *info)
+{
+    static char fmt_9999[] = "(\002 ** On entry to \002,a,\002 parameter num"
+	    "ber \002,i2,\002 had \002,\002an illegal value\002)";
+
+	printf("** On entry to %6s, parameter number %2i had an illegal value\n",
+		srname, *info);
+	assert(0 &&" error");
+	exit(1);
+    return 0;
+}
+__attribute__((noinline))
+logical lsame_(const char *ca, const char *cb)
+{
+    /* System generated locals */
+    logical ret_val;
+
+    /* Local variables */
+    integer inta, intb, zcode;
+
+
+/*  -- LAPACK auxiliary routine (version 3.1) -- */
+/*     Univ. of Tennessee, Univ. of California Berkeley and NAG Ltd.. */
+/*     November 2006 */
+
+/*     .. Scalar Arguments .. */
+/*     .. */
+
+/*  Purpose */
+/*  ======= */
+
+/*  LSAME returns .TRUE. if CA is the same letter as CB regardless of */
+/*  case. */
+
+/*  Arguments */
+/*  ========= */
+
+/*  CA      (input) CHARACTER*1 */
+
+/*  CB      (input) CHARACTER*1 */
+/*          CA and CB specify the single characters to be compared. */
+
+/* ===================================================================== */
+
+/*     .. Intrinsic Functions .. */
+/*     .. */
+/*     .. Local Scalars .. */
+/*     .. */
+
+/*     Test if the characters are equal */
+
+    ret_val = *(unsigned char *)ca == *(unsigned char *)cb;
+    if (ret_val) {
+	return ret_val;
+    }
+
+/*     Now test for equivalence if both characters are alphabetic. */
+
+    zcode = 'Z';
+
+/*     Use 'Z' rather than 'A' so that ASCII can be detected on Prime */
+/*     machines, on which ICHAR returns a value with bit 8 set. */
+/*     ICHAR('A') on Prime machines returns 193 which is the same as */
+/*     ICHAR('A') on an EBCDIC machine. */
+
+    inta = *(unsigned char *)ca;
+    intb = *(unsigned char *)cb;
+
+    if (zcode == 90 || zcode == 122) {
+
+/*        ASCII is assumed - ZCODE is the ASCII code of either lower or */
+/*        upper case 'Z'. */
+
+	if (inta >= 97 && inta <= 122) {
+	    inta += -32;
+	}
+	if (intb >= 97 && intb <= 122) {
+	    intb += -32;
+	}
+
+    } else if (zcode == 233 || zcode == 169) {
+
+/*        EBCDIC is assumed - ZCODE is the EBCDIC code of either lower or */
+/*        upper case 'Z'. */
+
+	if (inta >= 129 && inta <= 137 || inta >= 145 && inta <= 153 || inta 
+		>= 162 && inta <= 169) {
+	    inta += 64;
+	}
+	if (intb >= 129 && intb <= 137 || intb >= 145 && intb <= 153 || intb 
+		>= 162 && intb <= 169) {
+	    intb += 64;
+	}
+
+    } else if (zcode == 218 || zcode == 250) {
+
+/*        ASCII is assumed, on Prime machines - ZCODE is the ASCII code */
+/*        plus 128 of either lower or upper case 'Z'. */
+
+	if (inta >= 225 && inta <= 250) {
+	    inta += -32;
+	}
+	if (intb >= 225 && intb <= 250) {
+	    intb += -32;
+	}
+    }
+    ret_val = inta == intb;
+
+/*     RETURN */
+
+/*     End of LSAME */
+
+    return ret_val;
+} /* lsame_ */
+
+__attribute__((noinline))
+
+logical dlaisnan_(doublereal *din1, doublereal *din2)
+{
+    /* System generated locals */
+    logical ret_val;
+
+
+/*  -- LAPACK auxiliary routine (version 3.2) -- */
+/*     Univ. of Tennessee, Univ. of California Berkeley and NAG Ltd.. */
+/*     November 2006 */
+
+/*     .. Scalar Arguments .. */
+/*     .. */
+
+/*  Purpose */
+/*  ======= */
+
+/*  This routine is not for general use.  It exists solely to avoid */
+/*  over-optimization in DISNAN. */
+
+/*  DLAISNAN checks for NaNs by comparing its two arguments for */
+/*  inequality.  NaN is the only floating-point value where NaN != NaN */
+/*  returns .TRUE.  To check for NaNs, pass the same variable as both */
+/*  arguments. */
+
+/*  A compiler must assume that the two arguments are */
+/*  not the same variable, and the test will not be optimized away. */
+/*  Interprocedural or whole-program optimization may delete this */
+/*  test.  The ISNAN functions will be replaced by the correct */
+/*  Fortran 03 intrinsic once the intrinsic is widely available. */
+
+/*  Arguments */
+/*  ========= */
+
+/*  DIN1     (input) DOUBLE PRECISION */
+/*  DIN2     (input) DOUBLE PRECISION */
+/*          Two numbers to compare for inequality. */
+
+/*  ===================================================================== */
+
+/*  .. Executable Statements .. */
+    ret_val = *din1 != *din2;
+    return ret_val;
+} /* dlaisnan_ */
+
+__attribute__((noinline))
+logical disnan_(doublereal *din)
+{
+    /* System generated locals */
+    logical ret_val;
+
+    /* Local variables */
+
+/*  -- LAPACK auxiliary routine (version 3.2) -- */
+/*     Univ. of Tennessee, Univ. of California Berkeley and NAG Ltd.. */
+/*     November 2006 */
+
+/*     .. Scalar Arguments .. */
+/*     .. */
+
+/*  Purpose */
+/*  ======= */
+
+/*  DISNAN returns .TRUE. if its argument is NaN, and .FALSE. */
+/*  otherwise.  To be replaced by the Fortran 2003 intrinsic in the */
+/*  future. */
+
+/*  Arguments */
+/*  ========= */
+
+/*  DIN      (input) DOUBLE PRECISION */
+/*          Input to test for NaN. */
+
+/*  ===================================================================== */
+
+/*  .. External Functions .. */
+/*  .. */
+/*  .. Executable Statements .. */
+    ret_val = dlaisnan_(din, din);
+    return ret_val;
+} /* disnan_ */
+
+__attribute__((noinline))
+
+/* Subroutine */ int dlacpy_(char *uplo, integer *m, integer *n, doublereal *
+	a, integer *lda, doublereal *b, integer *ldb)
+{
+    /* System generated locals */
+    integer a_dim1, a_offset, b_dim1, b_offset, i__1, i__2;
+
+    /* Local variables */
+    integer i__, j;
+
+
+/*  -- LAPACK auxiliary routine (version 3.2) -- */
+/*     Univ. of Tennessee, Univ. of California Berkeley and NAG Ltd.. */
+/*     November 2006 */
+
+/*     .. Scalar Arguments .. */
+/*     .. */
+/*     .. Array Arguments .. */
+/*     .. */
+
+/*  Purpose */
+/*  ======= */
+
+/*  DLACPY copies all or part of a two-dimensional matrix A to another */
+/*  matrix B. */
+
+/*  Arguments */
+/*  ========= */
+
+/*  UPLO    (input) CHARACTER*1 */
+/*          Specifies the part of the matrix A to be copied to B. */
+/*          = 'U':      Upper triangular part */
+/*          = 'L':      Lower triangular part */
+/*          Otherwise:  All of the matrix A */
+
+/*  M       (input) INTEGER */
+/*          The number of rows of the matrix A.  M >= 0. */
+
+/*  N       (input) INTEGER */
+/*          The number of columns of the matrix A.  N >= 0. */
+
+/*  A       (input) DOUBLE PRECISION array, dimension (LDA,N) */
+/*          The m by n matrix A.  If UPLO = 'U', only the upper triangle */
+/*          or trapezoid is accessed; if UPLO = 'L', only the lower */
+/*          triangle or trapezoid is accessed. */
+
+/*  LDA     (input) INTEGER */
+/*          The leading dimension of the array A.  LDA >= max(1,M). */
+
+/*  B       (output) DOUBLE PRECISION array, dimension (LDB,N) */
+/*          On exit, B = A in the locations specified by UPLO. */
+
+/*  LDB     (input) INTEGER */
+/*          The leading dimension of the array B.  LDB >= max(1,M). */
+
+/*  ===================================================================== */
+
+/*     .. Local Scalars .. */
+/*     .. */
+/*     .. External Functions .. */
+/*     .. */
+/*     .. Intrinsic Functions .. */
+/*     .. */
+/*     .. Executable Statements .. */
+
+    /* Parameter adjustments */
+    a_dim1 = *lda;
+    a_offset = 1 + a_dim1;
+    a -= a_offset;
+    b_dim1 = *ldb;
+    b_offset = 1 + b_dim1;
+    b -= b_offset;
+
+    /* Function Body */
+    if (lsame_(uplo, "U")) {
+	i__1 = *n;
+	for (j = 1; j <= i__1; ++j) {
+	    i__2 = min(j,*m);
+	    for (i__ = 1; i__ <= i__2; ++i__) {
+		b[i__ + j * b_dim1] = a[i__ + j * a_dim1];
+/* L10: */
+	    }
+/* L20: */
+	}
+    } else if (lsame_(uplo, "L")) {
+	i__1 = *n;
+	for (j = 1; j <= i__1; ++j) {
+	    i__2 = *m;
+	    for (i__ = j; i__ <= i__2; ++i__) {
+		b[i__ + j * b_dim1] = a[i__ + j * a_dim1];
+/* L30: */
+	    }
+/* L40: */
+	}
+    } else {
+	i__1 = *n;
+	for (j = 1; j <= i__1; ++j) {
+	    i__2 = *m;
+	    for (i__ = 1; i__ <= i__2; ++i__) {
+		b[i__ + j * b_dim1] = a[i__ + j * a_dim1];
+/* L50: */
+	    }
+/* L60: */
+	}
+    }
+    return 0;
+
+/*     End of DLACPY */
+
+} /* dlacpy_ */
+
+__attribute__((noinline))
+
+/* Subroutine */ int dlascl_(char *type__, integer *kl, integer *ku, 
+	doublereal *cfrom, doublereal *cto, integer *m, integer *n, 
+	doublereal *a, integer *lda, integer *info)
+{
+    /* System generated locals */
+    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
+
+    /* Local variables */
+    integer i__, j, k1, k2, k3, k4;
+    doublereal mul, cto1;
+    logical done;
+    doublereal ctoc;
+    integer itype;
+    doublereal cfrom1;
+    // extern doublereal dlamch_(char *);
+    doublereal cfromc;
+    doublereal bignum, smlnum;
+
+
+/*  -- LAPACK auxiliary routine (version 3.2) -- */
+/*     Univ. of Tennessee, Univ. of California Berkeley and NAG Ltd.. */
+/*     November 2006 */
+
+/*     .. Scalar Arguments .. */
+/*     .. */
+/*     .. Array Arguments .. */
+/*     .. */
+
+/*  Purpose */
+/*  ======= */
+
+/*  DLASCL multiplies the M by N real matrix A by the real scalar */
+/*  CTO/CFROM.  This is done without over/underflow as long as the final */
+/*  result CTO*A(I,J)/CFROM does not over/underflow. TYPE specifies that */
+/*  A may be full, upper triangular, lower triangular, upper Hessenberg, */
+/*  or banded. */
+
+/*  Arguments */
+/*  ========= */
+
+/*  TYPE    (input) CHARACTER*1 */
+/*          TYPE indices the storage type of the input matrix. */
+/*          = 'G':  A is a full matrix. */
+/*          = 'L':  A is a lower triangular matrix. */
+/*          = 'U':  A is an upper triangular matrix. */
+/*          = 'H':  A is an upper Hessenberg matrix. */
+/*          = 'B':  A is a symmetric band matrix with lower bandwidth KL */
+/*                  and upper bandwidth KU and with the only the lower */
+/*                  half stored. */
+/*          = 'Q':  A is a symmetric band matrix with lower bandwidth KL */
+/*                  and upper bandwidth KU and with the only the upper */
+/*                  half stored. */
+/*          = 'Z':  A is a band matrix with lower bandwidth KL and upper */
+/*                  bandwidth KU. */
+
+/*  KL      (input) INTEGER */
+/*          The lower bandwidth of A.  Referenced only if TYPE = 'B', */
+/*          'Q' or 'Z'. */
+
+/*  KU      (input) INTEGER */
+/*          The upper bandwidth of A.  Referenced only if TYPE = 'B', */
+/*          'Q' or 'Z'. */
+
+/*  CFROM   (input) DOUBLE PRECISION */
+/*  CTO     (input) DOUBLE PRECISION */
+/*          The matrix A is multiplied by CTO/CFROM. A(I,J) is computed */
+/*          without over/underflow if the final result CTO*A(I,J)/CFROM */
+/*          can be represented without over/underflow.  CFROM must be */
+/*          nonzero. */
+
+/*  M       (input) INTEGER */
+/*          The number of rows of the matrix A.  M >= 0. */
+
+/*  N       (input) INTEGER */
+/*          The number of columns of the matrix A.  N >= 0. */
+
+/*  A       (input/output) DOUBLE PRECISION array, dimension (LDA,N) */
+/*          The matrix to be multiplied by CTO/CFROM.  See TYPE for the */
+/*          storage type. */
+
+/*  LDA     (input) INTEGER */
+/*          The leading dimension of the array A.  LDA >= max(1,M). */
+
+/*  INFO    (output) INTEGER */
+/*          0  - successful exit */
+/*          <0 - if INFO = -i, the i-th argument had an illegal value. */
+
+/*  ===================================================================== */
+
+/*     .. Parameters .. */
+/*     .. */
+/*     .. Local Scalars .. */
+/*     .. */
+/*     .. External Functions .. */
+/*     .. */
+/*     .. Intrinsic Functions .. */
+/*     .. */
+/*     .. External Subroutines .. */
+/*     .. */
+/*     .. Executable Statements .. */
+
+/*     Test the input arguments */
+
+    /* Parameter adjustments */
+    a_dim1 = *lda;
+    a_offset = 1 + a_dim1;
+    a -= a_offset;
+
+    /* Function Body */
+    *info = 0;
+
+    if (lsame_(type__, "G")) {
+	itype = 0;
+    } else if (lsame_(type__, "L")) {
+	itype = 1;
+    } else if (lsame_(type__, "U")) {
+	itype = 2;
+    } else if (lsame_(type__, "H")) {
+	itype = 3;
+    } else if (lsame_(type__, "B")) {
+	itype = 4;
+    } else if (lsame_(type__, "Q")) {
+	itype = 5;
+    } else if (lsame_(type__, "Z")) {
+	itype = 6;
+    } else {
+	itype = -1;
+    }
+
+    if (itype == -1) {
+	*info = -1;
+    } else if (*cfrom == 0. || disnan_(cfrom)) {
+	*info = -4;
+    } else if (disnan_(cto)) {
+	*info = -5;
+    } else if (*m < 0) {
+	*info = -6;
+    } else if (*n < 0 || itype == 4 && *n != *m || itype == 5 && *n != *m) {
+	*info = -7;
+    } else if (itype <= 3 && *lda < max(1,*m)) {
+	*info = -9;
+    } else if (itype >= 4) {
+/* Computing MAX */
+	i__1 = *m - 1;
+	if (*kl < 0 || *kl > max(i__1,0)) {
+	    *info = -2;
+	} else /* if(complicated condition) */ {
+/* Computing MAX */
+	    i__1 = *n - 1;
+	    if (*ku < 0 || *ku > max(i__1,0) || (itype == 4 || itype == 5) && 
+		    *kl != *ku) {
+		*info = -3;
+	    } else if (itype == 4 && *lda < *kl + 1 || itype == 5 && *lda < *
+		    ku + 1 || itype == 6 && *lda < (*kl << 1) + *ku + 1) {
+		*info = -9;
+	    }
+	}
+    }
+
+    if (*info != 0) {
+	i__1 = -(*info);
+	xerbla_("DLASCL", &i__1);
+	return 0;
+    }
+
+/*     Quick return if possible */
+
+    if (*n == 0 || *m == 0) {
+	return 0;
+    }
+
+/*     Get machine parameters */
+
+    smlnum = 0.0001; //dlamch_("S");
+    bignum = 1. / smlnum;
+
+    cfromc = *cfrom;
+    ctoc = *cto;
+
+L10:
+    cfrom1 = cfromc * smlnum;
+    if (cfrom1 == cfromc) {
+/*        CFROMC is an inf.  Multiply by a correctly signed zero for */
+/*        finite CTOC, or a NaN if CTOC is infinite. */
+	mul = ctoc / cfromc;
+	done = TRUE_;
+	cto1 = ctoc;
+    } else {
+	cto1 = ctoc / bignum;
+	if (cto1 == ctoc) {
+/*           CTOC is either 0 or an inf.  In both cases, CTOC itself */
+/*           serves as the correct multiplication factor. */
+	    mul = ctoc;
+	    done = TRUE_;
+	    cfromc = 1.;
+	} else if (abs(cfrom1) > abs(ctoc) && ctoc != 0.) {
+	    mul = smlnum;
+	    done = FALSE_;
+	    cfromc = cfrom1;
+	} else if (abs(cto1) > abs(cfromc)) {
+	    mul = bignum;
+	    done = FALSE_;
+	    ctoc = cto1;
+	} else {
+	    mul = ctoc / cfromc;
+	    done = TRUE_;
+	}
+    }
+
+    if (itype == 0) {
+
+/*        Full matrix */
+
+	i__1 = *n;
+	for (j = 1; j <= i__1; ++j) {
+	    i__2 = *m;
+	    for (i__ = 1; i__ <= i__2; ++i__) {
+		a[i__ + j * a_dim1] *= mul;
+/* L20: */
+	    }
+/* L30: */
+	}
+
+    } else if (itype == 1) {
+
+/*        Lower triangular matrix */
+
+	i__1 = *n;
+	for (j = 1; j <= i__1; ++j) {
+	    i__2 = *m;
+	    for (i__ = j; i__ <= i__2; ++i__) {
+		a[i__ + j * a_dim1] *= mul;
+/* L40: */
+	    }
+/* L50: */
+	}
+
+    } else if (itype == 2) {
+
+/*        Upper triangular matrix */
+
+	i__1 = *n;
+	for (j = 1; j <= i__1; ++j) {
+	    i__2 = min(j,*m);
+	    for (i__ = 1; i__ <= i__2; ++i__) {
+		a[i__ + j * a_dim1] *= mul;
+/* L60: */
+	    }
+/* L70: */
+	}
+
+    } else if (itype == 3) {
+
+/*        Upper Hessenberg matrix */
+
+	i__1 = *n;
+	for (j = 1; j <= i__1; ++j) {
+/* Computing MIN */
+	    i__3 = j + 1;
+	    i__2 = min(i__3,*m);
+	    for (i__ = 1; i__ <= i__2; ++i__) {
+		a[i__ + j * a_dim1] *= mul;
+/* L80: */
+	    }
+/* L90: */
+	}
+
+    } else if (itype == 4) {
+
+/*        Lower half of a symmetric band matrix */
+
+	k3 = *kl + 1;
+	k4 = *n + 1;
+	i__1 = *n;
+	for (j = 1; j <= i__1; ++j) {
+/* Computing MIN */
+	    i__3 = k3, i__4 = k4 - j;
+	    i__2 = min(i__3,i__4);
+	    for (i__ = 1; i__ <= i__2; ++i__) {
+		a[i__ + j * a_dim1] *= mul;
+/* L100: */
+	    }
+/* L110: */
+	}
+
+    } else if (itype == 5) {
+
+/*        Upper half of a symmetric band matrix */
+
+	k1 = *ku + 2;
+	k3 = *ku + 1;
+	i__1 = *n;
+	for (j = 1; j <= i__1; ++j) {
+/* Computing MAX */
+	    i__2 = k1 - j;
+	    i__3 = k3;
+	    for (i__ = max(i__2,1); i__ <= i__3; ++i__) {
+		a[i__ + j * a_dim1] *= mul;
+/* L120: */
+	    }
+/* L130: */
+	}
+
+    } else if (itype == 6) {
+
+/*        Band matrix */
+
+	k1 = *kl + *ku + 2;
+	k2 = *kl + 1;
+	k3 = (*kl << 1) + *ku + 1;
+	k4 = *kl + *ku + 1 + *m;
+	i__1 = *n;
+	for (j = 1; j <= i__1; ++j) {
+/* Computing MAX */
+	    i__3 = k1 - j;
+/* Computing MIN */
+	    i__4 = k3, i__5 = k4 - j;
+	    i__2 = min(i__4,i__5);
+	    for (i__ = max(i__3,k2); i__ <= i__2; ++i__) {
+		a[i__ + j * a_dim1] *= mul;
+/* L140: */
+	    }
+/* L150: */
+	}
+
+    }
+
+    if (! done) {
+	goto L10;
+    }
+
+    return 0;
+
+/*     End of DLASCL */
+
+} /* dlascl_ */
+
+__attribute__((noinline))
+
+doublereal ddot_(integer *n, doublereal *dx, integer *incx, doublereal *dy, 
+	integer *incy)
+{
+    /* System generated locals */
+    integer i__1;
+    doublereal ret_val;
+
+    /* Local variables */
+    integer i__, m, ix, iy, mp1;
+    doublereal dtemp;
+
+/*     .. Scalar Arguments .. */
+/*     .. */
+/*     .. Array Arguments .. */
+/*     .. */
+
+/*  Purpose */
+/*  ======= */
+
+/*     forms the dot product of two vectors. */
+/*     uses unrolled loops for increments equal to one. */
+/*     jack dongarra, linpack, 3/11/78. */
+/*     modified 12/3/93, array(1) declarations changed to array(*) */
+
+
+/*     .. Local Scalars .. */
+/*     .. */
+/*     .. Intrinsic Functions .. */
+/*     .. */
+    /* Parameter adjustments */
+    --dy;
+    --dx;
+
+    /* Function Body */
+    ret_val = 0.;
+    dtemp = 0.;
+    if (*n <= 0) {
+	return ret_val;
+    }
+    if (*incx == 1 && *incy == 1) {
+	goto L20;
+    }
+
+/*        code for unequal increments or equal increments */
+/*          not equal to 1 */
+
+    ix = 1;
+    iy = 1;
+    if (*incx < 0) {
+	ix = (-(*n) + 1) * *incx + 1;
+    }
+    if (*incy < 0) {
+	iy = (-(*n) + 1) * *incy + 1;
+    }
+    i__1 = *n;
+    for (i__ = 1; i__ <= i__1; ++i__) {
+	dtemp += dx[ix] * dy[iy];
+	ix += *incx;
+	iy += *incy;
+/* L10: */
+    }
+    ret_val = dtemp;
+    return ret_val;
+
+/*        code for both increments equal to 1 */
+
+
+/*        clean-up loop */
+
+L20:
+    m = *n % 5;
+    if (m == 0) {
+	goto L40;
+    }
+    i__1 = m;
+    for (i__ = 1; i__ <= i__1; ++i__) {
+	dtemp += dx[i__] * dy[i__];
+/* L30: */
+    }
+    if (*n < 5) {
+	goto L60;
+    }
+L40:
+    mp1 = m + 1;
+    i__1 = *n;
+    for (i__ = mp1; i__ <= i__1; i__ += 5) {
+	dtemp = dtemp + dx[i__] * dy[i__] + dx[i__ + 1] * dy[i__ + 1] + dx[
+		i__ + 2] * dy[i__ + 2] + dx[i__ + 3] * dy[i__ + 3] + dx[i__ + 
+		4] * dy[i__ + 4];
+/* L50: */
+    }
+L60:
+    ret_val = dtemp;
+    return ret_val;
+} /* ddot_ */
+
+__attribute__((noinline))
+/* Subroutine */ int dgemm_(char *transa, char *transb, integer *m, integer *
+	n, integer *k, doublereal *alpha, doublereal *a, integer *lda, 
+	doublereal *b, integer *ldb, doublereal *beta, doublereal *c, integer 
+	*ldc)
+{
+
+
+    /* System generated locals */
+    integer a_dim1, a_offset, b_dim1, b_offset, c_dim1, c_offset, i__1, i__2, 
+	    i__3;
+
+    /* Local variables */
+    integer info;
+    logical nota, notb;
+    doublereal temp;
+    integer i, j, l, ncola;
+    integer nrowa, nrowb;
+
+
+/*  Purpose   
+    =======   
+
+    DGEMM  performs one of the matrix-matrix operations   
+
+       C := alpha*op( A )*op( B ) + beta*C,   
+
+    where  op( X ) is one of   
+
+       op( X ) = X   or   op( X ) = X',   
+
+    alpha and beta are scalars, and A, B and C are matrices, with op( A ) 
+  
+    an m by k matrix,  op( B )  a  k by n matrix and  C an m by n matrix. 
+  
+
+    Parameters   
+    ==========   
+
+    TRANSA - CHARACTER*1.   
+             On entry, TRANSA specifies the form of op( A ) to be used in 
+  
+             the matrix multiplication as follows:   
+
+                TRANSA = 'N' or 'n',  op( A ) = A.   
+
+                TRANSA = 'T' or 't',  op( A ) = A'.   
+
+                TRANSA = 'C' or 'c',  op( A ) = A'.   
+
+             Unchanged on exit.   
+
+    TRANSB - CHARACTER*1.   
+             On entry, TRANSB specifies the form of op( B ) to be used in 
+  
+             the matrix multiplication as follows:   
+
+                TRANSB = 'N' or 'n',  op( B ) = B.   
+
+                TRANSB = 'T' or 't',  op( B ) = B'.   
+
+                TRANSB = 'C' or 'c',  op( B ) = B'.   
+
+             Unchanged on exit.   
+
+    M      - INTEGER.   
+             On entry,  M  specifies  the number  of rows  of the  matrix 
+  
+             op( A )  and of the  matrix  C.  M  must  be at least  zero. 
+  
+             Unchanged on exit.   
+
+    N      - INTEGER.   
+             On entry,  N  specifies the number  of columns of the matrix 
+  
+             op( B ) and the number of columns of the matrix C. N must be 
+  
+             at least zero.   
+             Unchanged on exit.   
+
+    K      - INTEGER.   
+             On entry,  K  specifies  the number of columns of the matrix 
+  
+             op( A ) and the number of rows of the matrix op( B ). K must 
+  
+             be at least  zero.   
+             Unchanged on exit.   
+
+    ALPHA  - DOUBLE PRECISION.   
+             On entry, ALPHA specifies the scalar alpha.   
+             Unchanged on exit.   
+
+    A      - DOUBLE PRECISION array of DIMENSION ( LDA, ka ), where ka is 
+  
+             k  when  TRANSA = 'N' or 'n',  and is  m  otherwise.   
+             Before entry with  TRANSA = 'N' or 'n',  the leading  m by k 
+  
+             part of the array  A  must contain the matrix  A,  otherwise 
+  
+             the leading  k by m  part of the array  A  must contain  the 
+  
+             matrix A.   
+             Unchanged on exit.   
+
+    LDA    - INTEGER.   
+             On entry, LDA specifies the first dimension of A as declared 
+  
+             in the calling (sub) program. When  TRANSA = 'N' or 'n' then 
+  
+             LDA must be at least  max( 1, m ), otherwise  LDA must be at 
+  
+             least  max( 1, k ).   
+             Unchanged on exit.   
+
+    B      - DOUBLE PRECISION array of DIMENSION ( LDB, kb ), where kb is 
+  
+             n  when  TRANSB = 'N' or 'n',  and is  k  otherwise.   
+             Before entry with  TRANSB = 'N' or 'n',  the leading  k by n 
+  
+             part of the array  B  must contain the matrix  B,  otherwise 
+  
+             the leading  n by k  part of the array  B  must contain  the 
+  
+             matrix B.   
+             Unchanged on exit.   
+
+    LDB    - INTEGER.   
+             On entry, LDB specifies the first dimension of B as declared 
+  
+             in the calling (sub) program. When  TRANSB = 'N' or 'n' then 
+  
+             LDB must be at least  max( 1, k ), otherwise  LDB must be at 
+  
+             least  max( 1, n ).   
+             Unchanged on exit.   
+
+    BETA   - DOUBLE PRECISION.   
+             On entry,  BETA  specifies the scalar  beta.  When  BETA  is 
+  
+             supplied as zero then C need not be set on input.   
+             Unchanged on exit.   
+
+    C      - DOUBLE PRECISION array of DIMENSION ( LDC, n ).   
+             Before entry, the leading  m by n  part of the array  C must 
+  
+             contain the matrix  C,  except when  beta  is zero, in which 
+  
+             case C need not be set on entry.   
+             On exit, the array  C  is overwritten by the  m by n  matrix 
+  
+             ( alpha*op( A )*op( B ) + beta*C ).   
+
+    LDC    - INTEGER.   
+             On entry, LDC specifies the first dimension of C as declared 
+  
+             in  the  calling  (sub)  program.   LDC  must  be  at  least 
+  
+             max( 1, m ).   
+             Unchanged on exit.   
+
+
+    Level 3 Blas routine.   
+
+    -- Written on 8-February-1989.   
+       Jack Dongarra, Argonne National Laboratory.   
+       Iain Duff, AERE Harwell.   
+       Jeremy Du Croz, Numerical Algorithms Group Ltd.   
+       Sven Hammarling, Numerical Algorithms Group Ltd.   
+
+
+
+       Set  NOTA  and  NOTB  as  true if  A  and  B  respectively are not 
+  
+       transposed and set  NROWA, NCOLA and  NROWB  as the number of rows 
+  
+       and  columns of  A  and the  number of  rows  of  B  respectively. 
+  
+
+    
+   Parameter adjustments   
+       Function Body */
+
+#define A(I,J) a[(I)-1 + ((J)-1)* ( *lda)]
+#define B(I,J) b[(I)-1 + ((J)-1)* ( *ldb)]
+#define C(I,J) c[(I)-1 + ((J)-1)* ( *ldc)]
+
+    nota = lsame_(transa, "N");
+    notb = lsame_(transb, "N");
+    if (nota) {
+	nrowa = *m;
+	ncola = *k;
+    } else {
+	nrowa = *k;
+	ncola = *m;
+    }
+    if (notb) {
+	nrowb = *k;
+    } else {
+	nrowb = *n;
+    }
+
+/*     Test the input parameters. */
+
+    info = 0;
+    if (! nota && ! lsame_(transa, "C") && ! lsame_(transa, "T")) {
+	info = 1;
+    } else if (! notb && ! lsame_(transb, "C") && ! lsame_(transb, 
+	    "T")) {
+	info = 2;
+    } else if (*m < 0) {
+	info = 3;
+    } else if (*n < 0) {
+	info = 4;
+    } else if (*k < 0) {
+	info = 5;
+    } else if (*lda < max(1,nrowa)) {
+	info = 8;
+    } else if (*ldb < max(1,nrowb)) {
+	info = 10;
+    } else if (*ldc < max(1,*m)) {
+	info = 13;
+    }
+    if (info != 0) {
+	xerbla_("DGEMM ", &info);
+	return 0;
+    }
+
+/*     Quick return if possible. */
+
+    if (*m == 0 || *n == 0 || (*alpha == 0. || *k == 0) && *beta == 1.) {
+	return 0;
+    }
+
+/*     And if  alpha.eq.zero. */
+
+    if (*alpha == 0.) {
+	if (*beta == 0.) {
+	    i__1 = *n;
+	    for (j = 1; j <= *n; ++j) {
+		i__2 = *m;
+		for (i = 1; i <= *m; ++i) {
+		    C(i,j) = 0.;
+/* L10: */
+		}
+/* L20: */
+	    }
+	} else {
+	    i__1 = *n;
+	    for (j = 1; j <= *n; ++j) {
+		i__2 = *m;
+		for (i = 1; i <= *m; ++i) {
+		    C(i,j) = *beta * C(i,j);
+/* L30: */
+		}
+/* L40: */
+	    }
+	}
+	return 0;
+    }
+
+/*     Start the operations. */
+
+    if (notb) {
+	if (nota) {
+
+/*           Form  C := alpha*A*B + beta*C. */
+
+	    i__1 = *n;
+	    for (j = 1; j <= *n; ++j) {
+		if (*beta == 0.) {
+		    i__2 = *m;
+		    for (i = 1; i <= *m; ++i) {
+			C(i,j) = 0.;
+/* L50: */
+		    }
+		} else if (*beta != 1.) {
+		    i__2 = *m;
+		    for (i = 1; i <= *m; ++i) {
+			C(i,j) = *beta * C(i,j);
+/* L60: */
+		    }
+		}
+		i__2 = *k;
+		for (l = 1; l <= *k; ++l) {
+		    if (B(l,j) != 0.) {
+			temp = *alpha * B(l,j);
+			i__3 = *m;
+			for (i = 1; i <= *m; ++i) {
+			    C(i,j) += temp * A(i,l);
+/* L70: */
+			}
+		    }
+/* L80: */
+		}
+/* L90: */
+	    }
+	} else {
+
+/*           Form  C := alpha*A'*B + beta*C */
+
+	    i__1 = *n;
+	    for (j = 1; j <= *n; ++j) {
+		i__2 = *m;
+		for (i = 1; i <= *m; ++i) {
+		    temp = 0.;
+		    i__3 = *k;
+		    for (l = 1; l <= *k; ++l) {
+			temp += A(l,i) * B(l,j);
+/* L100: */
+		    }
+		    if (*beta == 0.) {
+			C(i,j) = *alpha * temp;
+		    } else {
+			C(i,j) = *alpha * temp + *beta * C(i,j);
+		    }
+/* L110: */
+		}
+/* L120: */
+	    }
+	}
+    } else {
+	if (nota) {
+
+/*           Form  C := alpha*A*B' + beta*C */
+
+	    i__1 = *n;
+	    for (j = 1; j <= *n; ++j) {
+		if (*beta == 0.) {
+		    i__2 = *m;
+		    for (i = 1; i <= *m; ++i) {
+			C(i,j) = 0.;
+/* L130: */
+		    }
+		} else if (*beta != 1.) {
+		    i__2 = *m;
+		    for (i = 1; i <= *m; ++i) {
+			C(i,j) = *beta * C(i,j);
+/* L140: */
+		    }
+		}
+		i__2 = *k;
+		for (l = 1; l <= *k; ++l) {
+		    if (B(j,l) != 0.) {
+			temp = *alpha * B(j,l);
+			i__3 = *m;
+			for (i = 1; i <= *m; ++i) {
+			    C(i,j) += temp * A(i,l);
+/* L150: */
+			}
+		    }
+/* L160: */
+		}
+/* L170: */
+	    }
+	} else {
+
+/*           Form  C := alpha*A'*B' + beta*C */
+
+	    i__1 = *n;
+	    for (j = 1; j <= *n; ++j) {
+		i__2 = *m;
+		for (i = 1; i <= *m; ++i) {
+		    temp = 0.;
+		    i__3 = *k;
+		    for (l = 1; l <= *k; ++l) {
+			temp += A(l,i) * B(j,l);
+/* L180: */
+		    }
+		    if (*beta == 0.) {
+			C(i,j) = *alpha * temp;
+		    } else {
+			C(i,j) = *alpha * temp + *beta * C(i,j);
+		    }
+/* L190: */
+		}
+/* L200: */
+	    }
+	}
+    }
+
+    return 0;
+
+/*     End of DGEMM . */
+
+} /* dgemm_ */
+
+#ifdef __cplusplus
+}
+#endif

--- a/enzyme/tools/enzyme-tblgen/blas-tblgen.cpp
+++ b/enzyme/tools/enzyme-tblgen/blas-tblgen.cpp
@@ -940,7 +940,17 @@ void emit_fwd_rewrite_rules(const TGPattern &pattern, raw_ostream &os) {
   os << "  }\n";
 }
 
-void emit_tmp_creation(Record *Def, raw_ostream &os) {
+void emit_tmp_free(Record *Def, raw_ostream &os, StringRef builder) {
+  const auto args = Def->getValueAsListOfStrings("args");
+  // allocating tmp variables is optional, return if not required
+  if (args.size() == 0)
+    return;
+  const auto matName = args[0];
+  const auto allocName = "mat_" + matName;
+  os << "    CreateDealloc(" << builder << ", true_" << allocName << ");\n";
+}
+
+void emit_tmp_creation(Record *Def, raw_ostream &os, StringRef builder) {
   const auto args = Def->getValueAsListOfStrings("args");
   // allocating tmp variables is optional, return if not required
   if (args.size() == 0)
@@ -955,51 +965,53 @@ void emit_tmp_creation(Record *Def, raw_ostream &os) {
     const auto matName = args[0];
     const auto dim1 = "arg_" + args[2];
     const auto dim2 = "arg_" + args[3];
-    os << "    Value *len1 = load_if_ref(BuilderZ, intType," << dim1
+    os << "    Value *len1 = load_if_ref(" << builder << ", intType," << dim1
        << ", byRef);\n"
-       << "    Value *len2 = load_if_ref(BuilderZ, intType," << dim2
+       << "    Value *len2 = load_if_ref(" << builder << ", intType," << dim2
        << ", byRef);\n"
-       << "    Value *size_" << matName
-       << " = BuilderZ.CreateNUWMul(len1, len2, \"size_" << matName << "\");\n";
+       << "    Value *size_" << matName << " = " << builder
+       << ".CreateNUWMul(len1, len2, \"size_" << matName << "\");\n";
   } else if (action == "is_normal") {
     assert(args.size() == 5);
     const auto vecName = args[0];
     const auto trans = "arg_" + args[2];
     const auto dim1 = "arg_" + args[3];
     const auto dim2 = "arg_" + args[4];
-    os << "    Value *len1 = load_if_ref(BuilderZ, intType," << dim1
+    os << "    Value *len1 = load_if_ref(" << builder << ", intType," << dim1
        << ", byRef);\n"
-       << "    Value *len2 = load_if_ref(BuilderZ, intType," << dim2
+       << "    Value *len2 = load_if_ref(" << builder << ", intType," << dim2
        << ", byRef);\n";
-    os << "    Value *size_" << vecName
-       << " = BuilderZ.CreateSelect(is_normal(BuilderZ, " << trans
+    os << "    Value *size_" << vecName << " = " << builder
+       << ".CreateSelect(is_normal(" << builder << ", " << trans
        << ", byRef, cublas), len1, len2);\n";
   } else if (action == "triangular") {
     assert(args.size() == 3);
     const auto vecName = args[0];
     const auto dim1 = "arg_" + args[2];
-    os << "    Value *len = load_if_ref(BuilderZ, intType," << dim1
+    os << "    Value *len = load_if_ref(" << builder << ", intType," << dim1
        << ", byRef);\n";
     //  Size has to be (at least)
     //  ( ( n*( n + 1 ) )/2 )
-    os << "    Value *size_" << vecName
-       << " = BuilderZ.CreateMul(len, BuilderZ.CreateAdd(len, "
+    os << "    Value *size_" << vecName << " = " << builder
+       << ".CreateMul(len, " << builder
+       << ".CreateAdd(len, "
           "ConstantInt::get(intType, 1)), \"square_mat_size_"
        << vecName << "\");\n"
-       << "    size_" << vecName << " = BuilderZ.CreateUDiv(size_" << vecName
-       << ", ConstantInt::get(intType, 2), \"size_" << vecName << "\");\n";
+       << "    size_" << vecName << " = " << builder << ".CreateUDiv(size_"
+       << vecName << ", ConstantInt::get(intType, 2), \"size_" << vecName
+       << "\");\n";
   }
   const auto matName = args[0];
   const auto allocName = "mat_" + matName;
-  os << "    Value *" << allocName
-     << " = CreateAllocation(BuilderZ, fpType, size_" << matName << ", \""
-     << allocName << "\");\n"
+  os << "    Value * true_" << allocName << " = CreateAllocation(" << builder
+     << ", fpType, size_" << matName << ", \"" << allocName << "\");\n"
+     << "    Value * " << allocName << " = true_" << allocName << ";\n"
      << "    if (type_vec_like->isIntegerTy()) {\n"
-     << "      " << allocName << " = BuilderZ.CreatePtrToInt(" << allocName
-     << ", type_vec_like);\n"
+     << "      " << allocName << " = " << builder << ".CreatePtrToInt("
+     << allocName << ", type_vec_like);\n"
      << "    } else if (" << allocName << "->getType() != type_vec_like){\n"
-     << "      " << allocName << " = BuilderZ.CreatePointerCast(" << allocName
-     << ", type_vec_like);\n"
+     << "      " << allocName << " = " << builder << ".CreatePointerCast("
+     << allocName << ", type_vec_like);\n"
      << "    }\n";
 }
 
@@ -1644,7 +1656,7 @@ void emit_rev_rewrite_rules(const StringMap<TGPattern> &patternMap,
       emit_runtime_condition(ruleDag, name, "        ", "Builder2", true, os);
 
       // We might need to create a tmp vec or matrix
-      emit_tmp_creation(Def, os);
+      emit_tmp_creation(Def, os, "Builder2");
 
       os << "        const auto Defs = gutils->getInvertedBundles(&call, {"
          << valueTypes << "}, Builder2, /* lookup */ true);\n";
@@ -1708,6 +1720,7 @@ void emit_rev_rewrite_rules(const StringMap<TGPattern> &patternMap,
           }
         }
       }
+      emit_tmp_free(Def, os, "Builder2");
       emit_runtime_continue(ruleDag, name, "        ", "Builder2", true, os);
       os << "      }\n";
     } else {


### PR DESCRIPTION
We were allocating the temporary in the forward pass, before we had set byref_m, and byref_n -> the temporary allocation size was undef -> lots of errors.

Also now we deallocate things properly.