### PR TITLE
fix the enzyme to work again with rust and llvm 20

### DIFF
--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -2070,7 +2070,7 @@ getFirstNonPHIOrDbgOrLifetime(llvm::BasicBlock *B) {
 }
 
 static inline void addCallSiteNoCapture(llvm::CallBase *call, size_t idx) {
-#if LLVM_VERSION_MAJOR >= 20
+#if LLVM_VERSION_MAJOR > 20
   call->addParamAttr(
       idx, llvm::Attribute::get(call->getContext(), llvm::Attribute::Captures,
                                 llvm::CaptureInfo::none().toIntValue()));
@@ -2080,7 +2080,7 @@ static inline void addCallSiteNoCapture(llvm::CallBase *call, size_t idx) {
 }
 
 static inline void addFunctionNoCapture(llvm::Function *call, size_t idx) {
-#if LLVM_VERSION_MAJOR >= 20
+#if LLVM_VERSION_MAJOR > 20
   call->addParamAttr(
       idx, llvm::Attribute::get(call->getContext(), llvm::Attribute::Captures,
                                 llvm::CaptureInfo::none().toIntValue()));
@@ -2093,7 +2093,7 @@ static inline void addFunctionNoCapture(llvm::Function *call, size_t idx) {
 addFunctionNoCapture(llvm::LLVMContext &ctx, llvm::AttributeList list,
                      size_t idx) {
   unsigned idxs = {(unsigned)idx};
-#if LLVM_VERSION_MAJOR >= 20
+#if LLVM_VERSION_MAJOR > 20
   return list.addParamAttribute(
       ctx, idxs,
       llvm::Attribute::get(ctx, llvm::Attribute::Captures,


### PR DESCRIPTION
@wsmoses While trying to remove the plugin dependency I ran into this issue.
```
running: cd "/home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/enzyme/build" && CMAKE_PREFIX_PATH="" DESTDIR="" LLVM_CONFIG_REAL="/home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/llvm/bin/llvm-config" "cmake" "/home/manuel/prog/rust-new/src/tools/enzyme/enzyme/" "-G" "Ninja" "-DCMAKE_INSTALL_MESSAGE=LAZY" "-DCMAKE_C_COMPILER=cc" "-DCMAKE_CXX_COMPILER=c++" "-DCMAKE_ASM_COMPILER=cc" "-DCMAKE_C_FLAGS=-ffunction-sections -fdata-sections -fPIC -m64 --target=x86_64-unknown-linux-gnu" "-DCMAKE_CXX_FLAGS=-ffunction-sections -fdata-sections -fPIC -m64 --target=x86_64-unknown-linux-gnu" "-DCMAKE_SHARED_LINKER_FLAGS=" "-DCMAKE_MODULE_LINKER_FLAGS=" "-DCMAKE_EXE_LINKER_FLAGS=" "-DLLVM_ENABLE_ASSERTIONS=ON" "-DENZYME_EXTERNAL_SHARED_LIB=ON" "-DENZYME_RUNPASS=ON" "-DENZYME_CLANG=OFF" "-DLLVM_DIR=/home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/llvm" "-DENZYME_CLANG=OFF" "-DCMAKE_INSTALL_PREFIX=/home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/enzyme" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64 --target=x86_64-unknown-linux-gnu" "-DCMAKE_BUILD_TYPE=Release"
LLVM_SHLIBEXT=.so
LLVM ABS DIR /home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/llvm/lib/cmake/llvm
CMAKE_PREFIX_PATH 
found llvm lit /home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/enzyme/build/lit
LLVM dir /home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/llvm/lib/cmake/llvm
clang dir 
mlir dir 
found Clang 0
found MLIR 0
LLVM_INSTALL_PREFIX: /home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/llvm
LLVM_INCLUDE_DIRS: /home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/llvm/include
found LLVM definitions -D_GNU_SOURCE -D_DEBUG -D_GLIBCXX_ASSERTIONS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
found LLVM version 20
first llvm include directory/home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/llvm/include
MPFR lib: MPFR_LIB_PATH-NOTFOUND
MPFR header: 
-- Configuring done (0.0s)

// <Warnings>

-- Generating done (0.0s)
-- Build files have been written to: /home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/enzyme/build
running: cd "/home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/enzyme/build" && DESTDIR="" LLVM_CONFIG_REAL="/home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/llvm/bin/llvm-config" "cmake" "--build" "." "--target" "install" "--config" "Release" "--" "-j" "16"
[0/2] Re-checking globbed directories...
[1/25] Building CXX object Enzyme/CMakeFiles/Enzyme-20.dir/JLInstSimplify.cpp.o
FAILED: Enzyme/CMakeFiles/Enzyme-20.dir/JLInstSimplify.cpp.o 
/usr/bin/c++ -DENZYME_VERSION_MAJOR=0 -DENZYME_VERSION_MINOR=0 -DENZYME_VERSION_PATCH=79 -DEnzyme_20_EXPORTS -I/home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/llvm/include -I/home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/enzyme/build/include -I/home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/enzyme/build/Enzyme -Wall -fno-rtti -ffunction-sections -fdata-sections -fPIC -m64 --target=x86_64-unknown-linux-gnu -Werror=unused-variable -Werror=dangling-else -Werror=unused-but-set-variable -Werror=return-type -Werror=nonnull -Werror=unused-result -Werror=reorder -Werror=switch -O2 -std=gnu++17 -fPIC   -D_GNU_SOURCE -D_DEBUG -D_GLIBCXX_ASSERTIONS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -MD -MT Enzyme/CMakeFiles/Enzyme-20.dir/JLInstSimplify.cpp.o -MF Enzyme/CMakeFiles/Enzyme-20.dir/JLInstSimplify.cpp.o.d -o Enzyme/CMakeFiles/Enzyme-20.dir/JLInstSimplify.cpp.o -c /home/manuel/prog/rust-new/src/tools/enzyme/enzyme/Enzyme/JLInstSimplify.cpp
In file included from /home/manuel/prog/rust-new/src/tools/enzyme/enzyme/Enzyme/JLInstSimplify.cpp:52:
In file included from /home/manuel/prog/rust-new/src/tools/enzyme/enzyme/Enzyme/LibraryFuncs.h:33:
/home/manuel/prog/rust-new/src/tools/enzyme/enzyme/Enzyme/Utils.h:2076:52: error: no member named 'none' in 'llvm::CaptureInfo'
 2076 |                                 llvm::CaptureInfo::none().toIntValue()));
      |                                 ~~~~~~~~~~~~~~~~~~~^
/home/manuel/prog/rust-new/src/tools/enzyme/enzyme/Enzyme/Utils.h:2086:52: error: no member named 'none' in 'llvm::CaptureInfo'
 2086 |                                 llvm::CaptureInfo::none().toIntValue()));
      |                                 ~~~~~~~~~~~~~~~~~~~^
/home/manuel/prog/rust-new/src/tools/enzyme/enzyme/Enzyme/Utils.h:2100:47: error: no member named 'none' in 'llvm::CaptureInfo'
 2100 |                            llvm::CaptureInfo::none().toIntValue()));
      |                            ~~~~~~~~~~~~~~~~~~~^
3 errors generated.

```
I think this PR broke it: https://github.com/EnzymeAD/Enzyme/pull/2237
See.
https://github.com/llvm/llvm-project/blame/main/llvm/include/llvm/Support/ModRef.h#L348
and 
https://github.com/EnzymeAD/Enzyme/blame/69e20cccdaad0506b6788b274fc9762d36785ae6/enzyme/Enzyme/Utils.h#L2073

