### PR TITLE
Add flag to disable recursive activity analysis

### DIFF
--- a/enzyme/Enzyme/ActivityAnalysis.h
+++ b/enzyme/Enzyme/ActivityAnalysis.h
@@ -59,6 +59,7 @@ extern llvm::cl::opt<bool> EnzymePrintActivity;
 extern llvm::cl::opt<bool> EnzymeNonmarkedGlobalsInactive;
 extern llvm::cl::opt<bool> EnzymeGlobalActivity;
 extern llvm::cl::opt<bool> EnzymeEmptyFnInactive;
+extern llvm::cl::opt<bool> EnzymeEnableRecursiveHypotheses;
 }
 
 class PreProcessCache;


### PR DESCRIPTION
This flag disables the behaviour for activity analysis to re-evaluate instructions or values when new information is added. This introduces a potential tradeoff between the time spent in analysis and the precision of the analysis results.