### PR TITLE
mlir: mark loads of read-only pointers as movable during mincut

### DIFF
--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.cpp
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.cpp
@@ -30,6 +30,7 @@
 #include "mlir/Analysis/AliasAnalysis.h"
 #include "mlir/Analysis/DataFlow/DenseAnalysis.h"
 #include "mlir/Analysis/DataFlow/SparseAnalysis.h"
+#include "mlir/Analysis/DataFlow/Utils.h"
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
@@ -1193,4 +1194,65 @@ void enzyme::AliasAnalysis::visitExternalCall(
       propagateIfChanged(resultLattice, resultLattice->markUnknown());
     }
   }
+}
+
+void mlir::enzyme::markReadOnlyLoads(
+    CallableOpInterface funcOp, function_ref<void(Operation *op)> annotate) {
+  DataFlowSolver solver(DataFlowConfig().setInterprocedural(false));
+  dataflow::loadBaselineAnalyses(solver);
+  solver.load<enzyme::AliasAnalysis>(funcOp.getContext(), /*relative=*/false);
+  solver.load<enzyme::PointsToPointerAnalysis>();
+  if (failed(solver.initializeAndRun(funcOp))) {
+    assert(false && "dataflow analysis failed");
+    return;
+  }
+
+  // Determine all alias classes that were modified
+  AliasClassLattice modified(nullptr);
+  funcOp.walk([&](Operation *op) {
+    auto memory = dyn_cast<MemoryEffectOpInterface>(op);
+    // If we can't reason about memory effects, conservatively assume that any
+    // pointer could be modified.
+    if (!memory) {
+      if (isMemoryEffectFree(op) ||
+          isa<FunctionOpInterface, RegionBranchOpInterface>(op)) {
+        return WalkResult::advance();
+      }
+      (void)modified.markUnknown();
+      return WalkResult::interrupt();
+    }
+
+    SmallVector<MemoryEffects::EffectInstance> effects;
+    memory.getEffects(effects);
+    for (const auto &effect : effects) {
+      if (isa<MemoryEffects::Write>(effect.getEffect())) {
+        Value val = effect.getValue();
+        if (val) {
+          (void)modified.join(*solver.lookupState<AliasClassLattice>(val));
+        } else {
+          (void)modified.markUnknown();
+          return WalkResult::interrupt();
+        }
+      }
+    }
+    return WalkResult::advance();
+  });
+
+  funcOp.walk([&](MemoryEffectOpInterface memory) {
+    if (!hasSingleEffect<MemoryEffects::Read>(memory)) {
+      return;
+    }
+    SmallVector<MemoryEffects::EffectInstance> effects;
+    memory.getEffects(effects);
+    assert(effects.size() == 1 &&
+           isa<MemoryEffects::Read>(effects.front().getEffect()));
+    Value ptr = effects.front().getValue();
+    auto *ptrClass = solver.lookupState<AliasClassLattice>(ptr);
+    // TODO: in split mode, this check will no longer be sufficient because the
+    // caller may modify memory between function invocations even if the memory
+    // is not modified within the function body.
+    if (ptrClass->alias(modified).isNo()) {
+      annotate(memory);
+    }
+  });
 }

--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.h
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.h
@@ -276,6 +276,9 @@ private:
   OriginalClasses originalClasses;
 };
 
+void markReadOnlyLoads(CallableOpInterface funcOp,
+                       function_ref<void(Operation *)> annotate);
+
 } // namespace enzyme
 } // namespace mlir
 

--- a/enzyme/Enzyme/MLIR/Implementations/FuncAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/FuncAutoDiffOpInterfaceImpl.cpp
@@ -172,7 +172,8 @@ public:
         fn, RetActivity, ArgActivity, gutils->TA, returnPrimal, returnShadow,
         mode, freeMemory, gutils->AtomicAdd, width, /*addedType*/ nullptr,
         type_args, volatile_args, /*augmented*/ nullptr, gutils->omp,
-        gutils->postpasses, gutils->verifyPostPasses, gutils->strongZero);
+        gutils->postpasses, gutils->verifyPostPasses, gutils->strongZero,
+        /*markReadonly=*/false);
 
     SmallVector<Value> revArguments;
 

--- a/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogic.h
+++ b/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogic.h
@@ -231,14 +231,16 @@ public:
                     void *augmented, bool omp, llvm::StringRef postpasses,
                     bool verifyPostPasses, bool strongZero);
 
-  FunctionOpInterface CreateReverseDiff(
-      FunctionOpInterface fn, std::vector<DIFFE_TYPE> retType,
-      std::vector<DIFFE_TYPE> constants, MTypeAnalysis &TA,
-      std::vector<bool> returnPrimals, std::vector<bool> returnShadows,
-      DerivativeMode mode, bool freeMemory, bool atomicAdd, size_t width,
-      mlir::Type addedType, MFnTypeInfo type_args,
-      std::vector<bool> volatile_args, void *augmented, bool omp,
-      llvm::StringRef postpasses, bool verifyPostPasses, bool strongZero);
+  FunctionOpInterface
+  CreateReverseDiff(FunctionOpInterface fn, std::vector<DIFFE_TYPE> retType,
+                    std::vector<DIFFE_TYPE> constants, MTypeAnalysis &TA,
+                    std::vector<bool> returnPrimals,
+                    std::vector<bool> returnShadows, DerivativeMode mode,
+                    bool freeMemory, bool atomicAdd, size_t width,
+                    mlir::Type addedType, MFnTypeInfo type_args,
+                    std::vector<bool> volatile_args, void *augmented, bool omp,
+                    llvm::StringRef postpasses, bool verifyPostPasses,
+                    bool strongZero, bool markReadonly);
 
   void
   initializeShadowValues(SmallVector<mlir::Block *> &dominatorToposortBlocks,

--- a/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogicReverse.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogicReverse.cpp
@@ -1,3 +1,4 @@
+#include "Analysis/DataFlowAliasAnalysis.h"
 #include "Dialect/Ops.h"
 #include "Interfaces/AutoDiffOpInterface.h"
 #include "Interfaces/AutoDiffTypeInterface.h"
@@ -196,7 +197,8 @@ FunctionOpInterface MEnzymeLogic::CreateReverseDiff(
     DerivativeMode mode, bool freeMemory, bool atomicAdd, size_t width,
     mlir::Type addedType, MFnTypeInfo type_args,
     std::vector<bool> volatile_args, void *augmented, bool omp,
-    llvm::StringRef postpasses, bool verifyPostPasses, bool strongZero) {
+    llvm::StringRef postpasses, bool verifyPostPasses, bool strongZero,
+    bool markReadonly) {
 
   if (fn.getFunctionBody().empty()) {
     llvm::errs() << fn << "\n";
@@ -230,6 +232,12 @@ FunctionOpInterface MEnzymeLogic::CreateReverseDiff(
       *this, mode, width, fn, TA, type_args, returnPrimalsP, returnShadowsP,
       retType, constants, addedType, omp, postpasses, verifyPostPasses,
       strongZero);
+  if (markReadonly) {
+    markReadOnlyLoads(gutils->oldFunc, [&](Operation *origOp) {
+      gutils->getNewFromOriginal(origOp)->setAttr(
+          "enzyme.readonly", UnitAttr::get(origOp->getContext()));
+    });
+  }
   gutils->AtomicAdd = atomicAdd;
 
   ReverseCachedFunctions[tup] = gutils->newFunc;

--- a/enzyme/Enzyme/MLIR/Interfaces/GradientUtilsReverse.h
+++ b/enzyme/Enzyme/MLIR/Interfaces/GradientUtilsReverse.h
@@ -13,6 +13,7 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 
+#include "Analysis/DataFlowAliasAnalysis.h"
 #include "CloneFunction.h"
 #include "EnzymeLogic.h"
 

--- a/enzyme/Enzyme/MLIR/Passes/EnzymeMLIRPass.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/EnzymeMLIRPass.cpp
@@ -333,7 +333,7 @@ struct DifferentiatePass
         freeMemory, CI.getAtomicAdd(), width,
         /*addedType*/ nullptr, type_args, volatile_args,
         /*augmented*/ nullptr, omp, postpasses, verifyPostPasses,
-        CI.getStrongZero());
+        CI.getStrongZero(), markReadonly);
     if (!newFunc)
       return failure();
 

--- a/enzyme/Enzyme/MLIR/Passes/EnzymeWrapPass.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/EnzymeWrapPass.cpp
@@ -143,7 +143,8 @@ struct DifferentiateWrapperPass
           fn, RetActivity, ArgActivity, TA, returnPrimal, returnShadow, mode,
           freeMemory, atomicAdd, width,
           /*addedType*/ nullptr, type_args, volatile_args,
-          /*augmented*/ nullptr, omp, postpasses, verifyPostPasses, strongZero);
+          /*augmented*/ nullptr, omp, postpasses, verifyPostPasses, strongZero,
+          markReadonly);
     }
     if (!newFunc) {
       signalPassFailure();

--- a/enzyme/Enzyme/MLIR/Passes/Passes.td
+++ b/enzyme/Enzyme/MLIR/Passes/Passes.td
@@ -43,6 +43,13 @@ def DifferentiatePass : Pass<"enzyme"> {
       /*default=*/"false",
       /*description=*/"Whether or not to use the dataflow activity analysis"
     >,
+    Option<
+      /*C++ variable name=*/"markReadonly",
+      /*CLI argument=*/"markReadonly",
+      /*type=*/"bool",
+      /*default=*/"false",
+      /*description=*/"If using dataflow analysis, this will annotate loads from pointers that are never modified in the function"
+    >,
   ];
 }
 
@@ -181,6 +188,13 @@ def DifferentiateWrapperPass : Pass<"enzyme-wrap"> {
       /*type=*/"bool",
       /*default=*/"false",
       /*description=*/"Whether or not to use atomics by default (e.g. if within a parallel context)"
+    >,
+    Option<
+      /*C++ variable name=*/"markReadonly",
+      /*CLI argument=*/"markReadonly",
+      /*type=*/"bool",
+      /*default=*/"false",
+      /*description=*/"If using dataflow analysis, this will annotate loads from pointers that are never modified in the function"
     >,
   ];
 }

--- a/enzyme/Enzyme/MLIR/Passes/RemovalUtils.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/RemovalUtils.cpp
@@ -354,11 +354,18 @@ static inline void bfs(const Graph &G, const llvm::SetVector<Value> &Sources,
   }
 }
 
+static inline bool isLoadMovable(Operation *op) {
+  if (!hasSingleEffect<MemoryEffects::Read>(op)) {
+    return false;
+  }
+  return op->hasAttr("enzyme.readonly");
+}
+
 // Whether or not an operation can be moved from the forward region to the
 // reverse region or vice-versa.
 static inline bool isMovable(Operation *op) {
   return op->getNumRegions() == 0 && op->getBlock()->getTerminator() != op &&
-         mlir::isPure(op);
+         (mlir::isPure(op) || isLoadMovable(op));
 }
 
 // Given a graph `G`, construct a new graph `G2`, where all paths must terminate

--- a/enzyme/test/MLIR/ReverseMode/scf_parallel.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_parallel.mlir
@@ -1,5 +1,5 @@
-// RUN: %eopt %s --pass-pipeline="builtin.module(enzyme,canonicalize,remove-unnecessary-enzyme-ops)" | FileCheck %s
-func.func @foo(%x: memref<?xf32>, %y: memref<?xf32>) {
+// RUN: %eopt %s --pass-pipeline="builtin.module(enzyme{dataflow markReadonly},canonicalize,remove-unnecessary-enzyme-ops,enzyme-simplify-math)" | FileCheck %s
+func.func @foo(%x: memref<?xf32> {llvm.noalias}, %y: memref<?xf32> {llvm.noalias}) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
@@ -20,31 +20,27 @@ func.func @dfoo(%x: memref<?xf32>, %dx: memref<?xf32>, %y: memref<?xf32>, %dy: m
   return
 }
 
-// CHECK: func.func private @diffefoo(%arg0: memref<?xf32>, %arg1: memref<?xf32>, %arg2: memref<?xf32>, %arg3: memref<?xf32>) {
-// CHECK-NEXT:    %c4 = arith.constant 4 : index
-// CHECK-NEXT:    %c1 = arith.constant 1 : index
-// CHECK-NEXT:    %c0 = arith.constant 0 : index
-// CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f32
-// CHECK-NEXT:    %alloc = memref.alloc() : memref<4xf32>
-// CHECK-NEXT:    scf.parallel (%arg4) = (%c0) to (%c4) step (%c1) {
-// CHECK-NEXT:      %0 = memref.load %arg0[%arg4] : memref<?xf32>
-// CHECK-NEXT:      memref.store %0, %alloc[%arg4] : memref<4xf32>
-// CHECK-NEXT:      %1 = arith.mulf %0, %0 : f32
-// CHECK-NEXT:      memref.store %1, %arg2[%arg4] : memref<?xf32>
-// CHECK-NEXT:      scf.reduce
-// CHECK-NEXT:    }
-// CHECK-NEXT:    scf.parallel (%arg4) = (%c0) to (%c4) step (%c1) {
-// CHECK-NEXT:      %0 = memref.load %alloc[%arg4] : memref<4xf32>
-// CHECK-NEXT:      %1 = memref.load %arg3[%arg4] : memref<?xf32>
-// CHECK-NEXT:      %2 = arith.addf %1, %cst : f32
-// CHECK-NEXT:      memref.store %cst, %arg3[%arg4] : memref<?xf32>
-// CHECK-NEXT:      %3 = arith.mulf %2, %0 : f32
-// CHECK-NEXT:      %4 = arith.addf %3, %cst : f32
-// CHECK-NEXT:      %5 = arith.mulf %2, %0 : f32
-// CHECK-NEXT:      %6 = arith.addf %4, %5 : f32
-// CHECK-NEXT:      %7 = enzyme.atomic_rmw addf %6, %arg1[%arg4] monotonic : (f32, memref<?xf32>) -> f32
-// CHECK-NEXT:      scf.reduce
-// CHECK-NEXT:    }
-// CHECK-NEXT:    memref.dealloc %alloc : memref<4xf32>
-// CHECK-NEXT:    return
-// CHECK-NEXT:  }
+// CHECK-LABEL:   func.func private @diffefoo(
+// CHECK-SAME:      %[[ARG0:.*]]: memref<?xf32> {llvm.noalias}, %[[ARG1:.*]]: memref<?xf32>, %[[ARG2:.*]]: memref<?xf32> {llvm.noalias}, %[[ARG3:.*]]: memref<?xf32>) {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 4 : index
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 1 : index
+// CHECK:           %[[CONSTANT_2:.*]] = arith.constant 0 : index
+// CHECK:           %[[CONSTANT_3:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           scf.parallel (%[[VAL_0:.*]]) = (%[[CONSTANT_2]]) to (%[[CONSTANT_0]]) step (%[[CONSTANT_1]]) {
+// CHECK:             %[[LOAD_0:.*]] = memref.load %[[ARG0]]{{\[}}%[[VAL_0]]] {enzyme.readonly} : memref<?xf32>
+// CHECK:             %[[MULF_0:.*]] = arith.mulf %[[LOAD_0]], %[[LOAD_0]] : f32
+// CHECK:             memref.store %[[MULF_0]], %[[ARG2]]{{\[}}%[[VAL_0]]] : memref<?xf32>
+// CHECK:             scf.reduce
+// CHECK:           }
+// CHECK:           scf.parallel (%[[VAL_1:.*]]) = (%[[CONSTANT_2]]) to (%[[CONSTANT_0]]) step (%[[CONSTANT_1]]) {
+// CHECK:             %[[LOAD_1:.*]] = memref.load %[[ARG0]]{{\[}}%[[VAL_1]]] {enzyme.readonly} : memref<?xf32>
+// CHECK:             %[[LOAD_2:.*]] = memref.load %[[ARG3]]{{\[}}%[[VAL_1]]] : memref<?xf32>
+// CHECK:             memref.store %[[CONSTANT_3]], %[[ARG3]]{{\[}}%[[VAL_1]]] : memref<?xf32>
+// CHECK:             %[[MULF_1:.*]] = arith.mulf %[[LOAD_2]], %[[LOAD_1]] : f32
+// CHECK:             %[[MULF_2:.*]] = arith.mulf %[[LOAD_2]], %[[LOAD_1]] : f32
+// CHECK:             %[[ADDF_0:.*]] = arith.addf %[[MULF_1]], %[[MULF_2]] : f32
+// CHECK:             %[[ATOMIC_RMW_0:.*]] = enzyme.atomic_rmw addf %[[ADDF_0]], %[[ARG1]]{{\[}}%[[VAL_1]]] monotonic : (f32, memref<?xf32>) -> f32
+// CHECK:             scf.reduce
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
* implement MemoryEffectOpInterface for enzyme.push/pop
* fix warnings with int signedness