### PR TITLE
cpp interface improvements

### DIFF
--- a/enzyme/Enzyme/Clang/include_utils.td
+++ b/enzyme/Enzyme/Clang/include_utils.td
@@ -28,6 +28,9 @@ Return __enzyme_fwddiff(T...);
 
 namespace enzyme {
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-braces"
+
     struct nodiff{};
 
     template<bool ReturnPrimal = false>
@@ -45,7 +48,6 @@ namespace enzyme {
     template < typename T >
     struct Active{
       T value;
-      Active(T &&v) : value(v) {}
       operator T&() { return value; }
     };
 
@@ -53,22 +55,34 @@ namespace enzyme {
     struct Duplicated{  
       T value;
       T shadow;
-      Duplicated(T &&v, T&& s) : value(v), shadow(s) {}
     };
 
     template < typename T >
     struct DuplicatedNoNeed{  
       T value;
       T shadow;
-      DuplicatedNoNeed(T &&v, T&& s) : value(v), shadow(s) {}
     };
 
     template < typename T >
     struct Const{
       T value;
-      Const(T &&v) : value(v) {}
       operator T&() { return value; }
     };
+
+    // CTAD available in C++17 or later
+    #if __cplusplus >= 201703L 
+      template < typename T >
+      Active(T) -> Active<T>;
+
+      template < typename T >
+      Const(T) -> Const<T>;
+
+      template < typename T >
+      Duplicated(T,T) -> Duplicated<T>;
+
+      template < typename T >
+      DuplicatedNoNeed(T,T) -> DuplicatedNoNeed<T>;
+    #endif    
 
     template < typename T >
     struct type_info {
@@ -343,7 +357,9 @@ namespace enzyme {
         using return_type = typename autodiff_return<DiffMode, RetActivity, arg_types...>::type;
         return autodiff_impl<return_type, DiffMode, function, RetActivity>(impl::forward<function>(f), enzyme::tuple_cat(enzyme::tuple{detail::ret_used<DiffMode, RetActivity>::value}, expand_args(args)...));
     }
-}
+#pragma clang diagnostic pop
+
+} // namespace enzyme
 }]>;
 
 def : Headers<"/enzymeroot/enzyme/type_traits", [{
@@ -416,6 +432,9 @@ def : Headers<"/enzymeroot/enzyme/tuple", [{
 
 #define _NOEXCEPT noexcept
 namespace enzyme {
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-braces"
 
 template <int i>
 struct Index {};
@@ -504,7 +523,7 @@ struct concat_with_fwd_tuple<std::index_sequence<fwd_indices...>, std::index_seq
   template <typename FWD_TUPLE, typename TUPLE>
   __attribute__((always_inline))
   static constexpr auto f(FWD_TUPLE&& fwd, TUPLE&& t) {
-    return forward_as_tuple(get<fwd_indices>(impl::forward<FWD_TUPLE>(fwd))..., get<indices>(impl::forward<TUPLE>(t))...);
+    return enzyme::forward_as_tuple(get<fwd_indices>(impl::forward<FWD_TUPLE>(fwd))..., get<indices>(impl::forward<TUPLE>(t))...);
   }
 };
 
@@ -527,6 +546,8 @@ __attribute__((always_inline))
 constexpr auto tuple_cat(Tuples&&... tuples) {
   return impl::tuple_cat(impl::forward<Tuples>(tuples)...);
 }
+
+#pragma clang diagnostic pop
 
 } // namespace enzyme
 #undef _NOEXCEPT

--- a/enzyme/Enzyme/Clang/include_utils.td
+++ b/enzyme/Enzyme/Clang/include_utils.td
@@ -426,6 +426,7 @@ def : Headers<"/enzymeroot/enzyme/tuple", [{
 //        constexpr support for std::tuple). Owning the implementation lets
 //        us add __host__ __device__ annotations to any part of it
 
+#include <cstddef> // for std::size_t
 #include <utility> // for std::integer_sequence
 
 #include <enzyme/type_traits>
@@ -487,10 +488,10 @@ template <typename Tuple>
 struct tuple_size;
 
 template <typename... T>
-struct tuple_size<tuple<T...>> : std::integral_constant<size_t, sizeof...(T)> {};
+struct tuple_size<tuple<T...>> : std::integral_constant<std::size_t, sizeof...(T)> {};
 
 template <typename Tuple>
-static constexpr size_t tuple_size_v = tuple_size<Tuple>::value;
+static constexpr std::size_t tuple_size_v = tuple_size<Tuple>::value;
 
 template <typename... T>
 __attribute__((always_inline))
@@ -503,7 +504,7 @@ namespace impl {
 template <typename index_seq>
 struct make_tuple_from_fwd_tuple;
 
-template <size_t... indices>
+template <std::size_t... indices>
 struct make_tuple_from_fwd_tuple<std::index_sequence<indices...>> {
   template <typename FWD_TUPLE>
   __attribute__((always_inline))
@@ -518,7 +519,7 @@ struct concat_with_fwd_tuple;
 template < typename Tuple >
 using iseq = std::make_index_sequence<tuple_size_v< enzyme::remove_cvref_t< Tuple > > >;
 
-template <size_t... fwd_indices, size_t... indices>
+template <std::size_t... fwd_indices, std::size_t... indices>
 struct concat_with_fwd_tuple<std::index_sequence<fwd_indices...>, std::index_sequence<indices...>> {
   template <typename FWD_TUPLE, typename TUPLE>
   __attribute__((always_inline))

--- a/enzyme/test/CMakeLists.txt
+++ b/enzyme/test/CMakeLists.txt
@@ -8,6 +8,7 @@ configure_lit_site_cfg(
 set(ENZYME_TEST_DEPS LLVMEnzyme-${LLVM_VERSION_MAJOR})
 
 add_subdirectory(ActivityAnalysis)
+add_subdirectory(CppInterface)
 add_subdirectory(TypeAnalysis)
 add_subdirectory(Enzyme)
 if (${Clang_FOUND})

--- a/enzyme/test/CppInterface/CMakeLists.txt
+++ b/enzyme/test/CppInterface/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(CppInterfaceTests LANGUAGES CXX)
+
+file(GLOB_RECURSE cpp_tests ${PROJECT_SOURCE_DIR}/*.cpp)
+
+enable_testing()
+
+foreach(filename ${cpp_tests})		
+  get_filename_component(testname ${filename} NAME_WE)
+  add_executable(${testname} ${filename})
+  target_link_libraries(${testname} PUBLIC ClangEnzymeFlags)
+  add_test(${testname} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${testname})		
+endforeach(filename ${cpp_tests})

--- a/enzyme/test/CppInterface/enzyme_types.cpp
+++ b/enzyme/test/CppInterface/enzyme_types.cpp
@@ -1,0 +1,32 @@
+#include <utility>
+#include <iostream>
+
+#include <enzyme/enzyme>
+
+struct move_only_type {
+  move_only_type() {};
+  move_only_type(move_only_type && obj) {
+    std::cout << "calling move_only_type move ctor" << std::endl;
+  };
+};
+
+int main() {
+  double z = 3.0;
+  double & rz = z;
+  move_only_type foo{};
+
+  [[maybe_unused]] enzyme::Const<double> c1{3.0};
+  [[maybe_unused]] enzyme::Const<double> c2{z};
+  [[maybe_unused]] enzyme::Const<double&> c3{rz};
+  [[maybe_unused]] enzyme::Const<double&> c4{z};
+  [[maybe_unused]] enzyme::Const<move_only_type> c5{move_only_type{}};
+  [[maybe_unused]] enzyme::Const<move_only_type> c6{std::move(foo)};
+
+// CTAD examples for C++17 and later
+#if __cplusplus >= 201703L 
+  [[maybe_unused]] enzyme::Const d1{3.0};
+  [[maybe_unused]] enzyme::Const d2{z};
+  [[maybe_unused]] enzyme::Const d3{rz};
+#endif
+
+}

--- a/enzyme/test/CppInterface/forward_mode.cpp
+++ b/enzyme/test/CppInterface/forward_mode.cpp
@@ -1,0 +1,19 @@
+#include <iostream>
+
+#include "minimal_test_framework.hpp"
+
+#include <enzyme/enzyme>
+
+double square(double x) { return x * x; }
+
+double dsquare(double x) { 
+  return enzyme::autodiff<enzyme::Forward>((void*) square, enzyme::Duplicated{x, 1.0}); 
+//  return 1.0;
+}
+
+int main() {
+  for(double i=1; i<5; i++) {
+    EXPECT(dsquare(i) == 2 * i);
+  }
+  return any_tests_failed;
+}

--- a/enzyme/test/CppInterface/gh_issue_1785.cpp
+++ b/enzyme/test/CppInterface/gh_issue_1785.cpp
@@ -1,0 +1,26 @@
+#include <memory>
+#include <vector>
+#include <enzyme/enzyme>
+
+int main() {
+   auto elasticity_kernel = [](const std::vector<double> &dudxi,
+                               const std::vector<double> &J,
+                               const double &w)
+   {
+      auto r = dudxi;
+      return r;
+   };
+
+   std::vector<double> dudxi(4), s_dudxi(4), J(4);
+   double w = 1.0;
+
+   enzyme::get<0>
+   (enzyme::autodiff<enzyme::Forward,
+    enzyme::DuplicatedNoNeed<std::vector<double>>>
+    (+elasticity_kernel,
+     enzyme::Duplicated<std::vector<double> *>(&dudxi, &s_dudxi),
+     enzyme::Const<std::vector<double> *>{&J},
+     enzyme::Const<double*>{&w}));
+
+    return 0;
+}

--- a/enzyme/test/CppInterface/minimal_test_framework.hpp
+++ b/enzyme/test/CppInterface/minimal_test_framework.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+bool any_tests_failed = false; 
+
+#define EXPECT(boolean) \
+if (!(boolean)) { \
+  std::cout << "Test failure on " << __FILE__ << ":" << __LINE__ << ", EXPECT(" << (#boolean) << ")" << std::endl; \
+  any_tests_failed = true; \
+}


### PR DESCRIPTION
working on some fixes and improvements for the new cpp interface:

- fixing inconsistent `size_t` vs `std::size_t` usage
- use automatically generated ctors for `enzyme::Active`, `enzyme::Const`, ... , to support brace-initialization
- add CTAD guides for C++17 and later (so users don't have to explicitly name the argument types)
- added a new directory in tests for c++ interface examples and unit tests with CTest support (WIP)
- disambiguate `forward_by_reference` implementation (see https://github.com/EnzymeAD/Enzyme/issues/1785)

I think @wsmoses also mentioned something about casting the function pointers to the appropriate types-- can you clarify what you want to happen and I'll add a test for it.

I'm also seeing an error in the return type deduction for Forward mode, so I'll look into that.