### PR TITLE
[mlir] Define generic set/map lattices for dataflow analyses

### DIFF
--- a/enzyme/Enzyme/MLIR/Analysis/CMakeLists.txt
+++ b/enzyme/Enzyme/MLIR/Analysis/CMakeLists.txt
@@ -2,6 +2,7 @@ add_mlir_library(MLIREnzymeAnalysis
   ActivityAnalysis.cpp
   DataFlowAliasAnalysis.cpp
   DataFlowActivityAnalysis.cpp
+  DataFlowLattice.cpp
 
   DEPENDS
   MLIRAutoDiffTypeInterfaceIncGen

--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowActivityAnalysis.cpp
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowActivityAnalysis.cpp
@@ -490,7 +490,7 @@ std::optional<Value> getCopySource(Operation *op) {
 /// If the classes are undefined, the callback will not be called at all.
 void forEachAliasedAlloc(const AliasClassLattice *ptrAliasClass,
                          function_ref<void(DistinctAttr)> forEachFn) {
-  (void)ptrAliasClass->getAliasClassesObject().foreachClass(
+  (void)ptrAliasClass->getAliasClassesObject().foreachElement(
       [&](DistinctAttr alloc, enzyme::AliasClassSet::State state) {
         if (state != enzyme::AliasClassSet::State::Undefined)
           forEachFn(alloc);
@@ -636,7 +636,7 @@ public:
           continue;
         auto *argAliasClasses = getOrCreateFor<AliasClassLattice>(block, arg);
         ChangeResult changed =
-            argAliasClasses->getAliasClassesObject().foreachClass(
+            argAliasClasses->getAliasClassesObject().foreachElement(
                 [lattice](DistinctAttr argAliasClass,
                           enzyme::AliasClassSet::State state) {
                   if (state == enzyme::AliasClassSet::State::Undefined)
@@ -687,7 +687,7 @@ public:
         }
         auto *argAliasClasses = getOrCreateFor<AliasClassLattice>(op, arg);
         ChangeResult changed =
-            argAliasClasses->getAliasClassesObject().foreachClass(
+            argAliasClasses->getAliasClassesObject().foreachElement(
                 [before](DistinctAttr argAliasClass,
                          enzyme::AliasClassSet::State state) {
                   if (state == enzyme::AliasClassSet::State::Undefined)
@@ -703,7 +703,7 @@ public:
           auto *retAliasClasses =
               getOrCreateFor<AliasClassLattice>(op, operand);
           ChangeResult changed =
-              retAliasClasses->getAliasClassesObject().foreachClass(
+              retAliasClasses->getAliasClassesObject().foreachElement(
                   [before](DistinctAttr retAliasClass,
                            enzyme::AliasClassSet::State state) {
                     if (state == enzyme::AliasClassSet::State::Undefined)
@@ -854,7 +854,7 @@ void printActivityAnalysisResults(const DataFlowSolver &solver,
       std::deque<DistinctAttr> frontier;
       DenseSet<DistinctAttr> visited;
       auto scheduleVisit = [&](const enzyme::AliasClassSet &aliasClasses) {
-        (void)aliasClasses.foreachClass(
+        (void)aliasClasses.foreachElement(
             [&](DistinctAttr neighbor, enzyme::AliasClassSet::State state) {
               assert(neighbor &&
                      "unhandled undefined/unknown case before visit");

--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.cpp
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.cpp
@@ -49,67 +49,6 @@ static bool isPointerLike(Type type) {
   return isa<MemRefType, LLVM::LLVMPointerType>(type);
 }
 
-const enzyme::AliasClassSet enzyme::AliasClassSet::undefinedSet =
-    AliasClassSet(enzyme::AliasClassSet::State::Undefined);
-const enzyme::AliasClassSet enzyme::AliasClassSet::unknownSet =
-    AliasClassSet(enzyme::AliasClassSet::State::Unknown);
-
-ChangeResult enzyme::AliasClassSet::join(const AliasClassSet &other) {
-  if (isUnknown())
-    return ChangeResult::NoChange;
-  if (isUndefined() && other.isUndefined())
-    return ChangeResult::NoChange;
-  if (other.isUnknown()) {
-    state = State::Unknown;
-    return ChangeResult::Change;
-  }
-
-  ChangeResult result = updateStateToDefined();
-  return insert(other.aliasClasses) | result;
-}
-
-ChangeResult
-enzyme::AliasClassSet::insert(const DenseSet<DistinctAttr> &classes) {
-  if (isUnknown())
-    return ChangeResult::NoChange;
-
-  size_t oldSize = aliasClasses.size();
-  aliasClasses.insert(classes.begin(), classes.end());
-  ChangeResult result = aliasClasses.size() == oldSize ? ChangeResult::NoChange
-                                                       : ChangeResult::Change;
-  return updateStateToDefined() | result;
-}
-
-ChangeResult enzyme::AliasClassSet::markUnknown() {
-  if (isUnknown())
-    return ChangeResult::NoChange;
-
-  state = State::Unknown;
-  aliasClasses.clear();
-  return ChangeResult::Change;
-}
-
-bool enzyme::AliasClassSet::isCanonical() const {
-  return state == State::Defined || aliasClasses.empty();
-}
-
-bool enzyme::AliasClassSet::operator==(
-    const enzyme::AliasClassSet &other) const {
-  assert(isCanonical() && other.isCanonical());
-  return state == other.state && llvm::equal(aliasClasses, other.aliasClasses);
-}
-
-ChangeResult enzyme::AliasClassSet::foreachClass(
-    function_ref<ChangeResult(DistinctAttr, State)> callback) const {
-  if (state != State::Defined)
-    return callback(nullptr, state);
-
-  ChangeResult result = ChangeResult::NoChange;
-  for (DistinctAttr attr : aliasClasses)
-    result |= callback(attr, state);
-  return result;
-}
-
 //===----------------------------------------------------------------------===//
 // PointsToAnalysis
 //===----------------------------------------------------------------------===//
@@ -122,70 +61,21 @@ static ChangeResult mergeSets(DenseSet<T> &dest, const DenseSet<T> &src) {
 }
 
 void enzyme::PointsToSets::print(raw_ostream &os) const {
-  if (pointsTo.empty()) {
+  if (map.empty()) {
     os << "<empty>\n";
     return;
   }
-  for (const auto &[srcClass, destClasses] : pointsTo) {
+  for (const auto &[srcClass, destClasses] : map) {
     os << "  " << srcClass << " points to {";
     if (destClasses.isUnknown()) {
       os << "<unknown>";
     } else if (destClasses.isUndefined()) {
       os << "<undefined>";
     } else {
-      llvm::interleaveComma(destClasses.getAliasClasses(), os);
+      llvm::interleaveComma(destClasses.getElements(), os);
     }
     os << "}\n";
   }
-  // os << "other points to unknown: " << otherPointToUnknown << "\n";
-}
-
-/// Union for every variable.
-ChangeResult enzyme::PointsToSets::join(const AbstractDenseLattice &lattice) {
-  const auto &rhs = static_cast<const PointsToSets &>(lattice);
-  llvm::SmallDenseSet<DistinctAttr> keys;
-  auto lhsRange = llvm::make_first_range(pointsTo);
-  auto rhsRange = llvm::make_first_range(rhs.pointsTo);
-  keys.insert(lhsRange.begin(), lhsRange.end());
-  keys.insert(rhsRange.begin(), rhsRange.end());
-
-  ChangeResult result = ChangeResult::NoChange;
-  for (DistinctAttr key : keys) {
-    auto lhsIt = pointsTo.find(key);
-    auto rhsIt = rhs.pointsTo.find(key);
-    assert(lhsIt != pointsTo.end() || rhsIt != rhs.pointsTo.end());
-
-    // If present in both, join.
-    if (lhsIt != pointsTo.end() && rhsIt != rhs.pointsTo.end()) {
-      result |= lhsIt->getSecond().join(rhsIt->getSecond());
-      continue;
-    }
-
-    // Copy from RHS if available only there.
-    if (lhsIt == pointsTo.end()) {
-      pointsTo.try_emplace(rhsIt->getFirst(), rhsIt->getSecond());
-      result = ChangeResult::Change;
-    }
-
-    // Do nothing if available only in LHS.
-  }
-  return result;
-}
-
-ChangeResult
-enzyme::PointsToSets::joinPotentiallyMissing(DistinctAttr key,
-                                             const AliasClassSet &value) {
-  // Don't store explicitly undefined values in the mapping, keys absent from
-  // the mapping are treated as implicitly undefined.
-  if (value.isUndefined())
-    return ChangeResult::NoChange;
-
-  bool inserted;
-  decltype(pointsTo.begin()) iterator;
-  std::tie(iterator, inserted) = pointsTo.try_emplace(key, value);
-  if (!inserted)
-    return iterator->second.join(value);
-  return ChangeResult::Change;
 }
 
 ChangeResult enzyme::PointsToSets::update(const AliasClassSet &keysToUpdate,
@@ -198,14 +88,14 @@ ChangeResult enzyme::PointsToSets::update(const AliasClassSet &keysToUpdate,
   if (keysToUpdate.isUndefined())
     return ChangeResult::NoChange;
 
-  return keysToUpdate.foreachClass(
+  return keysToUpdate.foreachElement(
       [&](DistinctAttr dest, AliasClassSet::State state) {
         assert(state == AliasClassSet::State::Defined &&
                "unknown must have been handled above");
 #ifndef NDEBUG
         if (replace) {
-          auto it = pointsTo.find(dest);
-          if (it != pointsTo.end()) {
+          auto it = map.find(dest);
+          if (it != map.end()) {
             // Check that we are updating to a state that's >= in the
             // lattice.
             // TODO: consider a stricter check that we only replace unknown
@@ -242,17 +132,17 @@ enzyme::PointsToSets::addSetsFrom(const AliasClassSet &destClasses,
   if (destClasses.isUndefined())
     return ChangeResult::NoChange;
 
-  return destClasses.foreachClass(
+  return destClasses.foreachElement(
       [&](DistinctAttr dest, AliasClassSet::State destState) {
         assert(destState == AliasClassSet::State::Defined);
-        return srcClasses.foreachClass(
+        return srcClasses.foreachElement(
             [&](DistinctAttr src, AliasClassSet::State srcState) {
               const AliasClassSet *srcClasses = &AliasClassSet::getUndefined();
               if (srcState == AliasClassSet::State::Unknown)
                 srcClasses = &AliasClassSet::getUnknown();
               else if (srcState == AliasClassSet::State::Defined) {
-                auto it = pointsTo.find(src);
-                if (it != pointsTo.end())
+                auto it = map.find(src);
+                if (it != map.end())
                   srcClasses = &it->getSecond();
               }
               return joinPotentiallyMissing(dest, *srcClasses);
@@ -267,16 +157,10 @@ enzyme::PointsToSets::markPointToUnknown(const AliasClassSet &destClasses) {
   if (destClasses.isUndefined())
     return ChangeResult::NoChange;
 
-  return destClasses.foreachClass([&](DistinctAttr dest, AliasClassSet::State) {
-    return joinPotentiallyMissing(dest, AliasClassSet::getUnknown());
-  });
-}
-
-ChangeResult enzyme::PointsToSets::markAllPointToUnknown() {
-  ChangeResult result = ChangeResult::NoChange;
-  for (auto &it : pointsTo)
-    result |= it.getSecond().join(AliasClassSet::getUnknown());
-  return result;
+  return destClasses.foreachElement(
+      [&](DistinctAttr dest, AliasClassSet::State) {
+        return joinPotentiallyMissing(dest, AliasClassSet::getUnknown());
+      });
 }
 
 ChangeResult enzyme::PointsToSets::markAllExceptPointToUnknown(
@@ -285,18 +169,17 @@ ChangeResult enzyme::PointsToSets::markAllExceptPointToUnknown(
     return ChangeResult::NoChange;
 
   ChangeResult result = ChangeResult::NoChange;
-  for (auto &[key, value] : pointsTo) {
-    if (destClasses.isUnknown() ||
-        !destClasses.getAliasClasses().contains(key)) {
+  for (auto &[key, value] : map) {
+    if (destClasses.isUnknown() || !destClasses.getElements().contains(key)) {
       result |= value.markUnknown();
     }
   }
 
 #ifndef NDEBUG
-  (void)destClasses.foreachClass(
+  (void)destClasses.foreachElement(
       [&](DistinctAttr dest, AliasClassSet::State state) {
         if (state == AliasClassSet::State::Defined)
-          assert(pointsTo.contains(dest) && "unknown dest cannot be preserved");
+          assert(map.contains(dest) && "unknown dest cannot be preserved");
         return ChangeResult::NoChange;
       });
 #endif // NDEBUG
@@ -632,7 +515,7 @@ void enzyme::PointsToPointerAnalysis::visitCallControlFlowTransfer(
         // Otherwise, indicate that a pointer that belongs to any of the
         // classes captured by this function may be stored into the
         // destination class.
-        changed |= destClasses->getAliasClassesObject().foreachClass(
+        changed |= destClasses->getAliasClassesObject().foreachElement(
             [&](DistinctAttr dest, AliasClassSet::State) {
               return after->insert(dest, functionMayCapture);
             });
@@ -694,7 +577,7 @@ void enzyme::PointsToPointerAnalysis::visitCallControlFlowTransfer(
                    !nonWritableOperandClasses.isUndefined()) {
           DenseSet<DistinctAttr> nonOperandClasses =
               llvm::set_difference(destClasses->getAliasClasses(),
-                                   nonWritableOperandClasses.getAliasClasses());
+                                   nonWritableOperandClasses.getElements());
           (void)resultWithoutNonWritableOperands.insert(nonOperandClasses);
         } else {
           (void)resultWithoutNonWritableOperands.join(
@@ -741,25 +624,14 @@ void enzyme::PointsToPointerAnalysis::setToEntryState(PointsToSets *lattice) {}
 // AliasClassLattice
 //===----------------------------------------------------------------------===//
 
-void enzyme::AliasClassSet::print(raw_ostream &os) const {
-  if (isUnknown()) {
-    os << "<unknown>";
-  } else if (isUndefined()) {
-    os << "<undefined>";
-  } else {
-    llvm::interleaveComma(aliasClasses, os << "{");
-    os << "}";
-  }
-}
-
 void enzyme::AliasClassLattice::print(raw_ostream &os) const {
-  if (aliasClasses.isUnknown()) {
+  if (elements.isUnknown()) {
     os << "Unknown AC";
-  } else if (aliasClasses.isUndefined()) {
+  } else if (elements.isUndefined()) {
     os << "Undefined AC";
   } else {
-    os << "size: " << aliasClasses.getAliasClasses().size() << ":\n";
-    for (auto aliasClass : aliasClasses.getAliasClasses()) {
+    os << "size: " << elements.getElements().size() << ":\n";
+    for (auto aliasClass : elements.getElements()) {
       os << "  " << aliasClass << "\n";
     }
   }
@@ -774,12 +646,12 @@ enzyme::AliasClassLattice::alias(const AbstractSparseLattice &other) const {
   if (getPoint() == rhs->getPoint())
     return AliasResult::MustAlias;
 
-  if (aliasClasses.isUnknown() || rhs->aliasClasses.isUnknown())
+  if (elements.isUnknown() || rhs->elements.isUnknown())
     return AliasResult::MayAlias;
 
-  size_t overlap = llvm::count_if(
-      aliasClasses.getAliasClasses(), [rhs](DistinctAttr aliasClass) {
-        return rhs->aliasClasses.getAliasClasses().contains(aliasClass);
+  size_t overlap =
+      llvm::count_if(elements.getElements(), [rhs](DistinctAttr aliasClass) {
+        return rhs->elements.getElements().contains(aliasClass);
       });
 
   if (overlap == 0)
@@ -800,7 +672,7 @@ ChangeResult
 enzyme::AliasClassLattice::join(const AbstractSparseLattice &other) {
   // Set union of the alias classes
   const auto *otherAliasClass = static_cast<const AliasClassLattice *>(&other);
-  return aliasClasses.join(otherAliasClass->aliasClasses);
+  return elements.join(otherAliasClass->elements);
 }
 
 //===----------------------------------------------------------------------===//
@@ -896,7 +768,7 @@ void enzyme::AliasAnalysis::transfer(
               continue;
             } else {
               propagateIfChanged(result,
-                                 result->insert(srcPointsTo.getAliasClasses()));
+                                 result->insert(srcPointsTo.getElements()));
             }
           }
         }
@@ -1041,7 +913,7 @@ void enzyme::AliasAnalysis::visitExternalCall(
     // If can read from argument, collect the alias classes that can this
     // argument may be pointing to.
     const auto *pointsToLattice = getOrCreateFor<PointsToSets>(call, call);
-    (void)srcClasses->getAliasClassesObject().foreachClass(
+    (void)srcClasses->getAliasClassesObject().foreachElement(
         [&](DistinctAttr srcClass, AliasClassSet::State state) {
           // Nothing to do in top/bottom case. In the top case, we have already
           // set `operandAliasClasses` to top above.

--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.h
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.h
@@ -26,6 +26,8 @@
 #ifndef ENZYME_MLIR_ANALYSIS_DATAFLOW_ALIASANALYSIS_H
 #define ENZYME_MLIR_ANALYSIS_DATAFLOW_ALIASANALYSIS_H
 
+#include "DataFlowLattice.h"
+
 #include "mlir/Analysis/AliasAnalysis.h"
 #include "mlir/Analysis/DataFlow/DenseAnalysis.h"
 #include "mlir/Analysis/DataFlow/SparseAnalysis.h"
@@ -42,85 +44,7 @@ namespace enzyme {
 /// marked as "unknown", which is a conservative pessimistic state, or as
 /// "undefined", which is a "not-yet-analyzed" initial state. Undefined state is
 /// different from an empty alias set.
-class AliasClassSet {
-public:
-  enum class State {
-    Undefined, ///< Has not been analyzed yet (lattice bottom).
-    Defined,   ///< Has specific alias classes.
-    Unknown    ///< Analyzed and may point to any class (lattice top).
-  };
-
-  AliasClassSet() : state(State::Undefined) {}
-
-  AliasClassSet(DistinctAttr single) : state(State::Defined) {
-    aliasClasses.insert(single);
-  }
-
-  // TODO(zinenko): deprecate this and use a visitor instead.
-  DenseSet<DistinctAttr> &getAliasClasses() {
-    assert(state == State::Defined);
-    return aliasClasses;
-  }
-  const DenseSet<DistinctAttr> &getAliasClasses() const {
-    return const_cast<AliasClassSet *>(this)->getAliasClasses();
-  }
-
-  bool isUnknown() const { return state == State::Unknown; }
-  bool isUndefined() const { return state == State::Undefined; }
-
-  ChangeResult join(const AliasClassSet &other);
-  ChangeResult insert(const DenseSet<DistinctAttr> &classes);
-  ChangeResult markUnknown();
-
-  /// Returns true if this set is in the canonical form, i.e. either the state
-  /// is `State::Defined` or the explicit list of classes is empty, but not
-  /// both.
-  bool isCanonical() const;
-
-  /// Returns an instance of AliasClassSet known not to alias with anything.
-  /// This is different from "undefined" and "unknown". The instance is *not* a
-  /// classical singleton.
-  static const AliasClassSet &getEmpty() {
-    static const AliasClassSet empty(State::Defined);
-    return empty;
-  }
-
-  /// Returns an instance of AliasClassSet in "undefined" state, i.e. without a
-  /// set of alias classes. This is different from empty alias set, which
-  /// indicates that the value is known not to alias with any alias class. The
-  /// instance is *not* a classical singleton, there are other ways of obtaining
-  /// it.
-  static const AliasClassSet &getUndefined() { return undefinedSet; }
-
-  /// Returns an instance of AliasClassSet for the "unknown" class. The instance
-  /// is *not* a classical singleton, there are other ways of obtaining an
-  /// "unknown" alias set.
-  static const AliasClassSet &getUnknown() { return unknownSet; }
-
-  bool operator==(const AliasClassSet &other) const;
-
-  void print(llvm::raw_ostream &os) const;
-
-  ChangeResult
-  foreachClass(function_ref<ChangeResult(DistinctAttr, State)> callback) const;
-
-private:
-  explicit AliasClassSet(State state) : state(state) {}
-
-  ChangeResult updateStateToDefined() {
-    assert(state != State::Unknown && "cannot go back from unknown state");
-    ChangeResult result = state == State::Undefined ? ChangeResult::Change
-                                                    : ChangeResult::NoChange;
-    state = State::Defined;
-    return result;
-  }
-
-  const static AliasClassSet unknownSet;
-  const static AliasClassSet undefinedSet;
-
-  DenseSet<DistinctAttr> aliasClasses;
-  State state;
-};
+using AliasClassSet = SetLattice<DistinctAttr>;
 
 //===----------------------------------------------------------------------===//
 // OriginalClasses
@@ -179,13 +103,11 @@ private:
 // pointers stored/loaded through memory.
 //===----------------------------------------------------------------------===//
 
-class PointsToSets : public dataflow::AbstractDenseLattice {
+class PointsToSets : public MapOfSetsLattice<DistinctAttr, DistinctAttr> {
 public:
-  using AbstractDenseLattice::AbstractDenseLattice;
+  using MapOfSetsLattice::MapOfSetsLattice;
 
   void print(raw_ostream &os) const override;
-
-  ChangeResult join(const AbstractDenseLattice &lattice) override;
 
   /// Mark the pointer stored in `dest` as possibly pointing to any of `values`,
   /// instead of the values it may be currently pointing to.
@@ -214,18 +136,13 @@ public:
 
   /// Mark the entire data structure as "unknown", that is, any pointer may be
   /// containing any other pointer. This is the full pessimistic fixpoint.
-  ChangeResult markAllPointToUnknown();
+  ChangeResult markAllPointToUnknown() { return markAllUnknown(); }
 
   /// Mark all alias classes except the given ones to point to the "unknown"
   /// alias set.
   ChangeResult markAllExceptPointToUnknown(const AliasClassSet &destClasses);
 
-  const AliasClassSet &getPointsTo(DistinctAttr id) const {
-    auto it = pointsTo.find(id);
-    if (it == pointsTo.end())
-      return AliasClassSet::getUndefined();
-    return it->getSecond();
-  }
+  const AliasClassSet &getPointsTo(DistinctAttr id) const { return lookup(id); }
 
 private:
   /// Update all alias classes in `keysToUpdate` to additionally point to alias
@@ -242,24 +159,6 @@ private:
   /// in the lattice, not only the replacements described above.
   ChangeResult update(const AliasClassSet &keysToUpdate,
                       const AliasClassSet &values, bool replace);
-
-  ChangeResult joinPotentiallyMissing(DistinctAttr key,
-                                      const AliasClassSet &value);
-
-  /// Indicates that alias classes not listed as keys in `pointsTo` point to
-  /// unknown alias set (when true) or an empty alias set (when false).
-  // TODO: consider also differentiating between pointing to known-empty vs.
-  // not-yet-computed.
-  // bool otherPointToUnknown = false;
-
-  // missing from map always beings "undefined", "unknown"s are stored
-  // explicitly.
-
-  /// Maps an identifier of an alias set to the set of alias sets its value may
-  /// belong to. When an identifier is not present in this map, it is considered
-  /// to point to either the unknown set or nothing, based on the value of
-  /// `otherPointToUnknown`.
-  DenseMap<DistinctAttr, AliasClassSet> pointsTo;
 };
 
 //===----------------------------------------------------------------------===//
@@ -298,12 +197,9 @@ private:
 // AliasClassLattice
 //===----------------------------------------------------------------------===//
 
-class AliasClassLattice : public dataflow::AbstractSparseLattice {
+class AliasClassLattice : public SparseSetLattice<DistinctAttr> {
 public:
-  using AbstractSparseLattice::AbstractSparseLattice;
-  AliasClassLattice(Value value, AliasClassSet &&classes)
-      : dataflow::AbstractSparseLattice(value),
-        aliasClasses(std::move(classes)) {}
+  using SparseSetLattice::SparseSetLattice;
 
   void print(raw_ostream &os) const override;
 
@@ -311,31 +207,15 @@ public:
 
   ChangeResult join(const AbstractSparseLattice &other) override;
 
-  ChangeResult insert(const DenseSet<DistinctAttr> &classes) {
-    return aliasClasses.insert(classes);
-  }
-
   static AliasClassLattice single(Value point, DistinctAttr value) {
     return AliasClassLattice(point, AliasClassSet(value));
   }
 
-  ChangeResult markUnknown() { return aliasClasses.markUnknown(); }
-
-  // ChangeResult reset() { return aliasClasses.reset(); }
-
-  /// We don't know anything about the aliasing of this value.
-  bool isUnknown() const { return aliasClasses.isUnknown(); }
-
-  bool isUndefined() const { return aliasClasses.isUndefined(); }
-
   const DenseSet<DistinctAttr> &getAliasClasses() const {
-    return aliasClasses.getAliasClasses();
+    return elements.getElements();
   }
 
-  const AliasClassSet &getAliasClassesObject() const { return aliasClasses; }
-
-private:
-  AliasClassSet aliasClasses;
+  const AliasClassSet &getAliasClassesObject() const { return elements; }
 };
 
 //===----------------------------------------------------------------------===//

--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowLattice.cpp
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowLattice.cpp
@@ -1,0 +1,46 @@
+//===- DataFlowLattice.h - Implementation of common dataflow lattices -----===//
+//
+//                             Enzyme Project
+//
+// Part of the Enzyme Project, under the Apache License v2.0 with LLVM
+// Exceptions. See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// If using this code in an academic setting, please cite the following:
+// @inproceedings{NEURIPS2020_9332c513,
+// author = {Moses, William and Churavy, Valentin},
+// booktitle = {Advances in Neural Information Processing Systems},
+// editor = {H. Larochelle and M. Ranzato and R. Hadsell and M. F. Balcan and H.
+// Lin}, pages = {12472--12485}, publisher = {Curran Associates, Inc.}, title =
+// {Instead of Rewriting Foreign Code for Machine Learning, Automatically
+// Synthesize Fast Gradients}, url =
+// {https://proceedings.neurips.cc/paper/2020/file/9332c513ef44b682e9347822c2e457ac-Paper.pdf},
+// volume = {33},
+// year = {2020}
+// }
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains the implementation of reusable lattices in dataflow
+// analyses.
+//
+//===----------------------------------------------------------------------===//
+
+#include <Analysis/DataFlowLattice.h>
+
+#include <algorithm>
+
+using namespace mlir;
+
+bool enzyme::sortAttributes(Attribute a, Attribute b) {
+  std::string strA, strB;
+  llvm::raw_string_ostream sstreamA(strA), sstreamB(strB);
+  sstreamA << a;
+  sstreamB << b;
+  return strA < strB;
+}
+
+bool enzyme::sortArraysLexicographic(ArrayAttr a, ArrayAttr b) {
+  return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(),
+                                      sortAttributes);
+}

--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowLattice.h
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowLattice.h
@@ -1,0 +1,366 @@
+//===- DataFlowLattice.h - Declaration of common dataflow lattices --------===//
+//
+//                             Enzyme Project
+//
+// Part of the Enzyme Project, under the Apache License v2.0 with LLVM
+// Exceptions. See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// If using this code in an academic setting, please cite the following:
+// @inproceedings{NEURIPS2020_9332c513,
+// author = {Moses, William and Churavy, Valentin},
+// booktitle = {Advances in Neural Information Processing Systems},
+// editor = {H. Larochelle and M. Ranzato and R. Hadsell and M. F. Balcan and H.
+// Lin}, pages = {12472--12485}, publisher = {Curran Associates, Inc.}, title =
+// {Instead of Rewriting Foreign Code for Machine Learning, Automatically
+// Synthesize Fast Gradients}, url =
+// {https://proceedings.neurips.cc/paper/2020/file/9332c513ef44b682e9347822c2e457ac-Paper.pdf},
+// volume = {33},
+// year = {2020}
+// }
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains the declaration of reusable lattices in dataflow analyses.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ENZYME_MLIR_ANALYSIS_DATAFLOW_LATTICE_H
+#define ENZYME_MLIR_ANALYSIS_DATAFLOW_LATTICE_H
+
+#include "mlir/Analysis/DataFlow/DenseAnalysis.h"
+#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
+#include "mlir/Analysis/DataFlowFramework.h"
+
+namespace mlir {
+namespace enzyme {
+
+constexpr llvm::StringLiteral undefinedSetString = "<undefined>";
+constexpr llvm::StringLiteral unknownSetString = "<unknown>";
+
+//===----------------------------------------------------------------------===//
+// SetLattice
+//
+// A data structure representing a set of elements. It may be undefined, meaning
+// the analysis has no information about it, or unknown, meaning the analysis
+// has conservatively assumed it could contain anything.
+//===----------------------------------------------------------------------===//
+
+template <typename ValueT> class SetLattice {
+public:
+  enum class State {
+    Undefined, ///< Has not been analyzed yet (lattice bottom).
+    Defined,   ///< Has specific elements.
+    Unknown    ///< Analyzed and may contain anything (lattice top).
+  };
+
+  SetLattice() : state(State::Undefined) {}
+
+  SetLattice(ValueT single) : state(State::Defined) { elements.insert(single); }
+
+  // TODO(zinenko): deprecate this and use a visitor instead.
+  DenseSet<ValueT> &getElements() {
+    assert(state == State::Defined);
+    return elements;
+  }
+
+  const DenseSet<ValueT> &getElements() const {
+    return const_cast<SetLattice<ValueT> *>(this)->getElements();
+  }
+
+  bool isUnknown() const { return state == State::Unknown; }
+  bool isUndefined() const { return state == State::Undefined; }
+
+  ChangeResult join(const SetLattice<ValueT> &other) {
+    if (isUnknown())
+      return ChangeResult::NoChange;
+    if (isUndefined() && other.isUndefined())
+      return ChangeResult::NoChange;
+    if (other.isUnknown()) {
+      state = State::Unknown;
+      return ChangeResult::Change;
+    }
+
+    ChangeResult result = updateStateToDefined();
+    return insert(other.elements) | result;
+  }
+
+  ChangeResult insert(const DenseSet<ValueT> &newElements) {
+    if (isUnknown())
+      return ChangeResult::NoChange;
+
+    size_t oldSize = elements.size();
+    elements.insert(newElements.begin(), newElements.end());
+    ChangeResult result = elements.size() == oldSize ? ChangeResult::NoChange
+                                                     : ChangeResult::Change;
+    return updateStateToDefined() | result;
+  }
+
+  ChangeResult markUnknown() {
+    if (isUnknown())
+      return ChangeResult::NoChange;
+
+    state = State::Unknown;
+    elements.clear();
+    return ChangeResult::Change;
+  }
+
+  /// Returns true if this set is in the canonical form, i.e. either the state
+  /// is `State::Defined` or the explicit list of classes is empty, but not
+  /// both.
+  bool isCanonical() const {
+    return state == State::Defined || elements.empty();
+  }
+
+  /// Returns an instance of SetLattice known not to have any elements.
+  /// This is different from "undefined" and "unknown". The instance is *not* a
+  /// classical singleton.
+  static const SetLattice<ValueT> &getEmpty() {
+    static const SetLattice<ValueT> empty(State::Defined);
+    return empty;
+  }
+
+  /// Returns an instance of SetLattice in "undefined" state, i.e. without a set
+  /// of elements. This is different from empty set, which indicates that the
+  /// set is known not to contain any elements. The instance is *not* a
+  /// classical singleton, there are other ways of obtaining it.
+  static const SetLattice<ValueT> &getUndefined() { return undefinedSet; }
+
+  /// Returns an instance of SetLattice for the "unknown" class. The instance
+  /// is *not* a classical singleton, there are other ways of obtaining an
+  /// "unknown" alias set.
+  static const SetLattice<ValueT> &getUnknown() { return unknownSet; }
+
+  bool operator==(const SetLattice<ValueT> &other) const {
+    assert(isCanonical() && other.isCanonical());
+    return state == other.state && llvm::equal(elements, other.elements);
+  }
+
+  LLVM_DUMP_METHOD void print(llvm::raw_ostream &os) const {
+    if (isUnknown()) {
+      os << unknownSetString;
+    } else if (isUndefined()) {
+      os << undefinedSetString;
+    } else {
+      llvm::interleaveComma(elements, os << "{");
+      os << "}";
+    }
+  }
+
+  ChangeResult
+  foreachElement(function_ref<ChangeResult(ValueT, State)> callback) const {
+    if (state != State::Defined)
+      return callback(nullptr, state);
+
+    ChangeResult result = ChangeResult::NoChange;
+    for (ValueT element : elements)
+      result |= callback(element, state);
+    return result;
+  }
+
+private:
+  explicit SetLattice(State state) : state(state) {}
+
+  ChangeResult updateStateToDefined() {
+    assert(state != State::Unknown && "cannot go back from unknown state");
+    ChangeResult result = state == State::Undefined ? ChangeResult::Change
+                                                    : ChangeResult::NoChange;
+    state = State::Defined;
+    return result;
+  }
+
+  const static SetLattice<ValueT> unknownSet;
+  const static SetLattice<ValueT> undefinedSet;
+
+  DenseSet<ValueT> elements;
+  State state;
+};
+
+template <typename ValueT>
+const SetLattice<ValueT> SetLattice<ValueT>::unknownSet =
+    SetLattice<ValueT>(SetLattice<ValueT>::State::Unknown);
+
+template <typename ValueT>
+const SetLattice<ValueT> SetLattice<ValueT>::undefinedSet =
+    SetLattice<ValueT>(SetLattice<ValueT>::State::Undefined);
+
+/// Used when serializing to ensure a consistent order.
+bool sortAttributes(Attribute a, Attribute b);
+bool sortArraysLexicographic(ArrayAttr a, ArrayAttr b);
+
+//===----------------------------------------------------------------------===//
+// SparseSetLattice
+//
+// An abstract lattice for sparse analyses that wraps a set lattice.
+//===----------------------------------------------------------------------===//
+
+template <typename ValueT>
+class SparseSetLattice : public dataflow::AbstractSparseLattice {
+public:
+  using AbstractSparseLattice::AbstractSparseLattice;
+  SparseSetLattice(Value value, SetLattice<ValueT> &&elements)
+      : dataflow::AbstractSparseLattice(value), elements(std::move(elements)) {}
+
+  Attribute serialize(MLIRContext *ctx) const { return serializeSetNaive(ctx); }
+
+  ChangeResult merge(const SetLattice<ValueT> &other) {
+    return elements.join(other);
+  }
+
+  ChangeResult insert(const DenseSet<ValueT> &newElements) {
+    return elements.insert(newElements);
+  }
+
+  ChangeResult markUnknown() { return elements.markUnknown(); }
+
+  bool isUnknown() const { return elements.isUnknown(); }
+
+  bool isUndefined() const { return elements.isUndefined(); }
+
+  const DenseSet<ValueT> &getElements() const { return elements.getElements(); }
+
+protected:
+  SetLattice<ValueT> elements;
+
+private:
+  Attribute serializeSetNaive(MLIRContext *ctx) const {
+    if (elements.isUndefined())
+      return StringAttr::get(ctx, undefinedSetString);
+    if (elements.isUnknown())
+      return StringAttr::get(ctx, unknownSetString);
+    SmallVector<Attribute> elementsVec;
+    for (Attribute element : elements.getElements()) {
+      elementsVec.push_back(element);
+    }
+    llvm::sort(elementsVec, sortAttributes);
+    return ArrayAttr::get(ctx, elementsVec);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// MapOfSetsLattice
+//===----------------------------------------------------------------------===//
+
+template <typename KeyT, typename ElementT>
+class MapOfSetsLattice : public dataflow::AbstractDenseLattice {
+public:
+  using AbstractDenseLattice::AbstractDenseLattice;
+
+  Attribute serialize(MLIRContext *ctx) const {
+    return serializeMapOfSetsNaive(ctx);
+  }
+
+  ChangeResult join(const AbstractDenseLattice &other) {
+    const auto &rhs =
+        static_cast<const MapOfSetsLattice<KeyT, ElementT> &>(other);
+    llvm::SmallDenseSet<DistinctAttr> keys;
+    auto lhsRange = llvm::make_first_range(map);
+    auto rhsRange = llvm::make_first_range(rhs.map);
+    keys.insert(lhsRange.begin(), lhsRange.end());
+    keys.insert(rhsRange.begin(), rhsRange.end());
+
+    ChangeResult result = ChangeResult::NoChange;
+    for (DistinctAttr key : keys) {
+      auto lhsIt = map.find(key);
+      auto rhsIt = rhs.map.find(key);
+      assert(lhsIt != map.end() || rhsIt != rhs.map.end());
+
+      // If present in both, join.
+      if (lhsIt != map.end() && rhsIt != rhs.map.end()) {
+        result |= lhsIt->getSecond().join(rhsIt->getSecond());
+        continue;
+      }
+
+      // Copy from RHS if available only there.
+      if (lhsIt == map.end()) {
+        map.try_emplace(rhsIt->getFirst(), rhsIt->getSecond());
+        result = ChangeResult::Change;
+      }
+
+      // Do nothing if available only in LHS.
+    }
+    return result;
+  }
+
+  /// Map all keys to all values.
+  ChangeResult insert(const SetLattice<KeyT> &keysToUpdate,
+                      const SetLattice<ElementT> &values) {
+    if (keysToUpdate.isUnknown())
+      return markAllUnknown();
+
+    if (keysToUpdate.isUndefined())
+      return ChangeResult::NoChange;
+
+    return keysToUpdate.foreachElement(
+        [&](DistinctAttr key, typename SetLattice<KeyT>::State state) {
+          assert(state == SetLattice<KeyT>::State::Defined &&
+                 "unknown must have been handled above");
+          return joinPotentiallyMissing(key, values);
+        });
+  }
+
+  ChangeResult markAllUnknown() {
+    ChangeResult result = ChangeResult::NoChange;
+    for (auto &it : map)
+      result |= it.getSecond().join(SetLattice<ElementT>::getUnknown());
+    return result;
+  }
+
+  const SetLattice<ElementT> &lookup(KeyT key) const {
+    auto it = map.find(key);
+    if (it == map.end())
+      return SetLattice<ElementT>::getUndefined();
+    return it->getSecond();
+  }
+
+protected:
+  ChangeResult joinPotentiallyMissing(KeyT key,
+                                      const SetLattice<ElementT> &value) {
+    // Don't store explicitly undefined values in the mapping, keys absent from
+    // the mapping are treated as implicitly undefined.
+    if (value.isUndefined())
+      return ChangeResult::NoChange;
+
+    bool inserted;
+    decltype(map.begin()) iterator;
+    std::tie(iterator, inserted) = map.try_emplace(key, value);
+    if (!inserted)
+      return iterator->second.join(value);
+    return ChangeResult::Change;
+  }
+
+  /// Maps a key to a set of values. When a key is not present in this map, it
+  /// is considered to map to an uninitialized set.
+  DenseMap<KeyT, SetLattice<ElementT>> map;
+
+private:
+  Attribute serializeMapOfSetsNaive(MLIRContext *ctx) const {
+    SmallVector<Attribute> pointsToArray;
+
+    for (const auto &[srcClass, destClasses] : map) {
+      SmallVector<Attribute> pair = {srcClass};
+      SmallVector<Attribute> aliasClasses;
+      if (destClasses.isUnknown()) {
+        aliasClasses.push_back(StringAttr::get(ctx, unknownSetString));
+      } else if (destClasses.isUndefined()) {
+        aliasClasses.push_back(StringAttr::get(ctx, undefinedSetString));
+      } else {
+        for (const Attribute &destClass : destClasses.getElements()) {
+          aliasClasses.push_back(destClass);
+        }
+        llvm::sort(aliasClasses, sortAttributes);
+      }
+      pair.push_back(ArrayAttr::get(ctx, aliasClasses));
+      pointsToArray.push_back(ArrayAttr::get(ctx, pair));
+    }
+    llvm::sort(pointsToArray, [&](Attribute a, Attribute b) {
+      return sortArraysLexicographic(cast<ArrayAttr>(a), cast<ArrayAttr>(b));
+    });
+    return ArrayAttr::get(ctx, pointsToArray);
+  }
+};
+
+} // namespace enzyme
+} // namespace mlir
+
+#endif // ENZYME_MLIR_ANALYSIS_DATAFLOW_LATTICE_H

--- a/enzyme/Enzyme/MLIR/Passes/PrintAliasAnalysis.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/PrintAliasAnalysis.cpp
@@ -91,7 +91,7 @@ struct PrintAliasAnalysisPass
             continue;
           // TODO(zinenko): this has been overriding the argument...
           // Use an array attr instead (will break syntactic tests).
-          (void)state->getAliasClassesObject().foreachClass(
+          (void)state->getAliasClassesObject().foreachElement(
               [&](DistinctAttr aliasClass, enzyme::AliasClassSet::State state) {
                 if (state == enzyme::AliasClassSet::State::Undefined)
                   funcOp.setArgAttr(


### PR DESCRIPTION
For context, the conceptual `AliasClassSet`, `AliasClassLattice`, and `PointsToSets` data structures were immensely useful in implementing activity annotations. The "`lattice of sets that might be undefined or unknown`" and "`map of attributes to those sets`" are exactly the kind of data structures that activity annotations uses to propagate these relative "origins" both forward and backward, in an intraprocedural analysis.

This PR aims to be an intermediate step towards merging in activity annotations by breaking out the re-usable logic into abstract classes.