### PR TITLE
mlir: Replace hard coded codepaths with function interface

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/FuncAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/FuncAutoDiffOpInterfaceImpl.cpp
@@ -236,11 +236,30 @@ public:
                           MGradientUtilsReverse *gutils) const {}
 };
 
+class AutoDiffFuncFuncFunctionInterface
+    : public AutoDiffFunctionInterface::ExternalModel<
+          AutoDiffFuncFuncFunctionInterface, func::FuncOp> {
+public:
+  void transformResultTypes(Operation *self,
+                            SmallVectorImpl<Type> &types) const {}
+
+  Operation *createCall(Operation *self, OpBuilder &builder, Location loc,
+                        ValueRange args) const {
+    return func::CallOp::create(builder, loc, cast<func::FuncOp>(self), args);
+  }
+
+  Operation *createReturn(Operation *self, OpBuilder &builder, Location loc,
+                          ValueRange args) const {
+    return func::ReturnOp::create(builder, loc, args);
+  }
+};
+
 void mlir::enzyme::registerFuncDialectAutoDiffInterface(
     DialectRegistry &registry) {
   registry.addExtension(+[](MLIRContext *context, func::FuncDialect *) {
     registerInterfaces(context);
     func::CallOp::attachInterface<AutoDiffCallFwd>(*context);
     func::CallOp::attachInterface<AutoDiffCallRev>(*context);
+    func::FuncOp::attachInterface<AutoDiffFuncFuncFunctionInterface>(*context);
   });
 }

--- a/enzyme/Enzyme/MLIR/Interfaces/AutoDiffOpInterface.td
+++ b/enzyme/Enzyme/MLIR/Interfaces/AutoDiffOpInterface.td
@@ -219,4 +219,62 @@ def MathSimplifyInterface : OpInterface<"MathSimplifyInterface"> {
   ];
 }
 
+def AutoDiffFunctionInterface : OpInterface<"AutoDiffFunctionInterface"> {
+  let description = [{
+    A function operation which can be automatically differentiated.
+  }];
+  let cppNamespace = "::mlir::enzyme";
+
+  let methods = [
+    InterfaceMethod<
+    /*desc=*/[{
+      Transform result types.
+    }],
+    /*retTy=*/"void",
+    /*methodName=*/"transformResultTypes",
+    /*args=*/(ins "SmallVectorImpl<::mlir::Type> &" : $resultTypes)
+    >,
+    InterfaceMethod<
+    /*desc=*/[{
+      Get function type attr name.
+    }],
+    /*retTy=*/"StringRef",
+    /*methodName=*/"getFunctionTypeAttrName",
+    /*args=*/(ins),
+    /*methodBody=*/"",
+    /*defaultImplementation=*/[{
+      return $_op.getFunctionTypeAttrName();
+    }]
+    >,
+    InterfaceMethod<
+    /*desc=*/[{
+      Get arg attrs type attr name.
+    }],
+    /*retTy=*/"StringRef",
+    /*methodName=*/"getArgAttrsAttrName",
+    /*args=*/(ins),
+    /*methodBody=*/"",
+    /*defaultImplementation=*/[{
+      return $_op.getArgAttrsAttrName();
+    }]
+    >,
+    InterfaceMethod<
+    /*desc=*/[{
+      Generate call.
+    }],
+    /*retTy=*/"::mlir::Operation *",
+    /*methodName=*/"createCall",
+    /*args=*/(ins "::mlir::OpBuilder &" : $builder, "::mlir::Location" : $loc, "::mlir::ValueRange" : $args)
+    >,
+    InterfaceMethod<
+    /*desc=*/[{
+      Create return.
+    }],
+    /*retTy=*/"::mlir::Operation *",
+    /*methodName=*/"createReturn",
+    /*args=*/(ins "::mlir::OpBuilder &" : $builder, "::mlir::Location" : $loc, "::mlir::ValueRange" : $args)
+    >
+  ];
+}
+
 #endif // ENZYME_MLIR_INTERFACES_AUTODIFFOPINTERFACES

--- a/enzyme/Enzyme/MLIR/Passes/EnzymeMLIRPass.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/EnzymeMLIRPass.cpp
@@ -338,13 +338,15 @@ struct DifferentiatePass
       return failure();
 
     OpBuilder builder(CI);
-    if (auto llvmNewFn = dyn_cast<LLVM::LLVMFuncOp>(newFunc.getOperation())) {
-      auto dCI = LLVM::CallOp::create(builder, CI.getLoc(), llvmNewFn, args);
+    if (auto iface =
+            dyn_cast<AutoDiffFunctionInterface>(newFunc.getOperation())) {
+      auto dCI = iface.createCall(builder, CI.getLoc(), args);
       CI.replaceAllUsesWith(dCI);
     } else {
-      auto dCI = func::CallOp::create(builder, CI.getLoc(), newFunc.getName(),
-                                      newFunc.getResultTypes(), args);
-      CI.replaceAllUsesWith(dCI);
+      newFunc.getOperation()->emitError()
+          << "this function operation does not implement "
+             "AutoDiffFunctionInterface";
+      return failure();
     }
     CI->erase();
     return success();

--- a/enzyme/Enzyme/MLIR/Passes/InlineEnzymeRegions.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/InlineEnzymeRegions.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "Dialect/Ops.h"
+#include "Interfaces/AutoDiffOpInterface.h"
 #include "Passes/Passes.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -34,23 +35,15 @@ namespace {
 constexpr static llvm::StringLiteral kFnAttrsName = "fn_attrs";
 
 static StringRef getFunctionTypeAttrName(Operation *operation) {
-  return llvm::TypeSwitch<Operation *, StringRef>(operation)
-      .Case<func::FuncOp, LLVM::LLVMFuncOp>(
-          [](auto op) { return op.getFunctionTypeAttrName(); })
-      .Default([](Operation *) {
-        llvm_unreachable("expected op with a function type");
-        return "";
-      });
+  if (auto iface = dyn_cast<mlir::enzyme::AutoDiffFunctionInterface>(operation))
+    return iface.getFunctionTypeAttrName();
+  return "";
 }
 
 static StringRef getArgAttrsAttrName(Operation *operation) {
-  return llvm::TypeSwitch<Operation *, StringRef>(operation)
-      .Case<func::FuncOp, LLVM::LLVMFuncOp>(
-          [](auto op) { return op.getArgAttrsAttrName(); })
-      .Default([](Operation *) {
-        llvm_unreachable("expected op with arg attrs");
-        return "";
-      });
+  if (auto iface = dyn_cast<mlir::enzyme::AutoDiffFunctionInterface>(operation))
+    return iface.getArgAttrsAttrName();
+  return "";
 }
 
 static void serializeFunctionAttributes(Operation *fn,


### PR DESCRIPTION
This would enable things like autodiff of other function operations like `triton::FuncOp`.
