### PR TITLE
move away from using deprecated StringRef API

### DIFF
--- a/enzyme/BCLoad/BCLoader.cpp
+++ b/enzyme/BCLoad/BCLoader.cpp
@@ -16,6 +16,14 @@ using namespace llvm;
 #include "blas_headers.h"
 #undef DATA
 
+static inline bool endsWith(llvm::StringRef string, llvm::StringRef suffix) {
+#if LLVM_VERSION_MAJOR >= 18
+  return string.ends_with(suffix);
+#else
+  return string.endswith(suffix);
+#endif // LLVM_VERSION_MAJOR
+}
+
 bool provideDefinitions(Module &M, std::set<std::string> ignoreFunctions = {}) {
   std::vector<StringRef> todo;
   bool seen32 = false;
@@ -30,7 +38,7 @@ bool provideDefinitions(Module &M, std::set<std::string> ignoreFunctions = {}) {
       if (strlen(postfix) == 0) {
         str = F.getName().str();
         if (ignoreFunctions.count(str)) continue;
-      } else if (F.getName().endswith(postfix)) {
+      } else if (endsWith(F.getName(), postfix)) {
         auto blasName =
             F.getName().substr(0, F.getName().size() - strlen(postfix)).str();
         if (ignoreFunctions.count(blasName)) continue;
@@ -44,8 +52,7 @@ bool provideDefinitions(Module &M, std::set<std::string> ignoreFunctions = {}) {
           seen32 = true;
         if (index == 2)
           seen64 = true;
-        if (StringRef(str).endswith("gemm"))
-          seenGemm = true;
+        if (endsWith(str, "gemm")) seenGemm = true;
         break;
       }
       index++;

--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -465,20 +465,20 @@ bool ActivityAnalyzer::isFunctionArgumentConstant(CallInst *CI, Value *val) {
   std::string demangledName = llvm::demangle(Name.str());
   auto dName = StringRef(demangledName);
   for (auto FuncName : DemangledKnownInactiveFunctionsStartingWith) {
-    if (dName.startswith(FuncName)) {
+    if (startsWith(dName, FuncName)) {
       return true;
     }
   }
   if (demangledName == Name.str()) {
     // Either demangeling failed
     // or they are equal but matching failed
-    // if (!Name.startswith("llvm."))
+    // if (!startsWith(Name, "llvm."))
     //  llvm::errs() << "matching failed: " << Name.str() << " "
     //               << demangledName << "\n";
   }
 
   for (auto FuncName : KnownInactiveFunctionsStartingWith) {
-    if (Name.startswith(FuncName)) {
+    if (startsWith(Name, FuncName)) {
       return true;
     }
   }
@@ -1560,7 +1560,7 @@ bool ActivityAnalyzer::isConstantValue(TypeResults const &TR, Value *Val) {
 
         auto dName = demangle(funcName.str());
         for (auto FuncName : DemangledKnownInactiveFunctionsStartingWith) {
-          if (StringRef(dName).startswith(FuncName)) {
+          if (startsWith(dName, FuncName)) {
             InsertConstantValue(TR, Val);
             insertConstantsFrom(TR, *UpHypothesis);
             return true;
@@ -1568,7 +1568,7 @@ bool ActivityAnalyzer::isConstantValue(TypeResults const &TR, Value *Val) {
         }
 
         for (auto FuncName : KnownInactiveFunctionsStartingWith) {
-          if (funcName.startswith(FuncName)) {
+          if (startsWith(funcName, FuncName)) {
             InsertConstantValue(TR, Val);
             insertConstantsFrom(TR, *UpHypothesis);
             return true;
@@ -1886,13 +1886,13 @@ bool ActivityAnalyzer::isConstantValue(TypeResults const &TR, Value *Val) {
 
         auto dName = demangle(funcName.str());
         for (auto FuncName : DemangledKnownInactiveFunctionsStartingWith) {
-          if (StringRef(dName).startswith(FuncName)) {
+          if (startsWith(dName, FuncName)) {
             return false;
           }
         }
 
         for (auto FuncName : KnownInactiveFunctionsStartingWith) {
-          if (funcName.startswith(FuncName)) {
+          if (startsWith(funcName, FuncName)) {
             return false;
           }
         }
@@ -2553,13 +2553,13 @@ bool ActivityAnalyzer::isInstructionInactiveFromOrigin(TypeResults const &TR,
 
     auto dName = demangle(funcName.str());
     for (auto FuncName : DemangledKnownInactiveFunctionsStartingWith) {
-      if (StringRef(dName).startswith(FuncName)) {
+      if (startsWith(dName, FuncName)) {
         return true;
       }
     }
 
     for (auto FuncName : KnownInactiveFunctionsStartingWith) {
-      if (funcName.startswith(FuncName)) {
+      if (startsWith(funcName, FuncName)) {
         return true;
       }
     }

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -5932,7 +5932,7 @@ public:
     // not fully understood by LLVM. One of the results of this is that the
     // visitor dispatches to visitCallInst, rather than visitIntrinsicInst, when
     // presented with the intrinsic - hence why we are handling it here.
-    if (getFuncNameFromCall(&call).startswith("llvm.intel.subscript")) {
+    if (startsWith(getFuncNameFromCall(&call), ("llvm.intel.subscript"))) {
       assert(isa<IntrinsicInst>(call));
       visitIntrinsicInst(cast<IntrinsicInst>(call));
       return;

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -2244,7 +2244,7 @@ bool AdjointGenerator<T>::handleKnownCallDerivatives(
     }
   }
 
-  if ((funcName.startswith("MPI_") || funcName.startswith("PMPI_")) &&
+  if ((startsWith(funcName, "MPI_") || startsWith(funcName, "PMPI_")) &&
       (!gutils->isConstantInstruction(&call) || funcName == "MPI_Barrier" ||
        funcName == "MPI_Comm_free" || funcName == "MPI_Comm_disconnect" ||
        MPIInactiveCommAllocators.find(funcName) !=
@@ -2263,8 +2263,8 @@ bool AdjointGenerator<T>::handleKnownCallDerivatives(
   }
 
   if (funcName == "printf" || funcName == "puts" ||
-      funcName.startswith("_ZN3std2io5stdio6_print") ||
-      funcName.startswith("_ZN4core3fmt")) {
+      startsWith(funcName, "_ZN3std2io5stdio6_print") ||
+      startsWith(funcName, "_ZN4core3fmt")) {
     if (Mode == DerivativeMode::ReverseModeGradient) {
       eraseIfUnused(call, /*erase*/ true, /*check*/ false);
     }
@@ -2353,7 +2353,7 @@ bool AdjointGenerator<T>::handleKnownCallDerivatives(
       return true;
     }
 
-    if (funcName.startswith("__kmpc") &&
+    if (startsWith(funcName, "__kmpc") &&
         funcName != "__kmpc_global_thread_num") {
       llvm::errs() << *gutils->oldFunc << "\n";
       llvm::errs() << call << "\n";

--- a/enzyme/Enzyme/Clang/EnzymeClang.cpp
+++ b/enzyme/Enzyme/Clang/EnzymeClang.cpp
@@ -33,6 +33,8 @@
 #include "clang/Sema/Sema.h"
 #include "clang/Sema/SemaDiagnostic.h"
 
+#include "../Utils.h"
+
 using namespace clang;
 
 #if LLVM_VERSION_MAJOR >= 18
@@ -99,12 +101,12 @@ public:
     std::string pluginPath;
 #endif
     for (auto P : Opts.Plugins)
-      if (llvm::sys::path::stem(P).endswith(PluginName)) {
+      if (endsWith(llvm::sys::path::stem(P), PluginName)) {
 #if LLVM_VERSION_MAJOR < 18
         pluginPath = P;
 #endif
         for (auto passPlugin : CGOpts.PassPlugins) {
-          if (llvm::sys::path::stem(passPlugin).endswith(PluginName)) {
+          if (endsWith(llvm::sys::path::stem(passPlugin), PluginName)) {
             contains = true;
             break;
           }

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -749,7 +749,7 @@ public:
       Value *res = CI->getArgOperand(i);
       auto metaString = getMetadataName(res);
       // handle metadata
-      if (metaString && metaString->startswith("enzyme_")) {
+      if (metaString && startsWith(*metaString, "enzyme_")) {
         if (*metaString == "enzyme_const_return") {
           retType = DIFFE_TYPE::CONSTANT;
           continue;
@@ -862,7 +862,7 @@ public:
       bool skipArg = false;
 
       // handle metadata
-      while (metaString && metaString->startswith("enzyme_")) {
+      while (metaString && startsWith(*metaString, "enzyme_")) {
         if (*metaString == "enzyme_not_overwritten") {
           overwritten = false;
         } else if (*metaString == "enzyme_byref") {
@@ -1368,7 +1368,7 @@ public:
       auto metaString = getMetadataName(res);
 
       // handle metadata
-      if (metaString && metaString->startswith("enzyme_")) {
+      if (metaString && startsWith(*metaString, "enzyme_")) {
         if (*metaString == "enzyme_scalar") {
           ty = BATCH_TYPE::SCALAR;
         } else if (*metaString == "enzyme_vector") {

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -448,7 +448,8 @@ struct CacheAnalysis {
       return {};
     }
 
-    if (funcName.startswith("MPI_") || funcName.startswith("enzyme_wrapmpi$$"))
+    if (startsWith(funcName, "MPI_") ||
+        startsWith(funcName, "enzyme_wrapmpi$$"))
       return {};
 
     if (funcName == "__kmpc_for_static_init_4" ||
@@ -615,7 +616,7 @@ struct CacheAnalysis {
           // We do not need uncacheable args for intrinsic functions. So skip
           // such callsites.
           if (auto II = dyn_cast<IntrinsicInst>(&inst)) {
-            if (!II->getCalledFunction()->getName().startswith("llvm.julia"))
+            if (!startsWith(II->getCalledFunction()->getName(), "llvm.julia"))
               continue;
           }
 
@@ -5314,7 +5315,7 @@ llvm::Function *EnzymeLogic::CreateNoFree(RequestContext context, Function *F) {
       "MPI_Allreduce",
   };
 
-  if (F->getName().startswith("_ZNSolsE") || NoFrees.count(F->getName()))
+  if (startsWith(F->getName(), "_ZNSolsE") || NoFrees.count(F->getName()))
     return F;
 
   switch (F->getIntrinsicID()) {

--- a/enzyme/Enzyme/FunctionUtils.cpp
+++ b/enzyme/Enzyme/FunctionUtils.cpp
@@ -1131,12 +1131,13 @@ static void ForceRecursiveInlining(Function *NewF, size_t Limit) {
             continue;
           if (CI->getCalledFunction()->empty())
             continue;
-          if (CI->getCalledFunction()->getName().startswith(
-                  "_ZN3std2io5stdio6_print"))
+          if (startsWith(CI->getCalledFunction()->getName(),
+                         "_ZN3std2io5stdio6_print"))
             continue;
-          if (CI->getCalledFunction()->getName().startswith("_ZN4core3fmt"))
+          if (startsWith(CI->getCalledFunction()->getName(), "_ZN4core3fmt"))
             continue;
-          if (CI->getCalledFunction()->getName().startswith("enzyme_wrapmpi$$"))
+          if (startsWith(CI->getCalledFunction()->getName(),
+                         "enzyme_wrapmpi$$"))
             continue;
           if (CI->getCalledFunction()->hasFnAttribute(
                   Attribute::ReturnsTwice) ||
@@ -1539,7 +1540,7 @@ Function *PreProcessCache::preprocessForClone(Function *F,
           if (F && F->getName().contains("__enzyme_double")) {
             continue;
           }
-          if (F && (F->getName().startswith("f90io") ||
+          if (F && (startsWith(F->getName(), "f90io") ||
                     F->getName() == "ftnio_fmt_write64" ||
                     F->getName() == "__mth_i_ipowi" ||
                     F->getName() == "f90_pausea")) {
@@ -1599,7 +1600,7 @@ Function *PreProcessCache::preprocessForClone(Function *F,
                 if (F && F->getName().contains("__enzyme_double")) {
                   continue;
                 }
-                if (F && (F->getName().startswith("f90io") ||
+                if (F && (startsWith(F->getName(), "f90io") ||
                           F->getName() == "ftnio_fmt_write64" ||
                           F->getName() == "__mth_i_ipowi" ||
                           F->getName() == "f90_pausea")) {

--- a/enzyme/Enzyme/FunctionUtils.h
+++ b/enzyme/Enzyme/FunctionUtils.h
@@ -344,7 +344,7 @@ static inline void calculateUnusedValues(
     }
   }
 
-  if (false && oldFunc.getName().endswith("subfn")) {
+  if (false && endsWith(oldFunc.getName(), "subfn")) {
     llvm::errs() << "Prepping values for: " << oldFunc.getName()
                  << " returnValue: " << returnValue << "\n";
     for (auto v : unnecessaryInstructions) {

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -695,7 +695,7 @@ Value *GradientUtils::unwrapM(Value *const val, IRBuilder<> &BuilderM,
   }
 
   std::pair<Value *, BasicBlock *> idx = std::make_pair(val, scope);
-  // assert(!val->getName().startswith("$tapeload"));
+  // assert(!startsWith(val->getName(), "$tapeload"));
   if (permitCache) {
     auto found0 = unwrap_cache.find(BuilderM.GetInsertBlock());
     if (found0 != unwrap_cache.end()) {
@@ -4010,7 +4010,7 @@ bool GradientUtils::legalRecompute(const Value *val,
         n == "lgammal_r" || n == "__lgamma_r_finite" ||
         n == "__lgammaf_r_finite" || n == "__lgammal_r_finite" || n == "tanh" ||
         n == "tanhf" || n == "__pow_finite" ||
-        n == "julia.pointer_from_objref" || n.startswith("enzyme_wrapmpi$$") ||
+        n == "julia.pointer_from_objref" || startsWith(n, "enzyme_wrapmpi$$") ||
         n == "omp_get_thread_num" || n == "omp_get_max_threads") {
       return true;
     }
@@ -4160,7 +4160,7 @@ bool GradientUtils::shouldRecompute(const Value *val,
         n == "lgammal_r" || n == "__lgamma_r_finite" ||
         n == "__lgammaf_r_finite" || n == "__lgammal_r_finite" || n == "tanh" ||
         n == "tanhf" || n == "__pow_finite" ||
-        n == "julia.pointer_from_objref" || n.startswith("enzyme_wrapmpi$$") ||
+        n == "julia.pointer_from_objref" || startsWith(n, "enzyme_wrapmpi$$") ||
         n == "omp_get_thread_num" || n == "omp_get_max_threads") {
       return true;
     }
@@ -4451,7 +4451,7 @@ Constant *GradientUtils::GetOrCreateShadowConstant(
     if (arg->getName() == "_ZTVN10__cxxabiv120__si_class_type_infoE" ||
         arg->getName() == "_ZTVN10__cxxabiv117__class_type_infoE" ||
         arg->getName() == "_ZTVN10__cxxabiv121__vmi_class_type_infoE" ||
-        arg->getName().startswith("??_R")) // any of the MS RTTI manglings
+        startsWith(arg->getName(), "??_R")) // any of the MS RTTI manglings
       return arg;
 
     if (hasMetadata(arg, "enzyme_shadow")) {

--- a/enzyme/Enzyme/MLIR/Analysis/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/MLIR/Analysis/ActivityAnalysis.cpp
@@ -282,20 +282,20 @@ bool mlir::enzyme::ActivityAnalyzer::isFunctionArgumentConstant(
   std::string demangledName = llvm::demangle(Name.str());
   auto dName = StringRef(demangledName);
   for (auto FuncName : DemangledKnownInactiveFunctionsStartingWith) {
-    if (dName.startswith(FuncName)) {
+    if (startsWith(dName, FuncName)) {
       return true;
     }
   }
   if (demangledName == Name.str()) {
     // Either demangeling failed
     // or they are equal but matching failed
-    // if (!Name.startswith("llvm."))
+    // if (!startsWith(Name, "llvm."))
     //  llvm::errs() << "matching failed: " << Name.str() << " "
     //               << demangledName << "\n";
   }
 
   for (auto FuncName : KnownInactiveFunctionsStartingWith) {
-    if (Name.startswith(FuncName)) {
+    if (startsWith(Name, FuncName)) {
       return true;
     }
   }
@@ -315,7 +315,7 @@ bool mlir::enzyme::ActivityAnalyzer::isFunctionArgumentConstant(
   }
 
   for (unsigned intrinsicID : constantIntrinsics) {
-    if (Name.startswith(llvm::Intrinsic::getBaseName(intrinsicID)))
+    if (startsWith(Name, llvm::Intrinsic::getBaseName(intrinsicID)))
       return true;
   }
 
@@ -410,13 +410,13 @@ bool mlir::enzyme::ActivityAnalyzer::isFunctionArgumentConstant(
 //     // Certain intrinsics are inactive by definition
 //     // and have nothing to propagate.
 //     for (unsigned intrinsicID : constantIntrinsics) {
-//       if (Name.startswith(llvm::Intrinsic::getBaseName(intrinsicID)))
+//       if (startsWith(Name, llvm::Intrinsic::getBaseName(intrinsicID)))
 //         return;
 //     }
 
-//     if (Name.startswith(
+//     if (startsWith(Name,
 //             llvm::Intrinsic::getBaseName(llvm::Intrinsic::memcpy)) ||
-//         Name.startswith(
+//        startsWith(Name,
 //             llvm::Intrinsic::getBaseName(llvm::Intrinsic::memmove))) {
 //       propagateFromOperand(CI.getArgOperands()[0]);
 //       propagateFromOperand(CI.getArgOperands()[1]);
@@ -1586,7 +1586,7 @@ bool mlir::enzyme::ActivityAnalyzer::isConstantValue(MTypeResults const &TR,
 
         auto dName = llvm::demangle(funcName.str());
         for (auto FuncName : DemangledKnownInactiveFunctionsStartingWith) {
-          if (StringRef(dName).startswith(FuncName)) {
+          if (startsWith(dName, FuncName)) {
             InsertConstantValue(TR, Val);
             insertConstantsFrom(TR, *UpHypothesis);
             return true;
@@ -1594,7 +1594,7 @@ bool mlir::enzyme::ActivityAnalyzer::isConstantValue(MTypeResults const &TR,
         }
 
         for (auto FuncName : KnownInactiveFunctionsStartingWith) {
-          if (funcName.startswith(FuncName)) {
+          if (startsWith(funcName, FuncName)) {
             InsertConstantValue(TR, Val);
             insertConstantsFrom(TR, *UpHypothesis);
             return true;
@@ -1868,13 +1868,13 @@ bool mlir::enzyme::ActivityAnalyzer::isConstantValue(MTypeResults const &TR,
 
         auto dName = llvm::demangle(funcName.str());
         for (auto FuncName : DemangledKnownInactiveFunctionsStartingWith) {
-          if (StringRef(dName).startswith(FuncName)) {
+          if (startsWith(dName, FuncName)) {
             return false;
           }
         }
 
         for (auto FuncName : KnownInactiveFunctionsStartingWith) {
-          if (funcName.startswith(FuncName)) {
+          if (startsWith(funcName, FuncName)) {
             return false;
           }
         }
@@ -2594,13 +2594,13 @@ bool mlir::enzyme::ActivityAnalyzer::isOperationInactiveFromOrigin(
 
     auto dName = llvm::demangle(funcName.str());
     for (auto FuncName : DemangledKnownInactiveFunctionsStartingWith) {
-      if (StringRef(dName).startswith(FuncName)) {
+      if (startsWith(dName, FuncName)) {
         return true;
       }
     }
 
     for (auto FuncName : KnownInactiveFunctionsStartingWith) {
-      if (funcName.startswith(FuncName)) {
+      if (startsWith(funcName, FuncName)) {
         return true;
       }
     }

--- a/enzyme/Enzyme/PreserveNVVM.cpp
+++ b/enzyme/Enzyme/PreserveNVVM.cpp
@@ -116,7 +116,7 @@ handleCustomDerivative(llvm::Module &M, llvm::GlobalVariable &g,
                         CA->isCString()) {
 
                       auto str = CA->getAsCString();
-                      bool legal = str.startswith("byref_");
+                      bool legal = startsWith(str, "byref_");
                       size_t argnum = 0;
                       if (legal) {
                         for (size_t i = str.size() - 1, len = strlen("byref_");

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -199,7 +199,7 @@ const llvm::StringMap<llvm::Intrinsic::ID> LIBM_FUNCTIONS = {
 
 static bool isItaniumEncoding(StringRef S) {
   // Itanium encoding requires 1 or 3 leading underscores, followed by 'Z'.
-  return S.startswith("_Z") || S.startswith("___Z");
+  return startsWith(S, "_Z") || startsWith(S, "___Z");
 }
 
 bool dontAnalyze(StringRef str) {
@@ -4319,7 +4319,7 @@ void TypeAnalyzer::visitCallBase(CallBase &call) {
     // not fully understood by LLVM. One of the results of this is that the
     // visitor dispatches to visitCallBase, rather than visitIntrinsicInst, when
     // presented with the intrinsic - hence why we are handling it here.
-    if (funcName.startswith("llvm.intel.subscript")) {
+    if (startsWith(funcName, "llvm.intel.subscript")) {
       assert(isa<IntrinsicInst>(call));
       analyzeIntelSubscriptIntrinsic(cast<IntrinsicInst>(call), *this);
       return;
@@ -4376,8 +4376,8 @@ void TypeAnalyzer::visitCallBase(CallBase &call) {
     // All these are always valid => no direction check
     // CONSIDER(malloc)
     // TODO consider handling other allocation functions integer inputs
-    if (funcName.startswith("_ZN3std2io5stdio6_print") ||
-        funcName.startswith("_ZN4core3fmt")) {
+    if (startsWith(funcName, "_ZN3std2io5stdio6_print") ||
+        startsWith(funcName, "_ZN4core3fmt")) {
       return;
     }
     /// GEMM
@@ -4507,13 +4507,13 @@ void TypeAnalyzer::visitCallBase(CallBase &call) {
       return;
     }
 
-    if (funcName.startswith("_ZNKSt3__14hash")) {
+    if (startsWith(funcName, "_ZNKSt3__14hash")) {
       updateAnalysis(&call, TypeTree(BaseType::Integer).Only(-1, &call), &call);
       return;
     }
 
-    if (funcName.startswith("_ZNKSt3__112basic_stringIcNS_11char_traitsIcEENS_"
-                            "9allocatorIcEEE13__get_pointer")) {
+    if (startsWith(funcName, "_ZNKSt3__112basic_stringIcNS_11char_traitsIcEENS_"
+                             "9allocatorIcEEE13__get_pointer")) {
       return;
     }
 
@@ -4616,7 +4616,7 @@ void TypeAnalyzer::visitCallBase(CallBase &call) {
     }
 
     /// MPI
-    if (funcName.startswith("PMPI_"))
+    if (startsWith(funcName, "PMPI_"))
       funcName = funcName.substr(1);
     if (funcName == "MPI_Init") {
       TypeTree ptrint;

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.h
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.h
@@ -53,17 +53,18 @@
 #include "llvm/Analysis/PostDominators.h"
 #include "llvm/IR/Dominators.h"
 
+#include "../Utils.h"
 #include "TypeTree.h"
 
 extern const llvm::StringMap<llvm::Intrinsic::ID> LIBM_FUNCTIONS;
 
 static inline bool isMemFreeLibMFunction(llvm::StringRef str,
                                          llvm::Intrinsic::ID *ID = nullptr) {
-  if (str.startswith("__") && str.endswith("_finite")) {
+  if (startsWith(str, "__") && endsWith(str, "_finite")) {
     str = str.substr(2, str.size() - 2 - 7);
-  } else if (str.startswith("__fd_") && str.endswith("_1")) {
+  } else if (startsWith(str, "__fd_") && endsWith(str, "_1")) {
     str = str.substr(5, str.size() - 5 - 2);
-  } else if (str.startswith("__nv_")) {
+  } else if (startsWith(str, "__nv_")) {
     str = str.substr(5, str.size() - 5);
   }
   if (LIBM_FUNCTIONS.find(str.str()) != LIBM_FUNCTIONS.end()) {
@@ -71,7 +72,7 @@ static inline bool isMemFreeLibMFunction(llvm::StringRef str,
       *ID = LIBM_FUNCTIONS.find(str.str())->second;
     return true;
   }
-  if (str.endswith("f") || str.endswith("l")) {
+  if (endsWith(str, "f") || endsWith(str, "l")) {
     if (LIBM_FUNCTIONS.find(str.substr(0, str.size() - 1).str()) !=
         LIBM_FUNCTIONS.end()) {
       if (ID)

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -598,15 +598,32 @@ static inline bool isDebugFunction(llvm::Function *called) {
   return false;
 }
 
+static inline bool startsWith(llvm::StringRef string, llvm::StringRef prefix) {
+#if LLVM_VERSION_MAJOR >= 18
+  return string.starts_with(prefix);
+#else
+  return string.startswith(prefix);
+#endif // LLVM_VERSION_MAJOR
+}
+
+static inline bool endsWith(llvm::StringRef string, llvm::StringRef suffix) {
+#if LLVM_VERSION_MAJOR >= 18
+  return string.ends_with(suffix);
+#else
+  return string.endswith(suffix);
+#endif // LLVM_VERSION_MAJOR
+}
+
 static inline bool isCertainPrint(const llvm::StringRef name) {
   if (name == "printf" || name == "puts" || name == "fprintf" ||
       name == "putchar" ||
-      name.startswith("_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_") ||
-      name.startswith("_ZNSolsE") || name.startswith("_ZNSo9_M_insert") ||
-      name.startswith("_ZSt16__ostream_insert") ||
-      name.startswith("_ZNSo3put") || name.startswith("_ZSt4endl") ||
-      name.startswith("_ZN3std2io5stdio6_print") ||
-      name.startswith("_ZNSo5flushEv") || name.startswith("_ZN4core3fmt") ||
+      startsWith(name,
+                 "_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_") ||
+      startsWith(name, "_ZNSolsE") || startsWith(name, "_ZNSo9_M_insert") ||
+      startsWith(name, "_ZSt16__ostream_insert") ||
+      startsWith(name, "_ZNSo3put") || startsWith(name, "_ZSt4endl") ||
+      startsWith(name, "_ZN3std2io5stdio6_print") ||
+      startsWith(name, "_ZNSo5flushEv") || startsWith(name, "_ZN4core3fmt") ||
       name == "vprintf")
     return true;
   return false;
@@ -1232,7 +1249,7 @@ static inline bool shouldDisableNoWrite(const llvm::CallInst *CI) {
 }
 
 static inline bool isIntelSubscriptIntrinsic(const llvm::IntrinsicInst &II) {
-  return getFuncNameFromCall(&II).startswith("llvm.intel.subscript");
+  return startsWith(getFuncNameFromCall(&II), "llvm.intel.subscript");
 }
 
 static inline bool isIntelSubscriptIntrinsic(const llvm::Value *val) {
@@ -1789,4 +1806,4 @@ bool collectOffset(llvm::GEPOperator *gep, const llvm::DataLayout &DL,
                    unsigned BitWidth,
                    llvm::MapVector<llvm::Value *, llvm::APInt> &VariableOffsets,
                    llvm::APInt &ConstantOffset);
-#endif
+#endif // ENZYME_UTILS_H

--- a/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
+++ b/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
@@ -30,6 +30,22 @@
 
 using namespace llvm;
 
+static inline bool startsWith(llvm::StringRef string, llvm::StringRef prefix) {
+#if LLVM_VERSION_MAJOR >= 18
+  return string.starts_with(prefix);
+#else
+  return string.startswith(prefix);
+#endif // LLVM_VERSION_MAJOR
+}
+
+static inline bool endsWith(llvm::StringRef string, llvm::StringRef suffix) {
+#if LLVM_VERSION_MAJOR >= 18
+  return string.ends_with(suffix);
+#else
+  return string.endswith(suffix);
+#endif // LLVM_VERSION_MAJOR
+}
+
 static cl::opt<ActionType>
     action(cl::desc("Action to perform:"),
            cl::values(clEnumValN(GenBlasDerivatives, "gen-blas-derivatives",
@@ -198,14 +214,14 @@ SmallVector<bool, 1> prepareArgs(const Twine &curIndent, raw_ostream &os,
     if (isa<UnsetInit>(args) && names) {
       auto [ord, vecValue] =
           nameToOrdinal.lookup(names->getValue(), pattern, resultRoot);
-      if (!vecValue && !StringRef(ord).startswith("local")) {
+      if (!vecValue && !startsWith(ord, "local")) {
         if (lookup)
           os << "lookup(";
         if (newFromOriginal)
           os << "gutils->getNewFromOriginal(";
       }
       os << ord;
-      if (!vecValue && !StringRef(ord).startswith("local")) {
+      if (!vecValue && !startsWith(ord, "local")) {
         if (newFromOriginal)
           os << ")";
         if (lookup)
@@ -1621,16 +1637,16 @@ void emitDiffUse(const RecordKeeper &recordKeeper, raw_ostream &os,
 
               if (name.size()) {
                 if (foundPrimalUse2.size() &&
-                    !(StringRef(foundPrimalUse).startswith(foundPrimalUse2) ||
-                      StringRef(foundPrimalUse).endswith(foundPrimalUse2))) {
+                    !(startsWith(foundPrimalUse, foundPrimalUse2) ||
+                      endsWith(foundPrimalUse, foundPrimalUse2))) {
                   if (foundPrimalUse.size() == 0)
                     foundPrimalUse = foundPrimalUse2;
                   else
                     foundPrimalUse += " || " + foundPrimalUse2;
                 }
                 if (foundShadowUse2.size() &&
-                    !(StringRef(foundShadowUse).startswith(foundShadowUse2) ||
-                      StringRef(foundShadowUse).endswith(foundShadowUse2))) {
+                    !(startsWith(foundShadowUse, foundShadowUse2) ||
+                      endsWith(foundShadowUse, foundShadowUse2))) {
                   if (foundShadowUse.size() == 0)
                     foundShadowUse = foundShadowUse2;
                   else
@@ -1669,16 +1685,16 @@ void emitDiffUse(const RecordKeeper &recordKeeper, raw_ostream &os,
                 }
                 if (usesPrimal) {
                   if (foundPrimalUse2.size() &&
-                      !(StringRef(foundPrimalUse).startswith(foundPrimalUse2) ||
-                        StringRef(foundPrimalUse).endswith(foundPrimalUse2))) {
+                      !(startsWith(foundPrimalUse, foundPrimalUse2) ||
+                        endsWith(foundPrimalUse, foundPrimalUse2))) {
                     if (foundPrimalUse.size() == 0)
                       foundPrimalUse = foundPrimalUse2;
                     else
                       foundPrimalUse += " || " + foundPrimalUse2;
                   }
                   if (foundShadowUse2.size() &&
-                      !(StringRef(foundShadowUse).startswith(foundShadowUse2) ||
-                        StringRef(foundShadowUse).endswith(foundShadowUse2))) {
+                      !(startsWith(foundShadowUse, foundShadowUse2) ||
+                        endsWith(foundShadowUse, foundShadowUse2))) {
                     if (foundShadowUse.size() == 0)
                       foundShadowUse = foundShadowUse2;
                     else
@@ -1688,8 +1704,8 @@ void emitDiffUse(const RecordKeeper &recordKeeper, raw_ostream &os,
                 }
                 if (usesShadow) {
                   if (foundPrimalUse2.size() &&
-                      !(StringRef(foundShadowUse).startswith(foundPrimalUse2) ||
-                        StringRef(foundShadowUse).endswith(foundPrimalUse2))) {
+                      !(startsWith(foundShadowUse, foundPrimalUse2) ||
+                        endsWith(foundShadowUse, foundPrimalUse2))) {
                     if (foundShadowUse.size() == 0)
                       foundShadowUse = foundPrimalUse2;
                     else


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/5ac12951b4e9bbfcc5791282d0961ec2b65575e9 deprecated the use of `StringRef::startswith` and `StringRef::endswith` in favor of `starts_with` and `ends_with`. Introduce a helper and update all uses in Enzyme codebase.