### PR TITLE
mlir: Add Enzyme ops removal on structured control flow

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/BuiltinAutoDiffTypeInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/BuiltinAutoDiffTypeInterfaceImpl.cpp
@@ -28,6 +28,13 @@ namespace {
 
 static mlir::Type batchType(mlir::Type type, int64_t width) {
   if (width > 1 || ShapedType::isDynamic(width)) {
+    if (auto TT = dyn_cast<mlir::TensorType>(type)) {
+      SmallVector<int64_t> shape;
+      shape.reserve(TT.getShape().size());
+      shape.push_back(width);
+      shape.append(TT.getShape().begin(), TT.getShape().end());
+      return TT.clone(shape);
+    }
     return RankedTensorType::get({width}, type);
   }
   return type;

--- a/enzyme/Enzyme/MLIR/Implementations/BuiltinAutoDiffTypeInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/BuiltinAutoDiffTypeInterfaceImpl.cpp
@@ -27,17 +27,18 @@ using namespace mlir::enzyme;
 namespace {
 
 static mlir::Type batchType(mlir::Type type, int64_t width) {
-  if (width > 1 || ShapedType::isDynamic(width)) {
-    if (auto TT = dyn_cast<mlir::TensorType>(type)) {
-      SmallVector<int64_t> shape;
-      shape.reserve(TT.getShape().size() + 1);
-      shape.push_back(width);
-      shape.append(TT.getShape().begin(), TT.getShape().end());
-      return TT.clone(shape);
-    }
-    return RankedTensorType::get({width}, type);
+  if (width == 1)
+    return type;
+
+  if (auto TT = dyn_cast<mlir::TensorType>(type)) {
+    SmallVector<int64_t> shape;
+    shape.reserve(TT.getShape().size() + 1);
+    shape.push_back(width);
+    shape.append(TT.getShape().begin(), TT.getShape().end());
+    return TT.clone(shape);
   }
-  return type;
+
+  return RankedTensorType::get({width}, type);
 }
 
 class FloatTypeInterface

--- a/enzyme/Enzyme/MLIR/Implementations/BuiltinAutoDiffTypeInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/BuiltinAutoDiffTypeInterfaceImpl.cpp
@@ -30,7 +30,7 @@ static mlir::Type batchType(mlir::Type type, int64_t width) {
   if (width > 1 || ShapedType::isDynamic(width)) {
     if (auto TT = dyn_cast<mlir::TensorType>(type)) {
       SmallVector<int64_t> shape;
-      shape.reserve(TT.getShape().size());
+      shape.reserve(TT.getShape().size() + 1);
       shape.push_back(width);
       shape.append(TT.getShape().begin(), TT.getShape().end());
       return TT.clone(shape);

--- a/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
@@ -152,7 +152,7 @@ struct ForOpEnzymeOpsRemover
     }
 
     auto numIters = getConstantNumberOfIterations(forOp);
-    Value inductionVariable; // [0, N[ counter
+    Value inductionVariable; // [0,..., N - 1] counter
 
     if (matchPattern(forOp.getLowerBound(), m_Zero()) &&
         matchPattern(forOp.getStep(), m_One())) {

--- a/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
@@ -17,7 +17,10 @@
 #include "Interfaces/EnzymeLogic.h"
 #include "Interfaces/GradientUtils.h"
 #include "Interfaces/GradientUtilsReverse.h"
+#include "Passes/RemovalUtils.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
@@ -32,126 +35,418 @@ using namespace mlir::enzyme;
 namespace {
 #include "Implementations/SCFDerivatives.inc"
 
+// TODO: support non constant number of iteration by using unknown dimensions
+static std::optional<int64_t> getNumberOfIterations(scf::ForOp forOp) {
+  auto lb = forOp.getLowerBound();
+  auto ub = forOp.getUpperBound();
+  auto step = forOp.getStep();
+
+  IntegerAttr lbAttr, ubAttr, stepAttr;
+  if (!matchPattern(lb, m_Constant(&lbAttr)))
+    return std::nullopt;
+  if (!matchPattern(ub, m_Constant(&ubAttr)))
+    return std::nullopt;
+  if (!matchPattern(step, m_Constant(&stepAttr)))
+    return std::nullopt;
+
+  int64_t lbI = lbAttr.getInt(), ubI = ubAttr.getInt(),
+          stepI = stepAttr.getInt();
+
+  return (ubI - lbI) / stepI;
+}
+
+struct ForOpEnzymeOpsRemover
+    : public EnzymeOpsRemoverOpInterface::ExternalModel<ForOpEnzymeOpsRemover,
+                                                        scf::ForOp> {
+
+  LogicalResult removeEnzymeOps(Operation *op) const {
+    auto forOp = cast<scf::ForOp>(op);
+    scf::ForOp otherForOp; // where caches pops are
+
+    if (removeOpsWithinBlock(forOp.getBody()).failed())
+      return failure();
+
+    // Gradients whose values need to be passed as iteration variables.
+    llvm::SmallDenseSet<Value> updatedGradients;
+
+    llvm::SmallVector<CacheInfo> caches;
+
+    Block *body = forOp.getBody();
+
+    for (auto &it : *body) {
+      Operation *op = &it;
+
+      if (auto setOp = dyn_cast<enzyme::SetOp>(op))
+        updatedGradients.insert(setOp.getGradient());
+
+      if (auto pushOp = dyn_cast<enzyme::PushOp>(op)) {
+        CacheInfo info(pushOp.getCache());
+        caches.push_back(info);
+
+        otherForOp = cast<scf::ForOp>(info.popOp->getParentOp());
+      }
+    }
+
+    // nothing to do
+    if (updatedGradients.empty() && caches.empty())
+      return success();
+
+    OpBuilder builder(forOp);
+    for (auto &it : *body) {
+      Operation *op = &it;
+
+      auto getOp = dyn_cast<enzyme::GetOp>(op);
+      if (!getOp || updatedGradients.contains(getOp.getGradient()))
+        continue;
+
+      auto outerGet = builder.create<enzyme::GetOp>(
+          getOp->getLoc(),
+          cast<enzyme::GradientType>(getOp.getResult().getType()).getBasetype(),
+          getOp.getGradient());
+
+      getOp.getResult().replaceAllUsesWith(outerGet.getResult());
+      getOp->erase();
+    }
+
+    auto term = body->getTerminator();
+
+    SmallVector<Value> newOperands(forOp.getInitArgs());
+    for (auto grad : updatedGradients) {
+      auto Ty = cast<enzyme::GradientType>(grad.getType()).getBasetype();
+      auto outerGet = builder.create<enzyme::GetOp>(grad.getLoc(), Ty, grad);
+
+      newOperands.push_back(outerGet.getResult());
+      auto newArg = body->addArgument(Ty, grad.getLoc());
+
+      {
+        OpBuilder::InsertionGuard guard(builder);
+
+        builder.setInsertionPointToStart(body);
+        builder.create<enzyme::SetOp>(grad.getLoc(), grad, newArg);
+
+        builder.setInsertionPoint(term);
+
+        auto outputVal =
+            builder.create<enzyme::GetOp>(grad.getLoc(), Ty, grad).getResult();
+        term->insertOperands(term->getNumOperands(), ValueRange(outputVal));
+      }
+    }
+
+    auto numIters = getNumberOfIterations(forOp);
+    Value inductionVariable; // [0, N[ counter
+
+    if (matchPattern(forOp.getLowerBound(), m_Zero()) &&
+        matchPattern(forOp.getStep(), m_One())) {
+      inductionVariable = body->getArgument(0);
+    }
+
+    for (auto info : caches) {
+      Value cache = info.initOp.getResult();
+
+      // push does not depend on a value inside the loop, we can hoist the
+      // push/pop before the for loops.
+      if (info.pushedValue().getParentRegion() != forOp->getRegion(0)) {
+        auto newPush = builder.create<enzyme::PushOp>(cache.getLoc(), cache,
+                                                      info.pushedValue());
+        info.pushOp->erase();
+        info.pushOp = newPush;
+
+        {
+          OpBuilder::InsertionGuard guard(builder);
+          builder.setInsertionPoint(info.popOp->getParentOp());
+
+          auto popVal = info.popOp.getResult();
+          auto newPop = builder.create<enzyme::PopOp>(cache.getLoc(),
+                                                      popVal.getType(), cache);
+          popVal.replaceAllUsesWith(newPop.getResult());
+          info.popOp->erase();
+          info.popOp = newPop;
+        }
+
+        continue;
+      }
+
+      if (!inductionVariable) {
+        Value zero = builder.create<arith::ConstantOp>(forOp->getLoc(),
+                                                       builder.getIndexAttr(0));
+        newOperands.push_back(zero);
+
+        inductionVariable = body->addArgument(zero.getType(), forOp->getLoc());
+        {
+          OpBuilder::InsertionGuard guard(builder);
+          builder.setInsertionPoint(term);
+
+          auto one = builder.create<arith::ConstantOp>(forOp->getLoc(),
+                                                       builder.getIndexAttr(1));
+          auto newInductionVar = builder.create<arith::AddIOp>(
+              forOp->getLoc(), inductionVariable, one);
+          term->insertOperands(term->getNumOperands(),
+                               ValueRange(newInductionVar));
+        }
+      }
+
+      auto newType =
+          info.batchType(numIters.value_or(mlir::ShapedType::kDynamic));
+      ValueRange operands =
+          numIters.has_value()
+              ? ValueRange{}
+              : ValueRange{builder
+                               .create<arith::ConstantOp>(
+                                   forOp->getLoc(), builder.getIndexAttr(10))
+                               .getResult()};
+      auto initValue = builder.create<tensor::EmptyOp>(info.initOp->getLoc(),
+                                                       newType, operands);
+      // cast<AutoDiffTypeInterface>(newType).createNullValue(
+      // builder, info.initOp->getLoc());
+
+      newOperands.push_back(initValue);
+
+      auto cacheValue = body->addArgument(newType, info.pushOp->getLoc());
+
+      {
+        OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPoint(info.pushOp);
+
+        // TODO: if type is tensor, use insert_slice instead
+        auto newCacheValue = builder.create<tensor::InsertOp>(
+            info.pushOp->getLoc(), info.pushOp.getValue(), cacheValue,
+            inductionVariable);
+
+        term->insertOperands(term->getNumOperands(), ValueRange(newCacheValue));
+      }
+    }
+
+    auto numInitArgs = forOp.getInitArgs().size();
+    auto newFor = builder.create<scf::ForOp>(
+        op->getLoc(), forOp.getLowerBound(), forOp.getUpperBound(),
+        forOp.getStep(), newOperands);
+
+    newFor.getRegion().takeBody(forOp.getRegion());
+
+    unsigned resultIdx = numInitArgs;
+    for (auto grad : updatedGradients) {
+      // set the updated gradient after the new for op.
+      OpBuilder::InsertionGuard guard(builder);
+      builder.create<enzyme::SetOp>(grad.getLoc(), grad,
+                                    newFor->getResult(resultIdx));
+      ++resultIdx;
+    }
+
+    if (inductionVariable && caches.size()) {
+      if (isa<BlockArgument>(inductionVariable) &&
+          cast<BlockArgument>(inductionVariable).getArgNumber() != 0)
+        resultIdx++;
+
+      OpBuilder::InsertionGuard guard(builder);
+      builder.setInsertionPoint(otherForOp);
+      SmallVector<Value> operands(otherForOp.getInitArgs().begin(),
+                                  otherForOp.getInitArgs().end());
+      operands.push_back(builder.create<arith::ConstantOp>(
+          otherForOp->getLoc(),
+          builder.getIndexAttr(numIters.value_or(1) - 1)));
+
+      Block *otherBody = otherForOp.getBody();
+      Value otherInductionVariable =
+          otherBody->addArgument(builder.getIndexType(), otherForOp->getLoc());
+      auto otherTerm = otherBody->getTerminator();
+
+      builder.setInsertionPoint(otherTerm);
+
+      otherInductionVariable =
+          builder
+              .create<arith::SubIOp>(
+                  otherForOp->getLoc(), otherInductionVariable,
+                  builder
+                      .create<arith::ConstantOp>(otherForOp->getLoc(),
+                                                 builder.getIndexAttr(1))
+                      .getResult())
+              .getResult();
+      otherTerm->insertOperands(otherTerm->getNumOperands(),
+                                ValueRange(otherInductionVariable));
+
+      builder.setInsertionPoint(otherForOp);
+      auto newOtherForOp = builder.create<scf::ForOp>(
+          otherForOp->getLoc(), otherForOp.getLowerBound(),
+          otherForOp.getUpperBound(), otherForOp.getStep(), operands);
+
+      for (auto &&[res, newRes] :
+           llvm::zip(otherForOp->getResults(), newOtherForOp->getResults())) {
+        res.replaceAllUsesWith(newRes);
+      }
+      newOtherForOp.getRegion().takeBody(otherForOp.getRegion());
+
+      otherForOp->erase();
+      otherForOp = newOtherForOp;
+    }
+
+    for (auto info : caches) {
+      if (info.pushedValue().getParentRegion() != newFor->getRegion(0))
+        continue;
+
+      Value cache = info.initOp.getResult();
+
+      auto newType = info.batchType(numIters.value());
+      enzyme::InitOp newInit = ({
+        OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPoint(info.initOp);
+
+        builder.create<enzyme::InitOp>(
+            info.initOp->getLoc(),
+            enzyme::CacheType::get(cache.getContext(), newType));
+      });
+      info.pushOp = ({
+        OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPointAfter(newFor);
+        auto newPush = builder.create<enzyme::PushOp>(
+            cache.getLoc(), newInit.getResult(), newFor->getResult(resultIdx));
+        info.pushOp->erase();
+        newPush;
+      });
+
+      resultIdx++;
+
+      {
+        OpBuilder::InsertionGuard guard(builder);
+
+        builder.setInsertionPoint(otherForOp);
+
+        auto popNewValue = builder.create<enzyme::PopOp>(
+            info.popOp->getLoc(), newType, newInit.getResult());
+
+        Block *popBody = otherForOp.getBody();
+        builder.setInsertionPoint(info.popOp);
+        auto popValue =
+            builder
+                .create<tensor::ExtractOp>(
+                    info.popOp->getLoc(), popNewValue,
+                    popBody->getArgument(popBody->getNumArguments() - 1))
+                .getResult();
+
+        info.popOp.getResult().replaceAllUsesWith(popValue);
+        info.popOp->erase();
+      }
+    }
+
+    forOp->erase();
+
+    return success();
+  }
+};
+
 struct ForOpInterfaceReverse
     : public ReverseAutoDiffOpInterface::ExternalModel<ForOpInterfaceReverse,
                                                        scf::ForOp> {
   LogicalResult createReverseModeAdjoint(Operation *op, OpBuilder &builder,
                                          MGradientUtilsReverse *gutils,
                                          SmallVector<Value> caches) const {
+    // SCF ForOp has 3 more operands than results (lb, ub, step).
+    // Its body has 1 more argument than yielded values (the induction
+    // variable).
+
     auto forOp = cast<scf::ForOp>(op);
 
-    // Begin Perform d(yielded value[i]) += d(result[i]); d(result[i]) = 0
-    SmallVector<Value, 1> resDiffes;
-    for (OpResult v : forOp.getResults()) {
-      if (!gutils->isConstantValue(v)) {
-        auto autoDiffType = cast<AutoDiffTypeInterface>(v.getType());
-        if (!autoDiffType.isMutable()) {
-          auto prev = gutils->diffe(v, builder);
-          gutils->zeroDiffe(v, builder);
-          resDiffes.push_back(prev);
-          continue;
-        }
-      }
-      resDiffes.push_back(nullptr);
+    SmallVector<bool> operandsActive(forOp.getNumOperands() - 3, false);
+    for (int i = 0, e = operandsActive.size(); i < e; ++i) {
+      operandsActive[i] = !gutils->isConstantValue(op->getOperand(i + 3)) ||
+                          !gutils->isConstantValue(op->getResult(i));
     }
-
-    for (auto &reg : op->getRegions()) {
-      auto termIface =
-          cast<RegionBranchTerminatorOpInterface>(reg.begin()->getTerminator());
-
-      SmallVector<RegionSuccessor> successors;
-      termIface.getSuccessorRegions(
-          SmallVector<Attribute>(termIface->getNumOperands(), Attribute()),
-          successors);
-
-      for (auto &successor : successors) {
-        if (!successor.isParent())
-          continue;
-        OperandRange operandRange = termIface.getSuccessorOperands(successor);
-        assert(operandRange.size() == resDiffes.size());
-
-        // There is an assumption here that there is only regions that branch to
-        // the successor. Specifically, otherwise we would need to
-        // gutils->addToDiffe select (if came from that result)
-        for (auto &&[prev, post] : llvm::zip(operandRange, resDiffes)) {
-          if (!post)
-            continue;
-          if (!gutils->isConstantValue(prev))
-            gutils->addToDiffe(prev, post, builder);
-        }
-      }
-    }
-    // End Perform d(yielded value[i]) += d(result[i]); d(result[i]) = 0
 
     auto start = gutils->popCache(caches[0], builder);
     auto end = gutils->popCache(caches[1], builder);
     auto step = gutils->popCache(caches[2], builder);
 
-    auto repFor = builder.create<scf::ForOp>(forOp.getLoc(), start, end, step,
-                                             ArrayRef<Value>());
-    // erase scf yield
-    repFor.getBody()->begin()->erase();
+    SmallVector<Value> incomingGradients;
+    for (auto &&[active, res] :
+         llvm::zip_equal(operandsActive, op->getResults())) {
+      if (active) {
+        incomingGradients.push_back(gutils->diffe(res, builder));
+        if (!gutils->isConstantValue(res))
+          gutils->zeroDiffe(res, builder);
+      }
+    }
 
+    auto repFor = builder.create<scf::ForOp>(forOp.getLoc(), start, end, step,
+                                             incomingGradients);
+
+    bool valid = true;
     for (auto &&[oldReg, newReg] :
          llvm::zip(op->getRegions(), repFor->getRegions())) {
+      for (auto &&[oBB, revBB] : llvm::zip(oldReg, newReg)) {
+        OpBuilder bodyBuilder(&revBB, revBB.end());
 
-      // This code assumes at most one terminating block for each region (lest
-      // the append happen multiple times)
-      auto buildFuncReturnOp = [&](OpBuilder &builder, Block *oBB) {
-        auto loc = oBB->rbegin()->getLoc();
+        // Create implicit terminator if not present (when num results > 0)
+        if (revBB.empty()) {
+          bodyBuilder.create<scf::YieldOp>(repFor->getLoc());
+        }
+        bodyBuilder.setInsertionPoint(revBB.getTerminator());
 
-        auto idx = repFor.getInductionVar();
+        // All values defined in the body should have no use outside this block
+        // therefore we can set their diffe to zero upon entering the reverse
+        // block to simplify the work of the remove-unnecessary-enzyme-ops pass.
+        for (auto operand : oBB.getArguments().slice(1)) {
+          if (!gutils->isConstantValue(operand)) {
+            gutils->zeroDiffe(operand, bodyBuilder);
+          }
+        }
 
-        auto lhs = builder.create<arith::AddIOp>(loc, idx, step);
-
-        // This needs to know a condition describing which predecessor this will
-        // return to, to select the right value Here we use the condition i +
-        // step >= end   to determine the last iteration
-
-        auto condition = builder.create<arith::CmpIOp>(
-            loc, arith::CmpIPredicate::sge, lhs, end);
-
-        for (auto [arg, init_arg] :
-             llvm::zip(oBB->getArguments().slice(1), forOp.getInitArgs())) {
-          if (!gutils->isConstantValue(arg) &&
-              !cast<AutoDiffTypeInterface>(arg.getType()).isMutable()) {
-            auto diffe = gutils->diffe(arg, builder);
-            gutils->zeroDiffe(arg, builder);
-
-            auto zero = cast<AutoDiffTypeInterface>(diffe.getType())
-                            .createNullValue(builder, loc);
-            auto outside =
-                builder.create<arith::SelectOp>(loc, condition, diffe, zero);
-            auto inside =
-                builder.create<arith::SelectOp>(loc, condition, zero, diffe);
-
-            // For each predecessor, if we came from that predecessor += the
-            // shadow of the arg [after zero'ing]
-            if (!gutils->isConstantValue(init_arg)) {
-              gutils->addToDiffe(init_arg, outside, builder);
-            }
-
-            if (!gutils->isConstantValue(arg)) {
-              gutils->addToDiffe(arg, inside, builder);
+        for (auto &it : oBB.getOperations()) {
+          for (auto res : it.getResults()) {
+            if (!gutils->isConstantValue(res)) {
+              gutils->zeroDiffe(res, bodyBuilder);
             }
           }
         }
-        builder.create<scf::YieldOp>(loc);
-      };
 
-      for (auto &&[oBB, revBB] : llvm::zip(oldReg, newReg)) {
-        gutils->mapReverseModeBlocks.map(&oBB, &revBB);
-      }
-      for (auto &&[oBB, revBB] : llvm::zip(oldReg, newReg)) {
-        auto sub = gutils->Logic.visitChildren(&oBB, &revBB, gutils);
-        if (!sub.succeeded())
-          return sub;
-        Block *newBB = gutils->getNewFromOriginal(&oBB);
-        gutils->Logic.handlePredecessors(&oBB, newBB, &revBB, gutils,
-                                         buildFuncReturnOp);
+        auto term = oBB.getTerminator();
+
+        for (auto &&[active, arg, operand] :
+             llvm::zip_equal(operandsActive, revBB.getArguments().slice(1),
+                             term->getOperands())) {
+          if (active) {
+            // Set diffe here, not add because it should not accumulate across
+            // iterations. Instead the new gradient for this operand is passed
+            // in the return of the reverse for body.
+            gutils->setDiffe(operand, arg, bodyBuilder);
+          }
+        }
+
+        auto first = oBB.rbegin();
+        first++; // skip terminator
+
+        auto last = oBB.rend();
+
+        for (auto it = first; it != last; ++it) {
+          Operation *op = &*it;
+          valid &=
+              gutils->Logic.visitChild(op, bodyBuilder, gutils).succeeded();
+        }
+
+        SmallVector<Value> newResults;
+        newResults.reserve(incomingGradients.size());
+
+        for (auto &&[active, arg] :
+             llvm::zip_equal(operandsActive, oBB.getArguments().slice(1))) {
+          if (active) {
+            newResults.push_back(gutils->diffe(arg, bodyBuilder));
+            if (!gutils->isConstantValue(arg))
+              gutils->zeroDiffe(arg, bodyBuilder);
+          }
+        }
+
+        // yield new gradient values
+        revBB.getTerminator()->setOperands(newResults);
       }
     }
-    return success();
+
+    for (auto &&[active, res, arg] : llvm::zip_equal(
+             operandsActive, repFor->getResults(), forOp.getInitArgs())) {
+      if (active) {
+        if (!gutils->isConstantValue(arg))
+          gutils->addToDiffe(arg, res, builder);
+      }
+    }
+
+    return success(valid);
   }
 
   SmallVector<Value> cacheValues(Operation *op,
@@ -190,5 +485,6 @@ void mlir::enzyme::registerSCFDialectAutoDiffInterface(
   registry.addExtension(+[](MLIRContext *context, scf::SCFDialect *) {
     registerInterfaces(context);
     scf::ForOp::attachInterface<ForOpInterfaceReverse>(*context);
+    scf::ForOp::attachInterface<ForOpEnzymeOpsRemover>(*context);
   });
 }

--- a/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
@@ -306,7 +306,7 @@ struct ForOpEnzymeOpsRemover
 
       auto newType =
           info.cachedType().cast<AutoDiffTypeInterface>().getShadowType(
-              numIters.value());
+              numIters.value_or(ShapedType::kDynamic));
       enzyme::InitOp newInit = ({
         OpBuilder::InsertionGuard guard(builder);
         builder.setInsertionPoint(info.initOp);

--- a/enzyme/Enzyme/MLIR/Interfaces/AutoDiffOpInterface.h
+++ b/enzyme/Enzyme/MLIR/Interfaces/AutoDiffOpInterface.h
@@ -26,6 +26,7 @@ namespace enzyme {
 
 class MGradientUtils;
 class MGradientUtilsReverse;
+class RemovalUtils;
 
 }; // namespace enzyme
 }; // namespace mlir

--- a/enzyme/Enzyme/MLIR/Interfaces/AutoDiffOpInterface.h
+++ b/enzyme/Enzyme/MLIR/Interfaces/AutoDiffOpInterface.h
@@ -26,7 +26,6 @@ namespace enzyme {
 
 class MGradientUtils;
 class MGradientUtilsReverse;
-class RemovalUtils;
 
 }; // namespace enzyme
 }; // namespace mlir

--- a/enzyme/Enzyme/MLIR/Interfaces/AutoDiffOpInterface.td
+++ b/enzyme/Enzyme/MLIR/Interfaces/AutoDiffOpInterface.td
@@ -180,4 +180,22 @@ def BatchOpInterface : OpInterface<"BatchOpInterface"> {
   ];
 }
 
+def EnzymeOpsRemoverOpInterface : OpInterface<"EnzymeOpsRemoverOpInterface"> {
+  let description = [{
+    An operation with nested operations which can move inner enzyme operations outside of itself.
+  }];
+  let cppNamespace = "::mlir::enzyme";
+
+  let methods = [
+    InterfaceMethod<
+    /*desc=*/[{
+      Pushes the inner enzyme operations outside of self.
+    }],
+    /*retTy=*/"::mlir::LogicalResult",
+    /*methodName=*/"removeEnzymeOps",
+    /*args=*/(ins)
+    >
+  ];
+}
+
 #endif // ENZYME_MLIR_INTERFACES_AUTODIFFOPINTERFACES

--- a/enzyme/Enzyme/MLIR/Interfaces/AutoDiffTypeInterface.td
+++ b/enzyme/Enzyme/MLIR/Interfaces/AutoDiffTypeInterface.td
@@ -57,7 +57,7 @@ def AutoDiffTypeInterface : TypeInterface<"AutoDiffTypeInterface"> {
       }],
       /*retTy=*/"::mlir::Type",
       /*methodName=*/"getShadowType",
-      /*args=*/(ins "unsigned":$width)
+      /*args=*/(ins "int64_t":$width)
     >,
     InterfaceMethod<
       /*desc=*/[{

--- a/enzyme/Enzyme/MLIR/Passes/Passes.h
+++ b/enzyme/Enzyme/MLIR/Passes/Passes.h
@@ -89,6 +89,10 @@ namespace LLVM {
 class LLVMDialect;
 } // end namespace LLVM
 
+namespace tensor {
+class TensorDialect;
+} // end namespace tensor
+
 #define GEN_PASS_REGISTRATION
 #include "Passes/Passes.h.inc"
 

--- a/enzyme/Enzyme/MLIR/Passes/Passes.td
+++ b/enzyme/Enzyme/MLIR/Passes/Passes.td
@@ -183,6 +183,9 @@ def AddToOpToSplitPass : Pass<"add-to-op-to-split"> {
 
 def RemoveUnusedEnzymeOpsPass : Pass<"remove-unnecessary-enzyme-ops"> {
   let summary = "Remove Unnecessary Enzyme Ops";
+  let dependentDialects = [
+    "tensor::TensorDialect"
+  ];
   let constructor = "mlir::enzyme::createRemoveUnusedEnzymeOpsPass()";
 }
 

--- a/enzyme/Enzyme/MLIR/Passes/RemovalUtils.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/RemovalUtils.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Interfaces/AutoDiffOpInterface.h"
 #include "RemovalUtils.h"
+#include "Interfaces/AutoDiffOpInterface.h"
 
 mlir::Type mlir::enzyme::CacheInfo::batchType() {
   return mlir::enzyme::CacheInfo::batchType(mlir::ShapedType::kDynamic);

--- a/enzyme/Enzyme/MLIR/Passes/RemovalUtils.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/RemovalUtils.cpp
@@ -9,23 +9,6 @@
 #include "RemovalUtils.h"
 #include "Interfaces/AutoDiffOpInterface.h"
 
-mlir::Type mlir::enzyme::CacheInfo::batchType() {
-  return mlir::enzyme::CacheInfo::batchType(mlir::ShapedType::kDynamic);
-}
-
-mlir::Type mlir::enzyme::CacheInfo::batchType(int64_t dim) {
-  auto T = pushedValue().getType();
-
-  if (auto TT = dyn_cast<mlir::TensorType>(T)) {
-    SmallVector<int64_t> shape;
-    shape.push_back(dim);
-    shape.append(TT.getShape().begin(), TT.getShape().end());
-    return TT.clone(shape);
-  }
-
-  return mlir::RankedTensorType::get({dim}, T);
-}
-
 mlir::LogicalResult mlir::enzyme::removeOpsWithinBlock(mlir::Block *block) {
   bool valid = true;
 

--- a/enzyme/Enzyme/MLIR/Passes/RemovalUtils.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/RemovalUtils.cpp
@@ -1,0 +1,40 @@
+//===- RemovalUtils.cpp - Utilities to remove Enzyme ops -------* C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Interfaces/AutoDiffOpInterface.h"
+#include "RemovalUtils.h"
+
+mlir::Type mlir::enzyme::CacheInfo::batchType() {
+  return mlir::enzyme::CacheInfo::batchType(mlir::ShapedType::kDynamic);
+}
+
+mlir::Type mlir::enzyme::CacheInfo::batchType(int64_t dim) {
+  auto T = pushedValue().getType();
+
+  if (auto TT = dyn_cast<mlir::TensorType>(T)) {
+    SmallVector<int64_t> shape;
+    shape.push_back(dim);
+    shape.append(TT.getShape().begin(), TT.getShape().end());
+    return TT.clone(shape);
+  }
+
+  return mlir::RankedTensorType::get({dim}, T);
+}
+
+mlir::LogicalResult mlir::enzyme::removeOpsWithinBlock(mlir::Block *block) {
+  bool valid = true;
+
+  for (auto &it : *block) {
+    mlir::Operation *op = &it;
+    if (auto iface = dyn_cast<mlir::enzyme::EnzymeOpsRemoverOpInterface>(op)) {
+      valid &= iface.removeEnzymeOps().succeeded();
+    }
+  }
+
+  return success(valid);
+}

--- a/enzyme/Enzyme/MLIR/Passes/RemovalUtils.h
+++ b/enzyme/Enzyme/MLIR/Passes/RemovalUtils.h
@@ -35,9 +35,9 @@ struct CacheInfo {
   }
 
   Value pushedValue() { return pushOp.getValue(); }
-
-  Type batchType(int64_t dim);
-  Type batchType(); // unknown size
+  Type cachedType() {
+    return initOp.getResult().getType().cast<enzyme::CacheType>().getType();
+  }
 };
 
 LogicalResult removeOpsWithinBlock(Block *block);

--- a/enzyme/Enzyme/MLIR/Passes/RemovalUtils.h
+++ b/enzyme/Enzyme/MLIR/Passes/RemovalUtils.h
@@ -1,0 +1,46 @@
+//===- RemovalUtils.h - Utilities to remove Enzyme ops -------* C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#pragma once
+
+#include "Dialect/Ops.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/IRMapping.h"
+
+namespace mlir {
+namespace enzyme {
+
+/// Information about a cache, each cache init should have one corresponding
+/// push and pop.
+struct CacheInfo {
+  enzyme::InitOp initOp;
+  enzyme::PushOp pushOp = {};
+  enzyme::PopOp popOp = {};
+
+  CacheInfo(Value cache) {
+    initOp = cache.getDefiningOp<enzyme::InitOp>();
+    unsigned nusers = 0;
+    for (auto user : cache.getUsers()) {
+      nusers++;
+      if (!popOp)
+        popOp = dyn_cast<enzyme::PopOp>(user);
+      if (!pushOp)
+        pushOp = dyn_cast<enzyme::PushOp>(user);
+    }
+    assert(nusers == 2); // TODO: support more uses
+  }
+
+  Value pushedValue() { return pushOp.getValue(); }
+
+  Type batchType(int64_t dim);
+  Type batchType(); // unknown size
+};
+
+LogicalResult removeOpsWithinBlock(Block *block);
+
+} // namespace enzyme
+} // namespace mlir

--- a/enzyme/Enzyme/MLIR/Passes/RemovalUtils.h
+++ b/enzyme/Enzyme/MLIR/Passes/RemovalUtils.h
@@ -18,9 +18,14 @@ namespace enzyme {
 /// push and pop.
 struct CacheInfo {
   enzyme::InitOp initOp;
-  enzyme::PushOp pushOp = {};
-  enzyme::PopOp popOp = {};
+  enzyme::PushOp pushOp;
+  enzyme::PopOp popOp;
 
+  CacheInfo() {
+    initOp = nullptr;
+    pushOp = nullptr;
+    popOp = nullptr;
+  }
   CacheInfo(Value cache) {
     initOp = cache.getDefiningOp<enzyme::InitOp>();
     unsigned nusers = 0;
@@ -38,6 +43,9 @@ struct CacheInfo {
   Type cachedType() {
     return initOp.getResult().getType().cast<enzyme::CacheType>().getType();
   }
+
+  // Pushed values must be the same
+  CacheInfo merge(CacheInfo other);
 };
 
 LogicalResult removeOpsWithinBlock(Block *block);

--- a/enzyme/Enzyme/MLIR/enzymemlir-opt.cpp
+++ b/enzyme/Enzyme/MLIR/enzymemlir-opt.cpp
@@ -28,6 +28,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/InitAllPasses.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"

--- a/enzyme/test/MLIR/ReverseMode/scf_for.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_for.mlir
@@ -1,0 +1,42 @@
+// RUN: %eopt %s --enzyme-wrap="infn=reduce outfn= argTys=enzyme_active,enzyme_const retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s
+
+func.func @reduce(%x: f32, %ub: index) -> (f32) {
+  %lb = arith.constant 0 : index
+  %step = arith.constant 1 : index
+
+  // Initial sum set to 0.
+  %sum_0 = arith.constant 1.0 : f32
+  // iter_args binds initial values to the loop's region arguments.
+  %sum = scf.for %iv = %lb to %ub step %step
+      iter_args(%sum_iter = %sum_0) -> (f32) {
+    %sum_next = arith.mulf %sum_iter, %x : f32
+    // Yield current iteration sum to next iteration %sum_iter or to %sum
+    // if final iteration.
+    scf.yield %sum_next : f32
+  }
+  return %sum : f32
+}
+
+// CHECK:  func.func @reduce(%arg0: f32, %arg1: index, %arg2: f32) -> f32 {
+// CHECK-NEXT:    %cst = arith.constant 1.000000e+00 : f32
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %c0 = arith.constant 0 : index
+// CHECK-NEXT:    %cst_0 = arith.constant 0.000000e+00 : f32
+// CHECK-NEXT:    %0 = tensor.empty(%arg1) : tensor<?xf32>
+// CHECK-NEXT:    %1:2 = scf.for %arg3 = %c0 to %arg1 step %c1 iter_args(%arg4 = %cst, %arg5 = %0) -> (f32, tensor<?xf32>) {
+// CHECK-NEXT:      %inserted = tensor.insert %arg4 into %arg5[%arg3] : tensor<?xf32>
+// CHECK-NEXT:      %4 = arith.mulf %arg4, %arg0 : f32
+// CHECK-NEXT:      scf.yield %4, %inserted : f32, tensor<?xf32>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %2 = arith.addf %arg2, %cst_0 : f32
+// CHECK-NEXT:    %3:3 = scf.for %arg3 = %c0 to %arg1 step %c1 iter_args(%arg4 = %2, %arg5 = %arg1, %arg6 = %cst_0) -> (f32, index, f32) {
+// CHECK-NEXT:      %extracted = tensor.extract %1#1[%arg5] : tensor<?xf32>
+// CHECK-NEXT:      %4 = arith.mulf %arg4, %arg0 : f32
+// CHECK-NEXT:      %5 = arith.addf %4, %cst_0 : f32
+// CHECK-NEXT:      %6 = arith.mulf %arg4, %extracted : f32
+// CHECK-NEXT:      %7 = arith.addf %arg6, %6 : f32
+// CHECK-NEXT:      %8 = arith.subi %arg5, %c1 : index
+// CHECK-NEXT:      scf.yield %5, %8, %7 : f32, index, f32
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %3#2 : f32
+// CHECK-NEXT:  }


### PR DESCRIPTION
TODO:
 - [x] scf: support non-constant iterations `Cache<f32> -> tensor<?xf32>`.
 - [x] scf: push/pop only once if a value is pushed multiple times.
 - [x] Cache of tensor (nested for).
 - [x] passes: add option in enzyme pass to try to remove enzyme ops after generating the function. This should help with higher order diff. ref #2214.
 - [ ] scf: graph min-cut.
