### PR TITLE
update for llvm::Triple becoming a proper class

### DIFF
--- a/enzyme/Enzyme/PreserveNVVM.cpp
+++ b/enzyme/Enzyme/PreserveNVVM.cpp
@@ -290,7 +290,7 @@ handleCustomDerivative(llvm::Module &M, llvm::GlobalVariable &g,
         } else
           assert("Unknown mode");
       }
-    } else if (M.getTargetTriple().find("nvptx") != std::string::npos) {
+    } else if (isTargetNVPTX(M)) {
       llvm::errs() << M << "\n";
       llvm::errs() << "Use of " << handlername
                    << " must be a "

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -4032,3 +4032,12 @@ arePointersGuaranteedNoAlias(TargetLibraryInfo &TLI, llvm::AAResults &AA,
 
   return {};
 }
+
+bool isTargetNVPTX(llvm::Module &M) {
+#if LLVM_VERSION_MAJOR > 20
+  return M.getTargetTriple().getArch() == Triple::ArchType::nvptx ||
+         M.getTargetTriple().getArch() == Triple::ArchType::nvptx64;
+#else
+  return M.getTargetTriple().find("nvptx") != std::string::npos
+#endif
+}

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -2180,4 +2180,8 @@ arePointersGuaranteedNoAlias(llvm::TargetLibraryInfo &TLI, llvm::AAResults &AA,
                              llvm::LoopInfo &LI, llvm::Value *op0,
                              llvm::Value *op1, bool offsetAllowed = false);
 
+// Return true if the module has a triple indicating an nvptx target, false
+// otherwise.
+bool isTargetNVPTX(llvm::Module &M);
+
 #endif // ENZYME_UTILS_H


### PR DESCRIPTION
We no longer need to parse the string triple.