### PR TITLE
replace Module by Shared in cmake

### DIFF
--- a/enzyme/BCLoad/CMakeLists.txt
+++ b/enzyme/BCLoad/CMakeLists.txt
@@ -94,7 +94,7 @@ else()
 if ((WIN32 OR CYGWIN) AND LLVM_LINK_LLVM_DYLIB)
     add_llvm_library( BCPass-${LLVM_VERSION_MAJOR}
         BCLoader.cpp ClangBCLoader.cpp
-        MODULE
+        SHARED
         DEPENDS
         intrinsics_gen
 	LINK_COMPONENTS
@@ -104,7 +104,7 @@ if ((WIN32 OR CYGWIN) AND LLVM_LINK_LLVM_DYLIB)
 else()
     add_llvm_library( BCPass-${LLVM_VERSION_MAJOR}
         BCLoader.cpp ClangBCLoader.cpp
-        MODULE
+        SHARED
         DEPENDS
         intrinsics_gen
         PLUGIN_TOOL

--- a/enzyme/Enzyme/CMakeLists.txt
+++ b/enzyme/Enzyme/CMakeLists.txt
@@ -56,7 +56,7 @@ if ((WIN32 OR CYGWIN) AND LLVM_LINK_LLVM_DYLIB)
     add_llvm_library( LLVMEnzyme-${LLVM_VERSION_MAJOR}
         ${ENZYME_SRC}
         PARTIAL_SOURCES_INTENDED
-        MODULE
+        SHARED
         DEPENDS
         intrinsics_gen
 	LINK_COMPONENTS
@@ -67,7 +67,7 @@ if (${Clang_FOUND})
         ${ENZYME_SRC} Clang/EnzymeClang.cpp
         Clang/EnzymePassLoader.cpp
         PARTIAL_SOURCES_INTENDED
-        MODULE
+        SHARED
         DEPENDS
         intrinsics_gen
 	LINK_COMPONENTS
@@ -78,7 +78,7 @@ endif()
         add_llvm_library( LLDEnzyme-${LLVM_VERSION_MAJOR}
         ${ENZYME_SRC} Clang/EnzymePassLoader.cpp
         PARTIAL_SOURCES_INTENDED
-        MODULE
+        SHARED
         DEPENDS
         intrinsics_gen
 	LINK_COMPONENTS
@@ -89,7 +89,7 @@ else()
     add_llvm_library( LLVMEnzyme-${LLVM_VERSION_MAJOR}
         ${ENZYME_SRC}
         PARTIAL_SOURCES_INTENDED
-        MODULE
+        SHARED
         DEPENDS
         intrinsics_gen
         PLUGIN_TOOL
@@ -100,7 +100,7 @@ if (${Clang_FOUND})
         ${ENZYME_SRC} Clang/EnzymeClang.cpp
         Clang/EnzymePassLoader.cpp
         PARTIAL_SOURCES_INTENDED
-        MODULE
+        SHARED
         DEPENDS
         intrinsics_gen
         PLUGIN_TOOL
@@ -111,7 +111,7 @@ endif()
     add_llvm_library( LLDEnzyme-${LLVM_VERSION_MAJOR}
         ${ENZYME_SRC} Clang/EnzymePassLoader.cpp
         PARTIAL_SOURCES_INTENDED
-        MODULE
+        SHARED
         DEPENDS
         intrinsics_gen
         PLUGIN_TOOL


### PR DESCRIPTION
I need these changes lately when trying to build Enzyme against an LLVM version on a linux server.
Previous error was:

```
➜  build git:(cmake-shared) cmake .. -G Ninja -DLLVM_DIR=/h/344/drehwald/prog/rust/build2/build/x86_64-unknown-linux-gnu/llvm -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=YES -DBUILD_SHARED_LIBS=On
LLVM_SHLIBEXT=.so
LLVM ABS DIR /u/drehwald/prog/rust/build2/build/x86_64-unknown-linux-gnu/llvm/lib/cmake/llvm
CMAKE_PREFIX_PATH 
found llvm lit /u/drehwald/prog/rust/src/tools/enzyme/enzyme/build/lit
LLVM dir /u/drehwald/prog/rust/build2/build/x86_64-unknown-linux-gnu/llvm/lib/cmake/llvm
clang dir from llvm /u/drehwald/prog/rust/build2/build/x86_64-unknown-linux-gnu/llvm/lib/cmake/llvm/../clang
clang dir /u/drehwald/prog/rust/build2/build/x86_64-unknown-linux-gnu/llvm/lib/cmake/llvm/../clang
mlir dir 
clang inc dir /u/drehwald/prog/rust/build2/build/x86_64-unknown-linux-gnu/llvm/include
found Clang 1
found MLIR 0
LLVM_INSTALL_PREFIX: /u/drehwald/prog/rust/build2/build/x86_64-unknown-linux-gnu/llvm
LLVM_INCLUDE_DIRS: /u/drehwald/prog/rust/build2/build/x86_64-unknown-linux-gnu/llvm/include
found LLVM definitions -D_GNU_SOURCE -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_LIBCPP_ENABLE_HARDENED_MODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
found LLVM version 17
first llvm include directory/u/drehwald/prog/rust/build2/build/x86_64-unknown-linux-gnu/llvm/include
-- LLVMEnzyme-17 ignored -- Loadable modules not supported on this platform.
-- ClangEnzyme-17 ignored -- Loadable modules not supported on this platform.
CMake Error at Enzyme/CMakeLists.txt:103 (target_compile_definitions):
  target_compile_definitions called with non-compilable target type

-- LLDEnzyme-17 ignored -- Loadable modules not supported on this platform.
CMake Error at Enzyme/CMakeLists.txt:113 (target_compile_definitions):
  target_compile_definitions called with non-compilable target type

CMake Error at Enzyme/CMakeLists.txt:206 (install):
  install TARGETS given target "LLVMEnzyme-17" which is not an executable,
  library, or module.

CMake Error at Enzyme/CMakeLists.txt:213 (install):
  install TARGETS given target "ClangEnzyme-17" which is not an executable,
  library, or module.

CMake Error at Enzyme/CMakeLists.txt:219 (install):
  install TARGETS given target "LLDEnzyme-17" which is not an executable,
  library, or module.

-- BCPass-17 ignored -- Loadable modules not supported on this platform.
CMake Error at BCLoad/CMakeLists.txt:118 (target_include_directories):
  target_include_directories called with non-compilable target type

CMake Warning (dev) at /usr/share/cmake-3.26/Modules/ExternalProject.cmake:3091 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
Call Stack (most recent call first):
  /usr/share/cmake-3.26/Modules/ExternalProject.cmake:4208 (_ep_add_download_command)
  benchmarks/CMakeLists.txt:13 (ExternalProject_Add)
This warning is for project developers.  Use -Wno-dev to suppress it.

found bench flags: -I/u/drehwald/prog/rust/src/tools/enzyme/enzyme/build/benchmarks/adept2/src/adept2/include -I/u/drehwald/prog/rust/src/tools/enzyme/enzyme/build/benchmarks/tapenade/src/tapenade
CMake Error at CMakeLists.txt:290 (export):
  export given custom target "LLVMEnzyme-17" which may not be exported.

CMake Error at CMakeLists.txt:294 (export):
  export given custom target "ClangEnzyme-17" which may not be exported.

CMake Error at CMakeLists.txt:308 (export):
  export given custom target "LLDEnzyme-17" which may not be exported.

-- Configuring incomplete, errors occurred!
```
cc @motabbara who on Mac had a similar issue and first found the Module->Shared change as a solution, although his fix included a few more lines, so I'll let him create a follow-up PR. 

edit: nvm, looking at CI this also isn't the right approach.