### PR TITLE
Update MLIR to 2c9b6c1b36b8185299de083c3058e0c1e7760442

### DIFF
--- a/.github/workflows/enzyme-mlir.yml
+++ b/.github/workflows/enzyme-mlir.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         repository: 'llvm/llvm-project'
-        ref: 'bc82cfb38d83f1afeb2c290aa472c2e2e88919cb'
+        ref: '2c9b6c1b36b8185299de083c3058e0c1e7760442'
         path: 'llvm-project'
 
     - name: Get MLIR commit hash

--- a/enzyme/Enzyme/MLIR/Implementations/LinalgAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LinalgAutoDiffOpInterfaceImpl.cpp
@@ -79,9 +79,7 @@ struct GenericOpInterfaceReverse
         cast<linalg::LinalgOp>(gutils->getNewFromOriginal(linalgOp));
 
     // Replace the op by a linalg.generic op if necessary
-    // TODO : IRRewriter rewriter(builder.getContext()/*,
-    // builder.getListener()*/);
-    ConversionPatternRewriter rewriter(builder.getContext());
+    IRRewriter rewriter(builder.getContext(), builder.getListener());
     auto failiureOrLinalgOp = generalizeNamedOp(rewriter, newOp);
     if (!failed(failiureOrLinalgOp)) {
       linalg::GenericOp replacement = failiureOrLinalgOp.value();

--- a/enzyme/Enzyme/MLIR/Passes/AddToOpToIndexAndLoad.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/AddToOpToIndexAndLoad.cpp
@@ -11,18 +11,12 @@
 // procedure to the MemRef dialect.
 //===----------------------------------------------------------------------===//
 
-#include "Dialect/Dialect.h"
 #include "Dialect/Ops.h"
 #include "PassDetails.h"
 #include "Passes/Passes.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Transforms/DialectConversion.h"
 
-#include "mlir/Rewrite/PatternApplicator.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "Interfaces/AutoDiffTypeInterface.h"
@@ -51,9 +45,6 @@ SmallVector<Value> applyAffineMap(AffineMap aMap, SmallVector<Value> indices,
 struct AddToOpToIndexAndLoadPass
     : public enzyme::AddToOpToIndexAndLoadPassBase<AddToOpToIndexAndLoadPass> {
   void runOnOperation() override {
-    MLIRContext *context = &getContext();
-    ConversionPatternRewriter rewriter(context);
-
     getOperation()->walk([&](Operation *op) {
       auto loc = op->getLoc();
       auto enzymeAdjoint = dyn_cast<enzyme::GenericAdjointOp>(op);

--- a/enzyme/Enzyme/MLIR/Passes/AddToOpToSplit.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/AddToOpToSplit.cpp
@@ -105,9 +105,6 @@ void processGenericDuplication(Operation *op, OpBuilder &builder, Location loc,
 struct AddToOpToSplitPass
     : public enzyme::AddToOpToSplitPassBase<AddToOpToSplitPass> {
   void runOnOperation() override {
-    MLIRContext *context = &getContext();
-    ConversionPatternRewriter rewriter(context);
-
     getOperation()->walk([&](Operation *op) {
       auto enzymeAdjoint = dyn_cast<enzyme::GenericAdjointOp>(op);
       auto loc = op->getLoc();

--- a/enzyme/Enzyme/MLIR/Passes/EnzymeMLIRPass.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/EnzymeMLIRPass.cpp
@@ -11,16 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "Dialect/Ops.h"
-#include "Interfaces/GradientUtils.h"
 #include "Interfaces/GradientUtilsReverse.h"
 #include "PassDetails.h"
 #include "Passes/Passes.h"
-#include "mlir/IR/Builders.h"
-#include "mlir/IR/IRMapping.h"
-#include "mlir/Interfaces/ControlFlowInterfaces.h"
-#include "mlir/Interfaces/FunctionInterfaces.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 
 #define DEBUG_TYPE "enzyme"
 
@@ -221,13 +218,9 @@ std::unique_ptr<Pass> createDifferentiatePass() {
 } // namespace enzyme
 } // namespace mlir
 
-#include "mlir/IR/PatternMatch.h"
-#include "mlir/Transforms/DialectConversion.h"
-
 void DifferentiatePass::runOnOperation() {
   SymbolTableCollection symbolTable;
   symbolTable.getSymbolTable(getOperation());
-  ConversionPatternRewriter B(getOperation()->getContext());
   getOperation()->walk(
       [&](FunctionOpInterface op) { lowerEnzymeCalls(symbolTable, op); });
 }

--- a/enzyme/Enzyme/MLIR/Passes/ShadowedGradientToCache.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/ShadowedGradientToCache.cpp
@@ -11,18 +11,11 @@
 // procedure to the MemRef dialect.
 //===----------------------------------------------------------------------===//
 
-#include "Dialect/Dialect.h"
 #include "Dialect/Ops.h"
 #include "PassDetails.h"
 #include "Passes/Passes.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Transforms/DialectConversion.h"
-
-#include "mlir/Rewrite/PatternApplicator.h"
 
 #include "llvm/Support/raw_ostream.h"
 
@@ -34,9 +27,6 @@ struct ShadowedGradientToCachePass
     : public enzyme::ShadowedGradientToCachePassBase<
           ShadowedGradientToCachePass> {
   void runOnOperation() override {
-    MLIRContext *context = &getContext();
-    ConversionPatternRewriter rewriter(context);
-
     getOperation()->walk([&](Operation *op) {
       if (auto initOp = dyn_cast<enzyme::InitOp>(op)) {
         if (auto type =


### PR DESCRIPTION
Remove most uses of `ConversionPatternRewriter` that were spurious anyway. Update one use to use `IRRewriter` instead since the conversion rewriter should no longer be used directly. Clean up includes accordingly.