### PR TITLE
[mlir] fixes with region inlining/outlining

### DIFF
--- a/enzyme/test/MLIR/Passes/region_inline.mlir
+++ b/enzyme/test/MLIR/Passes/region_inline.mlir
@@ -19,7 +19,7 @@ func.func @dsquare(%x: f64, %dr: f64) -> f64 {
 // CHECK-NEXT:    ^bb0(%arg2: f64):
 // CHECK-NEXT:      %1 = arith.mulf %arg2, %arg2 : f64
 // CHECK-NEXT:      enzyme.yield %1 : f64
-// CHECK-NEXT:    } attributes {activity = [#enzyme<activity enzyme_active>], fn = "square", fn_attrs = {sym_name = "square"}, ret_activity = [#enzyme<activity enzyme_activenoneed>]} : (f64, f64) -> f64
+// CHECK-NEXT:    } attributes {activity = [#enzyme<activity enzyme_active>], fn = "square", fn_attrs = {}, ret_activity = [#enzyme<activity enzyme_activenoneed>]} : (f64, f64) -> f64
 // CHECK-NEXT:    return %0 : f64
 // CHECK-NEXT:  }
 
@@ -51,4 +51,4 @@ llvm.func internal @d_Z6squarePfS_(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !l
 // Make sure that function attributes are preserved
 // CHECK: llvm.func internal @d_Z6squarePfS_
 // CHECK:    enzyme.autodiff_region(%arg0, %arg1, %arg2, %arg3) {
-// CHECK:    } attributes {activity = [#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_dup>], fn = "_Z6squarePfS_", fn_attrs = {CConv = #llvm.cconv<ccc>, arg_attrs = [{llvm.noalias, llvm.nocapture, llvm.noundef, llvm.readonly}, {llvm.noalias, llvm.nocapture, llvm.noundef, llvm.writeonly}], dso_local, frame_pointer = #llvm.framePointerKind<all>, linkage = #llvm.linkage<internal>, memory_effects = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "sm_86"]], sym_name = "_Z6squarePfS_", sym_visibility = "private", target_cpu = "sm_86", target_features = #llvm.target_features<["+ptx88", "+sm_86"]>, unnamed_addr = 0 : i64, visibility_ = 0 : i64, will_return}, ret_activity = []} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> (
+// CHECK:    } attributes {activity = [#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_dup>], fn = "_Z6squarePfS_", fn_attrs = {CConv = #llvm.cconv<ccc>, arg_attrs = [{llvm.noalias, llvm.nocapture, llvm.noundef, llvm.readonly}, {llvm.noalias, llvm.nocapture, llvm.noundef, llvm.writeonly}], dso_local, frame_pointer = #llvm.framePointerKind<all>, linkage = #llvm.linkage<internal>, memory_effects = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "sm_86"]], sym_visibility = "private", target_cpu = "sm_86", target_features = #llvm.target_features<["+ptx88", "+sm_86"]>, unnamed_addr = 0 : i64, visibility_ = 0 : i64, will_return}, ret_activity = []} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> (

--- a/enzyme/test/MLIR/Passes/region_outline.mlir
+++ b/enzyme/test/MLIR/Passes/region_outline.mlir
@@ -31,7 +31,7 @@ func.func @to_outline(%26: !llvm.ptr, %27: !llvm.ptr, %28: !llvm.ptr, %29: !llvm
   return
 }
 
-// CHECK: func.func @outlined_func(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: index, %arg3: f64) {
+// CHECK: func.func @to_outline_to_diff0(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: index, %arg3: f64) {
 // CHECK-NEXT:    %0 = arith.index_castui %arg2 : index to i64
 // CHECK-NEXT:    %1 = llvm.getelementptr inbounds|nuw %arg0[%0] : (!llvm.ptr, i64) -> !llvm.ptr, f32
 // CHECK-NEXT:    %2 = llvm.load %1 invariant {alignment = 4 : i64} : !llvm.ptr -> f32
@@ -59,12 +59,12 @@ llvm.func internal @d_Z6squarePfS_(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !l
     %8 = llvm.getelementptr inbounds|nuw %arg5[%2] : (!llvm.ptr, i64) -> !llvm.ptr, f32
     llvm.store %7, %8 {alignment = 4 : i64} : f32, !llvm.ptr
     enzyme.yield
-  } attributes {activity = [#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_dup>], fn = "_Z6squarePfS_", fn_attrs = {CConv = #llvm.cconv<ccc>, arg_attrs = [{llvm.noalias, llvm.nocapture, llvm.noundef, llvm.readonly}, {llvm.noalias, llvm.nocapture, llvm.noundef, llvm.writeonly}], dso_local, frame_pointer = #llvm.framePointerKind<all>, linkage = #llvm.linkage<internal>, memory_effects = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "sm_86"]], sym_name = "_Z6squarePfS_", sym_visibility = "private", target_cpu = "sm_86", target_features = #llvm.target_features<["+ptx88", "+sm_86"]>, unnamed_addr = 0 : i64, visibility_ = 0 : i64, will_return}, ret_activity = []} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  } attributes {activity = [#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_dup>], fn = "_Z6squarePfS_", fn_attrs = {CConv = #llvm.cconv<ccc>, arg_attrs = [{llvm.noalias, llvm.nocapture, llvm.noundef, llvm.readonly}, {llvm.noalias, llvm.nocapture, llvm.noundef, llvm.writeonly}], dso_local, frame_pointer = #llvm.framePointerKind<all>, linkage = #llvm.linkage<internal>, memory_effects = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "sm_86"]], sym_visibility = "private", target_cpu = "sm_86", target_features = #llvm.target_features<["+ptx88", "+sm_86"]>, unnamed_addr = 0 : i64, visibility_ = 0 : i64, will_return}, ret_activity = []} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.return
 }
 
 // Attributes should be passed back to the outlined function
-// CHECK: func.func private @_Z6squarePfS_(%arg0: !llvm.ptr {llvm.noalias, llvm.nocapture, llvm.noundef, llvm.readonly}, %arg1: !llvm.ptr {llvm.noalias, llvm.nocapture, llvm.noundef, llvm.writeonly}, %arg2: f64) attributes {CConv = #llvm.cconv<ccc>, dso_local, frame_pointer = #llvm.framePointerKind<all>, linkage = #llvm.linkage<internal>, memory_effects = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "sm_86"]], target_cpu = "sm_86", target_features = #llvm.target_features<["+ptx88", "+sm_86"]>, unnamed_addr = 0 : i64, visibility_ = 0 : i64, will_return} {
+// CHECK: func.func private @d_Z6squarePfS__to_diff0(%arg0: !llvm.ptr {llvm.noalias, llvm.nocapture, llvm.noundef, llvm.readonly}, %arg1: !llvm.ptr {llvm.noalias, llvm.nocapture, llvm.noundef, llvm.writeonly}, %arg2: f64) attributes {CConv = #llvm.cconv<ccc>, dso_local, frame_pointer = #llvm.framePointerKind<all>, linkage = #llvm.linkage<internal>, memory_effects = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "sm_86"]], target_cpu = "sm_86", target_features = #llvm.target_features<["+ptx88", "+sm_86"]>, unnamed_addr = 0 : i64, visibility_ = 0 : i64, will_return} {
 
 // -----
 
@@ -126,5 +126,37 @@ func.func @free_var_ordering(%x: f64) -> f64 {
 
 // CHECK: func.func @free_var_ordering_to_diff0(%arg0: f64, %arg1: f64) -> f64 {
 // CHECK-NEXT:    %[[MUL:.*]] = arith.mulf %arg0, %arg1 : f64
+// CHECK-NEXT:    return %[[MUL]] : f64
+// CHECK-NEXT:  }
+
+// -----
+
+func.func @free_var_with_dup(%x: memref<f64>, %dx: memref<f64>) {
+  %const = arith.constant 2.0 : f64
+  %seed = arith.constant 1.0 : f64
+
+  enzyme.autodiff_region(%x, %dx, %seed) {
+  ^bb0(%arg0: memref<f64>):
+    %val = memref.load %arg0[] : memref<f64>
+    %mul = arith.mulf %val, %const : f64
+    enzyme.yield %mul : f64
+  } attributes {
+    activity = [#enzyme<activity enzyme_dup>],
+    ret_activity = [#enzyme<activity enzyme_activenoneed>]
+  } : (memref<f64>, memref<f64>, f64) -> ()
+
+  return
+}
+
+// CHECK: func.func @free_var_with_dup(%arg0: memref<f64>, %arg1: memref<f64>) {
+// CHECK-NEXT:    %[[CST:.*]] = arith.constant 2.000000e+00 : f64
+// CHECK-NEXT:    %[[SEED:.*]] = arith.constant 1.000000e+00 : f64
+// CHECK-NEXT:    enzyme.autodiff @free_var_with_dup_to_diff0(%arg0, %arg1, %[[CST]], %[[SEED]]) {activity = [#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_const>], ret_activity = [#enzyme<activity enzyme_activenoneed>]} : (memref<f64>, memref<f64>, f64, f64) -> ()
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @free_var_with_dup_to_diff0(%arg0: memref<f64>, %arg1: f64) -> f64 {
+// CHECK-NEXT:    %[[LOAD:.*]] = memref.load %arg0[] : memref<f64>
+// CHECK-NEXT:    %[[MUL:.*]] = arith.mulf %[[LOAD]], %arg1 : f64
 // CHECK-NEXT:    return %[[MUL]] : f64
 // CHECK-NEXT:  }

--- a/enzyme/test/MLIR/ReverseMode/canonicalize.mlir
+++ b/enzyme/test/MLIR/ReverseMode/canonicalize.mlir
@@ -24,7 +24,7 @@ module {
     // INLINE-NEXT:   %1 = arith.mulf %arg4, %arg4 : f32
     // INLINE-NEXT:   %2 = arith.mulf %arg5, %arg5 : f32
     // INLINE-NEXT:   enzyme.yield %1, %2 : f32, f32
-    // INLINE-NEXT: } attributes {activity = [#enzyme<activity enzyme_active>, #enzyme<activity enzyme_active>], fn = "square2", fn_attrs = {sym_name = "square2"}, ret_activity = [#enzyme<activity enzyme_active>, #enzyme<activity enzyme_active>]} : (f32, f32, f32, f32) -> (f32, f32, f32, f32)
+    // INLINE-NEXT: } attributes {activity = [#enzyme<activity enzyme_active>, #enzyme<activity enzyme_active>], fn = "square2", fn_attrs = {}, ret_activity = [#enzyme<activity enzyme_active>, #enzyme<activity enzyme_active>]} : (f32, f32, f32, f32) -> (f32, f32, f32, f32)
     return %r#0,%r#1,%r#2,%r#3 : f32,f32,f32,f32
   }
 


### PR DESCRIPTION
The initial region outlining had a calling convention bug when mixing free variables and seeds, then #2491 introduced a calling convention bug when mixing free variables with duplicated arguments. This PR should fix all of the above.

It also fixes a symbol re-definition issue when outlining.

cc @vimarsh6739 