### PR TITLE
Fix clang-tidy findings

### DIFF
--- a/enzyme/Enzyme/MLIR/Passes/AddToOpToIndexAndLoad.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/AddToOpToIndexAndLoad.cpp
@@ -85,7 +85,7 @@ struct AddToOpToIndexAndLoadPass
         // auto load = cacheBuilder.create<AffineLoadOp>(loc, inputs[i], map[i],
         // indices); auto store = cacheBuilder.create<AffineStoreOp>(loc, load,
         // inputs[i], map[i], indices);
-        ValueRange mapAppliedIndices =
+        SmallVector<Value> mapAppliedIndices =
             applyAffineMap(map[num_ins + i], indices, cacheBuilder, loc);
         auto load = cacheBuilder.create<memref::LoadOp>(loc, outs[i],
                                                         mapAppliedIndices);
@@ -96,7 +96,7 @@ struct AddToOpToIndexAndLoadPass
       }
 
       for (int i = 0; i < retargs.size(); i++) {
-        ValueRange mapAppliedIndices =
+        SmallVector<Value> mapAppliedIndices =
             applyAffineMap(map[num_ins + i], indices, cacheBuilder, loc);
         auto load = cacheBuilder.create<memref::LoadOp>(loc, outs[i],
                                                         mapAppliedIndices);

--- a/enzyme/Enzyme/MLIR/Passes/Passes.h
+++ b/enzyme/Enzyme/MLIR/Passes/Passes.h
@@ -65,12 +65,15 @@ class MemRefDialect;
 
 namespace func {
 class FuncDialect;
-}
+} // end namespace func
 
+namespace affine {
 class AffineDialect;
+} // end namespace affine
+
 namespace LLVM {
 class LLVMDialect;
-}
+} // end namespace LLVM
 
 #define GEN_PASS_REGISTRATION
 #include "Passes/Passes.h.inc"


### PR DESCRIPTION
Includes a real memory problem: ValueRange is a non-owning container, assining the returned value of type SmallVector<Value> to ValueRange will lead to ValueRange starting with a dangling pointer.