### PR TITLE
Update TypeAnalysis.cpp

### DIFF
--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -712,7 +712,7 @@ void getConstantAnalysis(Constant *Val, TypeAnalyzer &TA,
 
     // Constants explicitly marked as negative that aren't -1 are considered
     // integral
-    if (ci->isNegative() && ci->getSExtValue() < -1) {
+    if (ci->isNegative() && !ci->isMinusOne()) {
       analysis[Val].insert({-1}, BaseType::Integer);
       return;
     }

--- a/enzyme/test/TypeAnalysis/i128neg.ll
+++ b/enzyme/test/TypeAnalysis/i128neg.ll
@@ -1,0 +1,19 @@
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -print-type-analysis -type-analysis-func=caller -o /dev/null | FileCheck %s; fi
+; RUN: %opt < %s %newLoadEnzyme -passes="print-type-analysis" -type-analysis-func=caller -S | FileCheck %s
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @caller() {
+entry:
+  %a.dbg.spill = alloca i128, align 16
+  store i128 -12078052328127107563834081753142289173, i128* %a.dbg.spill, align 16
+  ret void
+}
+
+
+; CHECK: caller - {} |
+; CHECK-NEXT: entry
+; CHECK-NEXT:  %a.dbg.spill = alloca i128, align 16: {[-1]:Pointer, [-1,-1]:Integer}
+; CHECK-NEXT:  store i128 -12078052328127107563834081753142289173, i128* %a.dbg.spill, align 16: {}
+; CHECK-NEXT:  ret void: {}


### PR DESCRIPTION
fixes https://github.com/EnzymeAD/rust/issues/125
(at least the Enzyme bug, TA still fails even with loose types).

Extending i128 to 64 bit doesn't really work and llvm allows to directly check for -1, so let's make it more explicit.