### PR TITLE
add user data to EnzymeRegisterCallHandler

### DIFF
--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -350,8 +350,8 @@ void EnzymeRegisterCallHandler(const char *Name,
     LLVMValueRef normalR = wrap(normalReturn);
     LLVMValueRef shadowR = wrap(shadowReturn);
     LLVMValueRef tapeR = wrap(tape);
-    uint8_t noMod =
-        FwdHandle(wrap(&B), wrap(CI), &gutils, &normalR, &shadowR, &tapeR, data);
+    uint8_t noMod = FwdHandle(wrap(&B), wrap(CI), &gutils, &normalR, &shadowR,
+                              &tapeR, data);
     normalReturn = unwrap(normalR);
     shadowReturn = unwrap(shadowR);
     tape = unwrap(tapeR);

--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -340,9 +340,9 @@ void EnzymeRegisterAllocationHandler(char *Name, CustomShadowAlloc AHandle,
     };
 }
 
-void EnzymeRegisterCallHandler(char *Name,
+void EnzymeRegisterCallHandler(const char *Name,
                                CustomAugmentedFunctionForward FwdHandle,
-                               CustomFunctionReverse RevHandle) {
+                               CustomFunctionReverse RevHandle, void *data) {
   auto &pair = customCallHandlers[Name];
   pair.first = [=](IRBuilder<> &B, CallInst *CI, GradientUtils &gutils,
                    Value *&normalReturn, Value *&shadowReturn,
@@ -351,7 +351,7 @@ void EnzymeRegisterCallHandler(char *Name,
     LLVMValueRef shadowR = wrap(shadowReturn);
     LLVMValueRef tapeR = wrap(tape);
     uint8_t noMod =
-        FwdHandle(wrap(&B), wrap(CI), &gutils, &normalR, &shadowR, &tapeR);
+        FwdHandle(wrap(&B), wrap(CI), &gutils, &normalR, &shadowR, &tapeR, data);
     normalReturn = unwrap(normalR);
     shadowReturn = unwrap(shadowR);
     tape = unwrap(tapeR);
@@ -359,7 +359,7 @@ void EnzymeRegisterCallHandler(char *Name,
   };
   pair.second = [=](IRBuilder<> &B, CallInst *CI, DiffeGradientUtils &gutils,
                     Value *tape) {
-    RevHandle(wrap(&B), wrap(CI), &gutils, wrap(tape));
+    RevHandle(wrap(&B), wrap(CI), &gutils, wrap(tape), data);
   };
 }
 

--- a/enzyme/Enzyme/CApi.h
+++ b/enzyme/Enzyme/CApi.h
@@ -198,11 +198,11 @@ typedef uint8_t (*CustomAugmentedFunctionForward)(LLVMBuilderRef, LLVMValueRef,
                                                   GradientUtils *,
                                                   LLVMValueRef *,
                                                   LLVMValueRef *,
-                                                  LLVMValueRef *,
-                                                  void *);
+                                                  LLVMValueRef *, void *);
 
 typedef void (*CustomFunctionReverse)(LLVMBuilderRef, LLVMValueRef,
-                                      DiffeGradientUtils *, LLVMValueRef, void *);
+                                      DiffeGradientUtils *, LLVMValueRef,
+                                      void *);
 
 LLVMValueRef EnzymeCreateForwardDiff(
     EnzymeLogicRef Logic, LLVMValueRef request_req, LLVMBuilderRef request_ip,
@@ -225,8 +225,7 @@ LLVMValueRef EnzymeCreatePrimalAndGradient(
 
 void EnzymeRegisterCallHandler(const char *Name,
                                CustomAugmentedFunctionForward FwdHandle,
-                               CustomFunctionReverse RevHandle,
-                               void *data);
+                               CustomFunctionReverse RevHandle, void *data);
 
 LLVMValueRef EnzymeGradientUtilsNewFromOriginal(GradientUtils *gutils,
                                                 LLVMValueRef val);

--- a/enzyme/Enzyme/CApi.h
+++ b/enzyme/Enzyme/CApi.h
@@ -198,10 +198,11 @@ typedef uint8_t (*CustomAugmentedFunctionForward)(LLVMBuilderRef, LLVMValueRef,
                                                   GradientUtils *,
                                                   LLVMValueRef *,
                                                   LLVMValueRef *,
-                                                  LLVMValueRef *);
+                                                  LLVMValueRef *,
+                                                  void *);
 
 typedef void (*CustomFunctionReverse)(LLVMBuilderRef, LLVMValueRef,
-                                      DiffeGradientUtils *, LLVMValueRef);
+                                      DiffeGradientUtils *, LLVMValueRef, void *);
 
 LLVMValueRef EnzymeCreateForwardDiff(
     EnzymeLogicRef Logic, LLVMValueRef request_req, LLVMBuilderRef request_ip,
@@ -221,6 +222,14 @@ LLVMValueRef EnzymeCreatePrimalAndGradient(
     uint8_t forceAnonymousTape, CFnTypeInfo typeInfo,
     uint8_t *_overwritten_args, size_t overwritten_args_size,
     EnzymeAugmentedReturnPtr augmented, uint8_t AtomicAdd);
+
+void EnzymeRegisterCallHandler(const char *Name,
+                               CustomAugmentedFunctionForward FwdHandle,
+                               CustomFunctionReverse RevHandle,
+                               void *data);
+
+LLVMValueRef EnzymeGradientUtilsNewFromOriginal(GradientUtils *gutils,
+                                                LLVMValueRef val);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This adds two items to the C API:
1. a `void *data` arg to `EnzymeRegisterCallHandler` so users can supply their own data to the callbacks
2. `EnzymeRegisterCallHandler` and `EnzymeGradientUtilsNewFromOriginal` added to the C API header

My particular motivation for 1. is that I need access to the LLVM module pointer in my reverse callback, so the data arg allows me to pass this in. I know the LLVM C++ API has `getParent` that can be used to get the module from the original call instruction, but I'm using the LLVM C API from rust, which as far as I can see does not have this functionality. In any case, I figure it would be generally useful for users to pass arbitrary data to these callbacks.