### PR TITLE
`strcpy` to Known Inactive Functions

### DIFF
--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -169,6 +169,7 @@ bool isInactiveCall(CallBase &CI) {
 const char *KnownInactiveFunctionsStartingWith[] = {
     "f90io",
     "$ss5print",
+    "strcpy",
     "_ZTv0_n24_NSoD", //"1Ev, 0Ev
     "_ZNSt16allocator_traitsISaIdEE10deallocate",
     "_ZNSaIcED1Ev",


### PR DESCRIPTION
Seen in #2235  / https://github.com/ECP-WarpX/impactx/pull/825
```
error: Enzyme: No augmented forward pass found for
```

Per discussion in #2235: Should this also go in another list?