### PR TITLE
[NFC] Migrate enzyme-tblgen from builder.create<Op>() to Op::create()

### DIFF
--- a/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
+++ b/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
@@ -612,10 +612,9 @@ bool handle(const Twine &curIndent, const Twine &argPattern, raw_ostream &os,
         if (resultRoot->getNumArgs() > 1)
           PrintFatalError(pattern->getLoc(),
                           "only zero or single op constantfp supported");
-        os << builder << ".create<"
-           << cast<StringInit>(Def->getValueInit("dialect"))->getValue()
+        os << cast<StringInit>(Def->getValueInit("dialect"))->getValue()
            << "::" << cast<StringInit>(Def->getValueInit("opName"))->getValue()
-           << ">(op.getLoc(), ";
+           << "::create(" << builder << ", op.getLoc(), ";
         std::string ord;
         bool shadowType = false;
         if (resultRoot->getNumArgs() == 0) {
@@ -1151,8 +1150,8 @@ bool handle(const Twine &curIndent, const Twine &argPattern, raw_ostream &os,
           os << preop;
         }
         auto dialect = Def->getValueAsString("dialect");
-        os << builder << ".create<" << dialect << "::" << opName
-           << ">(op.getLoc(), ";
+        os << dialect << "::" << opName << "::create(" << builder
+           << ", op.getLoc(), ";
       } else {
         os << builder << ".Create" << opName << "(";
       }


### PR DESCRIPTION
These are deprecated since https://github.com/llvm/llvm-project/pull/164649