### PR TITLE
use correct NoFree list

### DIFF
--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -111,7 +111,6 @@ static const StringSet<> InactiveGlobals = {
     "ompi_request_null",
     "ompi_mpi_double",
     "ompi_mpi_comm_world",
-    "__cxa_thread_atexit_impl",
     "stderr",
     "stdout",
     "stdin",
@@ -211,6 +210,7 @@ const StringSet<> KnownInactiveFunctions = {
     "__cxa_guard_acquire",
     "__cxa_guard_release",
     "__cxa_guard_abort",
+    "__cxa_thread_atexit_impl",
     "getenv",
     "strtol",
     "fwrite",
@@ -428,9 +428,6 @@ const char *DemangledKnownInactiveFunctionsStartingWith[] = {
 
     "std::__detail::_Prime_rehash_policy",
     "std::__detail::_Hash_code_base",
-
-    // Rust
-    "std::io::stdio::_eprint",
 
 };
   // clang-format on

--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -211,7 +211,6 @@ const StringSet<> KnownInactiveFunctions = {
     "__cxa_guard_acquire",
     "__cxa_guard_release",
     "__cxa_guard_abort",
-    "__cxa_thread_atexit_impl",
     "getenv",
     "strtol",
     "fwrite",

--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -429,6 +429,9 @@ const char *DemangledKnownInactiveFunctionsStartingWith[] = {
     "std::__detail::_Prime_rehash_policy",
     "std::__detail::_Hash_code_base",
 
+    // Rust
+    "std::io::stdio::_eprint",
+
 };
   // clang-format on
 

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -6337,6 +6337,8 @@ llvm::Function *EnzymeLogic::CreateNoFree(RequestContext context, Function *F) {
       "std::basic_streambuf<char, std::char_traits<char>>::sputn",
       "std::istream& std::istream::_M_extract",
       "std::ctype<char>::widen",
+      //Rust
+      "std::io::stdio::_eprint",
   };
 
   StringSet<> NoFrees = {"mpfr_greater_p",

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -6069,9 +6069,6 @@ llvm::Value *EnzymeLogic::CreateNoFree(RequestContext context,
           "std::basic_ostream<char, std::char_traits<char>>::operator<<",
           "std::ostream::operator<<",
           "std::ostream& std::ostream::_M_insert",
-          // Rust
-          "std::io::stdio::_eprint",
-          "__cxa_thread_atexit_impl",
       };
       // clang-format on
 

--- a/enzyme/test/Enzyme/ReverseMode/rust-eprintln.ll
+++ b/enzyme/test/Enzyme/ReverseMode/rust-eprintln.ll
@@ -27,10 +27,10 @@ define dso_local "enzyme_type"="{}" void @eprintfunc() unnamed_addr #0 {
   ret void
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+; Function Attrs: nocallback nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #1
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+; Function Attrs: nocallback nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #1
 
 ; Function Attrs: nonlazybind sanitize_hwaddress uwtable
@@ -44,7 +44,7 @@ define void @enzyme_opt_helper_0() {
 }
 
 attributes #0 = { noinline nonlazybind sanitize_hwaddress uwtable "probe-stack"="inline-asm" "target-cpu"="x86-64" }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind willreturn }
 attributes #2 = { nonlazybind sanitize_hwaddress uwtable "probe-stack"="inline-asm" "target-cpu"="x86-64" }
 
 !llvm.module.flags = !{!0, !1, !2, !3}

--- a/enzyme/test/Enzyme/ReverseMode/rust-eprintln.ll
+++ b/enzyme/test/Enzyme/ReverseMode/rust-eprintln.ll
@@ -1,5 +1,5 @@
-; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -mem2reg -instsimplify -simplifycfg -S | FileCheck %s; fi
-; RUN: %opt < %s %newLoadEnzyme -passes="enzyme,function(mem2reg,instsimplify,%simplifycfg)" -enzyme-preopt=false -S | FileCheck %s
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -mem2reg -instsimplify -simplifycfg -S -opaque-pointers=1 | FileCheck %s; fi
+; RUN: %opt < %s %newLoadEnzyme -passes="enzyme,function(mem2reg,instsimplify,%simplifycfg)" -enzyme-preopt=false -S  -opaque-pointers=1 | FileCheck %s
 
 ; ModuleID = 'out.ll'
 source_filename = "ad.ab3e8598fedbb3bd-cgu.0"

--- a/enzyme/test/Enzyme/ReverseMode/rust-eprintln.ll
+++ b/enzyme/test/Enzyme/ReverseMode/rust-eprintln.ll
@@ -1,5 +1,5 @@
-; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -mem2reg -instsimplify -simplifycfg -S -opaque-pointers=1 | FileCheck %s; fi
-; RUN: %opt < %s %newLoadEnzyme -passes="enzyme,function(mem2reg,instsimplify,%simplifycfg)" -enzyme-preopt=false -S  -opaque-pointers=1 | FileCheck %s
+1:; RUN: if [ %llvmver -eq 15 ]; then %opt < %s %loadEnzyme -enzyme -opaque-pointers=1 -S | FileCheck %s; fi
+2:; RUN: if [ %llvmver -ge 15 ]; then %opt < %s %newLoadEnzyme -passes="enzyme" -opaque-pointers=1 -S | FileCheck %s; fi
 
 ; ModuleID = 'out.ll'
 source_filename = "ad.ab3e8598fedbb3bd-cgu.0"

--- a/enzyme/test/Enzyme/ReverseMode/rust-eprintln.ll
+++ b/enzyme/test/Enzyme/ReverseMode/rust-eprintln.ll
@@ -1,0 +1,65 @@
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -mem2reg -instsimplify -simplifycfg -S | FileCheck %s; fi
+; RUN: %opt < %s %newLoadEnzyme -passes="enzyme,function(mem2reg,instsimplify,%simplifycfg)" -enzyme-preopt=false -S | FileCheck %s
+
+; ModuleID = 'out.ll'
+source_filename = "ad.ab3e8598fedbb3bd-cgu.0"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@anon.a6304942fd3c743a92a7245cba3cd4a6.2 = external hidden unnamed_addr constant <{ ptr, [8 x i8] }>, align 8
+@anon.a6304942fd3c743a92a7245cba3cd4a6.3 = external hidden unnamed_addr constant <{}>, align 8
+
+; Function Attrs: noinline nonlazybind sanitize_hwaddress uwtable
+define dso_local "enzyme_type"="{}" void @eprintfunc() unnamed_addr #0 {
+  %1 = alloca { { ptr, i64 }, { ptr, i64 }, { ptr, i64 } }, align 8
+  call void @llvm.lifetime.start.p0(i64 48, ptr nonnull %1)
+  store ptr @anon.a6304942fd3c743a92a7245cba3cd4a6.2, ptr %1, align 8
+  %2 = getelementptr inbounds { ptr, i64 }, ptr %1, i64 0, i32 1
+  store i64 1, ptr %2, align 8
+  %3 = getelementptr inbounds { { ptr, i64 }, { ptr, i64 }, { ptr, i64 } }, ptr %1, i64 0, i32 2
+  store ptr null, ptr %3, align 8
+  %4 = getelementptr inbounds { { ptr, i64 }, { ptr, i64 }, { ptr, i64 } }, ptr %1, i64 0, i32 1
+  store ptr @anon.a6304942fd3c743a92a7245cba3cd4a6.3, ptr %4, align 8
+  %5 = getelementptr inbounds { { ptr, i64 }, { ptr, i64 }, { ptr, i64 } }, ptr %1, i64 0, i32 1, i32 1
+  store i64 0, ptr %5, align 8
+  call void @_ZN3std2io5stdio7_eprint17h557bd237e67376ddE(ptr noalias nocapture noundef nonnull align 8 dereferenceable(48) %1)
+  call void @llvm.lifetime.end.p0(i64 48, ptr nonnull %1)
+  ret void
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #1
+
+; Function Attrs: nonlazybind sanitize_hwaddress uwtable
+declare hidden void @_ZN3std2io5stdio7_eprint17h557bd237e67376ddE(ptr noalias nocapture noundef readonly align 8 dereferenceable(48)) unnamed_addr #2
+
+declare void @__enzyme_autodiff(...)
+
+define void @enzyme_opt_helper_0() {
+  call void (...) @__enzyme_autodiff(ptr @eprintfunc)
+  ret void
+}
+
+attributes #0 = { noinline nonlazybind sanitize_hwaddress uwtable "probe-stack"="inline-asm" "target-cpu"="x86-64" }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nonlazybind sanitize_hwaddress uwtable "probe-stack"="inline-asm" "target-cpu"="x86-64" }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 2, !"RtLibUseGOT", i32 1}
+!3 = !{i32 1, !"LTOPostLink", i32 1}
+!4 = !{!"rustc version 1.77.0-nightly (e3875bc6d 2024-07-26)"}
+
+; CHECK: define internal void @diffeeprintfunc() 
+; CHECK:  call void @_ZN3std2io5stdio7_eprint17h557bd237e67376ddE(ptr noalias nocapture noundef nonnull align 8 dereferenceable(48) %1) #4
+; CHECK:  br label %invert
+
+; CHECK: invert:                                           ; preds = %0
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ReverseMode/rust-eprintln.ll
+++ b/enzyme/test/Enzyme/ReverseMode/rust-eprintln.ll
@@ -1,5 +1,5 @@
-1:; RUN: if [ %llvmver -eq 15 ]; then %opt < %s %loadEnzyme -enzyme -opaque-pointers=1 -S | FileCheck %s; fi
-2:; RUN: if [ %llvmver -ge 15 ]; then %opt < %s %newLoadEnzyme -passes="enzyme" -opaque-pointers=1 -S | FileCheck %s; fi
+; RUN: if [ %llvmver -eq 15 ]; then %opt < %s %loadEnzyme -enzyme -opaque-pointers=1 -S | FileCheck %s; fi
+; RUN: if [ %llvmver -ge 15 ]; then %opt < %s %newLoadEnzyme -passes="enzyme" -opaque-pointers=1 -S | FileCheck %s; fi
 
 ; ModuleID = 'out.ll'
 source_filename = "ad.ab3e8598fedbb3bd-cgu.0"


### PR DESCRIPTION
Looks like during (manual) upstreaming I added it to the wrong NoFree list, so my test was still not passing after updating the Enzyme submodule. This one should be the right noFree list. 