### PR TITLE
LLVM optimizes the alloca for the mpi_wrapper to undef

### DIFF
--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -461,11 +461,6 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
       Value *request = gutils->invertPointerM(call.getArgOperand(0), Builder2);
       Value *status = gutils->invertPointerM(call.getArgOperand(1), Builder2);
 
-      if (request->getType()->isIntegerTy()) {
-        request = Builder2.CreateIntToPtr(
-            request, PointerType::getUnqual(getInt8PtrTy(call.getContext())));
-      }
-
       Value *args[] = {/*request*/ request,
                        /*status*/ status};
 


### PR DESCRIPTION
Took me a while to find the culprit, but looking at 

```julia
using Enzyme, MPI
MPI.Init()

function f(x, comm)
   @show MPI.Comm_size(comm)
   return x^2
end
Enzyme.Compiler.enzyme_code_llvm(f, Duplicated, Tuple{Duplicated{Float64}, Const{MPI.Comm}}, mode=Enzyme.API.DEM_ForwardMode, dump_module=true)
```

Showed that:
```
; Function Attrs: alwaysinline mustprogress nofree nosync nounwind speculatable willreturn memory(none)
define private i32 @"enzyme_wrapmpi$$ejlptr$MPI_Comm_size$1#"(i32 %0) #7 {
entry:
  %1 = alloca i32, align 4
  %2 = ptrtoint i32* %1 to i64
  %3 = call i32 @"ejlptr$MPI_Comm_size$1"(i32 %0, i64 noundef %2) #17
  ret i32 undef
}
```

Compare this to the Compiler-Explorer
https://godbolt.org/z/MErThjvz5

The culprit seems to be that `memory(argmem: readwrite, inaccessiblemem: readwrite)` and the pointers as integer ABI from Julia conflict,
and allow LLVM to prove that the alloca is never initialized, thus replacing the load with an undef.

I am worried that this assumption is in more places. @wsmoses could you take a look?

This does indeed fix the 1.11 issue on github.com/EnzymeAD/Enzyme.jl/pull/518 where MPI_Comm_size returns 0

