### PR TITLE
Mark rust tests as expected failure til upstream Rust fixes land

### DIFF
--- a/.github/workflows/enzyme-rust.yml
+++ b/.github/workflows/enzyme-rust.yml
@@ -85,6 +85,7 @@ jobs:
         ./x build --stage 1 library
     - name: Run Rust autodiff tests
       working-directory: rust
+      continue-on-error: true
       run: |
         . ~/.cargo/env
         ./x test --stage 1 tests/codegen-llvm/autodiff


### PR DESCRIPTION
@ZuseZ4 @sgasho @I-Al-Istannen like I mentioned on Zulip some of Enzyme's analyses now produce more attributes and the rust llvm tests hard-coded assumptions now fail.

Once rust adapts, we can re-mark this as expected pass