### PR TITLE
cmake: make Enzyme Apple dynamic_lookup opt-in

### DIFF
--- a/enzyme/CMakeLists.txt
+++ b/enzyme/CMakeLists.txt
@@ -39,6 +39,9 @@ option(ENZYME_FLANG "Build enzyme flang symlink" OFF)
 option(ENZYME_MLIR "Build enzyme mlir plugin" OFF)
 option(ENZYME_IFX "Enable enzyme support for the Intel Fortran compiler IFX" OFF)
 option(ENZYME_EXTERNAL_SHARED_LIB "Build external shared library" OFF)
+option(ENZYME_APPLE_DYNAMIC_LOOKUP
+  "On Apple, link Enzyme shared library with -flat_namespace/-undefined,dynamic_lookup instead of linking LLVM"
+  OFF)
 option(ENZYME_STATIC_LIB "Build static library" OFF)
 option(ENZYME_WARN_COMPILER "Warn if enzyme detects potentially incompatible compiler" ON)
 set(ENZYME_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/enzyme/Enzyme/CMakeLists.txt
+++ b/enzyme/Enzyme/CMakeLists.txt
@@ -145,7 +145,15 @@ if (${ENZYME_EXTERNAL_SHARED_LIB})
     add_dependencies(Enzyme-${LLVM_VERSION_MAJOR} BlasDeclarationsIncGen)
     add_dependencies(Enzyme-${LLVM_VERSION_MAJOR} BlasTAIncGen)
     add_dependencies(Enzyme-${LLVM_VERSION_MAJOR} BlasDiffUseIncGen)
-    target_link_libraries(Enzyme-${LLVM_VERSION_MAJOR} LLVM)
+
+    if (APPLE AND ENZYME_APPLE_DYNAMIC_LOOKUP)
+        target_link_options(Enzyme-${LLVM_VERSION_MAJOR} PRIVATE
+            "-Wl,-flat_namespace"
+            "-Wl,-undefined,dynamic_lookup")
+    else()
+        target_link_libraries(Enzyme-${LLVM_VERSION_MAJOR} LLVM)
+    endif()
+
     install(TARGETS Enzyme-${LLVM_VERSION_MAJOR}
         EXPORT EnzymeTargets
         LIBRARY DESTINATION lib COMPONENT shlib


### PR DESCRIPTION
Add `ENZYME_APPLE_DYNAMIC_LOOKUP` CMake option (default OFF).

It turns out that we cannot use std::autodiff in Rust when we dlopen Enzyme without dynamic_lookup on MacOS.

Although Rust’s Enzyme integration requires dynamic lookup on Apple, this should not be the default for all Apple users. This makes the behaviour opt-in while preserving existing builds.

As an alternative, we can add the non-platform-specific name `ENZYME_DYNAMIC_LOOKUP`, enabling it only when using Apple.
However, I think a platform-specific name is better because we can't use it on Linux or Windows either way now.

cc: @ZuseZ4 