### PR TITLE
Add __*_finite versions of derivatives

### DIFF
--- a/enzyme/test/Enzyme/ForwardMode/hypot.ll
+++ b/enzyme/test/Enzyme/ForwardMode/hypot.ll
@@ -8,13 +8,26 @@ entry:
   ret double %call
 }
 
+define double @tester2(double %x, double %y) {
+entry:
+  %call = tail call double @__hypot_finite(double %x, double %y)
+  ret double %call
+}
+
 define double @test_derivative(double %x, double %y) {
 entry:
   %0 = tail call double (...) @__enzyme_fwddiff(double (double, double)* nonnull @tester, double %x, double 1.000000e+00, double %y, double 1.000000e+00)
   ret double %0
 }
 
+define double @test_derivative2(double %x, double %y) {
+entry:
+  %0 = tail call double (...) @__enzyme_fwddiff(double (double, double)* nonnull @tester2, double %x, double 1.000000e+00, double %y, double 1.000000e+00)
+  ret double %0
+}
+
 declare double @hypot(double, double)
+declare double @__hypot_finite(double, double)
 
 ; Function Attrs: nounwind
 declare double @__enzyme_fwddiff(...)

--- a/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
+++ b/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
@@ -1726,10 +1726,17 @@ static void emitDerivatives(const RecordKeeper &recordKeeper, raw_ostream &os,
       bool prev = false;
       for (auto *nameI :
            *cast<ListInit>(pattern->getValueAsListInit("names"))) {
-        if (prev)
-          os << " ||\n      ";
-        os << "funcName == " << cast<StringInit>(nameI)->getAsString() << "";
-        prev = true;
+        auto nameIStr = cast<StringInit>(nameI)->getAsString();
+        auto nameIStrFinite = "\"__" +
+                              std::string(std::next(nameIStr.begin()),
+                                          std::prev(nameIStr.end())) +
+                              "_finite\"";
+        for (auto nameIStrAll : {nameIStr, nameIStrFinite}) {
+          if (prev)
+            os << " ||\n      ";
+          os << "funcName == " << nameIStrAll << "";
+          prev = true;
+        }
       }
       origName = "call";
 #if LLVM_VERSION_MAJOR >= 14


### PR DESCRIPTION
From my understanding, the __*_finite versions of math functions are either aliases to the normal ones or faster versions that can assume no infinite operands. This automatically generates the same derivatives for them as the normal function. 

@wsmoses How do you think we should handle this? Currently it would also generate derivatives for `___nv_asin_finite` for example, which doesn't exist.