### PR TITLE
Add `__nv_sincosf` and `__nv_sincos`

### DIFF
--- a/enzyme/Enzyme/InstructionDerivatives.td
+++ b/enzyme/Enzyme/InstructionDerivatives.td
@@ -538,7 +538,7 @@ def : CallPattern<(Op $x, $integral_part_ptr),
                   >;
 
 def : CallPattern<(Op $x),
-                  ["__fd_sincos_1", "__fd_sincos_1f", "__fd_sincos_1l"],
+                  ["__fd_sincos_1", "__fd_sincos_1f", "__fd_sincos_1l", "__nv_sincos", "__nv_sincosf"],
                   [
                   (
                    ArrayRet (FMul (ExtractValue<[1]> (Call<(SameFunc), [ReadNone,NoUnwind]> $x):$callset), (DiffeRet) ),


### PR DESCRIPTION
I added NVIDIA’s `sincos` symbols to the existing `sincos` `CallPattern`:

````td
def : CallPattern<(Op $x),
  ["__fd_sincos_1", "__fd_sincos_1f", "__fd_sincos_1l",
   "__nv_sincos", "__nv_sincosf"],
````

Fixes #2552.

However, I am not sure this is actually correct, ChatGPT says the ABIs differ (below):

---
Current Enzyme test uses a **struct‑return** function, e.g.:
```llvm
declare [2 x double] @__fd_sincos_1(double)
```
whereas the NVIDIA libdevice intrinsics are pointer‑out, **void return**:
```c
__device__ void __nv_sincos (double x, double *s, double *c);
__device__ void __nv_sincosf(float  x, float  *s, float  *c);
```
So with this change I am effectively binding symbols with a `[2 x T] (T)` ABI and symbols with a `void (T, T*, T*)` ABI to the same CallPattern. I am worried this might be wrong or at least fragile, since the existing derivative logic for sincos appears to assume a non‑void aggregate return (as in ReverseMode/sincos.ll).

---

I am not really sure how to test this, any pointers would be appreciated. 