### PR TITLE
Fix unused field and override warnings

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -69,7 +69,6 @@ private:
       &unnecessaryInstructions;
   const llvm::SmallPtrSetImpl<const llvm::Instruction *> &unnecessaryStores;
   const llvm::SmallPtrSetImpl<llvm::BasicBlock *> &oldUnreachable;
-  llvm::AllocaInst *dretAlloca;
 
 public:
   AdjointGenerator(
@@ -87,16 +86,14 @@ public:
       const llvm::SmallPtrSetImpl<const llvm::Instruction *>
           &unnecessaryInstructions,
       const llvm::SmallPtrSetImpl<const llvm::Instruction *> &unnecessaryStores,
-      const llvm::SmallPtrSetImpl<llvm::BasicBlock *> &oldUnreachable,
-      llvm::AllocaInst *dretAlloca)
+      const llvm::SmallPtrSetImpl<llvm::BasicBlock *> &oldUnreachable)
       : Mode(Mode), gutils(gutils), constant_args(constant_args),
         retType(retType), getIndex(getIndex),
         overwritten_args_map(overwritten_args_map), returnuses(returnuses),
         augmentedReturn(augmentedReturn), replacedReturns(replacedReturns),
         unnecessaryValues(unnecessaryValues),
         unnecessaryInstructions(unnecessaryInstructions),
-        unnecessaryStores(unnecessaryStores), oldUnreachable(oldUnreachable),
-        dretAlloca(dretAlloca) {
+        unnecessaryStores(unnecessaryStores), oldUnreachable(oldUnreachable) {
     using namespace llvm;
 
     assert(TR.getFunction() == gutils->oldFunc);

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -60,7 +60,6 @@ private:
       getIndex;
   const std::map<llvm::CallInst *, const std::vector<bool>>
       overwritten_args_map;
-  const llvm::SmallPtrSetImpl<llvm::Instruction *> *returnuses;
   const AugmentedReturn *augmentedReturn;
   const std::map<llvm::ReturnInst *, llvm::StoreInst *> *replacedReturns;
 
@@ -79,7 +78,6 @@ public:
           getIndex,
       const std::map<llvm::CallInst *, const std::vector<bool>>
           overwritten_args_map,
-      const llvm::SmallPtrSetImpl<llvm::Instruction *> *returnuses,
       const AugmentedReturn *augmentedReturn,
       const std::map<llvm::ReturnInst *, llvm::StoreInst *> *replacedReturns,
       const llvm::SmallPtrSetImpl<const llvm::Value *> &unnecessaryValues,
@@ -89,7 +87,7 @@ public:
       const llvm::SmallPtrSetImpl<llvm::BasicBlock *> &oldUnreachable)
       : Mode(Mode), gutils(gutils), constant_args(constant_args),
         retType(retType), getIndex(getIndex),
-        overwritten_args_map(overwritten_args_map), returnuses(returnuses),
+        overwritten_args_map(overwritten_args_map),
         augmentedReturn(augmentedReturn), replacedReturns(replacedReturns),
         unnecessaryValues(unnecessaryValues),
         unnecessaryInstructions(unnecessaryInstructions),
@@ -5681,8 +5679,7 @@ public:
         for (auto use : call.users()) {
           if (Mode == DerivativeMode::ReverseModePrimal ||
               !isa<ReturnInst>(
-                  use)) { // || returnuses.find(cast<Instruction>(use)) ==
-                          // returnuses.end()) {
+                  use)) {
             hasNonReturnUse = true;
           }
         }

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -5678,8 +5678,7 @@ public:
         bool hasNonReturnUse = false;
         for (auto use : call.users()) {
           if (Mode == DerivativeMode::ReverseModePrimal ||
-              !isa<ReturnInst>(
-                  use)) {
+              !isa<ReturnInst>(use)) {
             hasNonReturnUse = true;
           }
         }

--- a/enzyme/Enzyme/Clang/EnzymeClang.cpp
+++ b/enzyme/Enzyme/Clang/EnzymeClang.cpp
@@ -55,12 +55,12 @@ template <typename ConsumerType>
 class EnzymeAction final : public clang::PluginASTAction {
 protected:
   std::unique_ptr<clang::ASTConsumer>
-  CreateASTConsumer(clang::CompilerInstance &CI, llvm::StringRef InFile) {
+  CreateASTConsumer(clang::CompilerInstance &CI, llvm::StringRef InFile) override {
     return std::unique_ptr<clang::ASTConsumer>(new ConsumerType(CI));
   }
 
   bool ParseArgs(const clang::CompilerInstance &CI,
-                 const std::vector<std::string> &args) {
+                 const std::vector<std::string> &args) override {
     return true;
   }
 

--- a/enzyme/Enzyme/Clang/EnzymeClang.cpp
+++ b/enzyme/Enzyme/Clang/EnzymeClang.cpp
@@ -55,7 +55,8 @@ template <typename ConsumerType>
 class EnzymeAction final : public clang::PluginASTAction {
 protected:
   std::unique_ptr<clang::ASTConsumer>
-  CreateASTConsumer(clang::CompilerInstance &CI, llvm::StringRef InFile) override {
+  CreateASTConsumer(clang::CompilerInstance &CI,
+                    llvm::StringRef InFile) override {
     return std::unique_ptr<clang::ASTConsumer>(new ConsumerType(CI));
   }
 

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -2481,7 +2481,6 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
 
   AdjointGenerator maker(DerivativeMode::ReverseModePrimal, gutils,
                          constant_args, retType, getIndex, overwritten_args_map,
-                         &returnuses,
                          &AugmentedCachedFunctions.find(tup)->second, nullptr,
                          unnecessaryValues, unnecessaryInstructions,
                          unnecessaryStores, guaranteedUnreachable);
@@ -4326,8 +4325,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
   }
 
   AdjointGenerator maker(key.mode, gutils, key.constant_args, key.retType,
-                         getIndex, overwritten_args_map,
-                         /*returnuses*/ nullptr, augmenteddata,
+                         getIndex, overwritten_args_map, augmenteddata,
                          &replacedReturns, unnecessaryValues,
                          unnecessaryInstructions, unnecessaryStores,
                          guaranteedUnreachable);
@@ -4859,8 +4857,8 @@ Function *EnzymeLogic::CreateForwardDiff(
 
     maker = new AdjointGenerator(
         mode, gutils, constant_args, retType, getIndex, overwritten_args_map,
-        /*returnuses*/ nullptr, augmenteddata, nullptr, unnecessaryValues,
-        unnecessaryInstructions, unnecessaryStores, guaranteedUnreachable);
+        augmenteddata, nullptr, unnecessaryValues, unnecessaryInstructions,
+        unnecessaryStores, guaranteedUnreachable);
 
     if (additionalArg) {
       auto v = gutils->newFunc->arg_end();
@@ -4911,9 +4909,9 @@ Function *EnzymeLogic::CreateForwardDiff(
                                     unnecessaryInstructions, gutils, TLI);
     maker =
         new AdjointGenerator(mode, gutils, constant_args, retType, nullptr, {},
-                             /*returnuses*/ nullptr, nullptr, nullptr,
-                             unnecessaryValues, unnecessaryInstructions,
-                             unnecessaryStores, guaranteedUnreachable);
+                             nullptr, nullptr, unnecessaryValues,
+                             unnecessaryInstructions, unnecessaryStores,
+                             guaranteedUnreachable);
   }
 
   for (BasicBlock &oBB : *gutils->oldFunc) {

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -2484,7 +2484,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
                          &returnuses,
                          &AugmentedCachedFunctions.find(tup)->second, nullptr,
                          unnecessaryValues, unnecessaryInstructions,
-                         unnecessaryStores, guaranteedUnreachable, nullptr);
+                         unnecessaryStores, guaranteedUnreachable);
 
   for (BasicBlock &oBB : *gutils->oldFunc) {
     auto term = oBB.getTerminator();
@@ -4330,7 +4330,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
                          /*returnuses*/ nullptr, augmenteddata,
                          &replacedReturns, unnecessaryValues,
                          unnecessaryInstructions, unnecessaryStores,
-                         guaranteedUnreachable, dretAlloca);
+                         guaranteedUnreachable);
 
   for (BasicBlock &oBB : *gutils->oldFunc) {
     // Don't create derivatives for code that results in termination
@@ -4860,8 +4860,7 @@ Function *EnzymeLogic::CreateForwardDiff(
     maker = new AdjointGenerator(
         mode, gutils, constant_args, retType, getIndex, overwritten_args_map,
         /*returnuses*/ nullptr, augmenteddata, nullptr, unnecessaryValues,
-        unnecessaryInstructions, unnecessaryStores, guaranteedUnreachable,
-        nullptr);
+        unnecessaryInstructions, unnecessaryStores, guaranteedUnreachable);
 
     if (additionalArg) {
       auto v = gutils->newFunc->arg_end();
@@ -4914,7 +4913,7 @@ Function *EnzymeLogic::CreateForwardDiff(
         new AdjointGenerator(mode, gutils, constant_args, retType, nullptr, {},
                              /*returnuses*/ nullptr, nullptr, nullptr,
                              unnecessaryValues, unnecessaryInstructions,
-                             unnecessaryStores, guaranteedUnreachable, nullptr);
+                             unnecessaryStores, guaranteedUnreachable);
   }
 
   for (BasicBlock &oBB : *gutils->oldFunc) {

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -4324,11 +4324,10 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
     }
   }
 
-  AdjointGenerator maker(key.mode, gutils, key.constant_args, key.retType,
-                         getIndex, overwritten_args_map, augmenteddata,
-                         &replacedReturns, unnecessaryValues,
-                         unnecessaryInstructions, unnecessaryStores,
-                         guaranteedUnreachable);
+  AdjointGenerator maker(
+      key.mode, gutils, key.constant_args, key.retType, getIndex,
+      overwritten_args_map, augmenteddata, &replacedReturns, unnecessaryValues,
+      unnecessaryInstructions, unnecessaryStores, guaranteedUnreachable);
 
   for (BasicBlock &oBB : *gutils->oldFunc) {
     // Don't create derivatives for code that results in termination
@@ -4855,10 +4854,10 @@ Function *EnzymeLogic::CreateForwardDiff(
     calculateUnusedStoresInFunction(*gutils->oldFunc, unnecessaryStores,
                                     unnecessaryInstructions, gutils, TLI);
 
-    maker = new AdjointGenerator(
-        mode, gutils, constant_args, retType, getIndex, overwritten_args_map,
-        augmenteddata, nullptr, unnecessaryValues, unnecessaryInstructions,
-        unnecessaryStores, guaranteedUnreachable);
+    maker = new AdjointGenerator(mode, gutils, constant_args, retType, getIndex,
+                                 overwritten_args_map, augmenteddata, nullptr,
+                                 unnecessaryValues, unnecessaryInstructions,
+                                 unnecessaryStores, guaranteedUnreachable);
 
     if (additionalArg) {
       auto v = gutils->newFunc->arg_end();
@@ -4907,11 +4906,10 @@ Function *EnzymeLogic::CreateForwardDiff(
 
     calculateUnusedStoresInFunction(*gutils->oldFunc, unnecessaryStores,
                                     unnecessaryInstructions, gutils, TLI);
-    maker =
-        new AdjointGenerator(mode, gutils, constant_args, retType, nullptr, {},
-                             nullptr, nullptr, unnecessaryValues,
-                             unnecessaryInstructions, unnecessaryStores,
-                             guaranteedUnreachable);
+    maker = new AdjointGenerator(mode, gutils, constant_args, retType, nullptr,
+                                 {}, nullptr, nullptr, unnecessaryValues,
+                                 unnecessaryInstructions, unnecessaryStores,
+                                 guaranteedUnreachable);
   }
 
   for (BasicBlock &oBB : *gutils->oldFunc) {


### PR DESCRIPTION
I built this repository for the first time today and whilst doing so noticed a few warnings (on `clang-18`). I tidied up the ones that looked fairly simple in order to get cleaner build output locally, so thought I'd raise the changes.