### PR TITLE
Add nixpkgs to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,6 +39,10 @@ brew install enzyme
 ```
 spack install enzyme
 ```
+[Nix](https://nixos.org/)
+```
+nix-shell -p enzyme
+```
 
 To get involved or if you have questions, please join our [mailing list](https://groups.google.com/d/forum/enzyme-dev).
 


### PR DESCRIPTION
I just finished up merging Enzyme into nixpkgs, so I thought a mention in the README might be useful

https://search.nixos.org/packages?channel=unstable&show=enzyme&from=0&size=50&sort=relevance&type=packages&query=enzyme

Like spack, nix is really handy for deterministic builds and setting up ephemeral dev environments with all the dependencies baked in.

For example, with nix you can do something like
```nix
(
  system: let
    pkgs = import nixpkgs {inherit system;};
    buildInputs = with pkgs; [enzyme cmake llvmPackages.bintools];
  in
    with pkgs; {
      devShells.default = mkShell.override {stdenv = clangStdenv;} {
        inherit buildInputs;
      };
    }
);
```
and prepare an environment with everything you need already built and linked together to develop with Enzyme!