### PR TITLE
Marks functions inline in BLAS tblgen

### DIFF
--- a/enzyme/tools/enzyme-tblgen/blas-tblgen.h
+++ b/enzyme/tools/enzyme-tblgen/blas-tblgen.h
@@ -1,3 +1,6 @@
+#ifndef ENZYME_TBLGEN_BLAS_TBLGEN_H
+#define ENZYME_TBLGEN_BLAS_TBLGEN_H
+
 #include "llvm/ADT/SmallString.h"
 #include "llvm/TableGen/Record.h"
 
@@ -9,3 +12,5 @@ bool hasAdjoint(const TGPattern &pattern, const llvm::Init *resultTree,
                 llvm::StringRef argName);
 llvm::SmallString<80> ValueType_helper(const TGPattern &pattern, ssize_t actPos,
                                        const llvm::DagInit *ruleDag);
+
+#endif // ENZYME_TBLGEN_BLAS_TBLGEN_H

--- a/enzyme/tools/enzyme-tblgen/blasDeclUpdater.h
+++ b/enzyme/tools/enzyme-tblgen/blasDeclUpdater.h
@@ -1,3 +1,6 @@
+#ifndef ENZYME_TBLGEN_BLAS_DECL_UPDATER_H
+#define ENZYME_TBLGEN_BLAS_DECL_UPDATER_H
+
 #include "datastructures.h"
 
 void emit_attributeBLASCaller(ArrayRef<TGPattern> blasPatterns,
@@ -283,3 +286,5 @@ void emitBlasDeclUpdater(const RecordKeeper &RK, raw_ostream &os) {
   os << "  return changed;\n";
   os << "}\n";
 }
+
+#endif // ENZYME_TBLGEN_BLAS_DECL_UPDATER_H

--- a/enzyme/tools/enzyme-tblgen/blasDeclUpdater.h
+++ b/enzyme/tools/enzyme-tblgen/blasDeclUpdater.h
@@ -3,8 +3,8 @@
 
 #include "datastructures.h"
 
-void emit_attributeBLASCaller(ArrayRef<TGPattern> blasPatterns,
-                              raw_ostream &os) {
+inline void emit_attributeBLASCaller(ArrayRef<TGPattern> blasPatterns,
+                                     raw_ostream &os) {
   os << "void attributeBLAS(BlasInfo blas, llvm::Function *F) {             \n";
   os << "  if (!F->empty())\n";
   os << "    return;\n";
@@ -18,7 +18,7 @@ void emit_attributeBLASCaller(ArrayRef<TGPattern> blasPatterns,
   os << "}                                                                \n";
 }
 
-void emit_attributeBLAS(const TGPattern &pattern, raw_ostream &os) {
+inline void emit_attributeBLAS(const TGPattern &pattern, raw_ostream &os) {
   auto name = pattern.getName();
   bool lv23 = pattern.isBLASLevel2or3();
   os << "llvm::Constant* attribute_" << name
@@ -199,7 +199,7 @@ void emit_attributeBLAS(const TGPattern &pattern, raw_ostream &os) {
   os << "}\n";
 }
 
-void emitBlasDeclUpdater(const RecordKeeper &RK, raw_ostream &os) {
+inline void emitBlasDeclUpdater(const RecordKeeper &RK, raw_ostream &os) {
   emitSourceFileHeader("Rewriters", os);
   const auto &blasPatterns = RK.getAllDerivedDefinitions("CallBlasPattern");
 

--- a/enzyme/tools/enzyme-tblgen/blasDiffUseUpdater.h
+++ b/enzyme/tools/enzyme-tblgen/blasDiffUseUpdater.h
@@ -7,7 +7,7 @@
 #include "enzyme-tblgen.h"
 #include "llvm/Support/raw_ostream.h"
 
-void emit_BLASDiffUse(TGPattern &pattern, llvm::raw_ostream &os) {
+inline void emit_BLASDiffUse(TGPattern &pattern, llvm::raw_ostream &os) {
   auto typeMap = pattern.getArgTypeMap();
   auto argUsers = pattern.getArgUsers();
   bool lv23 = pattern.isBLASLevel2or3();
@@ -142,7 +142,7 @@ void emit_BLASDiffUse(TGPattern &pattern, llvm::raw_ostream &os) {
   os << "}\n";
 }
 
-void emitBlasDiffUse(const RecordKeeper &RK, llvm::raw_ostream &os) {
+inline void emitBlasDiffUse(const RecordKeeper &RK, llvm::raw_ostream &os) {
   emitSourceFileHeader("Rewriters", os);
   const auto &blasPatterns = RK.getAllDerivedDefinitions("CallBlasPattern");
 

--- a/enzyme/tools/enzyme-tblgen/blasDiffUseUpdater.h
+++ b/enzyme/tools/enzyme-tblgen/blasDiffUseUpdater.h
@@ -1,3 +1,6 @@
+#ifndef ENZYME_TBLGEN_BLAS_DIFF_USE_UPDATER_H
+#define ENZYME_TBLGEN_BLAS_DIFF_USE_UPDATER_H
+
 #include "blas-tblgen.h"
 #include "caching.h"
 #include "datastructures.h"
@@ -193,3 +196,5 @@ void emitBlasDiffUse(const RecordKeeper &RK, llvm::raw_ostream &os) {
   os << "    }\n";
   os << "}\n";
 }
+
+#endif // ENZYME_TBLGEN_BLAS_DIFF_USE_UPDATER_H

--- a/enzyme/tools/enzyme-tblgen/blasTAUpdater.h
+++ b/enzyme/tools/enzyme-tblgen/blasTAUpdater.h
@@ -3,7 +3,7 @@
 
 #include "datastructures.h"
 
-void emit_BLASTypes(raw_ostream &os) {
+inline void emit_BLASTypes(raw_ostream &os) {
   os << "const bool byRef = blas.prefix == \"\" || blas.prefix == "
         "\"cublas_\";\n";
   os << "const bool byRefFloat = byRef || blas.prefix == "
@@ -68,7 +68,7 @@ void emit_BLASTypes(raw_ostream &os) {
 
 // cblas lv23 => layout
 // cublas => always handle
-void emit_BLASTA(TGPattern &pattern, raw_ostream &os) {
+inline void emit_BLASTA(TGPattern &pattern, raw_ostream &os) {
   auto name = pattern.getName();
   bool lv23 = pattern.isBLASLevel2or3();
 
@@ -183,7 +183,7 @@ void emit_BLASTA(TGPattern &pattern, raw_ostream &os) {
   os << "}\n";
 }
 
-void emitBlasTAUpdater(const RecordKeeper &RK, raw_ostream &os) {
+inline void emitBlasTAUpdater(const RecordKeeper &RK, raw_ostream &os) {
   emitSourceFileHeader("Rewriters", os);
   const auto &blasPatterns = RK.getAllDerivedDefinitions("CallBlasPattern");
 

--- a/enzyme/tools/enzyme-tblgen/blasTAUpdater.h
+++ b/enzyme/tools/enzyme-tblgen/blasTAUpdater.h
@@ -1,3 +1,6 @@
+#ifndef ENZYME_TBLGEN_BLAS_TA_UPDATER_H
+#define ENZYME_TBLGEN_BLAS_TA_UPDATER_H
+
 #include "datastructures.h"
 
 void emit_BLASTypes(raw_ostream &os) {
@@ -199,3 +202,5 @@ void emitBlasTAUpdater(const RecordKeeper &RK, raw_ostream &os) {
     emit_BLASTA(newPattern, os);
   }
 }
+
+#endif // ENZYME_TBLGEN_BLAS_TA_UPDATER_H


### PR DESCRIPTION
Adds a few more missing header guards and marks some functions implemented in headers as `inline`.