### PR TITLE
support for LLVM 19

### DIFF
--- a/enzyme/Enzyme/InstructionDerivatives.td
+++ b/enzyme/Enzyme/InstructionDerivatives.td
@@ -1130,3 +1130,21 @@ def : InstPattern<(Op $x), "Freeze", 10, 0,
                   >;
 
 include "BlasDerivatives.td"                  
+
+def : IntrPattern<(Op $x),
+                  [["acos", "19", ""]],
+                  [(FNeg (FDiv (DiffeRet), (Intrinsic<"sqrt"> (FSub (ConstantFP<"1.0"> $x), (FMul $x, $x)))))]  ,
+                  (ForwardFromSummedReverse)                
+                  >;
+
+def : IntrPattern<(Op $x),
+                  [["atan", "19", ""]],
+                  [(FDiv (DiffeRet), (FAdd (FMul $x, $x), (ConstantFP<"1.0"> $x)))]  ,
+                  (ForwardFromSummedReverse)                
+                  >;
+
+def : IntrPattern<(Op $x),
+                  [["asin", "19", ""]],
+                  [(FDiv (DiffeRet), (Intrinsic<"sqrt"> (FSub (ConstantFP<"1.0"> $x), (FMul $x, $x))))]  ,
+                  (ForwardFromSummedReverse)                
+                  >;


### PR DESCRIPTION
fix: add support for LLVM 19 trigonometric function intrinsics

Add patterns for automatic differentiation of acos, atan, and asin functions
using LLVM 19's new intrinsics. This fixes the compilation error when using
__enzyme_autodiff with these trigonometric functions.

The implementation follows the mathematical derivatives:
- acos: -1/√(1-x²)
- atan: 1/(1+x²)
- asin: 1/√(1-x²)

Fixes #2243 