### PR TITLE
Add callback inactive callback to nofrees set

### DIFF
--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -6442,7 +6442,8 @@ llvm::Function *EnzymeLogic::CreateNoFree(RequestContext context, Function *F) {
                          "lgamma_r",
                          "__kmpc_global_thread_num",
                          "nlopt_force_stop",
-                         "cudaRuntimeGetVersion"
+                         "cudaRuntimeGetVersion",
+                         "__catalyst_inactive_callback"
   };
   // clang-format on
 


### PR DESCRIPTION
Hi @wsmoses !

We would like use to the latest version of Enzyme, but changes made in #1687 are not compatible with our `inactive_callback` function that we use inside an Enzyme inactive function. I have added `__catalyst_inactive_callback`  to the set of NoFrees, not sure if you are willing to accept it? I would like to avoid to turn the option that all unknown functions are marked with no free. Let me know if you see a more dynamic solution?