### PR TITLE
Fix enzyme scev

### DIFF
--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -8552,13 +8552,18 @@ bool GradientUtils::getContext(llvm::BasicBlock *BB, LoopContext &lc) {
 void GradientUtils::forceAugmentedReturns() {
   assert(TR.getFunction() == oldFunc);
 
+  // Pass 1: create BB-level contexts for the whole loop/function
   for (BasicBlock &oBB : *oldFunc) {
-    // Don't create derivatives for code that results in termination
     if (notForAnalysis.find(&oBB) != notForAnalysis.end())
       continue;
+    LoopContext LC;
+    getContext(cast<BasicBlock>(getNewFromOriginal(&oBB)), LC);
+  }
 
-    LoopContext loopContext;
-    getContext(cast<BasicBlock>(getNewFromOriginal(&oBB)), loopContext);
+  // Pass 2: instruction processing
+  for (BasicBlock &oBB : *oldFunc) {
+    if (notForAnalysis.find(&oBB) != notForAnalysis.end())
+      continue;
 
     for (Instruction &I : oBB) {
       Instruction *inst = &I;


### PR DESCRIPTION
Causes a new issue for
```
target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
target triple = "x86_64-unknown-linux-gnu"

define double @_ZN5case15a_f6417hd8c151c742c277cfE(ptr %0, double %1, double %2, ptr %3, i64 %4) personality ptr null {
  %6 = icmp eq i64 0, 0
  br i1 %6, label %9, label %7

7:                                                ; preds = %5
  %8 = load volatile ptr, ptr null, align 8
  br label %9

9:                                                ; preds = %7, %5
  %10 = phi ptr [ null, %5 ], [ @malloc, %7 ]
  br label %11

11:                                               ; preds = %11, %9
  %12 = phi i64 [ 0, %9 ], [ %13, %11 ]
  %13 = add i64 %12, 1
  store double 0.000000e+00, ptr %10, align 8
  %14 = icmp eq i64 %12, %4
  br i1 %14, label %15, label %11

15:                                               ; preds = %11
  ret double 0.000000e+00
}

define fastcc { double, double } @_ZN5case12da17h568bb07f7f5b7d7dE() personality ptr null {
  %1 = tail call { double, double } (...) @__enzyme_fwddiff_ZN5case12da17h568bb07f7f5b7d7dE(ptr @_ZN5case15a_f6417hd8c151c742c277cfE, metadata !"enzyme_primal_return", metadata !"enzyme_const", ptr null, metadata !"enzyme_dup", double 0.000000e+00, double 0.000000e+00, metadata !"enzyme_dup", double 0.000000e+00, double 0.000000e+00, metadata !"enzyme_const", ptr null, metadata !"enzyme_const", i64 0)
  ret { double, double } zeroinitializer
}

declare ptr @malloc()

declare { double, double } @__enzyme_fwddiff_ZN5case12da17h568bb07f7f5b7d7dE(...)

; uselistorder directives
uselistorder ptr null, { 1, 2, 6, 7, 0, 4, 5, 8, 9, 3 }
```


From the one in https://github.com/EnzymeAD/Enzyme/issues/2310 to:
```
opt test.ll -load-pass-plugin=/home/manuel/prog/Enzyme/enzyme/build/Enzyme/LLVMEnzyme-21.so -passes="enzyme"
WARNING: You're attempting to print out a bitcode file.
This is inadvisable as it may cause display problems. If
you REALLY want to taste LLVM bitcode first-hand, you
can force output with the `-f' option.

opt: /home/manuel/prog/llvm21/llvm/include/llvm/IR/Value.h:395: user_iterator llvm::Value::materialized_user_begin(): Assertion `hasUseList()' failed.
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
Stack dump:
0.	Program arguments: opt test.ll -load-pass-plugin=/home/manuel/prog/Enzyme/enzyme/build/Enzyme/LLVMEnzyme-21.so -passes=enzyme
1.	Running pass "EnzymeNewPM" on module "test.ll"
 #0 0x000062dc26c8b688 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/home/manuel/prog/llvm21/build/bin/opt+0x34b8688)
 #1 0x000062dc26c88ee5 llvm::sys::RunSignalHandlers() (/home/manuel/prog/llvm21/build/bin/opt+0x34b5ee5)
 #2 0x000062dc26c8c441 SignalHandler(int, siginfo_t*, void*) Signals.cpp:0:0
 #3 0x000077916f445330 (/lib/x86_64-linux-gnu/libc.so.6+0x45330)
 #4 0x000077916f49eb2c __pthread_kill_implementation ./nptl/pthread_kill.c:44:76
 #5 0x000077916f49eb2c __pthread_kill_internal ./nptl/pthread_kill.c:78:10
 #6 0x000077916f49eb2c pthread_kill ./nptl/pthread_kill.c:89:10
 #7 0x000077916f44527e raise ./signal/../sysdeps/posix/raise.c:27:6
 #8 0x000077916f4288ff abort ./stdlib/abort.c:81:7
 #9 0x000077916f42881b _nl_load_domain ./intl/loadmsgcat.c:1177:9
#10 0x000077916f43b517 (/lib/x86_64-linux-gnu/libc.so.6+0x3b517)
#11 0x000077916f06c3ca (/home/manuel/prog/Enzyme/enzyme/build/Enzyme/LLVMEnzyme-21.so+0x46c3ca)
#12 0x000077916f034256 llvm::ilist_detail::node_base_prevnext<llvm::ilist_node_base<true, llvm::BasicBlock>, true>::getNext() const /home/manuel/prog/llvm21/llvm/include/llvm/ADT/ilist_node_base.h:42:38
#13 0x000077916f034256 llvm::ilist_node_impl<llvm::ilist_detail::node_options<llvm::Instruction, true, false, void, true, llvm::BasicBlock>>::getNext() /home/manuel/prog/llvm21/llvm/include/llvm/ADT/ilist_node.h:119:59
#14 0x000077916f034256 llvm::ilist_iterator_w_bits<llvm::ilist_detail::node_options<llvm::Instruction, true, false, void, true, llvm::BasicBlock>, false, false>::operator++() /home/manuel/prog/llvm21/llvm/include/llvm/ADT/ilist_iterator.h:345:57
#15 0x000077916f034256 EnzymeLogic::CreateForwardDiff(RequestContext, llvm::Function*, DIFFE_TYPE, llvm::ArrayRef<DIFFE_TYPE>, TypeAnalysis&, bool, DerivativeMode, bool, bool, bool, unsigned int, llvm::Type*, FnTypeInfo const&, bool, std::vector<bool, std::allocator<bool>>, AugmentedReturn const*, bool) /home/manuel/prog/Enzyme/enzyme/Enzyme/EnzymeLogic.cpp:5089:39
#16 0x000077916eff4092 (anonymous namespace)::EnzymeBase::HandleAutoDiff(llvm::Instruction*, unsigned int, llvm::Value*, llvm::Type*, llvm::SmallVectorImpl<llvm::Value*>&, std::map<int, llvm::Type*, std::less<int>, std::allocator<std::pair<int const, llvm::Type*>>> const&, std::vector<DIFFE_TYPE, std::allocator<DIFFE_TYPE>> const&, llvm::Function*, DerivativeMode, (anonymous namespace)::EnzymeBase::Options&, bool, llvm::SmallVectorImpl<llvm::CallInst*>&) /home/manuel/prog/Enzyme/enzyme/Enzyme/Enzyme.cpp:1728:25
#17 0x000077916efecc07 (anonymous namespace)::EnzymeBase::HandleAutoDiffArguments(llvm::CallInst*, DerivativeMode, bool, llvm::SmallVectorImpl<llvm::CallInst*>&) /home/manuel/prog/Enzyme/enzyme/Enzyme/Enzyme.cpp:2074:12
#18 0x000077916efea1b4 (anonymous namespace)::EnzymeBase::lowerEnzymeCalls(llvm::Function&, std::set<llvm::Function*, std::less<llvm::Function*>, std::allocator<llvm::Function*>>&) /home/manuel/prog/Enzyme/enzyme/Enzyme/Enzyme.cpp:0:25
#19 0x000077916efe4f55 (anonymous namespace)::EnzymeBase::run(llvm::Module&) /home/manuel/prog/Enzyme/enzyme/Enzyme/Enzyme.cpp:0:18
#20 0x000077916f00b8c4 EnzymeNewPM::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) /home/manuel/prog/Enzyme/enzyme/Enzyme/Enzyme.cpp:3322:12
#21 0x000077916f00b8c4 llvm::detail::PassModel<llvm::Module, EnzymeNewPM, llvm::AnalysisManager<llvm::Module>>::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) /home/manuel/prog/llvm21/llvm/include/llvm/IR/PassManagerInternal.h:91:17
#22 0x000062dc26ad0ab7 llvm::PassManager<llvm::Module, llvm::AnalysisManager<llvm::Module>>::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) (/home/manuel/prog/llvm21/build/bin/opt+0x32fdab7)
#23 0x000062dc23d55c43 llvm::runPassPipeline(llvm::StringRef, llvm::Module&, llvm::TargetMachine*, llvm::TargetLibraryInfoImpl*, llvm::ToolOutputFile*, llvm::ToolOutputFile*, llvm::ToolOutputFile*, llvm::StringRef, llvm::ArrayRef<llvm::PassPlugin>, llvm::ArrayRef<std::function<void (llvm::PassBuilder&)>>, llvm::opt_tool::OutputKind, llvm::opt_tool::VerifierKind, bool, bool, bool, bool, bool, bool, bool) (/home/manuel/prog/llvm21/build/bin/opt+0x582c43)
#24 0x000062dc23d49138 optMain (/home/manuel/prog/llvm21/build/bin/opt+0x576138)
#25 0x000077916f42a1ca __libc_start_call_main ./csu/../sysdeps/nptl/libc_start_call_main.h:74:3
#26 0x000077916f42a28b call_init ./csu/../csu/libc-start.c:128:20
#27 0x000077916f42a28b __libc_start_main ./csu/../csu/libc-start.c:347:5
#28 0x000062dc23d42ca5 _start (/home/manuel/prog/llvm21/build/bin/opt+0x56fca5)
[1]    128520 IOT instruction (core dumped)  opt test.ll  -passes="enzyme"
```