### PR TITLE
Add C API for setting type-analysis-func via EnzymeSetCLString

### DIFF
--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -200,7 +200,7 @@ int64_t EnzymeGetCLInteger(void *ptr) {
   return (int64_t)cl->getValue();
 }
 
-void EnzymeSetCLString(void *ptr, const char* val) {
+void EnzymeSetCLString(void *ptr, const char *val) {
   if (auto *clopt = static_cast<cl::opt<std::string> *>(ptr))
     clopt->setValue(val);
 }

--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -200,11 +200,6 @@ int64_t EnzymeGetCLInteger(void *ptr) {
   return (int64_t)cl->getValue();
 }
 
-void EnzymeSetCLString(void *ptr, const char* val) {
-  if (auto *clopt = static_cast<cl::opt<std::string> *>(ptr))
-    clopt->setValue(val);
-}
-
 EnzymeLogicRef CreateEnzymeLogic(uint8_t PostOpt) {
   return (EnzymeLogicRef)(new EnzymeLogic((bool)PostOpt));
 }

--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -200,6 +200,11 @@ int64_t EnzymeGetCLInteger(void *ptr) {
   return (int64_t)cl->getValue();
 }
 
+void EnzymeSetCLString(void *ptr, const char* val) {
+  if (auto *clopt = static_cast<cl::opt<std::string> *>(ptr))
+    clopt->setValue(val);
+}
+
 EnzymeLogicRef CreateEnzymeLogic(uint8_t PostOpt) {
   return (EnzymeLogicRef)(new EnzymeLogic((bool)PostOpt));
 }

--- a/enzyme/Enzyme/CApi.h
+++ b/enzyme/Enzyme/CApi.h
@@ -100,7 +100,6 @@ void EnzymeTypeTreeToStringFree(const char *cstr);
 
 void EnzymeSetCLBool(void *, uint8_t);
 void EnzymeSetCLInteger(void *, int64_t);
-void EnzymeSetCLString(void *, const char*);
 
 struct CFnTypeInfo {
   /// Types of arguments, assumed of size len(Arguments)

--- a/enzyme/Enzyme/CApi.h
+++ b/enzyme/Enzyme/CApi.h
@@ -100,6 +100,7 @@ void EnzymeTypeTreeToStringFree(const char *cstr);
 
 void EnzymeSetCLBool(void *, uint8_t);
 void EnzymeSetCLInteger(void *, int64_t);
+void EnzymeSetCLString(void *, const char*);
 
 struct CFnTypeInfo {
   /// Types of arguments, assumed of size len(Arguments)

--- a/enzyme/Enzyme/CApi.h
+++ b/enzyme/Enzyme/CApi.h
@@ -100,7 +100,7 @@ void EnzymeTypeTreeToStringFree(const char *cstr);
 
 void EnzymeSetCLBool(void *, uint8_t);
 void EnzymeSetCLInteger(void *, int64_t);
-void EnzymeSetCLString(void *, const char*);
+void EnzymeSetCLString(void *, const char *);
 
 struct CFnTypeInfo {
   /// Types of arguments, assumed of size len(Arguments)

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysisPrinter.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysisPrinter.cpp
@@ -64,10 +64,12 @@ using namespace llvm;
 #endif
 #define DEBUG_TYPE "type-analysis-results"
 
+extern "C" {
 /// Function ActivityAnalysis will be starting its run from
 llvm::cl::opt<std::string>
     FunctionToAnalyze("type-analysis-func", cl::init(""), cl::Hidden,
                       cl::desc("Which function to analyze/print"));
+}
 
 namespace {
 bool printTypeAnalyses(llvm::Function &F) {

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysisPrinter.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysisPrinter.cpp
@@ -67,14 +67,14 @@ using namespace llvm;
 extern "C" {
 /// Function ActivityAnalysis will be starting its run from
 llvm::cl::opt<std::string>
-    FunctionToAnalyze("type-analysis-func", cl::init(""), cl::Hidden,
-                      cl::desc("Which function to analyze/print"));
+    EnzymeFunctionToAnalyze("type-analysis-func", cl::init(""), cl::Hidden,
+                            cl::desc("Which function to analyze/print"));
 }
 
 namespace {
 bool printTypeAnalyses(llvm::Function &F) {
 
-  if (F.getName() != FunctionToAnalyze)
+  if (F.getName() != EnzymeFunctionToAnalyze)
     return /*changed*/ false;
 
   FnTypeInfo type_args(&F);

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysisPrinter.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysisPrinter.cpp
@@ -64,12 +64,10 @@ using namespace llvm;
 #endif
 #define DEBUG_TYPE "type-analysis-results"
 
-extern "C" {
 /// Function ActivityAnalysis will be starting its run from
 llvm::cl::opt<std::string>
     FunctionToAnalyze("type-analysis-func", cl::init(""), cl::Hidden,
                       cl::desc("Which function to analyze/print"));
-}
 
 namespace {
 bool printTypeAnalyses(llvm::Function &F) {


### PR DESCRIPTION
This PR introduces a C API to dynamically set the type-analysis-func flag (FunctionToAnalyze).

## Changes:
- Added: EnzymeSetCLString(void* ptr, const char* val) to CApi.cpp and CApi.h
- This enables users to set string-based LLVM command-line options at runtime.
