### PR TITLE
Report diagnostic as errors in ops removal interface

### DIFF
--- a/enzyme/Enzyme/MLIR/Passes/RemoveUnusedEnzymeOps.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/RemoveUnusedEnzymeOps.cpp
@@ -376,6 +376,9 @@ protected:
                                OpBuilder::InsertPoint previous) override;
   void notifyOperationErased(Operation *op) override;
 
+  void notifyMatchFailure(Location loc,
+                          function_ref<void(Diagnostic &)> reasonCallback);
+
 private:
   void addToWorklist(Operation *op);
 
@@ -430,6 +433,12 @@ void PostOrderWalkDriver::notifyOperationErased(Operation *op) {
   if (!isa<EnzymeOpsRemoverOpInterface>(op))
     return;
   worklist.remove(op);
+}
+
+void PostOrderWalkDriver::notifyMatchFailure(
+    Location loc, function_ref<void(Diagnostic &)> reasonCallback) {
+  auto diag = mlir::emitError(loc);
+  reasonCallback(*diag.getUnderlyingDiagnostic());
 }
 
 void PostOrderWalkDriver::initializeWorklist() {


### PR DESCRIPTION
Useful to get error messages following https://github.com/EnzymeAD/Enzyme-JAX/pull/861.