### PR TITLE
ProbProg: support additional logpdf args

### DIFF
--- a/enzyme/Enzyme/MLIR/Interfaces/HMCUtils.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/HMCUtils.cpp
@@ -377,8 +377,11 @@ GradientResult MCMC::computePotentialAndGradient(OpBuilder &builder,
   Value qArg = autodiffBlock->getArgument(0);
 
   if (ctx.hasCustomLogpdf()) {
+    SmallVector<Value> callArgs;
+    callArgs.push_back(qArg);
+    callArgs.append(ctx.fnInputs.begin(), ctx.fnInputs.end());
     auto callOp = func::CallOp::create(builder, loc, ctx.logpdfFn,
-                                       TypeRange{scalarType}, ValueRange{qArg});
+                                       TypeRange{scalarType}, callArgs);
     Value U = arith::NegFOp::create(builder, loc, callOp.getResult(0));
     // TODO(#2695): handle hybrid case
     enzyme::YieldOp::create(builder, loc, {U, rng});
@@ -683,8 +686,11 @@ InitialHMCState MCMC::InitHMC(OpBuilder &builder, Location loc, Value rng,
 
   if (ctx.hasCustomLogpdf()) {
     q0 = initialPosition;
+    SmallVector<Value> callArgs;
+    callArgs.push_back(q0);
+    callArgs.append(ctx.fnInputs.begin(), ctx.fnInputs.end());
     auto callOp = func::CallOp::create(builder, loc, ctx.logpdfFn,
-                                       TypeRange{scalarType}, ValueRange{q0});
+                                       TypeRange{scalarType}, callArgs);
     U0 = arith::NegFOp::create(builder, loc, callOp.getResult(0));
   } else {
     auto fullTraceType =
@@ -748,8 +754,11 @@ InitialHMCState MCMC::InitHMC(OpBuilder &builder, Location loc, Value rng,
   auto q0Arg = autodiffInitBlock->getArgument(0);
 
   if (ctx.hasCustomLogpdf()) {
-    auto callOpInner = func::CallOp::create(
-        builder, loc, ctx.logpdfFn, TypeRange{scalarType}, ValueRange{q0Arg});
+    SmallVector<Value> callArgs;
+    callArgs.push_back(q0Arg);
+    callArgs.append(ctx.fnInputs.begin(), ctx.fnInputs.end());
+    auto callOpInner = func::CallOp::create(builder, loc, ctx.logpdfFn,
+                                            TypeRange{scalarType}, callArgs);
     auto U0_init =
         arith::NegFOp::create(builder, loc, callOpInner.getResult(0));
     enzyme::YieldOp::create(builder, loc, {U0_init, rngForAutodiff});

--- a/enzyme/Enzyme/MLIR/Interfaces/HMCUtils.h
+++ b/enzyme/Enzyme/MLIR/Interfaces/HMCUtils.h
@@ -123,11 +123,12 @@ struct HMCContext {
         trajectoryLength(trajectoryLength), positionSize(positionSize),
         supports(supports.begin(), supports.end()) {}
 
-  HMCContext(FlatSymbolRefAttr logpdfFn, Value invMass, Value massMatrixSqrt,
-             Value stepSize, Value trajectoryLength, int64_t positionSize)
-      : invMass(invMass), massMatrixSqrt(massMatrixSqrt), stepSize(stepSize),
-        trajectoryLength(trajectoryLength), positionSize(positionSize),
-        logpdfFn(logpdfFn) {}
+  HMCContext(FlatSymbolRefAttr logpdfFn, ArrayRef<Value> fnInputs,
+             Value invMass, Value massMatrixSqrt, Value stepSize,
+             Value trajectoryLength, int64_t positionSize)
+      : fnInputs(fnInputs), invMass(invMass), massMatrixSqrt(massMatrixSqrt),
+        stepSize(stepSize), trajectoryLength(trajectoryLength),
+        positionSize(positionSize), logpdfFn(logpdfFn) {}
 
   bool hasCustomLogpdf() const { return logpdfFn != nullptr; }
 
@@ -180,10 +181,11 @@ struct NUTSContext : public HMCContext {
                    supports),
         H0(H0), maxDeltaEnergy(maxDeltaEnergy), maxTreeDepth(maxTreeDepth) {}
 
-  NUTSContext(FlatSymbolRefAttr logpdfFn, Value invMass, Value massMatrixSqrt,
-              Value stepSize, int64_t positionSize, Value H0,
-              Value maxDeltaEnergy, int64_t maxTreeDepth)
-      : HMCContext(logpdfFn, invMass, massMatrixSqrt, stepSize,
+  NUTSContext(FlatSymbolRefAttr logpdfFn, ArrayRef<Value> fnInputs,
+              Value invMass, Value massMatrixSqrt, Value stepSize,
+              int64_t positionSize, Value H0, Value maxDeltaEnergy,
+              int64_t maxTreeDepth)
+      : HMCContext(logpdfFn, fnInputs, invMass, massMatrixSqrt, stepSize,
                    /* Unused trajectoryLength */ Value(), positionSize),
         H0(H0), maxDeltaEnergy(maxDeltaEnergy), maxTreeDepth(maxTreeDepth) {}
 

--- a/enzyme/Enzyme/MLIR/Passes/ProbProgMLIRPass.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/ProbProgMLIRPass.cpp
@@ -653,6 +653,7 @@ struct ProbProgPass : public enzyme::impl::ProbProgPassBase<ProbProgPass> {
 
       if (hasLogpdfFn) {
         logpdfFnAttr = mcmcOp.getLogpdfFnAttr();
+        fnInputs.assign(inputs.begin() + 1, inputs.end());
         auto initialPos = mcmcOp.getInitialPosition();
         positionSize =
             cast<RankedTensorType>(initialPos.getType()).getShape()[1];
@@ -735,8 +736,9 @@ struct ProbProgPass : public enzyme::impl::ProbProgPassBase<ProbProgPass> {
                                 Value currentMassMatrixSqrt,
                                 Value currentStepSize) -> HMCContext {
         if (hasLogpdfFn) {
-          return HMCContext(logpdfFnAttr, currentInvMass, currentMassMatrixSqrt,
-                            currentStepSize, trajectoryLength, positionSize);
+          return HMCContext(logpdfFnAttr, fnInputs, currentInvMass,
+                            currentMassMatrixSqrt, currentStepSize,
+                            trajectoryLength, positionSize);
         } else {
           return HMCContext(
               mcmcOp.getFnAttr(), fnInputs, fnResultTypes, originalTrace,
@@ -749,7 +751,7 @@ struct ProbProgPass : public enzyme::impl::ProbProgPassBase<ProbProgPass> {
           [&](Value currentInvMass, Value currentMassMatrixSqrt,
               Value currentStepSize, Value U) -> NUTSContext {
         if (hasLogpdfFn) {
-          return NUTSContext(logpdfFnAttr, currentInvMass,
+          return NUTSContext(logpdfFnAttr, fnInputs, currentInvMass,
                              currentMassMatrixSqrt, currentStepSize,
                              positionSize, U, maxDeltaEnergy, maxTreeDepth);
         } else {

--- a/enzyme/test/MLIR/ProbProg/mcmc_custom_logpdf.mlir
+++ b/enzyme/test/MLIR/ProbProg/mcmc_custom_logpdf.mlir
@@ -57,4 +57,123 @@ module {
       : (tensor<2xui64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>)
     return %res#0, %res#1, %res#2 : tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>
   }
+
+  func.func @shifted_logpdf(%x : tensor<1x2xf64>, %mu : tensor<1x2xf64>) -> tensor<f64> {
+    %diff = arith.subf %x, %mu : tensor<1x2xf64>
+    %sum_sq = enzyme.dot %diff, %diff {lhs_batching_dimensions = array<i64>, rhs_batching_dimensions = array<i64>, lhs_contracting_dimensions = array<i64: 0, 1>, rhs_contracting_dimensions = array<i64: 0, 1>} : (tensor<1x2xf64>, tensor<1x2xf64>) -> tensor<f64>
+    %neg_half = arith.constant dense<-5.000000e-01> : tensor<f64>
+    %result = arith.mulf %neg_half, %sum_sq : tensor<f64>
+    return %result : tensor<f64>
+  }
+
+  // CHECK-LABEL: func.func @nuts_shifted_logpdf
+  // CHECK: call @shifted_logpdf
+  // CHECK-NEXT: %[[U0:.+]] = arith.negf
+  // CHECK: enzyme.autodiff_region
+  // CHECK: func.call @shifted_logpdf
+  // CHECK-NEXT: %[[NEG:.+]] = arith.negf
+  // CHECK-NEXT: enzyme.yield
+  // CHECK: enzyme.for_loop
+  // CHECK: enzyme.autodiff_region
+  // CHECK: func.call @shifted_logpdf
+  // CHECK-NEXT: %{{.+}} = arith.negf
+  // CHECK-NEXT: enzyme.yield
+  func.func @nuts_shifted_logpdf(%rng : tensor<2xui64>, %mu : tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>) {
+    %init_pos = arith.constant dense<[[0.5, -0.5]]> : tensor<1x2xf64>
+    %step_size = arith.constant dense<0.1> : tensor<f64>
+    %res:3 = enzyme.mcmc (%rng, %mu)
+      step_size = %step_size
+      logpdf_fn = @shifted_logpdf
+      initial_position = %init_pos
+      { nuts_config = #enzyme.nuts_config<max_tree_depth = 3, max_delta_energy = 1000.0, adapt_step_size = false, adapt_mass_matrix = false>,
+        name = "nuts_shifted_logpdf", selection = [], all_addresses = [], num_warmup = 0, num_samples = 1 }
+      : (tensor<2xui64>, tensor<1x2xf64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>)
+    return %res#0, %res#1, %res#2 : tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>
+  }
+
+  // CHECK-LABEL: func.func @hmc_shifted_logpdf
+  // CHECK: call @shifted_logpdf
+  // CHECK-NEXT: %{{.+}} = arith.negf
+  // CHECK: enzyme.autodiff_region
+  // CHECK: func.call @shifted_logpdf
+  // CHECK-NEXT: %{{.+}} = arith.negf
+  // CHECK-NEXT: enzyme.yield
+  // CHECK: enzyme.for_loop
+  // CHECK: enzyme.autodiff_region
+  // CHECK: func.call @shifted_logpdf
+  // CHECK-NEXT: %{{.+}} = arith.negf
+  // CHECK-NEXT: enzyme.yield
+  func.func @hmc_shifted_logpdf(%rng : tensor<2xui64>, %mu : tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>) {
+    %init_pos = arith.constant dense<[[0.5, -0.5]]> : tensor<1x2xf64>
+    %step_size = arith.constant dense<0.1> : tensor<f64>
+    %res:3 = enzyme.mcmc (%rng, %mu)
+      step_size = %step_size
+      logpdf_fn = @shifted_logpdf
+      initial_position = %init_pos
+      { hmc_config = #enzyme.hmc_config<trajectory_length = 1.000000e+00 : f64, adapt_step_size = false, adapt_mass_matrix = false>,
+        name = "hmc_shifted_logpdf", selection = [], all_addresses = [], num_warmup = 0, num_samples = 1 }
+      : (tensor<2xui64>, tensor<1x2xf64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>)
+    return %res#0, %res#1, %res#2 : tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>
+  }
+
+  func.func @anisotropic_logpdf(%x : tensor<1x2xf64>, %mu : tensor<1x2xf64>, %precision : tensor<1x2xf64>) -> tensor<f64> {
+    %diff = arith.subf %x, %mu : tensor<1x2xf64>
+    %diff_sq = arith.mulf %diff, %diff : tensor<1x2xf64>
+    %weighted = arith.mulf %precision, %diff_sq : tensor<1x2xf64>
+    %ones = arith.constant dense<1.0> : tensor<1x2xf64>
+    %sum = enzyme.dot %ones, %weighted {lhs_batching_dimensions = array<i64>, rhs_batching_dimensions = array<i64>, lhs_contracting_dimensions = array<i64: 0, 1>, rhs_contracting_dimensions = array<i64: 0, 1>} : (tensor<1x2xf64>, tensor<1x2xf64>) -> tensor<f64>
+    %neg_half = arith.constant dense<-5.000000e-01> : tensor<f64>
+    %result = arith.mulf %neg_half, %sum : tensor<f64>
+    return %result : tensor<f64>
+  }
+
+  // CHECK-LABEL: func.func @nuts_anisotropic_logpdf
+  // CHECK: call @anisotropic_logpdf
+  // CHECK-NEXT: %[[U0:.+]] = arith.negf
+  // CHECK: enzyme.autodiff_region
+  // CHECK: func.call @anisotropic_logpdf
+  // CHECK-NEXT: %[[NEG:.+]] = arith.negf
+  // CHECK-NEXT: enzyme.yield
+  // CHECK: enzyme.for_loop
+  // CHECK: enzyme.autodiff_region
+  // CHECK: func.call @anisotropic_logpdf
+  // CHECK-NEXT: %{{.+}} = arith.negf
+  // CHECK-NEXT: enzyme.yield
+  func.func @nuts_anisotropic_logpdf(%rng : tensor<2xui64>, %mu : tensor<1x2xf64>, %precision : tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>) {
+    %init_pos = arith.constant dense<[[0.5, -0.5]]> : tensor<1x2xf64>
+    %step_size = arith.constant dense<0.1> : tensor<f64>
+    %res:3 = enzyme.mcmc (%rng, %mu, %precision)
+      step_size = %step_size
+      logpdf_fn = @anisotropic_logpdf
+      initial_position = %init_pos
+      { nuts_config = #enzyme.nuts_config<max_tree_depth = 3, max_delta_energy = 1000.0, adapt_step_size = false, adapt_mass_matrix = false>,
+        name = "nuts_anisotropic_logpdf", selection = [], all_addresses = [], num_warmup = 0, num_samples = 1 }
+      : (tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>)
+    return %res#0, %res#1, %res#2 : tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>
+  }
+
+  // CHECK-LABEL: func.func @hmc_anisotropic_logpdf
+  // CHECK: call @anisotropic_logpdf
+  // CHECK-NEXT: %{{.+}} = arith.negf
+  // CHECK: enzyme.autodiff_region
+  // CHECK: func.call @anisotropic_logpdf
+  // CHECK-NEXT: %{{.+}} = arith.negf
+  // CHECK-NEXT: enzyme.yield
+  // CHECK: enzyme.for_loop
+  // CHECK: enzyme.autodiff_region
+  // CHECK: func.call @anisotropic_logpdf
+  // CHECK-NEXT: %{{.+}} = arith.negf
+  // CHECK-NEXT: enzyme.yield
+  func.func @hmc_anisotropic_logpdf(%rng : tensor<2xui64>, %mu : tensor<1x2xf64>, %precision : tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>) {
+    %init_pos = arith.constant dense<[[0.5, -0.5]]> : tensor<1x2xf64>
+    %step_size = arith.constant dense<0.1> : tensor<f64>
+    %res:3 = enzyme.mcmc (%rng, %mu, %precision)
+      step_size = %step_size
+      logpdf_fn = @anisotropic_logpdf
+      initial_position = %init_pos
+      { hmc_config = #enzyme.hmc_config<trajectory_length = 1.000000e+00 : f64, adapt_step_size = false, adapt_mass_matrix = false>,
+        name = "hmc_anisotropic_logpdf", selection = [], all_addresses = [], num_warmup = 0, num_samples = 1 }
+      : (tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>)
+    return %res#0, %res#1, %res#2 : tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>
+  }
 }


### PR DESCRIPTION
This is to fix: in #2695 i overlooked the fact that logpdf can args in addition to the position vector