### PR TITLE
recognizing ENZYME_RUNPASS for lib/LLVM Enzyme builds

### DIFF
--- a/enzyme/Enzyme/CMakeLists.txt
+++ b/enzyme/Enzyme/CMakeLists.txt
@@ -154,10 +154,6 @@ if (${ENZYME_EXTERNAL_SHARED_LIB})
         COMPONENT dev)
 endif()
 
-if(${ENZYME_RUNPASS})
-    target_compile_definitions(LLVMEnzyme-${LLVM_VERSION_MAJOR} PUBLIC ENZYME_RUNPASS)
-endif()
-
 if (APPLE)
 # Darwin-specific linker flags for loadable modules.
 set_target_properties(LLVMEnzyme-${LLVM_VERSION_MAJOR} PROPERTIES

--- a/enzyme/Enzyme/CMakeLists.txt
+++ b/enzyme/Enzyme/CMakeLists.txt
@@ -144,9 +144,6 @@ if (${ENZYME_EXTERNAL_SHARED_LIB})
     add_dependencies(Enzyme-${LLVM_VERSION_MAJOR} BlasTAIncGen)
     add_dependencies(Enzyme-${LLVM_VERSION_MAJOR} BlasDiffUseIncGen)
     target_link_libraries(Enzyme-${LLVM_VERSION_MAJOR} LLVM)
-    if(${ENZYME_RUNPASS})
-        target_compile_definitions(Enzyme-${LLVM_VERSION_MAJOR} PUBLIC ENZYME_RUNPASS)
-    endif()
     install(TARGETS Enzyme-${LLVM_VERSION_MAJOR}
         EXPORT EnzymeTargets
         LIBRARY DESTINATION lib COMPONENT shlib

--- a/enzyme/Enzyme/CMakeLists.txt
+++ b/enzyme/Enzyme/CMakeLists.txt
@@ -144,11 +144,18 @@ if (${ENZYME_EXTERNAL_SHARED_LIB})
     add_dependencies(Enzyme-${LLVM_VERSION_MAJOR} BlasTAIncGen)
     add_dependencies(Enzyme-${LLVM_VERSION_MAJOR} BlasDiffUseIncGen)
     target_link_libraries(Enzyme-${LLVM_VERSION_MAJOR} LLVM)
+    if(${ENZYME_RUNPASS})
+        target_compile_definitions(Enzyme-${LLVM_VERSION_MAJOR} PUBLIC ENZYME_RUNPASS)
+    endif()
     install(TARGETS Enzyme-${LLVM_VERSION_MAJOR}
         EXPORT EnzymeTargets
         LIBRARY DESTINATION lib COMPONENT shlib
         PUBLIC_HEADER DESTINATION "${INSTALL_INCLUDE_DIR}/Enzyme"
         COMPONENT dev)
+endif()
+
+if(${ENZYME_RUNPASS})
+    target_compile_definitions(LLVMEnzyme-${LLVM_VERSION_MAJOR} PUBLIC ENZYME_RUNPASS)
 endif()
 
 if (APPLE)

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -3658,8 +3658,6 @@ void augmentPassBuilder(llvm::PassBuilder &PB) {
   PB.registerFullLinkTimeOptimizationEarlyEPCallback(loadLTO);
 }
 
-// A version used by Rust-Enzyme, which does not require cmake adjustments.
-// Rust just always sets augment to true.
 extern "C" void registerEnzyme2(llvm::PassBuilder &PB, bool augment = false) {
   if (augment) {
     augmentPassBuilder(PB);
@@ -3696,8 +3694,6 @@ extern "C" void registerEnzyme2(llvm::PassBuilder &PB, bool augment = false) {
       });
 }
 
-// A version used by ClangEnzyme and LLDEnzyme, allowing to
-// hardcode the usage of augmentPassBuilder at build time.
 extern "C" void registerEnzyme(llvm::PassBuilder &PB) {
 #ifdef ENZYME_RUNPASS
   registerEnzyme2(PB, /*augment*/ true);

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -3658,7 +3658,8 @@ void augmentPassBuilder(llvm::PassBuilder &PB) {
   PB.registerFullLinkTimeOptimizationEarlyEPCallback(loadLTO);
 }
 
-extern "C" void registerEnzymeAndPassPipeline(llvm::PassBuilder &PB, bool augment = false) {
+extern "C" void registerEnzymeAndPassPipeline(llvm::PassBuilder &PB,
+                                              bool augment = false) {
   if (augment) {
     augmentPassBuilder(PB);
   }

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -3658,7 +3658,7 @@ void augmentPassBuilder(llvm::PassBuilder &PB) {
   PB.registerFullLinkTimeOptimizationEarlyEPCallback(loadLTO);
 }
 
-extern "C" void registerEnzyme2(llvm::PassBuilder &PB, bool augment = false) {
+extern "C" void registerEnzymeAndPassPipeline(llvm::PassBuilder &PB, bool augment = false) {
   if (augment) {
     augmentPassBuilder(PB);
   }

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -3696,9 +3696,9 @@ extern "C" void registerEnzymeAndPassPipeline(llvm::PassBuilder &PB, bool augmen
 
 extern "C" void registerEnzyme(llvm::PassBuilder &PB) {
 #ifdef ENZYME_RUNPASS
-  registerEnzyme2(PB, /*augment*/ true);
+  registerEnzymeAndPassPipeline(PB, /*augment*/ true);
 #else
-  registerEnzyme2(PB, /*augment*/ false);
+  registerEnzymeAndPassPipeline(PB, /*augment*/ false);
 #endif
 }
 


### PR DESCRIPTION
I noticed that the ENZYME_RUNPASS variable is ignored, when you just pass it as `-DENZYME_RUNPASS` to cmake.
This might also affect your `BUILD` file, idk.
With these changes it now does run the augmentedPassBuilder.