### PR TITLE
Introduce __enzyme_ignore_derivatives

### DIFF
--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -178,7 +178,7 @@ const char *KnownInactiveFunctionsStartingWith[] = {
 
 const char *KnownInactiveFunctionsContains[] = {
     "__enzyme_float", "__enzyme_double", "__enzyme_integer",
-    "__enzyme_pointer"};
+    "__enzyme_pointer", "__enzyme_ignore_derivatives"};
 
 const StringSet<> KnownInactiveFunctions = {
     "mpfr_greater_p",

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -3659,30 +3659,6 @@ bool AdjointGenerator::handleKnownCallDerivatives(
     return true;
   }
 
-  if (funcName.contains("__enzyme_ignore_derivatives")) {
-    if (gutils->isConstantValue(&call)) {
-      eraseIfUnused(call);
-      return true;
-    }
-
-    auto ifound = gutils->invertedPointers.find(&call);
-    assert(ifound != gutils->invertedPointers.end());
-
-    auto placeholder = cast<PHINode>(&*ifound->second);
-
-    bool needShadow =
-        DifferentialUseAnalysis::is_value_needed_in_reverse<QueryType::Shadow>(
-            gutils, &call, Mode, oldUnreachable);
-    if (!needShadow) {
-      gutils->invertedPointers.erase(ifound);
-      gutils->erase(placeholder);
-      eraseIfUnused(call);
-      return true;
-    }
-
-    // TODO: How to create a shadow from nothing?
-  }
-
   if (funcName == "memcpy" || funcName == "memmove") {
     auto ID = (funcName == "memcpy") ? Intrinsic::memcpy : Intrinsic::memmove;
     visitMemTransferCommon(ID, /*srcAlign*/ MaybeAlign(1),

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -3659,6 +3659,30 @@ bool AdjointGenerator::handleKnownCallDerivatives(
     return true;
   }
 
+  if (funcName.contains("__enzyme_ignore_derivatives")) {
+    if (gutils->isConstantValue(&call)) {
+      eraseIfUnused(call);
+      return true;
+    }
+
+    auto ifound = gutils->invertedPointers.find(&call);
+    assert(ifound != gutils->invertedPointers.end());
+
+    auto placeholder = cast<PHINode>(&*ifound->second);
+
+    bool needShadow =
+        DifferentialUseAnalysis::is_value_needed_in_reverse<QueryType::Shadow>(
+            gutils, &call, Mode, oldUnreachable);
+    if (!needShadow) {
+      gutils->invertedPointers.erase(ifound);
+      gutils->erase(placeholder);
+      eraseIfUnused(call);
+      return true;
+    }
+
+    // TODO: How to create a shadow from nothing?
+  }
+
   if (funcName == "memcpy" || funcName == "memmove") {
     auto ID = (funcName == "memcpy") ? Intrinsic::memcpy : Intrinsic::memmove;
     visitMemTransferCommon(ID, /*srcAlign*/ MaybeAlign(1),

--- a/enzyme/Enzyme/DifferentialUseAnalysis.h
+++ b/enzyme/Enzyme/DifferentialUseAnalysis.h
@@ -387,6 +387,9 @@ inline bool is_value_needed_in_reverse(
       if (funcName.contains("__enzyme_todense")) {
         primalUsedInShadowPointer = false;
       }
+      if (funcName.contains("__enzyme_ignore_derivatives")) {
+        primalUsedInShadowPointer = false;
+      }
     }
     if (auto GEP = dyn_cast<GetElementPtrInst>(user)) {
       bool idxUsed = false;

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -3082,7 +3082,7 @@ public:
                 CI->eraseFromParent();
                 changed = true;
               }
-              if (F->getName() == "__enzyme_iter") {
+              if (F->getName() == "__enzyme_iter" || F->getName().contains("__enzyme_ignore_derivatives")) {
                 CI->replaceAllUsesWith(CI->getArgOperand(0));
                 CI->eraseFromParent();
                 changed = true;

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -135,6 +135,7 @@ bool attributeKnownFunctions(llvm::Function &F) {
       F.getName().contains("__enzyme_integer") ||
       F.getName().contains("__enzyme_pointer") ||
       F.getName().contains("__enzyme_todense") ||
+      F.getName().contains("__enzyme_ignore_derivatives") ||
       F.getName().contains("__enzyme_iter") ||
       F.getName().contains("__enzyme_virtualreverse")) {
     changed = true;
@@ -144,7 +145,8 @@ bool attributeKnownFunctions(llvm::Function &F) {
 #else
     F.addFnAttr(Attribute::ReadNone);
 #endif
-    if (!F.getName().contains("__enzyme_todense"))
+    if (!(F.getName().contains("__enzyme_todense") ||
+          F.getName().contains("__enzyme_ignore_derivatives"))) {
       for (auto &arg : F.args()) {
         if (arg.getType()->isPointerTy()) {
           arg.addAttr(Attribute::ReadNone);
@@ -2383,7 +2385,7 @@ public:
 
         size_t num_args = CI->arg_size();
 
-        if (Fn->getName().contains("__enzyme_todense")) {
+        if (Fn->getName().contains("__enzyme_todense") || Fn->getName().contains("__enzyme_ignore_derivatives")) {
 #if LLVM_VERSION_MAJOR >= 16
           CI->setOnlyReadsMemory();
           CI->setOnlyWritesMemory();

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -153,6 +153,7 @@ bool attributeKnownFunctions(llvm::Function &F) {
           addFunctionNoCapture(&F, arg.getArgNo());
         }
       }
+    }
   }
   if (F.getName() == "memcmp") {
     changed = true;
@@ -2385,7 +2386,8 @@ public:
 
         size_t num_args = CI->arg_size();
 
-        if (Fn->getName().contains("__enzyme_todense") || Fn->getName().contains("__enzyme_ignore_derivatives")) {
+        if (Fn->getName().contains("__enzyme_todense") ||
+            Fn->getName().contains("__enzyme_ignore_derivatives")) {
 #if LLVM_VERSION_MAJOR >= 16
           CI->setOnlyReadsMemory();
           CI->setOnlyWritesMemory();
@@ -2958,31 +2960,22 @@ public:
                                  /* CGSCC */ nullptr);
 
       DenseSet<const char *> Allowed = {
-        &AAHeapToStack::ID,
-        &AANoCapture::ID,
+          &AAHeapToStack::ID,     &AANoCapture::ID,
 
-        &AAMemoryBehavior::ID,
-        &AAMemoryLocation::ID,
-        &AANoUnwind::ID,
-        &AANoSync::ID,
-        &AANoRecurse::ID,
-        &AAWillReturn::ID,
-        &AANoReturn::ID,
-        &AANonNull::ID,
-        &AANoAlias::ID,
-        &AADereferenceable::ID,
-        &AAAlign::ID,
+          &AAMemoryBehavior::ID,  &AAMemoryLocation::ID, &AANoUnwind::ID,
+          &AANoSync::ID,          &AANoRecurse::ID,      &AAWillReturn::ID,
+          &AANoReturn::ID,        &AANonNull::ID,        &AANoAlias::ID,
+          &AADereferenceable::ID, &AAAlign::ID,
 #if LLVM_VERSION_MAJOR < 17
-        &AAReturnedValues::ID,
+          &AAReturnedValues::ID,
 #endif
-        &AANoFree::ID,
-        &AANoUndef::ID,
+          &AANoFree::ID,          &AANoUndef::ID,
 
-        //&AAValueSimplify::ID,
-        //&AAReachability::ID,
-        //&AAValueConstantRange::ID,
-        //&AAUndefinedBehavior::ID,
-        //&AAPotentialValues::ID,
+          //&AAValueSimplify::ID,
+          //&AAReachability::ID,
+          //&AAValueConstantRange::ID,
+          //&AAUndefinedBehavior::ID,
+          //&AAPotentialValues::ID,
       };
 
       AttributorConfig aconfig(CGUpdater);
@@ -3082,7 +3075,8 @@ public:
                 CI->eraseFromParent();
                 changed = true;
               }
-              if (F->getName() == "__enzyme_iter" || F->getName().contains("__enzyme_ignore_derivatives")) {
+              if (F->getName() == "__enzyme_iter" ||
+                  F->getName().contains("__enzyme_ignore_derivatives")) {
                 CI->replaceAllUsesWith(CI->getArgOperand(0));
                 CI->eraseFromParent();
                 changed = true;

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -2960,22 +2960,31 @@ public:
                                  /* CGSCC */ nullptr);
 
       DenseSet<const char *> Allowed = {
-          &AAHeapToStack::ID,     &AANoCapture::ID,
+        &AAHeapToStack::ID,
+        &AANoCapture::ID,
 
-          &AAMemoryBehavior::ID,  &AAMemoryLocation::ID, &AANoUnwind::ID,
-          &AANoSync::ID,          &AANoRecurse::ID,      &AAWillReturn::ID,
-          &AANoReturn::ID,        &AANonNull::ID,        &AANoAlias::ID,
-          &AADereferenceable::ID, &AAAlign::ID,
+        &AAMemoryBehavior::ID,
+        &AAMemoryLocation::ID,
+        &AANoUnwind::ID,
+        &AANoSync::ID,
+        &AANoRecurse::ID,
+        &AAWillReturn::ID,
+        &AANoReturn::ID,
+        &AANonNull::ID,
+        &AANoAlias::ID,
+        &AADereferenceable::ID,
+        &AAAlign::ID,
 #if LLVM_VERSION_MAJOR < 17
-          &AAReturnedValues::ID,
+        &AAReturnedValues::ID,
 #endif
-          &AANoFree::ID,          &AANoUndef::ID,
+        &AANoFree::ID,
+        &AANoUndef::ID,
 
-          //&AAValueSimplify::ID,
-          //&AAReachability::ID,
-          //&AAValueConstantRange::ID,
-          //&AAUndefinedBehavior::ID,
-          //&AAPotentialValues::ID,
+        //&AAValueSimplify::ID,
+        //&AAReachability::ID,
+        //&AAValueConstantRange::ID,
+        //&AAUndefinedBehavior::ID,
+        //&AAPotentialValues::ID,
       };
 
       AttributorConfig aconfig(CGUpdater);

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -4111,7 +4111,8 @@ bool GradientUtils::legalRecompute(const Value *val,
         n == "__lgammaf_r_finite" || n == "__lgammal_r_finite" || n == "tanh" ||
         n == "tanhf" || n == "__pow_finite" ||
         n == "julia.pointer_from_objref" || startsWith(n, "enzyme_wrapmpi$$") ||
-        n == "omp_get_thread_num" || n == "omp_get_max_threads" || "__enzyme_ignore_derivatives") {
+        n == "omp_get_thread_num" || n == "omp_get_max_threads" ||
+        n.contains("__enzyme_ignore_derivatives")) {
       return true;
     }
 #if LLVM_VERSION_MAJOR >= 14
@@ -4261,7 +4262,7 @@ bool GradientUtils::shouldRecompute(const Value *val,
         n == "tanhf" || n == "__pow_finite" ||
         n == "julia.pointer_from_objref" || startsWith(n, "enzyme_wrapmpi$$") ||
         n == "omp_get_thread_num" || n == "omp_get_max_threads" ||
-        startsWith(n, "_ZN4libm4math3log") || "__enzyme_ignore_derivatives") {
+        startsWith(n, "_ZN4libm4math3log") || n.contains("__enzyme_ignore_derivatives")) {
       return true;
     }
     if (isPointerArithmeticInst(ci))

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -4262,7 +4262,8 @@ bool GradientUtils::shouldRecompute(const Value *val,
         n == "tanhf" || n == "__pow_finite" ||
         n == "julia.pointer_from_objref" || startsWith(n, "enzyme_wrapmpi$$") ||
         n == "omp_get_thread_num" || n == "omp_get_max_threads" ||
-        startsWith(n, "_ZN4libm4math3log") || n.contains("__enzyme_ignore_derivatives")) {
+        startsWith(n, "_ZN4libm4math3log") ||
+        n.contains("__enzyme_ignore_derivatives")) {
       return true;
     }
     if (isPointerArithmeticInst(ci))

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -4111,7 +4111,7 @@ bool GradientUtils::legalRecompute(const Value *val,
         n == "__lgammaf_r_finite" || n == "__lgammal_r_finite" || n == "tanh" ||
         n == "tanhf" || n == "__pow_finite" ||
         n == "julia.pointer_from_objref" || startsWith(n, "enzyme_wrapmpi$$") ||
-        n == "omp_get_thread_num" || n == "omp_get_max_threads") {
+        n == "omp_get_thread_num" || n == "omp_get_max_threads" || "__enzyme_ignore_derivatives") {
       return true;
     }
 #if LLVM_VERSION_MAJOR >= 14
@@ -4261,7 +4261,7 @@ bool GradientUtils::shouldRecompute(const Value *val,
         n == "tanhf" || n == "__pow_finite" ||
         n == "julia.pointer_from_objref" || startsWith(n, "enzyme_wrapmpi$$") ||
         n == "omp_get_thread_num" || n == "omp_get_max_threads" ||
-        startsWith(n, "_ZN4libm4math3log")) {
+        startsWith(n, "_ZN4libm4math3log") || "__enzyme_ignore_derivatives") {
       return true;
     }
     if (isPointerArithmeticInst(ci))

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -1492,7 +1492,10 @@ static inline llvm::Value *getBaseObject(llvm::Value *V,
         V = Call->getArgOperand(1);
         continue;
       }
-      // TODO: funcName.contains("__enzyme_ignore_derivatives")) {
+      if (funcName.contains("__enzyme_ignore_derivatives")) {
+        V = Call->getArgOperand(0);
+        continue;
+      }
       if (funcName.contains("__enzyme_todense")) {
 #if LLVM_VERSION_MAJOR >= 14
         size_t numargs = Call->arg_size();

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -1426,6 +1426,9 @@ static inline bool isPointerArithmeticInst(const llvm::Value *V,
     if (funcName.contains("__enzyme_todense")) {
       return true;
     }
+    if (funcName.contains("__enzyme_ignore_derivatives")) {
+      return true;
+    }
   }
 
   return false;
@@ -1489,6 +1492,7 @@ static inline llvm::Value *getBaseObject(llvm::Value *V,
         V = Call->getArgOperand(1);
         continue;
       }
+      // TODO: funcName.contains("__enzyme_ignore_derivatives")) {
       if (funcName.contains("__enzyme_todense")) {
 #if LLVM_VERSION_MAJOR >= 14
         size_t numargs = Call->arg_size();

--- a/enzyme/test/Enzyme/ReverseMode/ignore_derivatives.ll
+++ b/enzyme/test/Enzyme/ReverseMode/ignore_derivatives.ll
@@ -5,8 +5,8 @@
 define double @tester(double %x) {
 entry:
   %y = tail call fast double @__enzyme_ignore_derivatives(double %x)
-  %y2 = fmul double %y, %y
-  %res = fmul add %y2, %x
+  %z = fadd double %y, %x
+  %res = fmul double %z, %z
   ret double %res
 }
 
@@ -21,12 +21,35 @@ declare double @__enzyme_ignore_derivatives(double)
 ; Function Attrs: nounwind
 declare double @__enzyme_autodiff(double (double)*, ...)
 
-; CHECK: define internal { double } @diffetester(double %x, double %differeturn) 
+; CHECK: define internal { double } @diffetester(double %x, double %differeturn)
 ; CHECK-NEXT: entry:
-; CHECK-NEXT:   %0 = fmul fast double %x, %x
-; CHECK-NEXT:   %1 = fsub fast double 1.000000e+00, %0
-; CHECK-NEXT:   %2 = call fast double @llvm.sqrt.f64(double %1)
-; CHECK-NEXT:   %3 = fdiv fast double %differeturn, %2
-; CHECK-NEXT:   %4 = insertvalue { double } undef, double %3, 0
-; CHECK-NEXT:   ret { double } %4
+; CHECK-NEXT:   %"res'de" = alloca double, align 8
+; CHECK-NEXT:   store double 0.000000e+00, double* %"res'de", align 8
+; CHECK-NEXT:   %"z'de" = alloca double, align 8
+; CHECK-NEXT:   store double 0.000000e+00, double* %"z'de", align 8
+; CHECK-NEXT:   %"x'de" = alloca double, align 8
+; CHECK-NEXT:   store double 0.000000e+00, double* %"x'de", align 8
+; CHECK-NEXT:   %z = fadd double %x, %x
+; CHECK-NEXT:   br label %invertentry
+
+; CHECK: invertentry:                                      ; preds = %entry
+; CHECK-NEXT:   store double %differeturn, double* %"res'de", align 8
+; CHECK-NEXT:   %0 = load double, double* %"res'de", align 8
+; CHECK-NEXT:   store double 0.000000e+00, double* %"res'de", align 8
+; CHECK-NEXT:   %1 = fmul fast double %0, %z
+; CHECK-NEXT:   %2 = load double, double* %"z'de", align 8
+; CHECK-NEXT:   %3 = fadd fast double %2, %1
+; CHECK-NEXT:   store double %3, double* %"z'de", align 8
+; CHECK-NEXT:   %4 = fmul fast double %0, %z
+; CHECK-NEXT:   %5 = load double, double* %"z'de", align 8
+; CHECK-NEXT:   %6 = fadd fast double %5, %4
+; CHECK-NEXT:   store double %6, double* %"z'de", align 8
+; CHECK-NEXT:   %7 = load double, double* %"z'de", align 8
+; CHECK-NEXT:   store double 0.000000e+00, double* %"z'de", align 8
+; CHECK-NEXT:   %8 = load double, double* %"x'de", align 8
+; CHECK-NEXT:   %9 = fadd fast double %8, %7
+; CHECK-NEXT:   store double %9, double* %"x'de", align 8
+; CHECK-NEXT:   %10 = load double, double* %"x'de", align 8
+; CHECK-NEXT:   %11 = insertvalue { double } undef, double %10, 0
+; CHECK-NEXT:   ret { double } %11
 ; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ReverseMode/ignore_derivatives.ll
+++ b/enzyme/test/Enzyme/ReverseMode/ignore_derivatives.ll
@@ -1,0 +1,32 @@
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -S | FileCheck %s; fi
+; RUN: %opt < %s %newLoadEnzyme -passes="enzyme" -enzyme-preopt=false -S | FileCheck %s
+
+; Function Attrs: nounwind readnone uwtable
+define double @tester(double %x) {
+entry:
+  %y = tail call fast double @__enzyme_ignore_derivatives(double %x)
+  %y2 = fmul double %y, %y
+  %res = fmul add %y2, %x
+  ret double %res
+}
+
+define double @test_derivative(double %x) {
+entry:
+  %0 = tail call double (double (double)*, ...) @__enzyme_autodiff(double (double)* nonnull @tester, double %x)
+  ret double %0
+}
+
+declare double @__enzyme_ignore_derivatives(double)
+
+; Function Attrs: nounwind
+declare double @__enzyme_autodiff(double (double)*, ...)
+
+; CHECK: define internal { double } @diffetester(double %x, double %differeturn) 
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %0 = fmul fast double %x, %x
+; CHECK-NEXT:   %1 = fsub fast double 1.000000e+00, %0
+; CHECK-NEXT:   %2 = call fast double @llvm.sqrt.f64(double %1)
+; CHECK-NEXT:   %3 = fdiv fast double %differeturn, %2
+; CHECK-NEXT:   %4 = insertvalue { double } undef, double %3, 0
+; CHECK-NEXT:   ret { double } %4
+; CHECK-NEXT: }


### PR DESCRIPTION
The goal is to provide a function `y = ignore_derivative(x)` that will detach uses of `y` from the derivative calculations for `x`

x-ref: https://github.com/EnzymeAD/Enzyme.jl/pull/2479#issuecomment-3089738818
