### PR TITLE
Adds initial CMake presets configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ enzyme/benchmarks/ReverseMode/*/results.txt
 enzyme/benchmarks/ReverseMode/*/results.json
 .cache
 CMakeUserPresets.json
+/out

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ enzyme/benchmarks/ReverseMode/*/*.exe
 enzyme/benchmarks/ReverseMode/*/results.txt
 enzyme/benchmarks/ReverseMode/*/results.json
 .cache
+CMakeUserPresets.json

--- a/enzyme/CMakeLists.txt
+++ b/enzyme/CMakeLists.txt
@@ -17,11 +17,13 @@ add_definitions(-DENZYME_VERSION_PATCH=${ENZYME_PATCH_VERSION})
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-SET(CMAKE_CXX_FLAGS "-Wall -fno-rtti ${CMAKE_CXX_FLAGS} -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch")
-SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -ggdb")
-SET(CMAKE_CXX_FLAGS_RELEASE "-O2")
 
-SET(CMAKE_CXX_FLAGS_DEBUG  "-O0 -g -ggdb -fno-omit-frame-pointer")
+if (NOT ENZYME_CONFIGURED_WITH_PRESETS AND NOT MSVC)
+  set(CMAKE_CXX_FLAGS "-Wall -fno-rtti ${CMAKE_CXX_FLAGS} -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch")
+  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -ggdb")
+  set(CMAKE_CXX_FLAGS_RELEASE "-O2")
+  set(CMAKE_CXX_FLAGS_DEBUG  "-O0 -g -ggdb -fno-omit-frame-pointer")
+endif()
 
 #SET(CMAKE_CXX_FLAGS_DEBUG  "-O0 -g -fno-omit-frame-pointer -fsanitize=address")
 #SET(CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")

--- a/enzyme/CMakeLists.txt
+++ b/enzyme/CMakeLists.txt
@@ -18,7 +18,7 @@ add_definitions(-DENZYME_VERSION_PATCH=${ENZYME_PATCH_VERSION})
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-if (NOT ENZYME_CONFIGURED_WITH_PRESETS)
+if (NOT DEFINED ENZYME_CONFIGURED_WITH_PRESETS)
   set(CMAKE_CXX_FLAGS "-Wall -fno-rtti ${CMAKE_CXX_FLAGS} -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -ggdb")
   set(CMAKE_CXX_FLAGS_RELEASE "-O2")

--- a/enzyme/CMakeLists.txt
+++ b/enzyme/CMakeLists.txt
@@ -18,7 +18,7 @@ add_definitions(-DENZYME_VERSION_PATCH=${ENZYME_PATCH_VERSION})
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-if (NOT ENZYME_CONFIGURED_WITH_PRESETS AND NOT MSVC)
+if (NOT ENZYME_CONFIGURED_WITH_PRESETS)
   set(CMAKE_CXX_FLAGS "-Wall -fno-rtti ${CMAKE_CXX_FLAGS} -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -ggdb")
   set(CMAKE_CXX_FLAGS_RELEASE "-O2")

--- a/enzyme/CMakePresets.json
+++ b/enzyme/CMakePresets.json
@@ -1,0 +1,82 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "config-base",
+            "description": "Base configure preset.",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/out/build/${presetName}",
+            "installDir": "${sourceDir}/out/install/${presetName}",
+            "cacheVariables": {
+                "CMAKE_CXX_STANDARD": "17",
+                "CMAKE_CXX_STANDARD_REQUIRED": "ON",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+            }
+        },
+        {
+            "name": "config-base-linux",
+            "description": "Base configure preset for Linux.",
+            "inherits": "config-base",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_POSITION_INDEPENDENT_CODE": "ON"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "config-base-x64",
+            "description": "Base preset for x64 platforms.",
+            "hidden": true,
+            "architecture": {
+                "value": "x64",
+                "strategy": "external"
+            }
+        },
+        {
+            "name": "x64-linux-clang",
+            "description": "Base preset for Linux development using Clang compilers.",
+            "hidden": true,
+            "inherits": [
+                "config-base-x64",
+                "config-base-linux"
+            ],
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_CXX_FLAGS": "-Wall -fno-rtti -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch",
+                "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g -ggdb -fno-omit-frame-pointer",
+                "CMAKE_CXX_FLAGS_RELEASE": "-O2",
+                "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -ggdb"
+            }
+        },
+        {
+            "name": "x64-linux-clang-debug",
+            "displayName": "Clang x64 Linux Debug",
+            "inherits": "x64-linux-clang",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "x64-linux-clang-release",
+            "displayName": "Clang x64 Linux Release",
+            "inherits": "x64-linux-clang",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "x64-linux-clang-release-with-debug-info",
+            "displayName": "Clang x64 Linux Release with Debug Info",
+            "inherits": "x64-linux-clang",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+            }
+        }
+    ]
+}

--- a/enzyme/CMakePresets.json
+++ b/enzyme/CMakePresets.json
@@ -12,7 +12,7 @@
                 "CMAKE_CXX_STANDARD": "17",
                 "CMAKE_CXX_STANDARD_REQUIRED": "ON",
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-                "ENZYME_CONFIGURED_WITH_PRESETS": "TRUE"
+                "ENZYME_CONFIGURED_WITH_PRESETS": "ON"
             }
         },
         {

--- a/enzyme/CMakePresets.json
+++ b/enzyme/CMakePresets.json
@@ -84,19 +84,19 @@
         {
             "name": "x64-linux-clang-debug",
             "displayName": "Clang x64 Linux Debug",
-            "description": "Builds the project using Clang on Linux in Debug mode.",
+            "description": "Builds the project using Clang on Linux in Debug configuration.",
             "configurePreset": "x64-linux-clang-debug"
         },
         {
             "name": "x64-linux-clang-release",
             "displayName": "Clang x64 Linux Release",
-            "description": "Builds the project using Clang on Linux in Release mode.",
+            "description": "Builds the project using Clang on Linux in Release configuration.",
             "configurePreset": "x64-linux-clang-release"
         },
         {
             "name": "x64-linux-clang-release-with-debug-info",
             "displayName": "Clang x64 Linux Release with Debug Info",
-            "description": "Builds the project using Clang on Linux in Release mode with debug info.",
+            "description": "Builds the project using Clang on Linux in Release configuration with debug info.",
             "configurePreset": "x64-linux-clang-release-with-debug-info"
         }
     ]

--- a/enzyme/CMakePresets.json
+++ b/enzyme/CMakePresets.json
@@ -11,7 +11,8 @@
             "cacheVariables": {
                 "CMAKE_CXX_STANDARD": "17",
                 "CMAKE_CXX_STANDARD_REQUIRED": "ON",
-                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "ENZYME_CONFIGURED_WITH_PRESETS": "TRUE"
             }
         },
         {

--- a/enzyme/CMakePresets.json
+++ b/enzyme/CMakePresets.json
@@ -78,5 +78,25 @@
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo"
             }
         }
+    ],
+    "buildPresets": [
+        {
+            "name": "x64-linux-clang-debug",
+            "displayName": "Clang x64 Linux Debug",
+            "description": "Builds the project using Clang on Linux in Debug mode.",
+            "configurePreset": "x64-linux-clang-debug"
+        },
+        {
+            "name": "x64-linux-clang-release",
+            "displayName": "Clang x64 Linux Release",
+            "description": "Builds the project using Clang on Linux in Release mode.",
+            "configurePreset": "x64-linux-clang-release"
+        },
+        {
+            "name": "x64-linux-clang-release-with-debug-info",
+            "displayName": "Clang x64 Linux Release with Debug Info",
+            "description": "Builds the project using Clang on Linux in Release mode with debug info.",
+            "configurePreset": "x64-linux-clang-release-with-debug-info"
+        }
     ]
 }


### PR DESCRIPTION
Adds CMake presets that have parity with the existing configuration. This will hopefully make it easier for people to extend/customize Enzyme builds on their platform.

No real changes to the build system are expected because the presets mirror the existing configuration. It's hopefully something that can be refined and extended in future, but works fine for the sake of an initial PR to make it available for basic builds.

Closes #2162