### PR TITLE
fix nrm2 forward rule

### DIFF
--- a/enzyme/Enzyme/BlasDerivatives.td
+++ b/enzyme/Enzyme/BlasDerivatives.td
@@ -239,7 +239,7 @@ def nrm2 : CallBlasPattern<(Op $n, $x, $incx),
                   [
                   (BlasCall<"axpy"> $n, (BFDiv DiffeRet, (BlasCall<"nrm2"> $n, $x)), $x, (Shadow $x))
                   ],
-		              (BFDiv (BSqrt (BlasCall<"dot"> $n, $x, (Shadow $x))), (BlasCall<"nrm2"> $n, $x))
+		              (BFDiv (BlasCall<"dot"> $n, $x, (Shadow $x)), (BlasCall<"nrm2"> $n, $x))
                   >;
 
 

--- a/enzyme/test/Integration/ForwardMode/blas.cpp
+++ b/enzyme/test/Integration/ForwardMode/blas.cpp
@@ -235,7 +235,7 @@ static void nrm2Tests() {
 
     double dres = cblas_ddot(N, A, incA, dA, incA);
     double nres = my_dnrm2(N, A, incA);
-    double trueRes = sqrt(dres) / nres;
+    double trueRes = dres / nres;
     my_dnrm2(N, A, incA);
 
     checkTest(Test);
@@ -248,6 +248,8 @@ static void nrm2Tests() {
     checkMemoryTrace(inputs, "Found " + Test, foundCalls);
 
     APPROX_EQ(ADres, trueRes, 1e-10);
+
+    // TODO: Check for nres == 0.0
   }
   {
     std::string Test = "NRM2 const";


### PR DESCRIPTION
Fixes #2419 

How do I express the:

```
    Ω = BLAS.nrm2(x)
    s = ifelse(iszero(Ω), one(Ω), Ω)
```

in tablegen? Returning NaN is not super helpful
