### PR TITLE
support for f128

### DIFF
--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -99,6 +99,8 @@ ConcreteType eunwrap(CConcreteType CDT, llvm::LLVMContext &ctx) {
     return ConcreteType(llvm::Type::getX86_FP80Ty(ctx));
   case DT_BFloat16:
     return ConcreteType(llvm::Type::getBFloatTy(ctx));
+  case DT_FP128:
+    return ConcreteType(llvm::Type::getFP128Ty(ctx));
   case DT_Unknown:
     return BaseType::Unknown;
   }
@@ -133,6 +135,8 @@ CConcreteType ewrap(const ConcreteType &CT) {
       return DT_X86_FP80;
     if (flt->isBFloatTy())
       return DT_BFloat16;
+    if (flt->isFP128Ty())
+      return DT_FP128;
   } else {
     switch (CT.SubTypeEnum) {
     case BaseType::Integer:

--- a/enzyme/Enzyme/CApi.h
+++ b/enzyme/Enzyme/CApi.h
@@ -61,6 +61,7 @@ typedef enum {
   DT_Unknown = 6,
   DT_X86_FP80 = 7,
   DT_BFloat16 = 8,
+  DT_FP128 = 9,
 } CConcreteType;
 
 struct CDataPair {

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -620,6 +620,8 @@ static inline llvm::Type *FloatToIntTy(llvm::Type *T) {
     return llvm::IntegerType::get(T->getContext(), 64);
   if (T->isX86_FP80Ty())
     return llvm::IntegerType::get(T->getContext(), 80);
+  if (T->isFP128Ty())
+    return llvm::IntegerType::get(T->getContext(), 128);
   assert(0 && "unknown floating point type");
   return nullptr;
 }
@@ -641,6 +643,10 @@ static inline llvm::Type *IntToFloatTy(llvm::Type *T) {
       return llvm::Type::getFloatTy(T->getContext());
     case 64:
       return llvm::Type::getDoubleTy(T->getContext());
+    case 80:
+      return llvm::Type::getX86_FP80Ty(T->getContext());
+    case 128:
+      return llvm::Type::getFP128Ty(T->getContext());
     }
   }
   assert(0 && "unknown int to floating point type");

--- a/enzyme/test/Enzyme/ForwardMode/fp128.ll
+++ b/enzyme/test/Enzyme/ForwardMode/fp128.ll
@@ -1,0 +1,32 @@
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -S | FileCheck %s; fi
+; RUN: %opt < %s %newLoadEnzyme -passes="enzyme" -enzyme-preopt=false -S | FileCheck %s
+
+; Function Attrs: mustprogress noinline nounwind optnone uwtable
+define double @tester(double %x0) #0 {
+entry:
+  %x2 = alloca double, align 8
+  %x3 = alloca fp128, align 16
+  store double %x0, double* %x2, align 8
+  %x4 = load double, double* %x2, align 8
+  %x5 = fpext double %x4 to fp128
+  store fp128 %x5, fp128* %x3, align 16
+  %x6 = load fp128, fp128* %x3, align 16
+  %x7 = fptrunc fp128 %x6 to double
+  ret double %x7
+}
+
+define double @test_derivative(double %x) {
+entry:
+  %0 = tail call double (double (double)*, ...) @__enzyme_fwddiff(double (double)* nonnull @tester, double %x, double 0.0)
+  ret double %0
+}
+
+; Function Attrs: nounwind
+declare double @__enzyme_fwddiff(double (double)*, ...)
+
+; CHECK: define internal double @fwddiffetester(double %x0, double %"x0'")
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %"x5'ipc" = fpext double %"x0'" to fp128
+; CHECK-NEXT:   %"x7'ipc" = fptrunc fp128 %"x5'ipc" to double
+; CHECK-NEXT:   ret double %"x7'ipc"
+; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ReverseMode/fp128.ll
+++ b/enzyme/test/Enzyme/ReverseMode/fp128.ll
@@ -1,0 +1,31 @@
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme-preopt=false -enzyme -mem2reg -instsimplify -simplifycfg -S | FileCheck %s; fi
+; RUN: %opt < %s %newLoadEnzyme -enzyme-preopt=false -passes="enzyme,function(mem2reg,instsimplify,%simplifycfg)" -S | FileCheck %s
+
+; Function Attrs: mustprogress noinline nounwind optnone uwtable
+define double @tester(double %x0) #0 {
+entry:
+  %x2 = alloca double, align 8
+  %x3 = alloca fp128, align 16
+  store double %x0, double* %x2, align 8
+  %x4 = load double, double* %x2, align 8
+  %x5 = fpext double %x4 to fp128
+  store fp128 %x5, fp128* %x3, align 16
+  %x6 = load fp128, fp128* %x3, align 16
+  %x7 = fptrunc fp128 %x6 to double
+  ret double %x7
+}
+
+define double @test_derivative(double %x) {
+entry:
+  %0 = tail call double (double (double)*, ...) @__enzyme_autodiff(double (double)* nonnull @tester, double %x)
+  ret double %0
+}
+
+; Function Attrs: nounwind
+declare double @__enzyme_autodiff(double (double)*, ...)
+
+; CHECK: define internal { double } @diffetester(double %x0, double %differeturn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %0 = insertvalue { double } undef, double %differeturn, 0
+; CHECK-NEXT:   ret { double } %0
+; CHECK-NEXT: }


### PR DESCRIPTION
This PR adds support for `fp128` (128-bit quad-precision floating-point) types in Enzyme, following the existing pattern used for
  `x86_fp80` support.
  

## Additional Fix
  While adding fp128 support, I noticed that `IntToFloatTy()` was missing the case for converting 80-bit integers to `x86_fp80`, even
  though the reverse function `FloatToIntTy()` already supported it. This has been fixed as well.

  Does this make sense? The case 80 addition is correct and should be kept.