### PR TITLE
abort compilation if cfg not found

### DIFF
--- a/enzyme/CMakeLists.txt
+++ b/enzyme/CMakeLists.txt
@@ -55,6 +55,9 @@ set(LLVM_DIR "${LLVM_ABSOLUTE_DIR}" CACHE FILEPATH "b" FORCE)
 
 if (EXISTS "${LLVM_DIR}/lib/cmake/llvm/LLVMConfig.cmake")
   set(LLVM_DIR "${LLVM_DIR}/lib/cmake/llvm")
+else()
+  message("LLVM Config: ${LLVM_DIR}/lib/cmake/llvm/LLVMConfig.cmake")
+  message(FATAL_ERROR "LLVM Config not found")
 endif()
 
 message("LLVM ABS DIR " ${LLVM_DIR})

--- a/enzyme/CMakeLists.txt
+++ b/enzyme/CMakeLists.txt
@@ -51,13 +51,14 @@ get_filename_component(LLVM_ABSOLUTE_DIR
     "${LLVM_DIR}"
     REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
 
+if (NOT EXISTS "${LLVM_DIR}")
+  message(SEND_ERROR "The given LLVM_DIR does not exist. Typo?")
+endif()
+
 set(LLVM_DIR "${LLVM_ABSOLUTE_DIR}" CACHE FILEPATH "b" FORCE)
 
 if (EXISTS "${LLVM_DIR}/lib/cmake/llvm/LLVMConfig.cmake")
   set(LLVM_DIR "${LLVM_DIR}/lib/cmake/llvm")
-else()
-  message("LLVM Config: ${LLVM_DIR}/lib/cmake/llvm/LLVMConfig.cmake")
-  message(FATAL_ERROR "LLVM Config not found")
 endif()
 
 message("LLVM ABS DIR " ${LLVM_DIR})

--- a/enzyme/CMakeLists.txt
+++ b/enzyme/CMakeLists.txt
@@ -52,6 +52,7 @@ get_filename_component(LLVM_ABSOLUTE_DIR
     REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
 
 if (NOT EXISTS "${LLVM_DIR}")
+  message("Looking for LLVM_DIR at ${LLVM_DIR}")
   message(SEND_ERROR "The given LLVM_DIR does not exist. Typo?")
 endif()
 


### PR DESCRIPTION
If we provide a path, we want Enzyme to actually use it.
If that's not possible, rather error than taking a surprising other version.

closes #1815
