### PR TITLE
mlir: Modify `BatchOpInterface` to allow generating more than one operation

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/ArithAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/ArithAutoDiffOpInterfaceImpl.cpp
@@ -32,10 +32,9 @@ struct ArithConstantOpBatchInterface
     : public BatchOpInterface::ExternalModel<ArithConstantOpBatchInterface,
                                              arith::ConstantOp> {
 
-  mlir::Operation *createBatch(Operation *src, IRMapping &mapper,
-                               Operation::CloneOptions options,
-                               std::map<Operation *, Operation *> &opMap,
-                               ArrayRef<int64_t> batchSizes) const {
+  mlir::LogicalResult createBatch(Operation *src, OpBuilder &builder,
+                                  IRMapping &mapper,
+                                  ArrayRef<int64_t> batchSizes) const {
 
     SmallVector<Type> resultTypes(src->getResultTypes().begin(),
                                   src->getResultTypes().end());
@@ -54,7 +53,9 @@ struct ArithConstantOpBatchInterface
     auto cop = mlir::Operation::create(
         src->getLoc(), src->getName(), resultTypes, {}, std::move(attrs),
         OpaqueProperties(nullptr), mlir::BlockRange(), 0);
-    return cop;
+    builder.insert(cop);
+    mapper.map(src->getResult(0), cop->getResult(0));
+    return success();
   }
 };
 

--- a/enzyme/Enzyme/MLIR/Interfaces/AutoDiffOpInterface.td
+++ b/enzyme/Enzyme/MLIR/Interfaces/AutoDiffOpInterface.td
@@ -136,7 +136,7 @@ def ActivityOpInterface
 def ADDataFlowOpInterface
     : OpInterface<"ADDataFlowOpInterface"> {
   let cppNamespace = "::mlir::enzyme";
-  
+
   let methods = [
     InterfaceMethod<
     /*desc=*/[{
@@ -171,11 +171,11 @@ def BatchOpInterface : OpInterface<"BatchOpInterface"> {
   let methods = [
     InterfaceMethod<
     /*desc=*/[{
-      Emits a batched version of a given operation.
+      Emits a batched version of a given operation and maps the newly created batched results to their correspondents in the original version.
     }],
-    /*retTy=*/"::mlir::Operation*",
+    /*retTy=*/"::mlir::LogicalResult",
     /*methodName=*/"createBatch",
-    /*args=*/(ins "::mlir::IRMapping &":$mapper, "::mlir::Operation::CloneOptions":$options, "::std::map<mlir::Operation*, mlir::Operation*>&":$opMap,  "::llvm::ArrayRef<int64_t>":$batchSizes)
+    /*args=*/(ins "::mlir::OpBuilder &":$builder, "::mlir::IRMapping &":$mapper, "::llvm::ArrayRef<int64_t>":$batchSizes)
     >
   ];
 }

--- a/enzyme/Enzyme/MLIR/Interfaces/CloneFunction.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/CloneFunction.cpp
@@ -103,7 +103,10 @@ Operation *clone(Operation *src, IRMapping &mapper,
 
   if (batchSizes.size())
     if (auto ifaceOp = dyn_cast<BatchOpInterface>(src)) {
-      newOp = ifaceOp.createBatch(mapper, options, opMap, batchSizes);
+      assert(false);
+      // mlir::OpBuilder builder();
+      // auto result = ifaceOp.createBatch(builder, mapper, options, opMap,
+      // batchSizes).succeeded(); assert(result.succeeded()); return opMap[src];
     }
 
   if (!newOp) {

--- a/enzyme/Enzyme/MLIR/Interfaces/CloneFunction.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/CloneFunction.cpp
@@ -20,23 +20,14 @@ getFunctionTypeForClone(mlir::FunctionType FTy, DerivativeMode mode,
                         const std::vector<bool> &returnPrimals,
                         const std::vector<bool> &returnShadows,
                         llvm::ArrayRef<DIFFE_TYPE> ReturnActivity,
-                        llvm::ArrayRef<DIFFE_TYPE> ArgActivity,
-                        llvm::ArrayRef<int64_t> batchSizes) {
+                        llvm::ArrayRef<DIFFE_TYPE> ArgActivity) {
 
   SmallVector<mlir::Type, 4> RetTypes;
 
   for (auto &&[Ty, returnPrimal, returnShadow, activity] : llvm::zip(
            FTy.getResults(), returnPrimals, returnShadows, ReturnActivity)) {
     if (returnPrimal) {
-      if (batchSizes.size()) {
-        auto T = cast<TensorType>(Ty);
-        SmallVector<int64_t> shape(batchSizes.begin(), batchSizes.end());
-        shape.append(T.getShape().begin(), T.getShape().end());
-        auto T2 = T.clone(shape);
-        RetTypes.push_back(T2);
-      } else {
-        RetTypes.push_back(Ty);
-      }
+      RetTypes.push_back(Ty);
     }
     if (returnShadow) {
       assert(activity != DIFFE_TYPE::CONSTANT);
@@ -48,15 +39,7 @@ getFunctionTypeForClone(mlir::FunctionType FTy, DerivativeMode mode,
   SmallVector<mlir::Type, 4> ArgTypes;
 
   for (auto &&[ITy, act] : llvm::zip(FTy.getInputs(), ArgActivity)) {
-    if (batchSizes.size()) {
-      auto T = cast<TensorType>(ITy);
-      SmallVector<int64_t> shape(batchSizes.begin(), batchSizes.end());
-      shape.append(T.getShape().begin(), T.getShape().end());
-      auto T2 = T.clone(shape);
-      ArgTypes.push_back(T2);
-    } else {
-      ArgTypes.push_back(ITy);
-    }
+    ArgTypes.push_back(ITy);
     if (act == DIFFE_TYPE::DUP_ARG || act == DIFFE_TYPE::DUP_NONEED) {
       ArgTypes.push_back(getShadowType(ITy, width));
     } else if (act == DIFFE_TYPE::OUT_DIFF) {
@@ -81,8 +64,7 @@ getFunctionTypeForClone(mlir::FunctionType FTy, DerivativeMode mode,
 
 Operation *clone(Operation *src, IRMapping &mapper,
                  Operation::CloneOptions options,
-                 std::map<Operation *, Operation *> &opMap,
-                 llvm::ArrayRef<int64_t> batchSizes) {
+                 std::map<Operation *, Operation *> &opMap) {
   SmallVector<Value, 8> operands;
   SmallVector<Block *, 2> successors;
 
@@ -101,25 +83,9 @@ Operation *clone(Operation *src, IRMapping &mapper,
   // Create the new operation.
   Operation *newOp = nullptr;
 
-  if (batchSizes.size())
-    if (auto ifaceOp = dyn_cast<BatchOpInterface>(src)) {
-      assert(false);
-      // mlir::OpBuilder builder();
-      // auto result = ifaceOp.createBatch(builder, mapper, options, opMap,
-      // batchSizes).succeeded(); assert(result.succeeded()); return opMap[src];
-    }
-
   if (!newOp) {
     SmallVector<Type> resultTypes(src->getResultTypes().begin(),
                                   src->getResultTypes().end());
-    if (batchSizes.size()) {
-      for (auto &Ty : resultTypes) {
-        auto T = cast<TensorType>(Ty);
-        SmallVector<int64_t> shape(batchSizes.begin(), batchSizes.end());
-        shape.append(T.getShape().begin(), T.getShape().end());
-        Ty = T.clone(shape);
-      }
-    }
     newOp = Operation::create(
         src->getLoc(), src->getName(), resultTypes, operands, src->getAttrs(),
         OpaqueProperties(nullptr), successors, src->getNumRegions());
@@ -127,8 +93,7 @@ Operation *clone(Operation *src, IRMapping &mapper,
     // Clone the regions.
     if (options.shouldCloneRegions()) {
       for (unsigned i = 0; i != src->getNumRegions(); ++i)
-        cloneInto(&src->getRegion(i), &newOp->getRegion(i), mapper, opMap,
-                  batchSizes);
+        cloneInto(&src->getRegion(i), &newOp->getRegion(i), mapper, opMap);
     }
   }
 
@@ -141,15 +106,13 @@ Operation *clone(Operation *src, IRMapping &mapper,
 }
 
 void cloneInto(Region *src, Region *dest, IRMapping &mapper,
-               std::map<Operation *, Operation *> &opMap,
-               llvm::ArrayRef<int64_t> batchSizes) {
-  cloneInto(src, dest, dest->end(), mapper, opMap, batchSizes);
+               std::map<Operation *, Operation *> &opMap) {
+  cloneInto(src, dest, dest->end(), mapper, opMap);
 }
 
 /// Clone this region into 'dest' before the given position in 'dest'.
 void cloneInto(Region *src, Region *dest, Region::iterator destPos,
-               IRMapping &mapper, std::map<Operation *, Operation *> &opMap,
-               llvm::ArrayRef<int64_t> batchSizes) {
+               IRMapping &mapper, std::map<Operation *, Operation *> &opMap) {
   assert(src);
   assert(dest && "expected valid region to clone into");
   assert(src != dest && "cannot clone region into itself");
@@ -180,12 +143,6 @@ void cloneInto(Region *src, Region *dest, Region::iterator destPos,
     for (auto arg : block.getArguments())
       if (!mapper.contains(arg)) {
         auto Ty = arg.getType();
-        if (batchSizes.size()) {
-          auto T = cast<TensorType>(Ty);
-          SmallVector<int64_t> shape(batchSizes.begin(), batchSizes.end());
-          shape.append(T.getShape().begin(), T.getShape().end());
-          Ty = T.clone(shape);
-        }
         mapper.map(arg, newBlock->addArgument(Ty, arg.getLoc()));
       }
 
@@ -208,8 +165,7 @@ void cloneInto(Region *src, Region *dest, Region::iterator destPos,
     Block &clonedBlock = std::get<1>(zippedBlocks);
     // Clone and remap the operations within this block.
     for (Operation &op : sourceBlock) {
-      clonedBlock.push_back(
-          clone(&op, mapper, cloneOptions, opMap, batchSizes));
+      clonedBlock.push_back(clone(&op, mapper, cloneOptions, opMap));
     }
   }
 
@@ -229,8 +185,7 @@ void cloneInto(Region *src, Region *dest, Region::iterator destPos,
       clone.setOperands(operands);
 
       for (auto regions : llvm::zip(source.getRegions(), clone.getRegions()))
-        cloneInto(&std::get<0>(regions), &std::get<1>(regions), mapper, opMap,
-                  batchSizes);
+        cloneInto(&std::get<0>(regions), &std::get<1>(regions), mapper, opMap);
     }
   }
 }
@@ -244,14 +199,13 @@ FunctionOpInterface CloneFunctionWithReturns(
     const std::vector<bool> &returnPrimals,
     const std::vector<bool> &returnShadows, ArrayRef<DIFFE_TYPE> RetActivity,
     Twine name, IRMapping &VMap, std::map<Operation *, Operation *> &OpMap,
-    mlir::Type additionalArg, llvm::ArrayRef<int64_t> batchSizes) {
+    mlir::Type additionalArg) {
   assert(!F.getFunctionBody().empty());
   // F = preprocessForClone(F, mode);
   // llvm::ValueToValueMapTy VMap;
   auto FTy = getFunctionTypeForClone(
       F.getFunctionType().cast<mlir::FunctionType>(), mode, width,
-      additionalArg, returnPrimals, returnShadows, RetActivity, ArgActivity,
-      batchSizes);
+      additionalArg, returnPrimals, returnShadows, RetActivity, ArgActivity);
 
   /*
   for (Block &BB : F.getFunctionBody().getBlocks()) {
@@ -274,8 +228,7 @@ FunctionOpInterface CloneFunctionWithReturns(
   table.insert(NewF);
   SymbolTable::setSymbolVisibility(NewF, SymbolTable::Visibility::Private);
 
-  cloneInto(&F.getFunctionBody(), &NewF.getFunctionBody(), VMap, OpMap,
-            batchSizes);
+  cloneInto(&F.getFunctionBody(), &NewF.getFunctionBody(), VMap, OpMap);
 
   {
     auto &blk = NewF.getFunctionBody().front();

--- a/enzyme/Enzyme/MLIR/Interfaces/CloneFunction.h
+++ b/enzyme/Enzyme/MLIR/Interfaces/CloneFunction.h
@@ -30,21 +30,17 @@ getFunctionTypeForClone(mlir::FunctionType FTy, DerivativeMode mode,
                         llvm::ArrayRef<bool> returnPrimals,
                         llvm::ArrayRef<bool> returnShadows,
                         llvm::ArrayRef<DIFFE_TYPE> ReturnActivity,
-                        llvm::ArrayRef<DIFFE_TYPE> ArgActivity,
-                        llvm::ArrayRef<int64_t> batchSizes = {});
+                        llvm::ArrayRef<DIFFE_TYPE> ArgActivity);
 
 void cloneInto(Region *src, Region *dest, Region::iterator destPos,
-               IRMapping &mapper, std::map<Operation *, Operation *> &opMap,
-               llvm::ArrayRef<int64_t> batchSizes);
+               IRMapping &mapper, std::map<Operation *, Operation *> &opMap);
 
 void cloneInto(Region *src, Region *dest, IRMapping &mapper,
-               std::map<mlir::Operation *, mlir::Operation *> &opMap,
-               llvm::ArrayRef<int64_t> batchSizes);
+               std::map<mlir::Operation *, mlir::Operation *> &opMap);
 
 Operation *clone(Operation *src, IRMapping &mapper,
                  Operation::CloneOptions options,
-                 std::map<Operation *, Operation *> &opMap,
-                 llvm::ArrayRef<int64_t> batchSizes);
+                 std::map<Operation *, Operation *> &opMap);
 
 FunctionOpInterface CloneFunctionWithReturns(
     DerivativeMode mode, unsigned width, FunctionOpInterface F,
@@ -55,4 +51,4 @@ FunctionOpInterface CloneFunctionWithReturns(
     const std::vector<bool> &returnPrimals,
     const std::vector<bool> &returnShadows, ArrayRef<DIFFE_TYPE> ReturnActivity,
     Twine name, IRMapping &VMap, std::map<Operation *, Operation *> &OpMap,
-    mlir::Type additionalArg, llvm::ArrayRef<int64_t> batchSizes = {});
+    mlir::Type additionalArg);

--- a/enzyme/Enzyme/MLIR/Passes/EnzymeBatchPass.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/EnzymeBatchPass.cpp
@@ -59,7 +59,8 @@ static void batchCloneRegion(Region *src, Region *dest, IRMapping &mapper,
 
       if (auto ifaceOp = dyn_cast<BatchOpInterface>(&src)) {
         auto res = ifaceOp.createBatch(builder, mapper, batchSizes);
-        if (res.succeeded()) continue;
+        if (res.succeeded())
+          continue;
       }
 
       SmallVector<Value, 8> operands;

--- a/enzyme/Enzyme/MLIR/Passes/EnzymeBatchPass.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/EnzymeBatchPass.cpp
@@ -27,9 +27,122 @@ using namespace mlir::enzyme;
 using namespace enzyme;
 
 namespace {
-struct BatchPass : public BatchPassBase<BatchPass> {
-  MEnzymeLogic Logic;
 
+static mlir::TensorType applyBatchSizes(mlir::Type Ty,
+                                        llvm::ArrayRef<int64_t> batchSizes) {
+  auto T = cast<TensorType>(Ty);
+  SmallVector<int64_t> shape(batchSizes.begin(), batchSizes.end());
+  shape.append(T.getShape().begin(), T.getShape().end());
+  auto T2 = T.clone(shape);
+  return T2;
+}
+
+static void batchCloneRegion(Region *src, Region *dest, IRMapping &mapper,
+                             llvm::ArrayRef<int64_t> batchSizes) {
+  // For each block in src, generate a corresponding block in the dest region.
+  for (auto &blk : *src) {
+    auto newBlk = new Block();
+    dest->push_back(newBlk);
+
+    mapper.map(&blk, newBlk);
+
+    for (auto arg : blk.getArguments()) {
+      Value newArg = newBlk->addArgument(
+          applyBatchSizes(arg.getType(), batchSizes), arg.getLoc());
+      mapper.map(arg, newArg);
+    }
+  }
+
+  for (auto &&[blk, newBlk] : llvm::zip(*src, *dest)) {
+    OpBuilder builder(&newBlk, newBlk.end());
+    for (auto &src : blk) {
+
+      if (auto ifaceOp = dyn_cast<BatchOpInterface>(&src)) {
+        auto res = ifaceOp.createBatch(builder, mapper, batchSizes);
+        if (res.succeeded()) continue;
+      }
+
+      SmallVector<Value, 8> operands;
+      SmallVector<Block *, 2> successors;
+
+      // Remap the operands.
+      operands.reserve(src.getNumOperands());
+      for (auto opValue : src.getOperands())
+        operands.push_back(mapper.lookup(opValue));
+
+      // Remap the successors.
+      successors.reserve(src.getNumSuccessors());
+      for (Block *successor : src.getSuccessors())
+        successors.push_back(mapper.lookup(successor));
+
+      SmallVector<Type> resultTypes(src.getResultTypes().begin(),
+                                    src.getResultTypes().end());
+      for (auto &Ty : resultTypes) {
+        Ty = applyBatchSizes(Ty, batchSizes);
+      }
+
+      Operation *newOp = Operation::create(
+          src.getLoc(), src.getName(), resultTypes, operands, src.getAttrs(),
+          OpaqueProperties(nullptr), successors, src.getNumRegions());
+
+      // Clone the regions.
+      for (auto &&[oldReg, newReg] :
+           llvm::zip(src.getRegions(), newOp->getRegions())) {
+        batchCloneRegion(&oldReg, &newReg, mapper, batchSizes);
+      }
+
+      // Remember the mapping of any results.
+      for (unsigned i = 0, e = src.getNumResults(); i != e; ++i)
+        mapper.map(src.getResult(i), newOp->getResult(i));
+
+      builder.insert(newOp);
+    }
+  }
+}
+
+static FunctionOpInterface
+batchCloneFunction(FunctionOpInterface F, Twine name,
+                   llvm::ArrayRef<int64_t> batchSizes) {
+  assert(!F.getFunctionBody().empty());
+
+  auto FTy = F.getFunctionType().cast<FunctionType>();
+
+  llvm::SmallVector<mlir::Type> RetTypes;
+  RetTypes.reserve(FTy.getNumResults());
+
+  for (auto Ty : FTy.getResults()) {
+    RetTypes.push_back(applyBatchSizes(Ty, batchSizes));
+  }
+
+  SmallVector<mlir::Type, 4> ArgTypes;
+  ArgTypes.reserve(FTy.getNumInputs());
+
+  for (auto Ty : FTy.getInputs()) {
+    ArgTypes.push_back(applyBatchSizes(Ty, batchSizes));
+  }
+
+  OpBuilder builder(FTy.getContext());
+  FunctionType newFTy = builder.getFunctionType(ArgTypes, RetTypes);
+
+  auto NewF = cast<FunctionOpInterface>(F->cloneWithoutRegions());
+  SymbolTable::setSymbolName(NewF, name.str());
+  NewF.setType(newFTy);
+
+  Operation *parent = F->getParentWithTrait<OpTrait::SymbolTable>();
+  SymbolTable table(parent);
+  table.insert(NewF);
+  SymbolTable::setSymbolVisibility(NewF, SymbolTable::Visibility::Private);
+
+  auto &origReg = F.getFunctionBody();
+  auto &newReg = NewF.getFunctionBody();
+
+  IRMapping mapper;
+  batchCloneRegion(&origReg, &newReg, mapper, batchSizes);
+
+  return NewF;
+}
+
+struct BatchPass : public BatchPassBase<BatchPass> {
   void runOnOperation() override;
 
   template <typename T>
@@ -39,27 +152,8 @@ struct BatchPass : public BatchPassBase<BatchPass> {
     auto *symbolOp = symbolTable.lookupNearestSymbolFrom(CI, CI.getFnAttr());
     auto fn = cast<FunctionOpInterface>(symbolOp);
 
-    SmallVector<DIFFE_TYPE> RetActivity(CI.getResults().size(),
-                                        DIFFE_TYPE::CONSTANT);
-    SmallVector<DIFFE_TYPE> ArgActivity(CI.getInputs().size(),
-                                        DIFFE_TYPE::CONSTANT);
-    std::vector<bool> returnPrimals(CI.getResults().size(), true);
-    std::vector<bool> returnShadows(CI.getResults().size(), false);
-
-    IRMapping originalToNew;
-    std::map<Operation *, Operation *> originalToNewOps;
-
-    SmallPtrSet<mlir::Value, 1> returnvals;
-    SmallPtrSet<mlir::Value, 1> constant_values;
-    SmallPtrSet<mlir::Value, 1> nonconstant_values;
-    IRMapping invertedPointers;
-
-    FunctionOpInterface newFunc = CloneFunctionWithReturns(
-        /*mode*/ DerivativeMode::ForwardMode, /*width*/ 1, fn, invertedPointers,
-        ArgActivity, constant_values, nonconstant_values, returnvals,
-        returnPrimals, returnShadows, RetActivity, "batched_" + fn.getName(),
-        originalToNew, originalToNewOps,
-        /*additionalArg*/ nullptr, CI.getBatchShape());
+    FunctionOpInterface newFunc =
+        batchCloneFunction(fn, "batched_" + fn.getName(), CI.getBatchShape());
 
     if (!newFunc)
       return failure();


### PR DESCRIPTION
This PR modifies the `BatchOpInterface` to enable generating multiple operations and then map from the original results to new values. To do this, `batchSizes` support is removed in the original Enzyme MLIR cloning and batch cloning is implemented on its own.

See https://github.com/EnzymeAD/Enzyme-JAX/pull/149#issuecomment-2450019084 for more context.