### PR TITLE
Mark ActivityAnalysis summaries as xfail for now

### DIFF
--- a/enzyme/test/MLIR/ActivityAnalysis/Summaries/basic.mlir
+++ b/enzyme/test/MLIR/ActivityAnalysis/Summaries/basic.mlir
@@ -1,5 +1,7 @@
 // RUN: %eopt --print-activity-analysis='relative verbose' --split-input-file %s | FileCheck %s
 
+// XFAIL: *
+
 // CHECK-LABEL: processing function @sparse_callee
 // CHECK: "fadd"(#0)
 // CHECK:   sources: [#enzyme.argorigin<@sparse_callee(0)>]


### PR DESCRIPTION
@pengmai looks like this got messed up during the lastest upstream mlir rebase. I'm going to mark this test as xfail for now so we can still debug the other files, but if you have a chance to help figure out what's going awry that would be great!