### PR TITLE
Fix usage of emplace_back

### DIFF
--- a/enzyme/Enzyme/CacheUtility.cpp
+++ b/enzyme/Enzyme/CacheUtility.cpp
@@ -1137,7 +1137,7 @@ CacheUtility::SubLimitType CacheUtility::getSubLimits(bool inForwardPass,
     if (!getContext(blk, idx, ctx.ReverseLimit)) {
       break;
     }
-    contexts.emplace_back(idx);
+    contexts.emplace_back(std::move(idx));
     blk = idx.preheader;
   }
 

--- a/enzyme/Enzyme/DiffeGradientUtils.cpp
+++ b/enzyme/Enzyme/DiffeGradientUtils.cpp
@@ -393,7 +393,7 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
           SelectInst *res = cast<SelectInst>(BuilderM.CreateSelect(
               select->getCondition(), old,
               faddForNeg(old, select->getFalseValue(), false)));
-          addedSelects.emplace_back(res);
+          addedSelects.push_back(res);
           return SanitizeDerivatives(val, res, BuilderM, mask);
         }
       }
@@ -402,7 +402,7 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
           SelectInst *res = cast<SelectInst>(BuilderM.CreateSelect(
               select->getCondition(),
               faddForNeg(old, select->getTrueValue(), false), old));
-          addedSelects.emplace_back(res);
+          addedSelects.push_back(res);
           return SanitizeDerivatives(val, res, BuilderM, mask);
         }
       }
@@ -420,7 +420,7 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
                                                select->getFalseValue(),
                                                bc->getDestTy()),
                            false)));
-            addedSelects.emplace_back(res);
+            addedSelects.push_back(res);
             return SanitizeDerivatives(val, res, BuilderM, mask);
           }
         }
@@ -434,7 +434,7 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
                                                bc->getDestTy()),
                            false),
                 old));
-            addedSelects.emplace_back(res);
+            addedSelects.push_back(res);
             return SanitizeDerivatives(val, res, BuilderM, mask);
           }
         }

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -3283,7 +3283,7 @@ void createInvertedTerminator(DiffeGradientUtils *gutils,
 
   std::map<BasicBlock *, SmallVector<BasicBlock *, 4>> targetToPreds;
   for (auto pred : predecessors(BB)) {
-    targetToPreds[gutils->getReverseOrLatchMerge(pred, BB)].emplace_back(pred);
+    targetToPreds[gutils->getReverseOrLatchMerge(pred, BB)].push_back(pred);
   }
 
   if (targetToPreds.size() == 0) {
@@ -3466,7 +3466,7 @@ void createInvertedTerminator(DiffeGradientUtils *gutils,
                     gutils->addToDiffe(oval, dif, Builder, PNfloatType);
 
                 for (auto select : addedSelects)
-                  selects.emplace_back(select);
+                  selects.push_back(select);
               }
               break;
             }
@@ -3517,7 +3517,7 @@ void createInvertedTerminator(DiffeGradientUtils *gutils,
                   gutils->addToDiffe(oval, dif, Builder, PNfloatType);
 
               for (auto select : addedSelects)
-                selects.emplace_back(select);
+                selects.push_back(select);
             }
           }
         }
@@ -3554,7 +3554,7 @@ void createInvertedTerminator(DiffeGradientUtils *gutils,
               gutils->addToDiffe(oval, dif, Builder, PNfloatType);
 
           for (auto select : addedSelects)
-            selects.emplace_back(select);
+            selects.push_back(select);
         }
       }
     }
@@ -3569,8 +3569,7 @@ void createInvertedTerminator(DiffeGradientUtils *gutils,
     for (auto pred : predecessors(BB)) {
       if (pred == loopContext.preheader)
         continue;
-      targetToPreds[gutils->getReverseOrLatchMerge(pred, BB)].emplace_back(
-          pred);
+      targetToPreds[gutils->getReverseOrLatchMerge(pred, BB)].push_back(pred);
     }
 
     assert(targetToPreds.size() &&
@@ -3605,7 +3604,7 @@ void createInvertedTerminator(DiffeGradientUtils *gutils,
     std::map<BasicBlock *, std::vector<std::pair<BasicBlock *, BasicBlock *>>>
         phiTargetToPreds;
     for (auto pair : replacePHIs) {
-      phiTargetToPreds[pair.first].emplace_back(std::make_pair(pair.first, BB));
+      phiTargetToPreds[pair.first].emplace_back(pair.first, BB);
     }
     BasicBlock *fakeTarget = nullptr;
     for (auto pred : predecessors(BB)) {
@@ -3613,7 +3612,7 @@ void createInvertedTerminator(DiffeGradientUtils *gutils,
         continue;
       if (fakeTarget == nullptr)
         fakeTarget = pred;
-      phiTargetToPreds[fakeTarget].emplace_back(std::make_pair(pred, BB));
+      phiTargetToPreds[fakeTarget].emplace_back(pred, BB);
     }
     gutils->branchToCorrespondingTarget(BB, phibuilder, phiTargetToPreds,
                                         &replacePHIs);
@@ -3621,8 +3620,8 @@ void createInvertedTerminator(DiffeGradientUtils *gutils,
     std::map<BasicBlock *, std::vector<std::pair<BasicBlock *, BasicBlock *>>>
         targetToPreds;
     for (auto pred : predecessors(BB)) {
-      targetToPreds[gutils->getReverseOrLatchMerge(pred, BB)].emplace_back(
-          std::make_pair(pred, BB));
+      targetToPreds[gutils->getReverseOrLatchMerge(pred, BB)].emplace_back(pred,
+                                                                           BB);
     }
     BB2 = gutils->reverseBlocks[BB].back();
     Builder.SetInsertPoint(BB2);

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -231,7 +231,7 @@ GradientUtils::GradientUtils(
     newToOriginalFn[originalToNewFn[&oArg]] = &oArg;
   }
   for (BasicBlock &BB : *newFunc) {
-    originalBlocks.emplace_back(&BB);
+    originalBlocks.push_back(&BB);
   }
   tape = nullptr;
   tapeidx = 0;
@@ -1368,7 +1368,7 @@ Value *GradientUtils::unwrapM(Value *const val, IRBuilder<> &BuilderM,
     for (unsigned i = 0; i < op->getNumArgOperands(); ++i)
 #endif
     {
-      args.emplace_back(getOp(op->getArgOperand(i)));
+      args.push_back(getOp(op->getArgOperand(i)));
       if (args[i] == nullptr)
         goto endCheck;
     }

--- a/enzyme/Enzyme/SCEV/ScalarEvolutionExpander11.cpp
+++ b/enzyme/Enzyme/SCEV/ScalarEvolutionExpander11.cpp
@@ -2008,7 +2008,7 @@ unsigned fake::SCEVExpander::replaceCongruentIVs(
       if (V->getType() != Phi->getType())
         continue;
       Phi->replaceAllUsesWith(V);
-      DeadInsts.emplace_back(Phi);
+      DeadInsts.push_back(Phi);
       ++NumElim;
       DEBUG_WITH_TYPE(DebugType, dbgs() << "INDVARS: Eliminated constant iv: "
                                         << *Phi << '\n');
@@ -2085,7 +2085,7 @@ unsigned fake::SCEVExpander::replaceCongruentIVs(
                 OrigInc, IsomorphicInc->getType(), IVName);
           }
           IsomorphicInc->replaceAllUsesWith(NewInc);
-          DeadInsts.emplace_back(IsomorphicInc);
+          DeadInsts.push_back(IsomorphicInc);
         }
       }
     }
@@ -2099,7 +2099,7 @@ unsigned fake::SCEVExpander::replaceCongruentIVs(
       NewIV = Builder.CreateTruncOrBitCast(OrigPhiRef, Phi->getType(), IVName);
     }
     Phi->replaceAllUsesWith(NewIV);
-    DeadInsts.emplace_back(Phi);
+    DeadInsts.push_back(Phi);
   }
   return NumElim;
 }
@@ -2196,7 +2196,7 @@ bool fake::SCEVExpander::isHighCostExpansionHelper(
     const SCEV *Op = CastExpr->getOperand();
     BudgetRemaining -= TTI.getCastInstrCost(Opcode, /*Dst=*/S->getType(),
                                             /*Src=*/Op->getType(), CostKind);
-    Worklist.emplace_back(Op);
+    Worklist.push_back(Op);
     return false; // Will answer upon next entry into this function.
   }
 
@@ -2209,7 +2209,7 @@ bool fake::SCEVExpander::isHighCostExpansionHelper(
         // Note that we don't count the cost of RHS, because it is a constant,
         // and we consider those to be free. But if that changes, we would need
         // to log2() it first before calling isHighCostExpansionHelper().
-        Worklist.emplace_back(UDivExpr->getLHS());
+        Worklist.push_back(UDivExpr->getLHS());
         return false; // Will answer upon next entry into this function.
       }
     }

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -2654,7 +2654,7 @@ getAllLoadedValuesFrom(AllocaInst *ptr0, size_t offset, size_t valSz,
               if (subOff != 0)
                 return options;
               for (const auto &pair3 : findAllUsersOf(subPtr)) {
-                todo.emplace_back(pair3);
+                todo.emplace_back(std::move(pair3));
               }
             }
             continue;
@@ -2686,7 +2686,7 @@ getAllLoadedValuesFrom(AllocaInst *ptr0, size_t offset, size_t valSz,
             return options;
           }
           for (const auto &pair3 : findAllUsersOf(AI2)) {
-            todo.emplace_back(pair3);
+            todo.emplace_back(std::move(pair3));
           }
           continue;
         }


### PR DESCRIPTION
- added  missing moves
- we don't want to use `emplace_back` if its not needed since it introduces compile time overhead due to templating