### PR TITLE
fix apple builds against a no-plugin LLVM

### DIFF
--- a/enzyme/BCLoad/CMakeLists.txt
+++ b/enzyme/BCLoad/CMakeLists.txt
@@ -14,6 +14,7 @@ if (APPLE)
     set(BC_LOAD_FLAGS2 "${BC_LOAD_FLAGS2} --sysroot=${CMAKE_OSX_SYSROOT}")
 endif()
 
+if (ENZYME_ENABLE_PLUGINS)
 if (NOT ("${BC_LOAD_HEADER}" STREQUAL ""))
     add_custom_target(blasheaders mkdir -p "${CMAKE_CURRENT_BINARY_DIR}/gsl" && cp ${BC_LOAD_HEADER} "${CMAKE_CURRENT_BINARY_DIR}/gsl/blas_headers.h")
 set_target_properties(blasheaders PROPERTIES EXCLUDE_FROM_ALL TRUE)
@@ -129,5 +130,6 @@ if (${ENZYME_EXTERNAL_SHARED_LIB})
         LIBRARY DESTINATION lib COMPONENT shlib
         PUBLIC_HEADER DESTINATION "${INSTALL_INCLUDE_DIR}/Enzyme"
         COMPONENT dev)
+endif()
 endif()
 endif()


### PR DESCRIPTION
This (in combination with yesterdays fix) let's me build rustc on apple.
Without this fix I get
```
-- BCPass-20 ignored -- Loadable modules not supported on this platform.
CMake Error at BCLoad/CMakeLists.txt:108 (target_include_directories):
  target_include_directories called with non-compilable target type
```


Used rust commands
`./configure --enable-llvm-link-shared --enable-llvm-enzyme --release-channel=nightly --enable-llvm-assertions --enable-clang --enable-lld --enable-option-checking --enable-ninja --disable-docs`
Not used flag: ` --enable-llvm-plugins `

I don't know under which flags exactly we should disable it.
if APPLE AND NO_PLUGINS?
