### PR TITLE
ProbProg: MemAlloc effect and remove unused InitTrace op

### DIFF
--- a/enzyme/Enzyme/MLIR/Dialect/EnzymeOps.td
+++ b/enzyme/Enzyme/MLIR/Dialect/EnzymeOps.td
@@ -578,6 +578,7 @@ def InitTraceOp : Enzyme_Op<"initTrace", [MemoryEffects<[MemAlloc]>]> {
   let arguments = (ins );
   let results = (outs Trace:$trace);
   let assemblyFormat = "attr-dict `:` type($trace)";
+  let hasCanonicalizer = 1;
 }
 
 def AddSampleToTraceOp : Enzyme_Op<"addSampleToTrace", [Pure]> {

--- a/enzyme/Enzyme/MLIR/Dialect/Ops.cpp
+++ b/enzyme/Enzyme/MLIR/Dialect/Ops.cpp
@@ -1039,3 +1039,27 @@ LogicalResult MCMCOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 
   return success();
 }
+
+//===----------------------------------------------------------------------===//
+// InitTraceOp
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct RemoveUnusedInitTrace : public OpRewritePattern<InitTraceOp> {
+  using OpRewritePattern<InitTraceOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(InitTraceOp op,
+                                PatternRewriter &rewriter) const final {
+    if (op.use_empty()) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+    return failure();
+  }
+};
+} // namespace
+
+void InitTraceOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
+                                              MLIRContext *context) {
+  patterns.add<RemoveUnusedInitTrace>(context);
+}

--- a/enzyme/test/MLIR/ProbProg/generate3.mlir
+++ b/enzyme/test/MLIR/ProbProg/generate3.mlir
@@ -1,4 +1,5 @@
 // RUN: %eopt --probprog %s | FileCheck %s
+// RUN: %eopt --probprog --inline --cse --canonicalize %s | FileCheck %s --check-prefix=INLINE
 
 module {
   func.func private @normal(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<2xui64>, tensor<f64>)
@@ -18,6 +19,7 @@ module {
   }
 
   func.func @generate(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (!enzyme.Trace, tensor<f64>, tensor<2xui64>, tensor<f64>, tensor<f64>) {
+    %unused = enzyme.initTrace : !enzyme.Trace
     %cst = arith.constant dense<42> : tensor<ui64>
     %0 = builtin.unrealized_conversion_cast %cst : tensor<ui64> to !enzyme.Constraint
     
@@ -83,3 +85,47 @@ module {
 // CHECK-NEXT:   %[[final_trace:.+]] = enzyme.addRetvalToTrace(%[[sample_from_constraint1]], %[[normal_call]]#1 : tensor<f64>, tensor<f64>) into %[[trace3]]
 // CHECK-NEXT:   return %[[final_trace]], %[[addf2]], %[[normal_call]]#0, %[[sample_from_constraint1]], %[[normal_call]]#1 : !enzyme.Trace, tensor<f64>, tensor<2xui64>, tensor<f64>, tensor<f64>
 // CHECK-NEXT: }
+
+// INLINE:  func.func @generate(%[[arg0:.+]]: tensor<2xui64>, %[[arg1:.+]]: tensor<f64>, %[[arg2:.+]]: tensor<f64>) -> (!enzyme.Trace, tensor<f64>, tensor<2xui64>, tensor<f64>, tensor<f64>) {
+// INLINE-NEXT:    %[[cst:.+]] = arith.constant dense<0.000000e+00> : tensor<f64>
+// INLINE-NEXT:    %[[cst_0:.+]] = arith.constant dense<42> : tensor<ui64>
+// INLINE-NEXT:    %[[v0:.+]] = builtin.unrealized_conversion_cast %[[cst_0]] : tensor<ui64> to !enzyme.Constraint
+// INLINE-NEXT:    %[[v1:.+]] = enzyme.initTrace : !enzyme.Trace
+// INLINE-NEXT:    %[[v2:.+]] = enzyme.getSampleFromConstraint %[[v0]] {symbol = #enzyme.symbol<1>} : tensor<f64>
+// INLINE-NEXT:    %[[v3:.+]] = call @logpdf(%[[v2]], %[[arg1]], %[[arg2]]) : (tensor<f64>, tensor<f64>, tensor<f64>) -> tensor<f64>
+// INLINE-NEXT:    %[[v4:.+]] = arith.addf %[[v3]], %[[cst]] : tensor<f64>
+// INLINE-NEXT:    %[[v5:.+]] = enzyme.addSampleToTrace(%[[v2]] : tensor<f64>) into %[[v1]] {symbol = #enzyme.symbol<1>}
+// INLINE-NEXT:    %[[v6:.+]] = enzyme.getSubconstraint %[[v0]] {symbol = #enzyme.symbol<2>}
+// INLINE-NEXT:    %[[v7:.+]] = enzyme.initTrace : !enzyme.Trace
+// INLINE-NEXT:    %[[v8:.+]] = enzyme.getSampleFromConstraint %[[v6]] {symbol = #enzyme.symbol<3>} : tensor<f64>
+// INLINE-NEXT:    %[[v9:.+]] = call @logpdf(%[[v8]], %[[v2]], %[[arg2]]) : (tensor<f64>, tensor<f64>, tensor<f64>) -> tensor<f64>
+// INLINE-NEXT:    %[[v10:.+]] = arith.addf %[[v9]], %[[cst]] : tensor<f64>
+// INLINE-NEXT:    %[[v11:.+]] = enzyme.addSampleToTrace(%[[v8]] : tensor<f64>) into %[[v7]] {symbol = #enzyme.symbol<3>}
+// INLINE-NEXT:    %[[v12:.+]]:2 = call @normal(%[[arg0]], %[[v2]], %[[arg2]]) : (tensor<2xui64>, tensor<f64>, tensor<f64>) -> (tensor<2xui64>, tensor<f64>)
+// INLINE-NEXT:    %[[v13:.+]] = call @logpdf(%[[v12]]#1, %[[v2]], %[[arg2]]) : (tensor<f64>, tensor<f64>, tensor<f64>) -> tensor<f64>
+// INLINE-NEXT:    %[[v14:.+]] = arith.addf %[[v10]], %[[v13]] : tensor<f64>
+// INLINE-NEXT:    %[[v15:.+]] = enzyme.addSampleToTrace(%[[v12]]#1 : tensor<f64>) into %[[v11]] {symbol = #enzyme.symbol<4>}
+// INLINE-NEXT:    %[[v16:.+]] = enzyme.addWeightToTrace(%[[v14]] : tensor<f64>) into %[[v15]]
+// INLINE-NEXT:    %[[v17:.+]] = enzyme.addRetvalToTrace(%[[v8]], %[[v12]]#1 : tensor<f64>, tensor<f64>) into %[[v16]]
+// INLINE-NEXT:    %[[v18:.+]] = enzyme.addSubtrace %[[v17]] into %[[v5]] {symbol = #enzyme.symbol<2>}
+// INLINE-NEXT:    %[[v19:.+]] = arith.addf %[[v4]], %[[v14]] : tensor<f64>
+// INLINE-NEXT:    %[[v20:.+]] = enzyme.addSampleToTrace(%[[v8]], %[[v12]]#1 : tensor<f64>, tensor<f64>) into %[[v18]] {symbol = #enzyme.symbol<2>}
+// INLINE-NEXT:    %[[v21:.+]] = enzyme.getSubconstraint %[[v0]] {symbol = #enzyme.symbol<6>}
+// INLINE-NEXT:    %[[v22:.+]] = enzyme.initTrace : !enzyme.Trace
+// INLINE-NEXT:    %[[v23:.+]]:2 = call @normal(%[[v12]]#0, %[[v8]], %[[arg2]]) : (tensor<2xui64>, tensor<f64>, tensor<f64>) -> (tensor<2xui64>, tensor<f64>)
+// INLINE-NEXT:    %[[v24:.+]] = call @logpdf(%[[v23]]#1, %[[v8]], %[[arg2]]) : (tensor<f64>, tensor<f64>, tensor<f64>) -> tensor<f64>
+// INLINE-NEXT:    %[[v25:.+]] = arith.addf %[[v24]], %[[cst]] : tensor<f64>
+// INLINE-NEXT:    %[[v26:.+]] = enzyme.addSampleToTrace(%[[v23]]#1 : tensor<f64>) into %[[v22]] {symbol = #enzyme.symbol<3>}
+// INLINE-NEXT:    %[[v27:.+]] = enzyme.getSampleFromConstraint %[[v21]] {symbol = #enzyme.symbol<4>} : tensor<f64>
+// INLINE-NEXT:    %[[v28:.+]] = call @logpdf(%[[v27]], %[[v8]], %[[arg2]]) : (tensor<f64>, tensor<f64>, tensor<f64>) -> tensor<f64>
+// INLINE-NEXT:    %[[v29:.+]] = arith.addf %[[v25]], %[[v28]] : tensor<f64>
+// INLINE-NEXT:    %[[v30:.+]] = enzyme.addSampleToTrace(%[[v27]] : tensor<f64>) into %[[v26]] {symbol = #enzyme.symbol<4>}
+// INLINE-NEXT:    %[[v31:.+]] = enzyme.addWeightToTrace(%[[v29]] : tensor<f64>) into %[[v30]]
+// INLINE-NEXT:    %[[v32:.+]] = enzyme.addRetvalToTrace(%[[v23]]#1, %[[v27]] : tensor<f64>, tensor<f64>) into %[[v31]]
+// INLINE-NEXT:    %[[v33:.+]] = enzyme.addSubtrace %[[v32]] into %[[v20]] {symbol = #enzyme.symbol<6>}
+// INLINE-NEXT:    %[[v34:.+]] = arith.addf %[[v19]], %[[v29]] : tensor<f64>
+// INLINE-NEXT:    %[[v35:.+]] = enzyme.addSampleToTrace(%[[v23]]#1, %[[v27]] : tensor<f64>, tensor<f64>) into %[[v33]] {symbol = #enzyme.symbol<6>}
+// INLINE-NEXT:    %[[v36:.+]] = enzyme.addWeightToTrace(%[[v34]] : tensor<f64>) into %[[v35]]
+// INLINE-NEXT:    %[[v37:.+]] = enzyme.addRetvalToTrace(%[[v23]]#1, %[[v27]] : tensor<f64>, tensor<f64>) into %[[v36]]
+// INLINE-NEXT:    return %[[v37]], %[[v34]], %[[v23]]#0, %[[v23]]#1, %[[v27]] : !enzyme.Trace, tensor<f64>, tensor<2xui64>, tensor<f64>, tensor<f64>
+// INLINE-NEXT:  }

--- a/enzyme/test/MLIR/ProbProg/hmc.mlir
+++ b/enzyme/test/MLIR/ProbProg/hmc.mlir
@@ -1,4 +1,4 @@
-// RUN: %eopt --probprog %s | FileCheck %s
+// RUN: %eopt --probprog --canonicalize %s | FileCheck %s
 
 module {
   func.func private @normal(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<2xui64>, tensor<f64>)
@@ -11,6 +11,7 @@ module {
   }
 
   func.func @hmc(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (!enzyme.Trace, tensor<i1>, tensor<2xui64>) {
+    %unused = enzyme.initTrace : !enzyme.Trace
     %init_trace = enzyme.initTrace : !enzyme.Trace
 
     %mass = arith.constant dense<[[1.0, 0.0], [0.0, 1.0]]> : tensor<2x2xf64>


### PR DESCRIPTION
~Attaching a `source_fn` so CSE won't merge trace init ops (for context, fresh trace objects are required for probprog calls as they may have different mode/address chains/rng states). ProbProg lowering always clones `toeval` with a new name that automatically differs across `MProbProgMode` and sample op address chains~

~Update: Mark InitTraceOp as `MemoryEffects<[MemAlloc]>` and add remove-unnecessary-enzyme-ops pattern~

Update^2: Mark InitTraceOp as `MemoryEffects<[MemAlloc]>` and add canonicalizer pattern to remove unused ones