### PR TITLE
Fix bazel build for macos

### DIFF
--- a/enzyme/Enzyme/InstructionDerivatives.td
+++ b/enzyme/Enzyme/InstructionDerivatives.td
@@ -220,41 +220,41 @@ class GlobalExpr<bit uses_primal, bit uses_shadow, string val> : Operation<uses_
 }
 // Create a bit-mask whose bitwise "and" with a floating-point number gives
 // the largest power of two not larger than that number (in terms of absolute values).
-def MantissaMaskOfReturnForFrexp : GlobalExpr</*primal*/0, /*shadow*/0, "({\n"
-"    auto ty = call.getType();\n"
-"    unsigned low = 0;\n"
-"    unsigned high = 0;\n"
-"    unsigned tsize = 0;\n"
-"    if (ty->isHalfTy()) {\n"
-"      tsize = 16;\n"
-"      high = tsize - 1;\n"
-"      low = high - 5;\n"
-"    } else if (ty->isFloatTy()) {\n"
-"      tsize = 32;\n"
-"      high = tsize - 1;\n"
-"      low = high - 8;\n"
-"    } else if (ty->isDoubleTy()) {\n"
-"      tsize = 64;\n"
-"      high = tsize - 1;\n"
-"      low = high - 11;\n"
-"    } else if (ty->isX86_FP80Ty()) {\n"
-"      tsize = 80;\n"
-"      high = tsize - 1;\n"
-"      low = high - 16;\n"
-       // x86_fp80 has only 15 exponent bits, but we must also
-       // retain the most-significant bit of the mantissa as
-       // there is no implicit leading 1.
-"    } else if (ty->isFP128Ty()) {\n"
-"      tsize = 128;\n"
-"      high = tsize - 1;\n"
-"      low = high - 15;\n"
-"    } else {\n"
-"      llvm_unreachable(\"Unknown type within frexp\");\n"
-"    }\n"
-"    APInt eval = APInt::getBitsSet(tsize, low, high);\n"
-"    auto ity = IntegerType::get(ty->getContext(), tsize);\n"
-"    ConstantInt::get(ity, eval);\n"
-"  })">;
+def MantissaMaskOfReturnForFrexp : GlobalExpr</*primal*/0, /*shadow*/0, [{
+  auto ty = call.getType();
+  unsigned low = 0;
+  unsigned high = 0;
+  unsigned tsize = 0;
+  if (ty->isHalfTy()) {
+    tsize = 16;
+    high = tsize - 1;
+    low = high - 5;
+  } else if (ty->isFloatTy()) {
+    tsize = 32;
+    high = tsize - 1;
+    low = high - 8;
+  } else if (ty->isDoubleTy()) {
+    tsize = 64;
+    high = tsize - 1;
+    low = high - 11;
+  } else if (ty->isX86_FP80Ty()) {
+    tsize = 80;
+    high = tsize - 1;
+    low = high - 16;
+    // x86_fp80 has only 15 exponent bits, but we must also
+    // retain the most-significant bit of the mantissa as
+    // there is no implicit leading
+  } else if (ty->isFP128Ty()) {
+    tsize = 128;
+    high = tsize - 1;
+    low = high - 15;
+  } else {
+    llvm_unreachable("Unknown type within frexp");
+  }
+  APInt eval = APInt::getBitsSet(tsize, low, high);
+  auto ity = IntegerType::get(ty->getContext(), tsize);
+  ConstantInt::get(ity, eval);
+}]>;
 
 class ConstantFP<string val> : Operation</*primal*/0, /*shadow*/0> {
   string value = val;

--- a/enzyme/Enzyme/MLIR/Analysis/CMakeLists.txt
+++ b/enzyme/Enzyme/MLIR/Analysis/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_mlir_library(MLIREnzymeAnalysis
   ActivityAnalysis.cpp
-  AliasAnalysis.cpp
+  DataFlowAliasAnalysis.cpp
   DataFlowActivityAnalysis.cpp
 
   DEPENDS

--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowActivityAnalysis.cpp
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowActivityAnalysis.cpp
@@ -25,7 +25,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "DataFlowActivityAnalysis.h"
-#include "AliasAnalysis.h"
+#include "DataFlowAliasAnalysis.h"
 #include "Dialect/Ops.h"
 #include "Interfaces/AutoDiffTypeInterface.h"
 

--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.cpp
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.cpp
@@ -1,4 +1,4 @@
-//===- AliasAnalysis.cpp - Implementation of Alias Analysis ---------------===//
+//===- DataFlowAliasAnalysis.cpp - Implementation of Alias Analysis  ------===//
 //
 //                             Enzyme Project
 //
@@ -23,7 +23,7 @@
 // that the pointers in a program may point to.
 //
 //===----------------------------------------------------------------------===//
-#include "AliasAnalysis.h"
+#include "DataFlowAliasAnalysis.h"
 
 #include "mlir/Analysis/AliasAnalysis.h"
 #include "mlir/Analysis/DataFlow/DenseAnalysis.h"

--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.h
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.h
@@ -1,4 +1,4 @@
-//===- AliasAnalysis.h - Declaration of Alias Analysis --------------------===//
+//===- DataflowAliasAnalysis.h - Declaration of Alias Analysis ------------===//
 //
 //                             Enzyme Project
 //
@@ -307,7 +307,7 @@ public:
 
   void print(raw_ostream &os) const override;
 
-  AliasResult alias(const AbstractSparseLattice &other) const;
+  ::mlir::AliasResult alias(const AbstractSparseLattice &other) const;
 
   ChangeResult join(const AbstractSparseLattice &other) override;
 

--- a/enzyme/Enzyme/MLIR/Passes/PrintAliasAnalysis.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/PrintAliasAnalysis.cpp
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Analysis/AliasAnalysis.h"
+#include "Analysis/DataFlowAliasAnalysis.h"
 #include "Dialect/Ops.h"
 #include "Passes/PassDetails.h"
 #include "Passes/Passes.h"

--- a/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
+++ b/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
@@ -609,8 +609,11 @@ bool handle(const Twine &curIndent, const Twine &argPattern, raw_ostream &os,
         PrintFatalError(pattern->getLoc(),
                         Twine("string 'value' not defined in ") +
                             resultTree->getAsString());
-
+      if (value->getValue().contains(';'))
+        os << "({ ";
       os << value->getValue();
+      if (value->getValue().contains(';'))
+        os << " })";
       return false;
     } else if (opName == "Undef" || Def->isSubClassOf("Undef")) {
       if (resultRoot->getNumArgs() != 1)


### PR DESCRIPTION
Macos Bazel build didn't like us calling something AliasAnalysis.h and MLIR also having the same leading to nonsense issues that was strictly easier for us to rename to DataFlowAliasAnalysis anyways