### PR TITLE
Fix clang compilation (failing since 0.0.150)

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -3488,7 +3488,7 @@ public:
       }
     }
 
-    for (auto &&[floatTy, seg_start, seg_size] : toIterate) {
+    for (auto &&[floatTy_ref, seg_start_ref, seg_size_ref] : toIterate) {
       auto floatTy = floatTy_ref;
       auto seg_start = seg_start_ref;
       auto seg_size = seg_size_ref;

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -3108,7 +3108,11 @@ public:
       op3 = gutils->getNewFromOriginal(MS.getOperand(3));
     }
 
-    for (auto &&[secretty, seg_start, seg_size] : toIterate) {
+    for (auto &&[secretty_ref, seg_start_ref, seg_size_ref] : toIterate) {
+      auto secretty = secretty_ref;
+      auto seg_start = seg_start_ref;
+      auto seg_size = seg_size_ref;
+
       Value *length = new_size;
       if (seg_start != std::get<1>(toIterate.back())) {
         length = ConstantInt::get(new_size->getType(), seg_start + seg_size);
@@ -3485,6 +3489,10 @@ public:
     }
 
     for (auto &&[floatTy, seg_start, seg_size] : toIterate) {
+      auto floatTy = floatTy_ref;
+      auto seg_start = seg_start_ref;
+      auto seg_size = seg_size_ref;
+
       Value *length = new_size;
       if (seg_start != std::get<1>(toIterate.back())) {
         length = ConstantInt::get(new_size->getType(), seg_start + seg_size);


### PR DESCRIPTION
Since the v0.0.150, it is not possible to compile Enzyme with clang. The source of the issue is a loop over references (local binding) that contains a lambda function. https://github.com/EnzymeAD/Enzyme/pull/2079/files#diff-ab7735609ebf1b75b3d6baedc231689532dff0a7a8e4e1838c3aed11c99795e5R3111

Clang refuses to compile it because local binding are not variables and cannot be captured by the lambda function. Solution here is to create a variable that can be then captured by the lambda function.

https://stackoverflow.com/questions/50799719/reference-to-local-binding-declared-in-enclosing-function?noredirect=1&lq=1