### PR TITLE
[mlir] Function summary-based pointer analysis

### DIFF
--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.h
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.h
@@ -185,6 +185,11 @@ public:
                              Value capturedValue, Value destinationAddress,
                              bool isMustStore = false);
 
+  void processCallToSummarizedFunc(
+      CallOpInterface call,
+      const DenseMap<DistinctAttr, AliasClassSet> &summary,
+      PointsToSets *after);
+
 private:
   /// Alias classes originally assigned to known-distinct values, e.g., fresh
   /// allocations, by this analysis. This does NOT necessarily need to be shared
@@ -226,9 +231,13 @@ public:
 class AliasAnalysis
     : public dataflow::SparseForwardDataFlowAnalysis<AliasClassLattice> {
 public:
-  AliasAnalysis(DataFlowSolver &solver, MLIRContext *ctx)
+  AliasAnalysis(DataFlowSolver &solver, MLIRContext *ctx, bool relative = false)
       : SparseForwardDataFlowAnalysis(solver),
-        entryClass(DistinctAttr::create(StringAttr::get(ctx, "entry"))) {}
+        entryClass(DistinctAttr::create(StringAttr::get(ctx, "entry"))),
+        relative(relative) {
+    if (relative)
+      assert(!solver.getConfig().isInterprocedural());
+  }
 
   void setToEntryState(AliasClassLattice *lattice) override;
 
@@ -245,8 +254,20 @@ private:
                 ArrayRef<const AliasClassLattice *> operands,
                 ArrayRef<AliasClassLattice *> results);
 
+  /// Create a pseudo alias class when loading from a function argument that
+  /// points to unknown locations. The pseudo class indicates that it points to
+  /// _something_ and is expected to be unified with a concrete alias class when
+  /// the function summaries are used at this function's call sites.
+  void createImplicitArgDereference(Operation *op, AliasClassLattice *source,
+                                    DistinctAttr srcClass,
+                                    AliasClassLattice *result);
+
   /// A special alias class to denote unannotated pointer arguments.
   const DistinctAttr entryClass;
+
+  /// If true, the analysis will operate in an intraprocedural way assuming it
+  /// is called bottom-up on the function call graph.
+  const bool relative;
 
   /// Alias classes originally assigned to known-distinct values, e.g., fresh
   /// allocations, by this analysis. This does NOT necessarily need to be shared

--- a/enzyme/Enzyme/MLIR/Dialect/Dialect.td
+++ b/enzyme/Enzyme/MLIR/Dialect/Dialect.td
@@ -22,6 +22,12 @@ def Enzyme_Dialect : Dialect {
   let cppNamespace = "::mlir::enzyme";
   let useDefaultAttributePrinterParser = 1;
   let useDefaultTypePrinterParser = 1;
+
+  let extraClassDeclaration = [{
+    /// Names of analysis summary attributes
+    static StringRef getPointerSummaryAttrName() { return "enzyme.p2p"; }
+    static StringRef getAliasSummaryAttrName() { return "enzyme.alias"; }
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/enzyme/Enzyme/MLIR/Dialect/EnzymeOps.td
+++ b/enzyme/Enzyme/MLIR/Dialect/EnzymeOps.td
@@ -27,6 +27,31 @@ include "mlir/Interfaces/LoopLikeInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 
+class Enzyme_Attr<string name, string attrMnemonic, list<Trait> traits = []>
+    : AttrDef<Enzyme_Dialect, name, traits> {
+  let mnemonic = attrMnemonic;
+}
+
+def PseudoAliasClassAttr : Enzyme_Attr<"PseudoAliasClass", "pseudoclass"> {
+  let summary = "A pseudo alias class represents a memory allocation passed into a function.";
+
+  let parameters = (ins
+    "FlatSymbolRefAttr":$function,
+    "unsigned":$argNumber,
+    "unsigned":$depth
+  );
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "FlatSymbolRefAttr":$function,
+                                        "unsigned":$argNumber,
+                                        "unsigned":$depth), [{
+      return $_get(function.getContext(), function, argNumber, depth);
+    }]>
+  ];
+
+  let assemblyFormat = "`<` $function `(` $argNumber `,` $depth `)` `>`";
+}
+
 def Activity : I32EnumAttr<"Activity",
     "Possible activity states for variables",
     [

--- a/enzyme/Enzyme/MLIR/Passes/Passes.td
+++ b/enzyme/Enzyme/MLIR/Passes/Passes.td
@@ -85,6 +85,9 @@ def DifferentiateWrapperPass : Pass<"enzyme-wrap"> {
 def PrintActivityAnalysisPass : Pass<"print-activity-analysis"> {
   let summary = "Print the results of activity analysis";
   let constructor = "mlir::enzyme::createPrintActivityAnalysisPass()";
+  let dependentDialects = [
+    "enzyme::EnzymeDialect"
+  ];
   let options = [
     ListOption<
       /*C++ variable name=*/"funcsToAnalyze",
@@ -112,6 +115,13 @@ def PrintActivityAnalysisPass : Pass<"print-activity-analysis"> {
       /*type=*/"bool",
       /*default=*/"true",
       /*description=*/"Whether to use the new Dataflow activity analysis"
+    >,
+    Option<
+      /*C++ variable name=*/"relative",
+      /*CLI argument=*/"relative",
+      /*type=*/"bool",
+      /*default=*/"false",
+      /*description=*/"Use relative bottom-up activity analysis"
     >,
     Option<
       /*C++ variable name=*/"inactiveArgs",


### PR DESCRIPTION
Add a mode for pointer analysis to operate in "relative" mode, operating on each function intra-procedurally starting with leaf nodes on the function call graph and serializing function summaries that are used when analyzing their call sites.