### PR TITLE
Adds Intel oneAPI and GCC Linux CMake presets

### DIFF
--- a/enzyme/CMakePresets.json
+++ b/enzyme/CMakePresets.json
@@ -49,10 +49,7 @@
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_CXX_FLAGS": "-Wall -fno-rtti -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch",
-                "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g -ggdb -fno-omit-frame-pointer",
-                "CMAKE_CXX_FLAGS_RELEASE": "-O2",
-                "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -ggdb"
+                "CMAKE_CXX_FLAGS": "-Wall -fno-rtti -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch"
             }
         },
         {
@@ -60,7 +57,8 @@
             "displayName": "Clang x64 Linux Debug",
             "inherits": "x64-linux-clang",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug"
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g -ggdb -fno-omit-frame-pointer"
             }
         },
         {
@@ -68,7 +66,8 @@
             "displayName": "Clang x64 Linux Release",
             "inherits": "x64-linux-clang",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release"
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_CXX_FLAGS_RELEASE": "-O2"
             }
         },
         {
@@ -76,7 +75,8 @@
             "displayName": "Clang x64 Linux Release with Debug Info",
             "inherits": "x64-linux-clang",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -ggdb"
             }
         },
         {
@@ -90,10 +90,7 @@
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "gcc",
                 "CMAKE_CXX_COMPILER": "g++",
-                "CMAKE_CXX_FLAGS": "-Wall -fno-rtti -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch -Wno-comment",
-                "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g -ggdb -fno-omit-frame-pointer",
-                "CMAKE_CXX_FLAGS_RELEASE": "-O2",
-                "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -ggdb"
+                "CMAKE_CXX_FLAGS": "-Wall -fno-rtti -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch -Wno-comment"
             }
         },
         {
@@ -101,7 +98,8 @@
             "displayName": "GCC x64 Linux Debug",
             "inherits": "x64-linux-gcc",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug"
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g -ggdb -fno-omit-frame-pointer"
             }
         },
         {
@@ -109,7 +107,8 @@
             "displayName": "GCC x64 Linux Release",
             "inherits": "x64-linux-gcc",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release"
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_CXX_FLAGS_RELEASE": "-O2"
             }
         },
         {
@@ -117,7 +116,8 @@
             "displayName": "GCC x64 Linux Release with Debug Info",
             "inherits": "x64-linux-gcc",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -ggdb"
             }
         },
         {
@@ -131,10 +131,7 @@
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "icx",
                 "CMAKE_CXX_COMPILER": "icpx",
-                "CMAKE_CXX_FLAGS": "-Wall -fno-rtti -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch -Wno-comment",
-                "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g -ggdb -fno-omit-frame-pointer",
-                "CMAKE_CXX_FLAGS_RELEASE": "-O2",
-                "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -ggdb"
+                "CMAKE_CXX_FLAGS": "-Wall -fno-rtti -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch -Wno-comment"
             }
         },
         {
@@ -142,7 +139,8 @@
             "displayName": "Intel x64 Linux Debug",
             "inherits": "x64-linux-intel",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug"
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g -ggdb -fno-omit-frame-pointer"
             }
         },
         {
@@ -150,7 +148,8 @@
             "displayName": "Intel x64 Linux Release",
             "inherits": "x64-linux-intel",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release"
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_CXX_FLAGS_RELEASE": "-O2"
             }
         },
         {
@@ -158,7 +157,8 @@
             "displayName": "Intel x64 Linux Release with Debug Info",
             "inherits": "x64-linux-intel",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -ggdb"
             }
         }
     ],

--- a/enzyme/CMakePresets.json
+++ b/enzyme/CMakePresets.json
@@ -90,7 +90,7 @@
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "gcc",
                 "CMAKE_CXX_COMPILER": "g++",
-                "CMAKE_CXX_FLAGS": "-Wall -Wextra -pedantic -pedantic-errors -fno-rtti -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch -Wno-comment",
+                "CMAKE_CXX_FLAGS": "-Wall -fno-rtti -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch -Wno-comment",
                 "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g -ggdb -fno-omit-frame-pointer",
                 "CMAKE_CXX_FLAGS_RELEASE": "-O2",
                 "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -ggdb"
@@ -116,6 +116,47 @@
             "name": "x64-linux-gcc-release-with-debug-info",
             "displayName": "GCC x64 Linux Release with Debug Info",
             "inherits": "x64-linux-gcc",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+            }
+        },
+        {
+            "name": "x64-linux-intel",
+            "description": "Base preset for Linux development using Intel oneAPI compilers.",
+            "hidden": true,
+            "inherits": [
+                "config-base-x64",
+                "config-base-linux"
+            ],
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "icx",
+                "CMAKE_CXX_COMPILER": "icpx",
+                "CMAKE_CXX_FLAGS": "-Wall -fno-rtti -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch -Wno-comment",
+                "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g -ggdb -fno-omit-frame-pointer",
+                "CMAKE_CXX_FLAGS_RELEASE": "-O2",
+                "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -ggdb"
+            }
+        },
+        {
+            "name": "x64-linux-intel-debug",
+            "displayName": "Intel x64 Linux Debug",
+            "inherits": "x64-linux-intel",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "x64-linux-intel-release",
+            "displayName": "Intel x64 Linux Release",
+            "inherits": "x64-linux-intel",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "x64-linux-intel-release-with-debug-info",
+            "displayName": "Intel x64 Linux Release with Debug Info",
+            "inherits": "x64-linux-intel",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo"
             }
@@ -157,6 +198,24 @@
             "displayName": "GCC x64 Linux Release with Debug Info",
             "description": "Builds the project using GCC on Linux in Release configuration with debug info.",
             "configurePreset": "x64-linux-gcc-release-with-debug-info"
+        },
+        {
+            "name": "x64-linux-intel-debug",
+            "displayName": "Intel x64 Linux Debug",
+            "description": "Builds the project using Intel oneAPI compilers on Linux in Debug configuration.",
+            "configurePreset": "x64-linux-intel-debug"
+        },
+        {
+            "name": "x64-linux-intel-release",
+            "displayName": "Intel x64 Linux Release",
+            "description": "Builds the project using Intel oneAPI compilers on Linux in Release configuration.",
+            "configurePreset": "x64-linux-intel-release"
+        },
+        {
+            "name": "x64-linux-intel-release-with-debug-info",
+            "displayName": "Intel x64 Linux Release with Debug Info",
+            "description": "Builds the project using Intel oneAPI compilers on Linux in Release configuration with debug info.",
+            "configurePreset": "x64-linux-intel-release-with-debug-info"
         }
     ]
 }

--- a/enzyme/CMakePresets.json
+++ b/enzyme/CMakePresets.json
@@ -131,7 +131,8 @@
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "icx",
                 "CMAKE_CXX_COMPILER": "icpx",
-                "CMAKE_CXX_FLAGS": "-Wall -fno-rtti -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch -Wno-comment"
+                "CMAKE_CXX_FLAGS": "-Wall -fno-rtti -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch",
+                "CMAKE_BUILD_WITH_INSTALL_RPATH": "ON"
             }
         },
         {

--- a/enzyme/CMakePresets.json
+++ b/enzyme/CMakePresets.json
@@ -78,6 +78,47 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo"
             }
+        },
+        {
+            "name": "x64-linux-gcc",
+            "description": "Base preset for Linux development using GNU compilers.",
+            "hidden": true,
+            "inherits": [
+                "config-base-x64",
+                "config-base-linux"
+            ],
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++",
+                "CMAKE_CXX_FLAGS": "-Wall -Wextra -pedantic -pedantic-errors -fno-rtti -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch -Wno-comment",
+                "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g -ggdb -fno-omit-frame-pointer",
+                "CMAKE_CXX_FLAGS_RELEASE": "-O2",
+                "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -ggdb"
+            }
+        },
+        {
+            "name": "x64-linux-gcc-debug",
+            "displayName": "GCC x64 Linux Debug",
+            "inherits": "x64-linux-gcc",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "x64-linux-gcc-release",
+            "displayName": "GCC x64 Linux Release",
+            "inherits": "x64-linux-gcc",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "x64-linux-gcc-release-with-debug-info",
+            "displayName": "GCC x64 Linux Release with Debug Info",
+            "inherits": "x64-linux-gcc",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+            }
         }
     ],
     "buildPresets": [
@@ -98,6 +139,24 @@
             "displayName": "Clang x64 Linux Release with Debug Info",
             "description": "Builds the project using Clang on Linux in Release configuration with debug info.",
             "configurePreset": "x64-linux-clang-release-with-debug-info"
+        },
+        {
+            "name": "x64-linux-gcc-debug",
+            "displayName": "GCC x64 Linux Debug",
+            "description": "Builds the project using GCC on Linux in Debug configuration.",
+            "configurePreset": "x64-linux-gcc-debug"
+        },
+        {
+            "name": "x64-linux-gcc-release",
+            "displayName": "GCC x64 Linux Release",
+            "description": "Builds the project using GCC on Linux in Release configuration.",
+            "configurePreset": "x64-linux-gcc-release"
+        },
+        {
+            "name": "x64-linux-gcc-release-with-debug-info",
+            "displayName": "GCC x64 Linux Release with Debug Info",
+            "description": "Builds the project using GCC on Linux in Release configuration with debug info.",
+            "configurePreset": "x64-linux-gcc-release-with-debug-info"
         }
     ]
 }


### PR DESCRIPTION
The Intel compilers are LLVM based and somewhat commonly used for HPC applications so I think presets for them are potentially useful to someone building everything from source. I was on the fence about GCC but it is used in some of the CI workflows and using its tooling/analysis of the Enzyme source code doesn't seem completely redundant, therefore I added those also.

Includes a tiny improvement to move configuration specific compiler flag cache variables to their respective configuration's preset, which reduces CMake warnings about unused cache variables.