### PR TITLE
Memory truncation mode

### DIFF
--- a/enzyme/Enzyme/Clang/include_utils.td
+++ b/enzyme/Enzyme/Clang/include_utils.td
@@ -782,6 +782,7 @@ __ENZYME_MPFR_DOUBLE_BINFUNCINTR_DEFAULT_ROUNDING(pow, pow);
 
 __ENZYME_MPFR_SINGOP(func, sqrt, sqrt, 64_52, double, d, double, d, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
 __ENZYME_MPFR_SINGOP(func, __sqrt_finite, sqrt, 64_52, double, d, double, d, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
+__ENZYME_MPFR_SINGOP(intr, llvm_sqrt_f64, sqrt, 64_52, double, d, double, d, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
 __ENZYME_MPFR_SINGOP(intr, fabs, abs, 64_52, double, d, double, d, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
 __ENZYME_MPFR_SINGOP(intr, llvm_fabs_f64, abs, 64_52, double, d, double, d, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
 

--- a/enzyme/Enzyme/Clang/include_utils.td
+++ b/enzyme/Enzyme/Clang/include_utils.td
@@ -572,7 +572,7 @@ def : Headers < "/enzymeroot/enzyme/mpfr", [{
 #include <stdlib.h>
 
 #ifdef __cplusplus
-      extern "C" {
+extern "C" {
 #endif
 
 // TODO s
@@ -608,70 +608,151 @@ def : Headers < "/enzymeroot/enzyme/mpfr", [{
 // operations to source location
 
 #define __ENZYME_MPFR_ATTRIBUTES __attribute__((weak))
+#define __ENZYME_MPFR_DEFAULT_ROUNDING_MODE GMP_RNDN
+
+bool __enzyme_fprt_is_mem_mode(int64_t mode) {
+  return mode & 0b0001;
+}
+bool __enzyme_fprt_is_op_mode(int64_t mode) { return mode & 0b0010; }
+
+typedef struct {
+  mpfr_t fp;
+} __enzyme_fp;
+
+double __enzyme_fprt_ptr_to_double(__enzyme_fp *p) { return *((double *)(&p)); }
+__enzyme_fp *__enzyme_fprt_double_to_ptr(double d) {
+  return *((__enzyme_fp **)(&d));
+}
+
+__ENZYME_MPFR_ATTRIBUTES
+double __enzyme_fprt_64_52_get(double _a, int64_t exponent, int64_t significand,
+                               int64_t mode) {
+  __enzyme_fp *a = __enzyme_fprt_double_to_ptr(_a);
+  return mpfr_get_d(a->fp, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
+}
+
+__ENZYME_MPFR_ATTRIBUTES
+double __enzyme_fprt_64_52_new(double _a, int64_t exponent, int64_t significand,
+                               int64_t mode) {
+  __enzyme_fp *a = (__enzyme_fp *) malloc(sizeof(__enzyme_fp));
+  mpfr_init2(a->fp, significand);
+  mpfr_set_d(a->fp, _a, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
+  return __enzyme_fprt_ptr_to_double(a);
+}
+
+__ENZYME_MPFR_ATTRIBUTES
+__enzyme_fp *__enzyme_fprt_64_52_new_intermediate(int64_t exponent,
+                                                  int64_t significand,
+                                                  int64_t mode) {
+  __enzyme_fp *a = (__enzyme_fp *) malloc(sizeof(__enzyme_fp));
+  mpfr_init2(a->fp, significand);
+  return a;
+}
+
+__ENZYME_MPFR_ATTRIBUTES
+void __enzyme_fprt_64_52_delete(double a, int64_t exponent, int64_t significand,
+                                int64_t mode) {
+  free(__enzyme_fprt_double_to_ptr(a));
+}
+
 #define __ENZYME_MPFR_SINGOP(OP_TYPE, LLVM_OP_NAME, MPFR_FUNC_NAME, FROM_TYPE, \
                              RET, MPFR_GET, ARG1, MPFR_SET_ARG1,               \
                              ROUNDING_MODE)                                    \
-  __ENZYME_MPFR_ATTRIBUTES                                                        \
+  __ENZYME_MPFR_ATTRIBUTES                                                     \
   RET __enzyme_fprt_##FROM_TYPE##_##OP_TYPE##_##LLVM_OP_NAME(                  \
       ARG1 a, int64_t exponent, int64_t significand, int64_t mode) {           \
-    mpfr_t ma, mc;                                                             \
-    mpfr_init2(ma, significand);                                               \
-    mpfr_init2(mc, significand);                                               \
-    mpfr_set_##MPFR_SET_ARG1(ma, a, ROUNDING_MODE);                            \
-    mpfr_##MPFR_FUNC_NAME(mc, ma, ROUNDING_MODE);                              \
-    RET c = mpfr_get_##MPFR_GET(mc, ROUNDING_MODE);                            \
-    mpfr_clear(ma);                                                            \
-    mpfr_clear(mc);                                                            \
-    return c;                                                                  \
+    if (__enzyme_fprt_is_op_mode(mode)) {                                      \
+      mpfr_t ma, mc;                                                           \
+      mpfr_init2(ma, significand);                                             \
+      mpfr_init2(mc, significand);                                             \
+      mpfr_set_##MPFR_SET_ARG1(ma, a, ROUNDING_MODE);                          \
+      mpfr_##MPFR_FUNC_NAME(mc, ma, ROUNDING_MODE);                            \
+      RET c = mpfr_get_##MPFR_GET(mc, ROUNDING_MODE);                          \
+      mpfr_clear(ma);                                                          \
+      mpfr_clear(mc);                                                          \
+      return c;                                                                \
+    } else if (__enzyme_fprt_is_mem_mode(mode)) {                              \
+      __enzyme_fp *ma = __enzyme_fprt_double_to_ptr(a);                        \
+      __enzyme_fp *mc =                                                        \
+          __enzyme_fprt_64_52_new_intermediate(exponent, significand, mode);   \
+      mpfr_##MPFR_FUNC_NAME(mc->fp, ma->fp, ROUNDING_MODE);                    \
+      return __enzyme_fprt_ptr_to_double(mc);                                  \
+    } else {                                                                   \
+      abort();                                                                 \
+    }                                                                          \
   }
 
 #define __ENZYME_MPFR_BIN(OP_TYPE, LLVM_OP_NAME, MPFR_FUNC_NAME, FROM_TYPE,    \
                           RET, MPFR_GET, ARG1, MPFR_SET_ARG1, ARG2,            \
                           MPFR_SET_ARG2, ROUNDING_MODE)                        \
-  __ENZYME_MPFR_ATTRIBUTES                                                        \
+  __ENZYME_MPFR_ATTRIBUTES                                                     \
   RET __enzyme_fprt_##FROM_TYPE##_##OP_TYPE##_##LLVM_OP_NAME(                  \
       ARG1 a, ARG2 b, int64_t exponent, int64_t significand, int64_t mode) {   \
-    mpfr_t ma, mb, mc;                                                         \
-    mpfr_init2(ma, significand);                                               \
-    mpfr_init2(mb, significand);                                               \
-    mpfr_init2(mc, significand);                                               \
-    mpfr_set_##MPFR_SET_ARG1(ma, a, ROUNDING_MODE);                            \
-    mpfr_set_##MPFR_SET_ARG1(mb, b, ROUNDING_MODE);                            \
-    mpfr_##MPFR_FUNC_NAME(mc, ma, mb, ROUNDING_MODE);                          \
-    RET c = mpfr_get_##MPFR_GET(mc, ROUNDING_MODE);                            \
-    mpfr_clear(ma);                                                            \
-    mpfr_clear(mb);                                                            \
-    mpfr_clear(mc);                                                            \
-    return c;                                                                  \
+    if (__enzyme_fprt_is_op_mode(mode)) {                                      \
+      mpfr_t ma, mb, mc;                                                       \
+      mpfr_init2(ma, significand);                                             \
+      mpfr_init2(mb, significand);                                             \
+      mpfr_init2(mc, significand);                                             \
+      mpfr_set_##MPFR_SET_ARG1(ma, a, ROUNDING_MODE);                          \
+      mpfr_set_##MPFR_SET_ARG1(mb, b, ROUNDING_MODE);                          \
+      mpfr_##MPFR_FUNC_NAME(mc, ma, mb, ROUNDING_MODE);                        \
+      RET c = mpfr_get_##MPFR_GET(mc, ROUNDING_MODE);                          \
+      mpfr_clear(ma);                                                          \
+      mpfr_clear(mb);                                                          \
+      mpfr_clear(mc);                                                          \
+      return c;                                                                \
+    } else if (__enzyme_fprt_is_mem_mode(mode)) {                              \
+      __enzyme_fp *ma = __enzyme_fprt_double_to_ptr(a);                        \
+      __enzyme_fp *mb = __enzyme_fprt_double_to_ptr(b);                        \
+      __enzyme_fp *mc =                                                        \
+          __enzyme_fprt_64_52_new_intermediate(exponent, significand, mode);   \
+      mpfr_##MPFR_FUNC_NAME(mc->fp, ma->fp, mb->fp, ROUNDING_MODE);            \
+      return __enzyme_fprt_ptr_to_double(mc);                                  \
+    } else {                                                                   \
+      abort();                                                                 \
+    }                                                                          \
   }
 
 #define __ENZYME_MPFR_FMULADD(FROM_TYPE, TYPE, MPFR_TYPE, LLVM_TYPE,           \
                               ROUNDING_MODE)                                   \
-  __ENZYME_MPFR_ATTRIBUTES                                                        \
+  __ENZYME_MPFR_ATTRIBUTES                                                     \
   TYPE __enzyme_fprt_##FROM_TYPE##_intr_llvm_fmuladd_##LLVM_TYPE(              \
       TYPE a, TYPE b, TYPE c, int64_t exponent, int64_t significand,           \
       int64_t mode) {                                                          \
-    mpfr_t ma, mb, mc, mmul, madd;                                             \
-    mpfr_init2(ma, significand);                                               \
-    mpfr_init2(mb, significand);                                               \
-    mpfr_init2(mc, significand);                                               \
-    mpfr_init2(mmul, significand);                                             \
-    mpfr_init2(madd, significand);                                             \
-    mpfr_set_##MPFR_TYPE(ma, a, ROUNDING_MODE);                                \
-    mpfr_set_##MPFR_TYPE(mb, b, ROUNDING_MODE);                                \
-    mpfr_set_##MPFR_TYPE(mc, c, ROUNDING_MODE);                                \
-    mpfr_mul(mmul, ma, mb, ROUNDING_MODE);                                     \
-    mpfr_add(madd, mmul, mc, ROUNDING_MODE);                                   \
-    TYPE res = mpfr_get_##MPFR_TYPE(madd, ROUNDING_MODE);                      \
-    mpfr_clear(ma);                                                            \
-    mpfr_clear(mb);                                                            \
-    mpfr_clear(mc);                                                            \
-    mpfr_clear(mmul);                                                          \
-    mpfr_clear(madd);                                                          \
-    return res;                                                                \
+    if (__enzyme_fprt_is_op_mode(mode)) {                                      \
+      mpfr_t ma, mb, mc, mmul, madd;                                           \
+      mpfr_init2(ma, significand);                                             \
+      mpfr_init2(mb, significand);                                             \
+      mpfr_init2(mc, significand);                                             \
+      mpfr_init2(mmul, significand);                                           \
+      mpfr_init2(madd, significand);                                           \
+      mpfr_set_##MPFR_TYPE(ma, a, ROUNDING_MODE);                              \
+      mpfr_set_##MPFR_TYPE(mb, b, ROUNDING_MODE);                              \
+      mpfr_set_##MPFR_TYPE(mc, c, ROUNDING_MODE);                              \
+      mpfr_mul(mmul, ma, mb, ROUNDING_MODE);                                   \
+      mpfr_add(madd, mmul, mc, ROUNDING_MODE);                                 \
+      TYPE res = mpfr_get_##MPFR_TYPE(madd, ROUNDING_MODE);                    \
+      mpfr_clear(ma);                                                          \
+      mpfr_clear(mb);                                                          \
+      mpfr_clear(mc);                                                          \
+      mpfr_clear(mmul);                                                        \
+      mpfr_clear(madd);                                                        \
+      return res;                                                              \
+    } else if (__enzyme_fprt_is_mem_mode(mode)) {                              \
+      __enzyme_fp *ma = __enzyme_fprt_double_to_ptr(a);                        \
+      __enzyme_fp *mb = __enzyme_fprt_double_to_ptr(b);                        \
+      __enzyme_fp *mc = __enzyme_fprt_double_to_ptr(c);                        \
+      double mmul = __enzyme_fprt_##FROM_TYPE##_binop_fmul(                    \
+          __enzyme_fprt_ptr_to_double(ma), __enzyme_fprt_ptr_to_double(mb),    \
+          exponent, significand, mode);                                        \
+      double madd = __enzyme_fprt_##FROM_TYPE##_binop_fadd(                    \
+          mmul, __enzyme_fprt_ptr_to_double(mc), exponent, significand, mode); \
+      return madd;                                                             \
+    } else {                                                                   \
+      abort();                                                                 \
+    }                                                                          \
   }
 
-#define __ENZYME_MPFR_DEFAULT_ROUNDING_MODE GMP_RNDN
 #define __ENZYME_MPFR_DOUBLE_BINOP(LLVM_OP_NAME, MPFR_FUNC_NAME,               \
                                    ROUNDING_MODE)                              \
   __ENZYME_MPFR_BIN(binop, LLVM_OP_NAME, MPFR_FUNC_NAME, 64_52, double, d,     \
@@ -700,43 +781,15 @@ __ENZYME_MPFR_DOUBLE_BINOP_DEFAULT_ROUNDING(fdiv, div);
 __ENZYME_MPFR_DOUBLE_BINFUNCINTR_DEFAULT_ROUNDING(pow, pow);
 
 __ENZYME_MPFR_SINGOP(func, sqrt, sqrt, 64_52, double, d, double, d, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
+__ENZYME_MPFR_SINGOP(func, __sqrt_finite, sqrt, 64_52, double, d, double, d, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
 __ENZYME_MPFR_SINGOP(intr, fabs, abs, 64_52, double, d, double, d, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
 __ENZYME_MPFR_SINGOP(intr, llvm_fabs_f64, abs, 64_52, double, d, double, d, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
 
 __ENZYME_MPFR_FMULADD(64_52, double, d, f64, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
 // clang-format on
 
-typedef struct {
-  mpfr_t fp;
-} __enzyme_fp;
-
-double __enzyme_fprt_ptr_to_double(__enzyme_fp *p) {
-  return *((double *)(&p));
-}
-__enzyme_fp *__enzyme_fprt_double_to_ptr(double d) {
-  return *((__enzyme_fp **)(&d));
-}
-
-__ENZYME_MPFR_ATTRIBUTES
-double __enzyme_fprt_64_52_get(double _a,  int64_t exponent, int64_t significand, int64_t mode) {
-  __enzyme_fp *a = __enzyme_fprt_double_to_ptr(_a);
-  return mpfr_get_d(a->fp, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
-}
-
-__ENZYME_MPFR_ATTRIBUTES
-double __enzyme_fprt_64_52_new(double _a, int64_t exponent, int64_t significand, int64_t mode) {
-  __enzyme_fp *a = (__enzyme_fp *) malloc(sizeof(__enzyme_fp));
-  mpfr_set_d(a->fp, _a, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
-  return __enzyme_fprt_ptr_to_double(a);
-}
-
-__ENZYME_MPFR_ATTRIBUTES
-void __enzyme_fprt_64_52_delete(double a,  int64_t exponent, int64_t significand, int64_t mode) {
-  free(__enzyme_fprt_double_to_ptr(a));
-}
-
 #ifdef __cplusplus
-      }
+}
 #endif
 
 #endif // #ifndef __ENZYME_RUNTIME_ENZYME_MPFR__

--- a/enzyme/Enzyme/Clang/include_utils.td
+++ b/enzyme/Enzyme/Clang/include_utils.td
@@ -540,7 +540,7 @@ def : Headers<"/enzymeroot/enzyme/enzyme", [{
 #endif
 }]>;
 
-def : Headers<"/enzymeroot/enzyme/mpfr", [{
+def : Headers < "/enzymeroot/enzyme/mpfr", [{
 //===- EnzymeMPFR.h - MPFR wrappers ---------------------------------------===//
 //
 //                             Enzyme Project
@@ -569,9 +569,10 @@ def : Headers<"/enzymeroot/enzyme/mpfr", [{
 
 #include <mpfr.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #ifdef __cplusplus
-extern "C" {
+      extern "C" {
 #endif
 
 // TODO s
@@ -603,13 +604,16 @@ extern "C" {
 // simulation:
 //   [...] subnormal numbers are not implemented.
 //
+// TODO maybe take debug info as parameter - then we can emit warnings or tie
+// operations to source location
 
+#define __ENZYME_MPFR_ATTRIBUTES __attribute__((weak))
 #define __ENZYME_MPFR_SINGOP(OP_TYPE, LLVM_OP_NAME, MPFR_FUNC_NAME, FROM_TYPE, \
                              RET, MPFR_GET, ARG1, MPFR_SET_ARG1,               \
                              ROUNDING_MODE)                                    \
-  __attribute__((weak))                                                        \
+  __ENZYME_MPFR_ATTRIBUTES                                                        \
   RET __enzyme_fprt_##FROM_TYPE##_##OP_TYPE##_##LLVM_OP_NAME(                  \
-      ARG1 a, int64_t exponent, int64_t significand) {                         \
+      ARG1 a, int64_t exponent, int64_t significand, int64_t mode) {           \
     mpfr_t ma, mc;                                                             \
     mpfr_init2(ma, significand);                                               \
     mpfr_init2(mc, significand);                                               \
@@ -621,12 +625,12 @@ extern "C" {
     return c;                                                                  \
   }
 
-#define __ENZYME_MPFR_BINOP(OP_TYPE, LLVM_OP_NAME, MPFR_FUNC_NAME, FROM_TYPE,  \
-                            RET, MPFR_GET, ARG1, MPFR_SET_ARG1, ARG2,          \
-                            MPFR_SET_ARG2, ROUNDING_MODE)                      \
-  __attribute__((weak))                                                        \
+#define __ENZYME_MPFR_BIN(OP_TYPE, LLVM_OP_NAME, MPFR_FUNC_NAME, FROM_TYPE,    \
+                          RET, MPFR_GET, ARG1, MPFR_SET_ARG1, ARG2,            \
+                          MPFR_SET_ARG2, ROUNDING_MODE)                        \
+  __ENZYME_MPFR_ATTRIBUTES                                                        \
   RET __enzyme_fprt_##FROM_TYPE##_##OP_TYPE##_##LLVM_OP_NAME(                  \
-      ARG1 a, ARG2 b, int64_t exponent, int64_t significand) {                 \
+      ARG1 a, ARG2 b, int64_t exponent, int64_t significand, int64_t mode) {   \
     mpfr_t ma, mb, mc;                                                         \
     mpfr_init2(ma, significand);                                               \
     mpfr_init2(mb, significand);                                               \
@@ -641,25 +645,98 @@ extern "C" {
     return c;                                                                  \
   }
 
+#define __ENZYME_MPFR_FMULADD(FROM_TYPE, TYPE, MPFR_TYPE, LLVM_TYPE,           \
+                              ROUNDING_MODE)                                   \
+  __ENZYME_MPFR_ATTRIBUTES                                                        \
+  TYPE __enzyme_fprt_##FROM_TYPE##_intr_llvm_fmuladd_##LLVM_TYPE(              \
+      TYPE a, TYPE b, TYPE c, int64_t exponent, int64_t significand,           \
+      int64_t mode) {                                                          \
+    mpfr_t ma, mb, mc, mmul, madd;                                             \
+    mpfr_init2(ma, significand);                                               \
+    mpfr_init2(mb, significand);                                               \
+    mpfr_init2(mc, significand);                                               \
+    mpfr_init2(mmul, significand);                                             \
+    mpfr_init2(madd, significand);                                             \
+    mpfr_set_##MPFR_TYPE(ma, a, ROUNDING_MODE);                                \
+    mpfr_set_##MPFR_TYPE(mb, b, ROUNDING_MODE);                                \
+    mpfr_set_##MPFR_TYPE(mc, c, ROUNDING_MODE);                                \
+    mpfr_mul(mmul, ma, mb, ROUNDING_MODE);                                     \
+    mpfr_add(madd, mmul, mc, ROUNDING_MODE);                                   \
+    TYPE res = mpfr_get_##MPFR_TYPE(madd, ROUNDING_MODE);                      \
+    mpfr_clear(ma);                                                            \
+    mpfr_clear(mb);                                                            \
+    mpfr_clear(mc);                                                            \
+    mpfr_clear(mmul);                                                          \
+    mpfr_clear(madd);                                                          \
+    return res;                                                                \
+  }
+
 #define __ENZYME_MPFR_DEFAULT_ROUNDING_MODE GMP_RNDN
 #define __ENZYME_MPFR_DOUBLE_BINOP(LLVM_OP_NAME, MPFR_FUNC_NAME,               \
                                    ROUNDING_MODE)                              \
-  __ENZYME_MPFR_BINOP(binop, LLVM_OP_NAME, MPFR_FUNC_NAME, 64_52, double, d,   \
-                      double, d, double, d, ROUNDING_MODE)
+  __ENZYME_MPFR_BIN(binop, LLVM_OP_NAME, MPFR_FUNC_NAME, 64_52, double, d,     \
+                    double, d, double, d, ROUNDING_MODE)
+#define __ENZYME_MPFR_DOUBLE_BINFUNCINTR(LLVM_OP_NAME, MPFR_FUNC_NAME,         \
+                                         ROUNDING_MODE)                        \
+  __ENZYME_MPFR_BIN(intr, LLVM_OP_NAME, MPFR_FUNC_NAME, 64_52, double, d,      \
+                    double, d, double, d, ROUNDING_MODE)                       \
+  __ENZYME_MPFR_BIN(func, LLVM_OP_NAME, MPFR_FUNC_NAME, 64_52, double, d,      \
+                    double, d, double, d, ROUNDING_MODE)
 #define __ENZYME_MPFR_DOUBLE_BINOP_DEFAULT_ROUNDING(LLVM_OP_NAME,              \
                                                     MPFR_FUNC_NAME)            \
   __ENZYME_MPFR_DOUBLE_BINOP(LLVM_OP_NAME, MPFR_FUNC_NAME,                     \
                              __ENZYME_MPFR_DEFAULT_ROUNDING_MODE)
+#define __ENZYME_MPFR_DOUBLE_BINFUNCINTR_DEFAULT_ROUNDING(LLVM_OP_NAME,        \
+                                                          MPFR_FUNC_NAME)      \
+  __ENZYME_MPFR_DOUBLE_BINFUNCINTR(LLVM_OP_NAME, MPFR_FUNC_NAME,               \
+                                   __ENZYME_MPFR_DEFAULT_ROUNDING_MODE)
 
-__ENZYME_MPFR_DOUBLE_BINOP_DEFAULT_ROUNDING(fmul, mul)
-__ENZYME_MPFR_DOUBLE_BINOP_DEFAULT_ROUNDING(fadd, add)
-__ENZYME_MPFR_DOUBLE_BINOP_DEFAULT_ROUNDING(fdiv, div)
+// clang-format off
+__ENZYME_MPFR_DOUBLE_BINOP_DEFAULT_ROUNDING(fmul, mul);
+__ENZYME_MPFR_DOUBLE_BINOP_DEFAULT_ROUNDING(fadd, add);
+__ENZYME_MPFR_DOUBLE_BINOP_DEFAULT_ROUNDING(fsub, sub);
+__ENZYME_MPFR_DOUBLE_BINOP_DEFAULT_ROUNDING(fdiv, div);
 
-__ENZYME_MPFR_SINGOP(func, sqrt, sqrt, 64_52, double, d, double, d,
-                     __ENZYME_MPFR_DEFAULT_ROUNDING_MODE)
+__ENZYME_MPFR_DOUBLE_BINFUNCINTR_DEFAULT_ROUNDING(pow, pow);
+
+__ENZYME_MPFR_SINGOP(func, sqrt, sqrt, 64_52, double, d, double, d, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
+__ENZYME_MPFR_SINGOP(intr, fabs, abs, 64_52, double, d, double, d, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
+__ENZYME_MPFR_SINGOP(intr, llvm_fabs_f64, abs, 64_52, double, d, double, d, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
+
+__ENZYME_MPFR_FMULADD(64_52, double, d, f64, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
+// clang-format on
+
+typedef struct {
+  mpfr_t fp;
+} __enzyme_fp;
+
+double __enzyme_fprt_ptr_to_double(__enzyme_fp *p) {
+  return *((double *)(&p));
+}
+__enzyme_fp *__enzyme_fprt_double_to_ptr(double d) {
+  return *((__enzyme_fp **)(&d));
+}
+
+__ENZYME_MPFR_ATTRIBUTES
+double __enzyme_fprt_64_52_get(double _a,  int64_t exponent, int64_t significand, int64_t mode) {
+  __enzyme_fp *a = __enzyme_fprt_double_to_ptr(_a);
+  return mpfr_get_d(a->fp, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
+}
+
+__ENZYME_MPFR_ATTRIBUTES
+double __enzyme_fprt_64_52_new(double _a, int64_t exponent, int64_t significand, int64_t mode) {
+  __enzyme_fp *a = (__enzyme_fp *) malloc(sizeof(__enzyme_fp));
+  mpfr_set_d(a->fp, _a, __ENZYME_MPFR_DEFAULT_ROUNDING_MODE);
+  return __enzyme_fprt_ptr_to_double(a);
+}
+
+__ENZYME_MPFR_ATTRIBUTES
+void __enzyme_fprt_64_52_delete(double a,  int64_t exponent, int64_t significand, int64_t mode) {
+  free(__enzyme_fprt_double_to_ptr(a));
+}
 
 #ifdef __cplusplus
-}
+      }
 #endif
 
 #endif // #ifndef __ENZYME_RUNTIME_ENZYME_MPFR__

--- a/enzyme/Enzyme/Clang/include_utils.td
+++ b/enzyme/Enzyme/Clang/include_utils.td
@@ -608,7 +608,7 @@ extern "C" {
                              RET, MPFR_GET, ARG1, MPFR_SET_ARG1,               \
                              ROUNDING_MODE)                                    \
   __attribute__((weak))                                                        \
-  RET __enzyme_mpfr_##FROM_TYPE##_##OP_TYPE##_##LLVM_OP_NAME(                  \
+  RET __enzyme_fprt_##FROM_TYPE##_##OP_TYPE##_##LLVM_OP_NAME(                  \
       ARG1 a, int64_t exponent, int64_t significand) {                         \
     mpfr_t ma, mc;                                                             \
     mpfr_init2(ma, significand);                                               \
@@ -625,7 +625,7 @@ extern "C" {
                             RET, MPFR_GET, ARG1, MPFR_SET_ARG1, ARG2,          \
                             MPFR_SET_ARG2, ROUNDING_MODE)                      \
   __attribute__((weak))                                                        \
-  RET __enzyme_mpfr_##FROM_TYPE##_##OP_TYPE##_##LLVM_OP_NAME(                  \
+  RET __enzyme_fprt_##FROM_TYPE##_##OP_TYPE##_##LLVM_OP_NAME(                  \
       ARG1 a, ARG2 b, int64_t exponent, int64_t significand) {                 \
     mpfr_t ma, mb, mc;                                                         \
     mpfr_init2(ma, significand);                                               \

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -1355,7 +1355,8 @@ public:
         assert(Cto);
         return FloatTruncation(
             getDefaultFloatRepr((unsigned)Cfrom->getValue().getZExtValue()),
-            getDefaultFloatRepr((unsigned)Cto->getValue().getZExtValue()), mode);
+            getDefaultFloatRepr((unsigned)Cto->getValue().getZExtValue()),
+            mode);
       } else if (ArgSize == 4) {
         auto Cfrom = cast<ConstantInt>(CI->getArgOperand(1));
         assert(Cfrom);
@@ -1367,7 +1368,8 @@ public:
             getDefaultFloatRepr((unsigned)Cfrom->getValue().getZExtValue()),
             FloatRepresentation(
                 (unsigned)Cto_exponent->getValue().getZExtValue(),
-                (unsigned)Cto_significand->getValue().getZExtValue()), mode);
+                (unsigned)Cto_significand->getValue().getZExtValue()),
+            mode);
       }
       llvm_unreachable("??");
     }();

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -1355,7 +1355,7 @@ public:
         assert(Cto);
         return FloatTruncation(
             getDefaultFloatRepr((unsigned)Cfrom->getValue().getZExtValue()),
-            getDefaultFloatRepr((unsigned)Cto->getValue().getZExtValue()));
+            getDefaultFloatRepr((unsigned)Cto->getValue().getZExtValue()), mode);
       } else if (ArgSize == 4) {
         auto Cfrom = cast<ConstantInt>(CI->getArgOperand(1));
         assert(Cfrom);
@@ -1367,7 +1367,7 @@ public:
             getDefaultFloatRepr((unsigned)Cfrom->getValue().getZExtValue()),
             FloatRepresentation(
                 (unsigned)Cto_exponent->getValue().getZExtValue(),
-                (unsigned)Cto_significand->getValue().getZExtValue()));
+                (unsigned)Cto_significand->getValue().getZExtValue()), mode);
       }
       llvm_unreachable("??");
     }();
@@ -2107,7 +2107,7 @@ public:
         auto To = parseFloatRepr();
         if (!To)
           Invalid();
-        Tmp.push_back({*From, *To});
+        Tmp.push_back({*From, *To, TruncOpFullModuleMode});
         ConfigStr.consume_front(";");
       }
       return Tmp;

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -5505,9 +5505,9 @@ bool EnzymeLogic::CreateTruncateValue(RequestContext context, Value *v,
   auto truncation = FloatTruncation(from, to, TruncMemMode);
   TruncateUtils TU(truncation, B.GetInsertBlock()->getParent()->getParent());
   if (isTruncate)
-    converted = TU.createFPRTGetCall(B, v);
-  else
     converted = TU.createFPRTNewCall(B, v);
+  else
+    converted = TU.createFPRTGetCall(B, v);
   assert(converted);
 
   context.req->replaceAllUsesWith(converted);

--- a/enzyme/Enzyme/EnzymeLogic.h
+++ b/enzyme/Enzyme/EnzymeLogic.h
@@ -287,7 +287,11 @@ getTypeForWidth(llvm::LLVMContext &ctx, unsigned width, bool builtinFloat) {
   }
 }
 
-enum TruncateMode { TruncMemMode, TruncOpMode, TruncOpFullModuleMode };
+enum TruncateMode {
+  TruncMemMode = 0b0001,
+  TruncOpMode = 0b0010,
+  TruncOpFullModuleMode = 0b0110,
+};
 [[maybe_unused]] static const char *truncateModeStr(TruncateMode mode) {
   switch (mode) {
   case TruncMemMode:
@@ -376,7 +380,7 @@ public:
   llvm::Type *getFromType(llvm::LLVMContext &ctx) {
     return from.getBuiltinType(ctx);
   }
-  bool isToFPRTCall() {
+  bool isToFPRT() {
     // TODO maybe add new mode in which we directly truncate to native fp ops,
     // for now everything goes through the runtime
     return true;

--- a/enzyme/Enzyme/EnzymeLogic.h
+++ b/enzyme/Enzyme/EnzymeLogic.h
@@ -363,10 +363,12 @@ public:
       : from(From), to(To), mode(mode) {
     if (!From.canBeBuiltin())
       llvm::report_fatal_error("Float truncation `from` type is not builtin.");
-    if (From.exponentWidth < To.exponentWidth && (mode == TruncOpMode || mode == TruncOpFullModuleMode))
+    if (From.exponentWidth < To.exponentWidth &&
+        (mode == TruncOpMode || mode == TruncOpFullModuleMode))
       llvm::report_fatal_error("Float truncation `from` type must have "
                                "a wider exponent than `to`.");
-    if (From.significandWidth < To.significandWidth && (mode == TruncOpMode || mode == TruncOpFullModuleMode))
+    if (From.significandWidth < To.significandWidth &&
+        (mode == TruncOpMode || mode == TruncOpFullModuleMode))
       llvm::report_fatal_error("Float truncation `from` type must have "
                                "a wider significand than `to`.");
     if (From == To)
@@ -385,12 +387,8 @@ public:
     // for now everything goes through the runtime
     return true;
   }
-  llvm::Type *getToType(llvm::LLVMContext &ctx) {
-    return getFromType(ctx);
-  }
-  auto getTuple() const {
-    return std::tuple(from, to, mode);
-  }
+  llvm::Type *getToType(llvm::LLVMContext &ctx) { return getFromType(ctx); }
+  auto getTuple() const { return std::tuple(from, to, mode); }
   bool operator==(const FloatTruncation &other) const {
     return getTuple() == other.getTuple();
   }

--- a/enzyme/test/Enzyme/Truncate/cmp.ll
+++ b/enzyme/test/Enzyme/Truncate/cmp.ll
@@ -29,7 +29,7 @@ entry:
 }
 
 ; CHECK: define internal i1 @__enzyme_done_truncate_mem_func_64_52to32_23_f(double %x, double %y) {
-; CHECK-NEXT:   %res = call i1 @__enzyme_fprt_64_52_fcmp_olt(double %x, double %y, i64 8, i64 23, i64 0)
+; CHECK-NEXT:   %res = call i1 @__enzyme_fprt_64_52_fcmp_olt(double %x, double %y, i64 8, i64 23, i64 1)
 ; CHECK-NEXT:   ret i1 %res
 ; CHECK-NEXT: }
 

--- a/enzyme/test/Enzyme/Truncate/cmp.ll
+++ b/enzyme/test/Enzyme/Truncate/cmp.ll
@@ -29,18 +29,16 @@ entry:
 }
 
 ; CHECK: define internal i1 @__enzyme_done_truncate_mem_func_64_52to32_23_f(double %x, double %y) {
-; CHECK-DAG:   %1 = alloca double, align 8
-; CHECK-DAG:   store double %x, double* %1, align 8
-; CHECK-DAG:   %2 = bitcast double* %1 to float*
-; CHECK-DAG:   %3 = load float, float* %2, align 4
-; CHECK-DAG:   store double %y, double* %1, align 8
-; CHECK-DAG:   %4 = bitcast double* %1 to float*
-; CHECK-DAG:   %5 = load float, float* %4, align 4
-; CHECK-DAG:   %res = fcmp olt float %3, %5
-; CHECK-DAG:   ret i1 %res
+; CHECK-NEXT:   %res = call i1 @__enzyme_fprt_64_52_fcmp_olt(double %x, double %y, i64 8, i64 23, i64 0)
+; CHECK-NEXT:   ret i1 %res
+; CHECK-NEXT: }
 
 ; CHECK: define internal i1 @__enzyme_done_truncate_op_func_64_52to32_23_f(double %x, double %y) {
-; CHECK-DAG:   %enzyme_trunc = fptrunc double %x to float
-; CHECK-DAG:   %enzyme_trunc1 = fptrunc double %y to float
-; CHECK-DAG:   %res = fcmp olt float %enzyme_trunc, %enzyme_trunc1
-; CHECK-DAG:   ret i1 %res
+; CHECK-NEXT:   %res = fcmp olt double %x, %y
+; CHECK-NEXT:   ret i1 %res
+; CHECK-NEXT: }
+
+; CHECK: define internal i1 @__enzyme_done_truncate_op_func_64_52to11_7_f(double %x, double %y) {
+; CHECK-NEXT:   %res = fcmp olt double %x, %y
+; CHECK-NEXT:   ret i1 %res
+; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/Truncate/const.ll
+++ b/enzyme/test/Enzyme/Truncate/const.ll
@@ -1,0 +1,34 @@
+; RUN: if [ %llvmver -gt 12 ]; then if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme -S | FileCheck %s; fi; fi
+; RUN: if [ %llvmver -gt 12 ]; then %opt < %s %newLoadEnzyme -passes="enzyme" -S | FileCheck %s; fi
+
+define double @f(double %x) {
+  %res = fadd double %x, 1.0
+  ret double %res
+}
+
+declare double (double)* @__enzyme_truncate_mem_func(...)
+declare double (double)* @__enzyme_truncate_op_func(...)
+
+define double @tester(double %x) {
+entry:
+  %ptr = call double (double)* (...) @__enzyme_truncate_mem_func(double (double)* @f, i64 64, i64 32)
+  %res = call double %ptr(double %x)
+  ret double %res
+}
+define double @tester_op_mpfr(double %x) {
+entry:
+  %ptr = call double (double)* (...) @__enzyme_truncate_op_func(double (double)* @f, i64 64, i64 3, i64 7)
+  %res = call double %ptr(double %x)
+  ret double %res
+}
+
+; CHECK: define internal double @__enzyme_done_truncate_mem_func_64_52to32_23_f(double %x) {
+; CHECK-NEXT:   %1 = call double @__enzyme_fprt_64_52_const(double 1.000000e+00, i64 8, i64 23, i64 0)
+; CHECK-NEXT:   %res = call double @__enzyme_fprt_64_52_binop_fadd(double %x, double %1, i64 8, i64 23, i64 0)
+; CHECK-NEXT:   ret double %res
+; CHECK-NEXT: }
+
+; CHECK: define internal double @__enzyme_done_truncate_op_func_64_52to11_7_f(double %x) {
+; CHECK-NEXT:   %res = call double @__enzyme_fprt_64_52_binop_fadd(double %x, double 1.000000e+00, i64 3, i64 7, i64 1)
+; CHECK-NEXT:   ret double %res
+; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/Truncate/const.ll
+++ b/enzyme/test/Enzyme/Truncate/const.ll
@@ -23,12 +23,12 @@ entry:
 }
 
 ; CHECK: define internal double @__enzyme_done_truncate_mem_func_64_52to32_23_f(double %x) {
-; CHECK-NEXT:   %1 = call double @__enzyme_fprt_64_52_const(double 1.000000e+00, i64 8, i64 23, i64 0)
-; CHECK-NEXT:   %res = call double @__enzyme_fprt_64_52_binop_fadd(double %x, double %1, i64 8, i64 23, i64 0)
+; CHECK-NEXT:   %1 = call double @__enzyme_fprt_64_52_const(double 1.000000e+00, i64 8, i64 23, i64 1)
+; CHECK-NEXT:   %res = call double @__enzyme_fprt_64_52_binop_fadd(double %x, double %1, i64 8, i64 23, i64 1)
 ; CHECK-NEXT:   ret double %res
 ; CHECK-NEXT: }
 
 ; CHECK: define internal double @__enzyme_done_truncate_op_func_64_52to11_7_f(double %x) {
-; CHECK-NEXT:   %res = call double @__enzyme_fprt_64_52_binop_fadd(double %x, double 1.000000e+00, i64 3, i64 7, i64 1)
+; CHECK-NEXT:   %res = call double @__enzyme_fprt_64_52_binop_fadd(double %x, double 1.000000e+00, i64 3, i64 7, i64 2)
 ; CHECK-NEXT:   ret double %res
 ; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/Truncate/intrinsic.ll
+++ b/enzyme/test/Enzyme/Truncate/intrinsic.ll
@@ -42,15 +42,6 @@ entry:
 }
 
 ; CHECK: define internal double @__enzyme_done_truncate_mem_func_64_52to32_23_f(double %x, double %y) {
-; CHECK-DAG:   %1 = call double @__enzyme_fprt_64_52_func_pow(double %x, double %y, i64 8, i64 23, i64 0)
-; CHECK-DAG:   %2 = call double @__enzyme_fprt_64_52_intr_llvm_pow_f64(double %x, double %y, i64 8, i64 23, i64 0)
-; CHECK-DAG:   %3 = call double @__enzyme_fprt_64_52_intr_llvm_powi_f64_i16(double %x, i16 2, i64 8, i64 23, i64 0)
-; CHECK-DAG:   %res = call double @__enzyme_fprt_64_52_binop_fadd(double %2, double %3, i64 8, i64 23, i64 0)
-; CHECK-DAG:   call void @llvm.nvvm.barrier0()
-; CHECK-DAG:   ret double %res
-; CHECK-DAG: }
-
-; CHECK: define internal double @__enzyme_done_truncate_op_func_64_52to32_23_f(double %x, double %y) {
 ; CHECK-DAG:   %1 = call double @__enzyme_fprt_64_52_func_pow(double %x, double %y, i64 8, i64 23, i64 1)
 ; CHECK-DAG:   %2 = call double @__enzyme_fprt_64_52_intr_llvm_pow_f64(double %x, double %y, i64 8, i64 23, i64 1)
 ; CHECK-DAG:   %3 = call double @__enzyme_fprt_64_52_intr_llvm_powi_f64_i16(double %x, i16 2, i64 8, i64 23, i64 1)
@@ -59,11 +50,20 @@ entry:
 ; CHECK-DAG:   ret double %res
 ; CHECK-DAG: }
 
+; CHECK: define internal double @__enzyme_done_truncate_op_func_64_52to32_23_f(double %x, double %y) {
+; CHECK-DAG:   %1 = call double @__enzyme_fprt_64_52_func_pow(double %x, double %y, i64 8, i64 23, i64 2)
+; CHECK-DAG:   %2 = call double @__enzyme_fprt_64_52_intr_llvm_pow_f64(double %x, double %y, i64 8, i64 23, i64 2)
+; CHECK-DAG:   %3 = call double @__enzyme_fprt_64_52_intr_llvm_powi_f64_i16(double %x, i16 2, i64 8, i64 23, i64 2)
+; CHECK-DAG:   %res = call double @__enzyme_fprt_64_52_binop_fadd(double %2, double %3, i64 8, i64 23, i64 2)
+; CHECK-DAG:   call void @llvm.nvvm.barrier0()
+; CHECK-DAG:   ret double %res
+; CHECK-DAG: }
+
 ; CHECK: define internal double @__enzyme_done_truncate_op_func_64_52to11_7_f(double %x, double %y) {
-; CHECK-DAG:   %1 = call double @__enzyme_fprt_64_52_func_pow(double %x, double %y, i64 3, i64 7, i64 1)
-; CHECK-DAG:   %2 = call double @__enzyme_fprt_64_52_intr_llvm_pow_f64(double %x, double %y, i64 3, i64 7, i64 1)
-; CHECK-DAG:   %3 = call double @__enzyme_fprt_64_52_intr_llvm_powi_f64_i16(double %x, i16 2, i64 3, i64 7, i64 1)
-; CHECK-DAG:   %res = call double @__enzyme_fprt_64_52_binop_fadd(double %2, double %3, i64 3, i64 7, i64 1)
+; CHECK-DAG:   %1 = call double @__enzyme_fprt_64_52_func_pow(double %x, double %y, i64 3, i64 7, i64 2)
+; CHECK-DAG:   %2 = call double @__enzyme_fprt_64_52_intr_llvm_pow_f64(double %x, double %y, i64 3, i64 7, i64 2)
+; CHECK-DAG:   %3 = call double @__enzyme_fprt_64_52_intr_llvm_powi_f64_i16(double %x, i16 2, i64 3, i64 7, i64 2)
+; CHECK-DAG:   %res = call double @__enzyme_fprt_64_52_binop_fadd(double %2, double %3, i64 3, i64 7, i64 2)
 ; CHECK-DAG:   call void @llvm.nvvm.barrier0()
 ; CHECK-DAG:   ret double %res
 ; CHECK-DAG: }

--- a/enzyme/test/Enzyme/Truncate/intrinsic.ll
+++ b/enzyme/test/Enzyme/Truncate/intrinsic.ll
@@ -24,6 +24,10 @@ entry:
   %res = call double %ptr(double %x, double %y)
   ret double %res
 }
+; TODO This used to test if we detect that we truncate to a native float type
+; and use that instead of MPFR but now we always generate the FPRT calls.
+; Instead we shuold probably add an additional flag/mode to truncate to native
+; types
 define double @tester_op(double %x, double %y) {
 entry:
   %ptr = call double (double, double)* (...) @__enzyme_truncate_op_func(double (double, double)* @f, i64 64, i64 32)
@@ -38,79 +42,28 @@ entry:
 }
 
 ; CHECK: define internal double @__enzyme_done_truncate_mem_func_64_52to32_23_f(double %x, double %y) {
-; CHECK-DAG:   %1 = alloca double, align 8
-; CHECK-DAG:   store double %x, double* %1, align 8
-; CHECK-DAG:   %2 = bitcast double* %1 to float*
-; CHECK-DAG:   %3 = load float, float* %2, align 4
-; CHECK-DAG:   store double %y, double* %1, align 8
-; CHECK-DAG:   %4 = bitcast double* %1 to float*
-; CHECK-DAG:   %5 = load float, float* %4, align 4
-; CHECK-DAG:   %res01 = call float @llvm.pow.f32(float %3, float %5)
-; CHECK-DAG:   %6 = bitcast double* %1 to i64*
-; CHECK-DAG:   store i64 0, i64* %6, align 4
-; CHECK-DAG:   %7 = bitcast double* %1 to float*
-; CHECK-DAG:   store float %res01, float* %7, align 4
-; CHECK-DAG:   %8 = load double, double* %1, align 8
-; CHECK-DAG:   store double %x, double* %1, align 8
-; CHECK-DAG:   %9 = bitcast double* %1 to float*
-; CHECK-DAG:   %10 = load float, float* %9, align 4
-; CHECK-DAG:   store double %y, double* %1, align 8
-; CHECK-DAG:   %11 = bitcast double* %1 to float*
-; CHECK-DAG:   %12 = load float, float* %11, align 4
-; CHECK-DAG:   %res12 = call float @llvm.pow.f32(float %10, float %12)
-; CHECK-DAG:   %13 = bitcast double* %1 to i64*
-; CHECK-DAG:   store i64 0, i64* %13, align 4
-; CHECK-DAG:   %14 = bitcast double* %1 to float*
-; CHECK-DAG:   store float %res12, float* %14, align 4
-; CHECK-DAG:   %15 = load double, double* %1, align 8
-; CHECK-DAG:   store double %x, double* %1, align 8
-; CHECK-DAG:   %16 = bitcast double* %1 to float*
-; CHECK-DAG:   %17 = load float, float* %16, align 4
-; CHECK-DAG:   %res23 = call float @llvm.powi.f32.i16(float %17, i16 2)
-; CHECK-DAG:   %18 = bitcast double* %1 to i64*
-; CHECK-DAG:   store i64 0, i64* %18, align 4
-; CHECK-DAG:   %19 = bitcast double* %1 to float*
-; CHECK-DAG:   store float %res23, float* %19, align 4
-; CHECK-DAG:   %20 = load double, double* %1, align 8
-; CHECK-DAG:   store double %15, double* %1, align 8
-; CHECK-DAG:   %21 = bitcast double* %1 to float*
-; CHECK-DAG:   %22 = load float, float* %21, align 4
-; CHECK-DAG:   store double %20, double* %1, align 8
-; CHECK-DAG:   %23 = bitcast double* %1 to float*
-; CHECK-DAG:   %24 = load float, float* %23, align 4
-; CHECK-DAG:   %res = fadd float %22, %24
-; CHECK-DAG:   %25 = bitcast double* %1 to i64*
-; CHECK-DAG:   store i64 0, i64* %25, align 4
-; CHECK-DAG:   %26 = bitcast double* %1 to float*
-; CHECK-DAG:   store float %res, float* %26, align 4
-; CHECK-DAG:   %27 = load double, double* %1, align 8
+; CHECK-DAG:   %1 = call double @__enzyme_fprt_64_52_func_pow(double %x, double %y, i64 8, i64 23, i64 0)
+; CHECK-DAG:   %2 = call double @__enzyme_fprt_64_52_intr_llvm_pow_f64(double %x, double %y, i64 8, i64 23, i64 0)
+; CHECK-DAG:   %3 = call double @__enzyme_fprt_64_52_intr_llvm_powi_f64_i16(double %x, i16 2, i64 8, i64 23, i64 0)
+; CHECK-DAG:   %res = call double @__enzyme_fprt_64_52_binop_fadd(double %2, double %3, i64 8, i64 23, i64 0)
 ; CHECK-DAG:   call void @llvm.nvvm.barrier0()
-; CHECK-DAG:   ret double %27
+; CHECK-DAG:   ret double %res
+; CHECK-DAG: }
 
 ; CHECK: define internal double @__enzyme_done_truncate_op_func_64_52to32_23_f(double %x, double %y) {
-; CHECK-DAG:   %enzyme_trunc = fptrunc double %x to float
-; CHECK-DAG:   %enzyme_trunc1 = fptrunc double %y to float
-; CHECK-DAG:   %res02 = call float @llvm.pow.f32(float %enzyme_trunc, float %enzyme_trunc1)
-; CHECK-DAG:   %enzyme_exp = fpext float %res02 to double
-; CHECK-DAG:   %enzyme_trunc3 = fptrunc double %x to float
-; CHECK-DAG:   %enzyme_trunc4 = fptrunc double %y to float
-; CHECK-DAG:   %res15 = call float @llvm.pow.f32(float %enzyme_trunc3, float %enzyme_trunc4)
-; CHECK-DAG:   %enzyme_exp6 = fpext float %res15 to double
-; CHECK-DAG:   %enzyme_trunc7 = fptrunc double %x to float
-; CHECK-DAG:   %res28 = call float @llvm.powi.f32.i16(float %enzyme_trunc7, i16 2)
-; CHECK-DAG:   %enzyme_exp9 = fpext float %res28 to double
-; CHECK-DAG:   %enzyme_trunc10 = fptrunc double %enzyme_exp6 to float
-; CHECK-DAG:   %enzyme_trunc11 = fptrunc double %enzyme_exp9 to float
-; CHECK-DAG:   %res = fadd float %enzyme_trunc10, %enzyme_trunc11
-; CHECK-DAG:   %enzyme_exp12 = fpext float %res to double
+; CHECK-DAG:   %1 = call double @__enzyme_fprt_64_52_func_pow(double %x, double %y, i64 8, i64 23, i64 1)
+; CHECK-DAG:   %2 = call double @__enzyme_fprt_64_52_intr_llvm_pow_f64(double %x, double %y, i64 8, i64 23, i64 1)
+; CHECK-DAG:   %3 = call double @__enzyme_fprt_64_52_intr_llvm_powi_f64_i16(double %x, i16 2, i64 8, i64 23, i64 1)
+; CHECK-DAG:   %res = call double @__enzyme_fprt_64_52_binop_fadd(double %2, double %3, i64 8, i64 23, i64 1)
 ; CHECK-DAG:   call void @llvm.nvvm.barrier0()
-; CHECK-DAG:   ret double %enzyme_exp12
+; CHECK-DAG:   ret double %res
+; CHECK-DAG: }
 
 ; CHECK: define internal double @__enzyme_done_truncate_op_func_64_52to11_7_f(double %x, double %y) {
-; CHECK-DAG:   %1 = call double @__enzyme_mpfr_64_52_func_pow(double %x, double %y, i64 3, i64 7)
-; CHECK-DAG:   %2 = call double @__enzyme_mpfr_64_52_intr_llvm_pow_f64(double %x, double %y, i64 3, i64 7)
-; CHECK-DAG:   %3 = call double @__enzyme_mpfr_64_52_intr_llvm_powi_f64_i16(double %x, i16 2, i64 3, i64 7)
-; CHECK-DAG:   %res = call double @__enzyme_mpfr_64_52_binop_fadd(double %2, double %3, i64 3, i64 7)
+; CHECK-DAG:   %1 = call double @__enzyme_fprt_64_52_func_pow(double %x, double %y, i64 3, i64 7, i64 1)
+; CHECK-DAG:   %2 = call double @__enzyme_fprt_64_52_intr_llvm_pow_f64(double %x, double %y, i64 3, i64 7, i64 1)
+; CHECK-DAG:   %3 = call double @__enzyme_fprt_64_52_intr_llvm_powi_f64_i16(double %x, i16 2, i64 3, i64 7, i64 1)
+; CHECK-DAG:   %res = call double @__enzyme_fprt_64_52_binop_fadd(double %2, double %3, i64 3, i64 7, i64 1)
 ; CHECK-DAG:   call void @llvm.nvvm.barrier0()
 ; CHECK-DAG:   ret double %res
 ; CHECK-DAG: }

--- a/enzyme/test/Enzyme/Truncate/select.ll
+++ b/enzyme/test/Enzyme/Truncate/select.ll
@@ -23,27 +23,12 @@ entry:
   ret double %res
 }
 
-; CHECK: define double @tester(double %x, double %y, i1 %cond) {
-; CHECK-NEXT: entry:
-; CHECK-NEXT:   %res = call double @__enzyme_done_truncate_mem_func_64_52to32_23_f(double %x, double %y, i1 %cond)
-; CHECK-NEXT:   ret double %res
-
 ; CHECK: define internal double @__enzyme_done_truncate_mem_func_64_52to32_23_f(double %x, double %y, i1 %cond) {
-; CHECK-DAG:    %1 = alloca double, align 8
-; CHECK-DAG:    store double %x, double* %1, align 8
-; CHECK-DAG:    %2 = bitcast double* %1 to float*
-; CHECK-DAG:    %3 = load float, float* %2, align 4
-; CHECK-DAG:    store double %y, double* %1, align 8
-; CHECK-DAG:    %4 = bitcast double* %1 to float*
-; CHECK-DAG:    %5 = load float, float* %4, align 4
-; CHECK-DAG:    %res = select i1 %cond, float %3, float %5
-; CHECK-DAG:    %6 = bitcast double* %1 to i64*
-; CHECK-DAG:    store i64 0, i64* %6, align 4
-; CHECK-DAG:    %7 = bitcast double* %1 to float*
-; CHECK-DAG:    store float %res, float* %7, align 4
-; CHECK-DAG:    %8 = load double, double* %1, align 8
-; CHECK-DAG:    ret double %8
+; CHECK-NEXT:   %res = select i1 %cond, double %x, double %y
+; CHECK-NEXT:   ret double %res
+; CHECK-NEXT: }
 
 ; CHECK: define internal double @__enzyme_done_truncate_op_func_64_52to32_23_f(double %x, double %y, i1 %cond) {
-; CHECK-DAG:   %res = select i1 %cond, double %x, double %y
-; CHECK-DAG:   ret double %res
+; CHECK-NEXT:   %res = select i1 %cond, double %x, double %y
+; CHECK-NEXT:   ret double %res
+; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/Truncate/simple.ll
+++ b/enzyme/test/Enzyme/Truncate/simple.ll
@@ -36,21 +36,21 @@ entry:
 
 ; CHECK: define internal void @__enzyme_done_truncate_mem_func_64_52to32_23_f(double* %x) {
 ; CHECK-DAG:   %y = load double, double* %x, align 8
-; CHECK-DAG:   %m = call double @__enzyme_fprt_64_52_binop_fmul(double %y, double %y, i64 8, i64 23, i64 0)
+; CHECK-DAG:   %m = call double @__enzyme_fprt_64_52_binop_fmul(double %y, double %y, i64 8, i64 23, i64 1)
 ; CHECK-DAG:   store double %m, double* %x, align 8
 ; CHECK-DAG:   ret void
 ; CHECK-DAG: }
 
 ; CHECK: define internal void @__enzyme_done_truncate_op_func_64_52to32_23_f(double* %x) {
 ; CHECK-DAG:   %y = load double, double* %x, align 8
-; CHECK-DAG:   %m = call double @__enzyme_fprt_64_52_binop_fmul(double %y, double %y, i64 8, i64 23, i64 1)
+; CHECK-DAG:   %m = call double @__enzyme_fprt_64_52_binop_fmul(double %y, double %y, i64 8, i64 23, i64 2)
 ; CHECK-DAG:   store double %m, double* %x, align 8
 ; CHECK-DAG:   ret void
 ; CHECK-DAG: }
 
 ; CHECK: define internal void @__enzyme_done_truncate_op_func_64_52to11_7_f(double* %x) {
 ; CHECK-DAG:   %y = load double, double* %x, align 8
-; CHECK-DAG:   %m = call double @__enzyme_fprt_64_52_binop_fmul(double %y, double %y, i64 3, i64 7, i64 1)
+; CHECK-DAG:   %m = call double @__enzyme_fprt_64_52_binop_fmul(double %y, double %y, i64 3, i64 7, i64 2)
 ; CHECK-DAG:   store double %m, double* %x, align 8
 ; CHECK-DAG:   ret void
 ; CHECK-DAG: }

--- a/enzyme/test/Enzyme/Truncate/simple.ll
+++ b/enzyme/test/Enzyme/Truncate/simple.ll
@@ -17,6 +17,10 @@ entry:
   call void %ptr(double* %data)
   ret void
 }
+; TODO This used to test if we detect that we truncate to a native float type
+; and use that instead of MPFR but now we always generate the FPRT calls.
+; Instead we shuold probably add an additional flag/mode to truncate to native
+; types
 define void @tester_op(double* %data) {
 entry:
   %ptr = call void (double*)* (...) @__enzyme_truncate_op_func(void (double*)* @f, i64 64, i64 32)
@@ -30,35 +34,23 @@ entry:
   ret void
 }
 
-; CHECK: define internal void @__enzyme_done_truncate_mem_func_64_52to32_23_f(double* %x)
-; CHECK-DAG:   %1 = alloca double, align 8
+; CHECK: define internal void @__enzyme_done_truncate_mem_func_64_52to32_23_f(double* %x) {
 ; CHECK-DAG:   %y = load double, double* %x, align 8
-; CHECK-DAG:   store double %y, double* %1, align 8
-; CHECK-DAG:   %2 = bitcast double* %1 to float*
-; CHECK-DAG:   %3 = load float, float* %2, align 4
-; CHECK-DAG:   store double %y, double* %1, align 8
-; CHECK-DAG:   %4 = bitcast double* %1 to float*
-; CHECK-DAG:   %5 = load float, float* %4, align 4
-; CHECK-DAG:   %m = fmul float %3, %5
-; CHECK-DAG:   %6 = bitcast double* %1 to i64*
-; CHECK-DAG:   store i64 0, i64* %6, align 4
-; CHECK-DAG:   %7 = bitcast double* %1 to float*
-; CHECK-DAG:   store float %m, float* %7, align 4
-; CHECK-DAG:   %8 = load double, double* %1, align 8
-; CHECK-DAG:   store double %8, double* %x, align 8
+; CHECK-DAG:   %m = call double @__enzyme_fprt_64_52_binop_fmul(double %y, double %y, i64 8, i64 23, i64 0)
+; CHECK-DAG:   store double %m, double* %x, align 8
 ; CHECK-DAG:   ret void
+; CHECK-DAG: }
 
 ; CHECK: define internal void @__enzyme_done_truncate_op_func_64_52to32_23_f(double* %x) {
 ; CHECK-DAG:   %y = load double, double* %x, align 8
-; CHECK-DAG:   %enzyme_trunc = fptrunc double %y to float
-; CHECK-DAG:   %enzyme_trunc1 = fptrunc double %y to float
-; CHECK-DAG:   %m = fmul float %enzyme_trunc, %enzyme_trunc1
-; CHECK-DAG:   %enzyme_exp = fpext float %m to double
-; CHECK-DAG:   store double %enzyme_exp, double* %x, align 8
+; CHECK-DAG:   %m = call double @__enzyme_fprt_64_52_binop_fmul(double %y, double %y, i64 8, i64 23, i64 1)
+; CHECK-DAG:   store double %m, double* %x, align 8
 ; CHECK-DAG:   ret void
+; CHECK-DAG: }
 
 ; CHECK: define internal void @__enzyme_done_truncate_op_func_64_52to11_7_f(double* %x) {
 ; CHECK-DAG:   %y = load double, double* %x, align 8
-; CHECK-DAG:   %m = call double @__enzyme_mpfr_64_52_binop_fmul(double %y, double %y, i64 3, i64 7)
+; CHECK-DAG:   %m = call double @__enzyme_fprt_64_52_binop_fmul(double %y, double %y, i64 3, i64 7, i64 1)
 ; CHECK-DAG:   store double %m, double* %x, align 8
 ; CHECK-DAG:   ret void
+; CHECK-DAG: }

--- a/enzyme/test/Enzyme/Truncate/value.ll
+++ b/enzyme/test/Enzyme/Truncate/value.ll
@@ -18,10 +18,10 @@ entry:
 
 ; CHECK: define double @expand_tester(double %a, double* %c) {
 ; CHECK-NEXT: entry:
-; CHECK-NEXT:   %0 = call double @__enzyme_fprt_64_52_new(double %a, i64 8, i64 23, i64 0)
+; CHECK-NEXT:   %0 = call double @__enzyme_fprt_64_52_get(double %a, i64 8, i64 23, i64 1)
 ; CHECK-NEXT:   ret double %0
 
 ; CHECK: define double @truncate_tester(double %a) {
 ; CHECK-NEXT: entry:
-; CHECK-NEXT:   %0 = call double @__enzyme_fprt_64_52_get(double %a, i64 8, i64 23, i64 0)
+; CHECK-NEXT:   %0 = call double @__enzyme_fprt_64_52_new(double %a, i64 8, i64 23, i64 1)
 ; CHECK-NEXT:   ret double %0

--- a/enzyme/test/Enzyme/Truncate/value.ll
+++ b/enzyme/test/Enzyme/Truncate/value.ll
@@ -18,20 +18,10 @@ entry:
 
 ; CHECK: define double @expand_tester(double %a, double* %c) {
 ; CHECK-NEXT: entry:
-; CHECK-NEXT:   %0 = alloca double, align 8
-; CHECK-NEXT:   store double %a, double* %0, align 8
-; CHECK-NEXT:   %1 = bitcast double* %0 to float*
-; CHECK-NEXT:   %2 = load float, float* %1, align 4
-; CHECK-NEXT:   %3 = fpext float %2 to double
-; CHECK-NEXT:   ret double %3
+; CHECK-NEXT:   %0 = call double @__enzyme_fprt_64_52_new(double %a, i64 8, i64 23, i64 0)
+; CHECK-NEXT:   ret double %0
 
 ; CHECK: define double @truncate_tester(double %a) {
 ; CHECK-NEXT: entry:
-; CHECK-NEXT:   %0 = fptrunc double %a to float
-; CHECK-NEXT:   %1 = alloca double, align 8
-; CHECK-NEXT:   %2 = bitcast double* %1 to i64*
-; CHECK-NEXT:   store i64 0, i64* %2, align 4
-; CHECK-NEXT:   %3 = bitcast double* %1 to float*
-; CHECK-NEXT:   store float %0, float* %3, align 4
-; CHECK-NEXT:   %4 = load double, double* %1, align 8
-; CHECK-NEXT:   ret double %4
+; CHECK-NEXT:   %0 = call double @__enzyme_fprt_64_52_get(double %a, i64 8, i64 23, i64 0)
+; CHECK-NEXT:   ret double %0

--- a/enzyme/test/Integration/Truncate/simple.cpp
+++ b/enzyme/test/Integration/Truncate/simple.cpp
@@ -1,7 +1,8 @@
-// RUN: %clang             -DTRUNC_OP -O0                %s -S -emit-llvm -o - | %opt - %OPloadEnzyme %enzyme -S | %lli -
-// RUN: %clang -DTRUNC_MEM -DTRUNC_OP -O2                %s -S -emit-llvm -o - | %opt - %OPloadEnzyme %enzyme -S | %lli -
-// RUN: %clang             -DTRUNC_OP -O2    -ffast-math %s -S -emit-llvm -o - | %opt - %OPloadEnzyme %enzyme -S | %lli -
-// RUN: %clang                        -O1 -g             %s -S -emit-llvm -o - | %opt - %OPloadEnzyme %enzyme -S | %lli -
+// clang-format off
+// RUN: if [ %llvmver -ge 12 ] && [ %hasMPFR == "yes" ] ; then %clang             -DTRUNC_OP -O0                %s -o %s.a.out %newLoadClangEnzyme -include enzyme/mpfr -lm -lmpfr; %s.a.out ; fi
+// RUN: if [ %llvmver -ge 12 ] && [ %hasMPFR == "yes" ] ; then %clang             -DTRUNC_OP -O2    -ffast-math %s -o %s.a.out %newLoadClangEnzyme -include enzyme/mpfr -lm -lmpfr; %s.a.out ; fi
+// RUN: if [ %llvmver -ge 12 ] && [ %hasMPFR == "yes" ] ; then %clang                        -O1 -g             %s -o %s.a.out %newLoadClangEnzyme -include enzyme/mpfr -lm -lmpfr; %s.a.out ; fi
+// RUN: if [ %llvmver -ge 12 ] && [ %hasMPFR == "yes" ] ; then %clang -DTRUNC_MEM -DTRUNC_OP -O2                %s -o %s.a.out %newLoadClangEnzyme -include enzyme/mpfr -lm -lmpfr; %s.a.out ; fi
 
 #include <math.h>
 

--- a/enzyme/test/Integration/Truncate/simple.cpp
+++ b/enzyme/test/Integration/Truncate/simple.cpp
@@ -1,8 +1,10 @@
 // clang-format off
-// RUN: if [ %llvmver -ge 12 ] && [ %hasMPFR == "yes" ] ; then %clang             -DTRUNC_OP -O0                %s -o %s.a.out %newLoadClangEnzyme -include enzyme/mpfr -lm -lmpfr; %s.a.out ; fi
-// RUN: if [ %llvmver -ge 12 ] && [ %hasMPFR == "yes" ] ; then %clang             -DTRUNC_OP -O2    -ffast-math %s -o %s.a.out %newLoadClangEnzyme -include enzyme/mpfr -lm -lmpfr; %s.a.out ; fi
-// RUN: if [ %llvmver -ge 12 ] && [ %hasMPFR == "yes" ] ; then %clang                        -O1 -g             %s -o %s.a.out %newLoadClangEnzyme -include enzyme/mpfr -lm -lmpfr; %s.a.out ; fi
-// RUN: if [ %llvmver -ge 12 ] && [ %hasMPFR == "yes" ] ; then %clang -DTRUNC_MEM -DTRUNC_OP -O2                %s -o %s.a.out %newLoadClangEnzyme -include enzyme/mpfr -lm -lmpfr; %s.a.out ; fi
+// RUN: if [ %llvmver -ge 12 ] && [ %hasMPFR == "yes" ] ; then %clang                -DTRUNC_OP -O0                %s -o %s.a.out %newLoadClangEnzyme -include enzyme/mpfr -lm -lmpfr; %s.a.out ; fi
+// RUN: if [ %llvmver -ge 12 ] && [ %hasMPFR == "yes" ] ; then %clang                -DTRUNC_OP -O2    -ffast-math %s -o %s.a.out %newLoadClangEnzyme -include enzyme/mpfr -lm -lmpfr; %s.a.out ; fi
+// RUN: if [ %llvmver -ge 12 ] && [ %hasMPFR == "yes" ] ; then %clang                           -O1 -g             %s -o %s.a.out %newLoadClangEnzyme -include enzyme/mpfr -lm -lmpfr; %s.a.out ; fi
+// RUN: if [ %llvmver -ge 12 ] && [ %hasMPFR == "yes" ] ; then %clang    -DTRUNC_MEM -DTRUNC_OP -O2                %s -o %s.a.out %newLoadClangEnzyme -include enzyme/mpfr -lm -lmpfr; %s.a.out ; fi
+// TODO:
+// COM: if [ %llvmver -ge 12 ] && [ %hasMPFR == "yes" ] ; then %clang -g -DTRUNC_MEM -DTRUNC_OP -O2                %s -o %s.a.out %newLoadClangEnzyme -include enzyme/mpfr -lm -lmpfr; %s.a.out ; fi
 
 #include <math.h>
 

--- a/enzyme/test/Integration/Truncate/truncate-all.cpp
+++ b/enzyme/test/Integration/Truncate/truncate-all.cpp
@@ -1,3 +1,4 @@
+// clang-format off
 // Baseline
 
 // RUN: if [ %llvmver -ge 12 ]; then %clang -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme -S -mllvm --enzyme-truncate-all="" | %lli - | FileCheck --check-prefix BASELINE %s; fi
@@ -6,10 +7,10 @@
 
 // Truncated
 
-// RUN: if [ %llvmver -ge 12 ]; then %clang -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme -S -mllvm --enzyme-truncate-all="64to32" | %lli - | FileCheck --check-prefix TO_32 %s; fi
+// RUN: if [ %llvmver -ge 12 ] && [ %hasMPFR == "yes" ] ; then %clang -DENZYME_TEST_TO_MPFR -O3 %s -o %s.a.out %newLoadClangEnzyme -mllvm --enzyme-truncate-all="64to32" -lmpfr;  %s.a.out | FileCheck --check-prefix TO_32 %s; fi
 // TO_32: 900000000.000000
 
-// RUN: if [ %llvmver -ge 12 ]; then %clang -O3 %s -S -emit-llvm -o - %newLoadClangEnzyme -S -mllvm --enzyme-truncate-all="11-52to8-23" | %lli - | FileCheck --check-prefix TO_28_23 %s; fi
+// RUN: if [ %llvmver -ge 12 ] && [ %hasMPFR == "yes" ] ; then %clang -DENZYME_TEST_TO_MPFR -O3 %s -o %s.a.out %newLoadClangEnzyme -mllvm --enzyme-truncate-all="11-52to8-23" -lmpfr;  %s.a.out | FileCheck --check-prefix TO_28_23 %s; fi
 // TO_28_23: 900000000.000000
 
 // RUN: if [ %llvmver -ge 12 ] && [ %hasMPFR == "yes" ] ; then %clang -DENZYME_TEST_TO_MPFR -O3 %s -o %s.a.out %newLoadClangEnzyme -mllvm --enzyme-truncate-all="11-52to3-7" -lmpfr;  %s.a.out | FileCheck --check-prefix TO_3_7 %s; fi


### PR DESCRIPTION
This allows all floating point numbers of a given precision to be replaced with a custom representation on which we can perform arbitrary computation at each original fp operation.