### PR TITLE
fix-cuda-custom-gradient

### DIFF
--- a/enzyme/Enzyme/PreserveNVVM.cpp
+++ b/enzyme/Enzyme/PreserveNVVM.cpp
@@ -290,7 +290,7 @@ handleCustomDerivative(llvm::Module &M, llvm::GlobalVariable &g,
         } else
           assert("Unknown mode");
       }
-    } else {
+    } else if (M.getTargetTriple().find("nvptx") != std::string::npos) {
       llvm::errs() << M << "\n";
       llvm::errs() << "Use of " << handlername
                    << " must be a "


### PR DESCRIPTION
@wsmoses  This is to fix the defect reported in [here ](https://github.com/EnzymeAD/Enzyme/issues/2053): the custom gradient for cuda device code give the error of 

`__enzyme_register_gradient must be a constant aggregate @__enzyme_register_gradient_AtomicAdd = internal global [3 x ptr] undef, align 16
`

