### PR TITLE
Extended analysis to ignore fputc

### DIFF
--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -222,6 +222,7 @@ const StringSet<> KnownInactiveFunctions = {
     "vprintf",
     "vsnprintf",
     "puts",
+    "fputc",
     "fflush",
     "__kmpc_for_static_init_4",
     "__kmpc_for_static_init_4u",

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -348,6 +348,7 @@ bool attributeKnownFunctions(llvm::Function &F) {
       "_ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm",
       "fprintf",
       "fwrite",
+      "fputc",
       "strtol",
       "getenv",
       "memchr",

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -6339,6 +6339,7 @@ llvm::Function *EnzymeLogic::CreateNoFree(RequestContext context, Function *F) {
 
   StringSet<> NoFrees = {"mpfr_greater_p",
                         "fprintf",
+                        "fputc",
                          "memchr",
                          "time",
                          "strlen",

--- a/enzyme/Enzyme/MLIR/Analysis/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/MLIR/Analysis/ActivityAnalysis.cpp
@@ -106,6 +106,7 @@ static const std::set<std::string> KnownInactiveFunctions = {
     "vprintf",
     "vsnprintf",
     "puts",
+    "fputc",
     "fflush",
     "__kmpc_for_static_init_4",
     "__kmpc_for_static_init_4u",

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -5549,7 +5549,8 @@ void TypeAnalyzer::visitCallBase(CallBase &call) {
     }
 
     if (funcName == "__cxa_guard_acquire" || funcName == "printf" ||
-        funcName == "vprintf" || funcName == "puts" || funcName == "fputc" || funcName == "fprintf") {
+        funcName == "vprintf" || funcName == "puts" || funcName == "fputc" ||
+        funcName == "fprintf") {
       updateAnalysis(&call, TypeTree(BaseType::Integer).Only(-1, &call), &call);
     }
 

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -5549,7 +5549,7 @@ void TypeAnalyzer::visitCallBase(CallBase &call) {
     }
 
     if (funcName == "__cxa_guard_acquire" || funcName == "printf" ||
-        funcName == "vprintf" || funcName == "puts" || funcName == "fprintf") {
+        funcName == "vprintf" || funcName == "puts" || funcName == "fputc" || funcName == "fprintf") {
       updateAnalysis(&call, TypeTree(BaseType::Integer).Only(-1, &call), &call);
     }
 

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -652,7 +652,7 @@ static inline bool endsWith(llvm::StringRef string, llvm::StringRef suffix) {
 
 static inline bool isCertainPrint(const llvm::StringRef name) {
   if (name == "printf" || name == "puts" || name == "fprintf" ||
-      name == "putchar" ||
+      name == "putchar" || name == "fputc" ||
       startsWith(name,
                  "_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_") ||
       startsWith(name, "_ZNSolsE") || startsWith(name, "_ZNSo9_M_insert") ||


### PR DESCRIPTION
In C, single-char `fprintf`'s such as `fprintf(stdout, "\n");` are optimized to `fputc("\n", stdout);` for `-O{1-3}` (technically the `\n` would really be a single system-dependent character being interpreted as a newline, this example is for ease of comparison). Thus, code such as the following:
```C
// main.c
#include <stdlib.h>
#include <stdio.h>

extern double __enzyme_autodiff(void*, ...);
int enzyme_const, enzyme_dup, enzyme_out;

double calc(int n, double *x)
{
	fprintf(stdout, "hello world!"); // this is handled correctly
	fprintf(stdout, "\n"); // this gets optimized to `fputc` for O{1-3} and causes the error

	return 0.0;
}

int main()
{
	int n = 12;
	double *x = (double *)malloc((size_t)n * sizeof(double));
	double *grad = (double *)malloc((size_t)n * sizeof(double));
	for (int i = 0; i < n; i++)
	{
		x[i] = i/1.0E-06;
		grad[i] = 0.0;
	}

	__enzyme_autodiff((void*)calc,
			enzyme_const, n,
			enzyme_dup  , x, grad);

	return 0;
}
```
results in the error
```C
error: main.c:10:2: in function preprocess_calc double (i32, ptr): Enzyme: No reverse pass found for fputc
 at context:   %fputc = tail call i32 @fputc(i32 10, ptr %2) #10, !dbg !55
```

In this PR, I have modified the analysis portions of the code where functions such as `printf` and `fprintf` are handled to handle `fputc` in a similar manner. This allows the code to be compiled and ran successfully as expected.

For this test, I am using the following Makefile:
```Makefile
CC = clang

LIBS = -I/usr/local/include -L/usr/local/lib
CFLAGS  = -Wall -Wno-unused-command-line-argument -fPIC -O1 -g -flto
ENZFLAGS  = -S -emit-llvm

ENZLLD = /path/to/Enzyme/enzyme/build/Enzyme/LLDEnzyme-17.so
ENZLLVM = /path/to/Enzyme/enzyme/build/Enzyme/LLVMEnzyme-17.so
OUTPUT_NAME = playground

##  debug targets
debug: main.ll
	llvm-link main.ll -S -o debug_in.ll
	opt debug_in.ll -o debug_out.ll -S -load-pass-plugin=$(ENZLLVM) -passes=enzyme
	opt debug_out.ll -o debug_opt.ll -S -O1
	$(CC) debug_opt.ll -o $(OUTPUT_NAME) -O0

main.ll : main.c
	$(CC) $(CFLAGS) -c main.c $(ENZFLAGS) -o main.ll
```

P.S. I suspect something similar would occur after a `printf -> putc` optimization, though I haven't tested it yet and am not sure whether that should go in a separate PR.