### PR TITLE
Avoid seqfault of minIndicies.size() == 0

### DIFF
--- a/enzyme/Enzyme/TypeAnalysis/TypeTree.h
+++ b/enzyme/Enzyme/TypeAnalysis/TypeTree.h
@@ -764,7 +764,9 @@ public:
     // Non-combined ones do not conflict, since they were already in
     // a TT which we can assume contained no conflicts.
     mapping = std::move(unCombinedToAdd);
-    minIndices[0] = -1;
+    if (minIndices.size() > 0) {
+      minIndices[0] = -1;
+    }
 
     // Fusing several terms into a minus one can create a conflict
     // if the prior minus one was already in the map


### PR DESCRIPTION
When looking into https://github.com/EnzymeAD/Enzyme.jl/issues/2317 the issue seemed to be that `minIndices.size() == 0` and thus this assignment does fail.
