### PR TITLE
[mlir] add explicit dependency on BytecodeOpInterface

### DIFF
--- a/enzyme/BUILD
+++ b/enzyme/BUILD
@@ -616,6 +616,7 @@ cc_library(
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:ArithUtils",
         "@llvm-project//mlir:AsyncDialect",
+        "@llvm-project//mlir:BytecodeOpInterface",
         "@llvm-project//mlir:CallOpInterfaces",
         "@llvm-project//mlir:CastInterfaces",
         "@llvm-project//mlir:ControlFlowDialect",


### PR DESCRIPTION
This makes C++ modules happier.