### PR TITLE
Replace `LLVM_FALLTHROUGH` with `[[fallthrough]]`

### DIFF
--- a/enzyme/Enzyme/TypeAnalysis/ConcreteType.h
+++ b/enzyme/Enzyme/TypeAnalysis/ConcreteType.h
@@ -456,7 +456,7 @@ public:
           }
           break;
         }
-        LLVM_FALLTHROUGH;
+        [[fallthrough]];
       case BinaryOperator::Add:
       case BinaryOperator::Mul:
         if (SubTypeEnum != BaseType::Pointer) {


### PR DESCRIPTION
LLVM's in-tree use was mostly migrated in https://github.com/llvm/llvm-project/commit/3f18f7c0072b642f5fe88d2fb7bb8ccf69a6c6f5. This will prevent breakages if/when that macro is deleted.