### PR TITLE
Check for both MPI and PMPI versions

### DIFF
--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -1800,13 +1800,13 @@ llvm::Function *getOrInsertDifferentialMPI_Wait(llvm::Module &M,
   Value *d_req = buff + 7;
   d_req->setName("d_req");
 
-  auto isendfn = M.getFunction(getRenamedPerCallingConv(caller, "MPI_Isend"));
+  auto isendfn = M.getFunction(getMPIFunction(M, caller, "MPI_Isend"));
   assert(isendfn);
   // TODO: what if Isend not defined, but Irecv is?
   FunctionType *FuT = isendfn->getFunctionType();
 
   auto irecvfn = cast<Function>(
-      M.getOrInsertFunction(getRenamedPerCallingConv(caller, "MPI_Irecv"), FuT)
+      M.getOrInsertFunction(getMPIFunction(M, caller, "MPI_Irecv"), FuT)
           .getCallee());
   assert(irecvfn);
 


### PR DESCRIPTION
@wsmoses on 1.10 I am seeing:

```
; Function Attrs: nofree norecurse nosync nounwind willreturn
declare i32 @PMPI_Wait(i64, i64) local_unnamed_addr #13

; Function Attrs: nofree norecurse nosync nounwind willreturn
declare i32 @MPI_Comm_rank(i32, i64) local_unnamed_addr #16

; Function Attrs: nofree norecurse nosync nounwind willreturn
declare i32 @MPI_Comm_size(i32, i64) local_unnamed_addr #17

; Function Attrs: nofree norecurse nosync nounwind willreturn
declare i32 @MPI_Irecv(i64, i32, i32, i32, i32, i32, i64) local_unnamed_addr #18

; Function Attrs: nofree norecurse nosync nounwind willreturn
declare i32 @MPI_Isend(i64, i32, i32, i32, i32, i32, i64) local_unnamed_addr #1
```

So when `PMPI_Wait` goes looking for `MPI_Isend` it fails to look at the right one.

If this looks kosher to you, I can also go and fix all the other users for getRenamedPerCallingConv
