### PR TITLE
Fix bazel to include "complex-derivatives" rule

### DIFF
--- a/enzyme/BUILD
+++ b/enzyme/BUILD
@@ -566,6 +566,7 @@ cc_library(
         ":affine-derivatives",
         ":arith-derivatives",
         ":cf-derivatives",
+        ":complex-derivatives",
         ":llvm-derivatives",
         ":func-derivatives",
         ":math-derivatives",


### PR DESCRIPTION
CC @wsmoses 