### PR TITLE
libLLVM.a doesn't exist, so how enzyme is linking LLVM

### DIFF
--- a/enzyme/Enzyme/CMakeLists.txt
+++ b/enzyme/Enzyme/CMakeLists.txt
@@ -145,7 +145,20 @@ if (${ENZYME_EXTERNAL_SHARED_LIB})
     add_dependencies(Enzyme-${LLVM_VERSION_MAJOR} BlasDeclarationsIncGen)
     add_dependencies(Enzyme-${LLVM_VERSION_MAJOR} BlasTAIncGen)
     add_dependencies(Enzyme-${LLVM_VERSION_MAJOR} BlasDiffUseIncGen)
-    target_link_libraries(Enzyme-${LLVM_VERSION_MAJOR} LLVM)
+
+    # This would be the desired way to link against LLVM components,
+    # however this function is bugged and does not work with `all`, see:
+    # https://github.com/llvm/llvm-project/issues/46347
+    #llvm_map_components_to_libnames(llvm_libs all)
+    # Therefore, manually invoke llvm-config
+    execute_process(COMMAND ${LLVM_TOOLS_BINARY_DIR}/llvm-config --libs all
+                OUTPUT_VARIABLE llvm_libraries)
+    string(STRIP "${llvm_libraries}" llvm_libraries)
+    # In theory, adding --libs should also add all the -l flags,
+    # but it isn't picked up correctly by clang, so we call target_link_libraries
+    set_target_properties(Enzyme-${LLVM_VERSION_MAJOR} PROPERTIES
+        LINK_FLAGS "`${LLVM_TOOLS_BINARY_DIR}/llvm-config --ldflags`")
+    target_link_libraries(Enzyme-${LLVM_VERSION_MAJOR} ${llvm_libraries})
     install(TARGETS Enzyme-${LLVM_VERSION_MAJOR}
         EXPORT EnzymeTargets
         LIBRARY DESTINATION lib COMPONENT shlib


### PR DESCRIPTION
There are a couple of bugs in both Enzyme and LLVM, so it took me a while to figure this one out.

1) linking against "LLVM" as a constant string only works if there's some type of libLLVM.something.
We only have a libLLVM.so if we build LLVM as a dynamically linked library, which rust does e.g. for x86-64.
There is no libLLVM.a equivalent otherwise, just a lot of individual archives. 

2) In theory, the right thing to fix this would be
```cmake
llvm_map_components_to_libnames(llvm_libs all)
target_link_libraries(Enzyme-${LLVM_VERSION_MAJOR} ${llvm_libs})
```
However, "all" isn't being handled correctly, see https://github.com/llvm/llvm-project/issues/46347
It seems to be a common experience that some cmake macros are unreliable, so I was recommended
to just call the llvm-config binary.

3)
```
    execute_process(COMMAND ${LLVM_TOOLS_BINARY_DIR}/llvm-config --libs all
                OUTPUT_VARIABLE llvm_libraries)
```
Trying to also add the --ldflags fails the subsequent parsing:
```
CMake Error:
  Running

   '/usr/bin/ninja' '-C' '/home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/enzyme/build' '-t' 'recompact'

  failed with:

   ninja: error: build.ninja:606: expected '=', got identifier

  -lLLVMWindowsManifest -lLLVMXRay -lLLVMLibDriver -lLLVMDlltoolDriver -lL...

                        ^ near here
```
so we have to add the `-L somedir`  in yet another command.

4) We therefore call
```
    set_target_properties(Enzyme-${LLVM_VERSION_MAJOR} PROPERTIES
        LINK_FLAGS "`${LLVM_TOOLS_BINARY_DIR}/llvm-config --ldflags`")
```
which correctly gives e.g. on my system `-L/home/manuel/prog/rust-new/build/x86_64-unknown-linux-gnu/llvm/lib`, where all the libLLVMSomething.a files are located.

So this still seems messy, but at least it should be more often correct than the current code. I'd be happy if someone else can fix it in upstream. 