### PR TITLE
Add ubsan functions to KnownInactiveFunctions

### DIFF
--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -297,6 +297,9 @@ const StringSet<> KnownInactiveFunctions = {
     "\01_fopen",
     "fopen",
     "fclose",
+    "__ubsan_handle_type_mismatch_v1",
+    "__ubsan_handle_dynamic_type_cache_miss",
+    "__ubsan_handle_pointer_overflow",
 };
 
 const std::set<Intrinsic::ID> KnownInactiveIntrinsics = {

--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -297,9 +297,10 @@ const StringSet<> KnownInactiveFunctions = {
     "\01_fopen",
     "fopen",
     "fclose",
-    "__ubsan_handle_type_mismatch_v1",
     "__ubsan_handle_dynamic_type_cache_miss",
     "__ubsan_handle_pointer_overflow",
+    "__ubsan_handle_type_mismatch_v1",
+    "__ubsan_vptr_type_cache",
 };
 
 const std::set<Intrinsic::ID> KnownInactiveIntrinsics = {


### PR DESCRIPTION
This fixes errors encountered when attempting to build a [library](https://github.com/ORNL/GridKit/issues/141) with Enzyme and an undefined behavior sanitizer, e.g., `Enzyme: No forward mode derivative found for __ubsan_handle_type_mismatch_v1`. 

Adding the flagged functions to `KnownInactiveFunctions` is a step in the right direction, though there are other errors that popped up for our use case, and will be addressed at a later time.

CC @wsmoses @pelesh