### PR TITLE
Adding __cxa_thread_atexit_impl

### DIFF
--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -210,6 +210,7 @@ const StringSet<> KnownInactiveFunctions = {
     "__cxa_guard_acquire",
     "__cxa_guard_release",
     "__cxa_guard_abort",
+    "__cxa_thread_atexit_impl",
     "getenv",
     "strtol",
     "fwrite",


### PR DESCRIPTION
Attemping to add __cxa_thread_atexit_impl.

We ran into an issue using enzyme and we got this error message, we're not sure if the line-change will fix it.
```
error: <unknown>:0:0: in function preprocess__ZN3std3sys6common12thread_local10fast_local12Key$LT$T$GT$14try_initialize17h538e209caf245dc5E.llvm.5507895982844929938 ptr (ptr, ptr): Enzyme: cannot compute with global variable that doesn't have marked shadow global
@__cxa_thread_atexit_impl = extern_weak global i8
```
