### PR TITLE
Fixes warnings and adds missing header guards

### DIFF
--- a/enzyme/Enzyme/ActivityAnalysisPrinter.h
+++ b/enzyme/Enzyme/ActivityAnalysisPrinter.h
@@ -22,6 +22,10 @@
 // results of a given function.
 //
 //===----------------------------------------------------------------------===//
+
+#ifndef ENZYME_ACTIVITY_ANALYSIS_PRINTER_H
+#define ENZYME_ACTIVITY_ANALYSIS_PRINTER_H
+
 #include <llvm/Config/llvm-config.h>
 
 #include "llvm/IR/PassManager.h"
@@ -46,3 +50,5 @@ public:
 
   static bool isRequired() { return true; }
 };
+
+#endif // ENZYME_ACTIVITY_ANALYSIS_PRINTER_H

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -23,6 +23,10 @@
 // LLVM instructions.
 //
 //===----------------------------------------------------------------------===//
+
+#ifndef ENZYME_ADJOINT_GENERATOR_H
+#define ENZYME_ADJOINT_GENERATOR_H
+
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
@@ -6414,3 +6418,5 @@ public:
                                         subretused);
   }
 };
+
+#endif // ENZYME_ADJOINT_GENERATOR_H

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -3333,8 +3333,7 @@ extern cl::opt<unsigned> SetLicmMssaOptCap;
 
 void augmentPassBuilder(llvm::PassBuilder &PB) {
 
-  auto PB0 = new llvm::PassBuilder(PB);
-  auto prePass = [PB0](ModulePassManager &MPM, OptimizationLevel Level) {
+  auto prePass = [](ModulePassManager &MPM, OptimizationLevel Level) {
     FunctionPassManager OptimizePM;
     OptimizePM.addPass(Float2IntPass());
     OptimizePM.addPass(LowerConstantIntrinsicsPass());

--- a/enzyme/Enzyme/Enzyme.h
+++ b/enzyme/Enzyme/Enzyme.h
@@ -24,8 +24,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef ENZYME_H
+#define ENZYME_H
+
 #include "llvm/Pass.h"
 #include "llvm/Passes/PassBuilder.h"
 
 llvm::ModulePass *createEnzymePass(bool PostOpt = false);
 void augmentPassBuilder(llvm::PassBuilder &PB);
+
+#endif // ENZYME_H

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -1352,21 +1352,6 @@ bool shouldAugmentCall(CallInst *op, const GradientUtils *gutils) {
   return modifyPrimal;
 }
 
-static inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                                            ModRefInfo mri) {
-  if (mri == ModRefInfo::NoModRef)
-    return os << "nomodref";
-  else if (mri == ModRefInfo::ModRef)
-    return os << "modref";
-  else if (mri == ModRefInfo::Mod)
-    return os << "mod";
-  else if (mri == ModRefInfo::Ref)
-    return os << "ref";
-  else
-    llvm_unreachable("unknown modref");
-  return os;
-}
-
 bool legalCombinedForwardReverse(
     CallInst *origop,
     const std::map<ReturnInst *, StoreInst *> &replacedReturns,

--- a/enzyme/Enzyme/JLInstSimplify.h
+++ b/enzyme/Enzyme/JLInstSimplify.h
@@ -17,6 +17,10 @@
 // }
 //
 //===----------------------------------------------------------------------===//
+
+#ifndef ENZYME_JL_INST_SIMPLIFY_H
+#define ENZYME_JL_INST_SIMPLIFY_H
+
 #include <llvm/Config/llvm-config.h>
 
 #include "llvm/IR/PassManager.h"
@@ -41,3 +45,5 @@ public:
 
   static bool isRequired() { return true; }
 };
+
+#endif // ENZYME_JL_INST_SIMPLIFY_H

--- a/enzyme/Enzyme/MLIR/Interfaces/GradientUtilsReverse.h
+++ b/enzyme/Enzyme/MLIR/Interfaces/GradientUtilsReverse.h
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef ENZYME_MLIR_INTERFACES_GRADIENT_UTILS_REVERSE_H
+#define ENZYME_MLIR_INTERFACES_GRADIENT_UTILS_REVERSE_H
+
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 
@@ -71,3 +74,5 @@ public:
 
 } // namespace enzyme
 } // namespace mlir
+
+#endif // ENZYME_MLIR_INTERFACES_GRADIENT_UTILS_REVERSE_H

--- a/enzyme/Enzyme/PreserveNVVM.h
+++ b/enzyme/Enzyme/PreserveNVVM.h
@@ -24,6 +24,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef ENZYME_PRESERVE_NVVM_H
+#define ENZYME_PRESERVE_NVVM_H
+
 #include "llvm/IR/PassManager.h"
 #include "llvm/Passes/PassPlugin.h"
 
@@ -50,3 +53,5 @@ public:
 
   static bool isRequired() { return true; }
 };
+
+#endif // ENZYME_PRESERVE_NVVM_H

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysisPrinter.h
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysisPrinter.h
@@ -23,6 +23,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef ENZYME_TYPE_ANALYSIS_TYPE_ANALYSIS_PRINTER_H
+#define ENZYME_TYPE_ANALYSIS_TYPE_ANALYSIS_PRINTER_H
+
 #include "llvm/IR/PassManager.h"
 #include "llvm/Passes/PassPlugin.h"
 
@@ -45,3 +48,5 @@ public:
 
   static bool isRequired() { return true; }
 };
+
+#endif // ENZYME_TYPE_ANALYSIS_TYPE_ANALYSIS_PRINTER_H

--- a/enzyme/tools/enzyme-tblgen/blas-tblgen.cpp
+++ b/enzyme/tools/enzyme-tblgen/blas-tblgen.cpp
@@ -739,7 +739,7 @@ void emit_extract_calls(const TGPattern &pattern, raw_ostream &os) {
 }
 
 // Will be used by Julia
-SmallString<80> ValueType_helper(const TGPattern &pattern, ssize_t actPos,
+SmallString<80> ValueType_helper(const TGPattern &pattern, size_t actPos,
                                  DagInit *ruleDag) {
   const auto nameVec = pattern.getArgNames();
   const auto typeMap = pattern.getArgTypeMap();

--- a/enzyme/tools/enzyme-tblgen/blas-tblgen.h
+++ b/enzyme/tools/enzyme-tblgen/blas-tblgen.h
@@ -7,5 +7,5 @@ void emitBlasDerivatives(const llvm::RecordKeeper &RK, llvm::raw_ostream &os);
 bool hasDiffeRet(llvm::Init *resultTree);
 bool hasAdjoint(const TGPattern &pattern, llvm::Init *resultTree,
                 llvm::StringRef argName);
-llvm::SmallString<80> ValueType_helper(const TGPattern &pattern, ssize_t actPos,
+llvm::SmallString<80> ValueType_helper(const TGPattern &pattern, size_t actPos,
                                        llvm::DagInit *ruleDag);


### PR DESCRIPTION
This change should produce no warnings when building with the `all` target with `clang-19`