### PR TITLE
MLIR: broadcast complex add and conj with linalg.map

### DIFF
--- a/enzyme/Enzyme/MLIR/Passes/Passes.h
+++ b/enzyme/Enzyme/MLIR/Passes/Passes.h
@@ -15,6 +15,7 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 
 #include "Dialect/Dialect.h"
 
@@ -63,6 +64,10 @@ class ComplexDialect;
 namespace cf {
 class ControlFlowDialect;
 } // end namespace cf
+
+namespace linalg {
+class LinalgDialect;
+} // end namespace memref
 
 namespace scf {
 class SCFDialect;

--- a/enzyme/Enzyme/MLIR/Passes/Passes.td
+++ b/enzyme/Enzyme/MLIR/Passes/Passes.td
@@ -16,7 +16,8 @@ def DifferentiatePass : Pass<"enzyme"> {
   let dependentDialects = [
     "arith::ArithDialect",
     "complex::ComplexDialect",
-    "cf::ControlFlowDialect"
+    "cf::ControlFlowDialect",
+    "linalg::LinalgDialect"
   ];
   let constructor = "mlir::enzyme::createDifferentiatePass()";
 }
@@ -34,7 +35,8 @@ def DifferentiateWrapperPass : Pass<"enzyme-wrap"> {
     "arith::ArithDialect",
     "complex::ComplexDialect",
     "cf::ControlFlowDialect",
-    "enzyme::EnzymeDialect"
+    "enzyme::EnzymeDialect",
+    "linalg::LinalgDialect"
   ];
   let constructor = "mlir::enzyme::createDifferentiateWrapperPass()";
   let options = [


### PR DESCRIPTION
`complex.add` and `complex.conj` do not broadcast like `arith.add` so when creating an add or conj or for a tensor of complex number, it needs element-wise broadcasting.

This currently implements broadcasting with a `linalg.map` which does not seem ideal. Maybe enzyme could emit `enzyme.add` instead and then consumers could lower to their own dialect when possibl. For example, `enzyme.add` to `stablehlo.add` in [Enzyme-JAX](https://github.com/EnzymeAD/Enzyme-jax) and still have the current lowering as a default? That would remove the need for arith raising in the case of Enzyme-JAX.