### PR TITLE
don't access LLVMEnzyme on apple builds if LLVM_PLUGINS isn't set

### DIFF
--- a/enzyme/Enzyme/CMakeLists.txt
+++ b/enzyme/Enzyme/CMakeLists.txt
@@ -155,9 +155,9 @@ endif()
 
 if (APPLE)
 # Darwin-specific linker flags for loadable modules.
+if (ENZYME_ENABLE_PLUGINS)
 set_target_properties(LLVMEnzyme-${LLVM_VERSION_MAJOR} PROPERTIES
     LINK_FLAGS "-Wl,-flat_namespace -Wl,-undefined -Wl,suppress")
-if (ENZYME_ENABLE_PLUGINS)
 if (${Clang_FOUND})
 set_target_properties(ClangEnzyme-${LLVM_VERSION_MAJOR} PROPERTIES
         LINK_FLAGS "-Wl,-flat_namespace -Wl,-undefined -Wl,suppress")


### PR DESCRIPTION
Upstreaming of https://github.com/rust-lang/enzyme/pull/4
Incorrect guard caused a build failure in https://github.com/rust-lang/rust/pull/140064#issuecomment-2836408078
(There might be another fix needed, but this seems uncontroversial?)