### PR TITLE
add EnzymeRegisterCallHandler to C API header 

### DIFF
--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -340,7 +340,7 @@ void EnzymeRegisterAllocationHandler(char *Name, CustomShadowAlloc AHandle,
     };
 }
 
-void EnzymeRegisterCallHandler(char *Name,
+void EnzymeRegisterCallHandler(const char *Name,
                                CustomAugmentedFunctionForward FwdHandle,
                                CustomFunctionReverse RevHandle) {
   auto &pair = customCallHandlers[Name];

--- a/enzyme/Enzyme/CApi.h
+++ b/enzyme/Enzyme/CApi.h
@@ -222,6 +222,13 @@ LLVMValueRef EnzymeCreatePrimalAndGradient(
     uint8_t *_overwritten_args, size_t overwritten_args_size,
     EnzymeAugmentedReturnPtr augmented, uint8_t AtomicAdd);
 
+void EnzymeRegisterCallHandler(const char *Name,
+                               CustomAugmentedFunctionForward FwdHandle,
+                               CustomFunctionReverse RevHandle);
+
+LLVMValueRef EnzymeGradientUtilsNewFromOriginal(GradientUtils *gutils,
+                                                LLVMValueRef val);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- adds EnzymeRegisterCallHandler and EnzymeGradientUtilsNewFromOriginal to C API header
- const qualify arg to make it easier to use from rust

Reduced version of #2223