### PR TITLE
Add LLVM STATISTIC tracking for cached and recomputed values

### DIFF
--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -51,12 +51,19 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/StringMap.h"
 
 #include "llvm/Support/AMDGPUMetadata.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/TimeProfiler.h"
+
+#define DEBUG_TYPE "enzyme"
+
+STATISTIC(NumValuesCached, "Number of values cached for the reverse pass");
+STATISTIC(NumValuesRecomputed,
+          "Number of values recomputed instead of cached");
 
 #if LLVM_VERSION_MAJOR >= 14
 #define addAttribute addAttributeAtIndex
@@ -8492,6 +8499,7 @@ void GradientUtils::computeMinCache() {
 
             if (oneneed || shadowOneNeed) {
               knownRecomputeHeuristic[&I] = false;
+              ++NumValuesCached;
 
               CountTrackedPointers T(I.getType());
               assert(!T.derived);
@@ -8569,6 +8577,10 @@ void GradientUtils::computeMinCache() {
 
     for (auto V : Intermediates) {
       knownRecomputeHeuristic[V] = !MinReq.count(V);
+      if (MinReq.count(V))
+        ++NumValuesCached;
+      else
+        ++NumValuesRecomputed;
       if (!MinReq.count(V) && NeedGraph.count(V)) {
         if (auto CI = dyn_cast<CallInst>(V))
           if (getFuncNameFromCall(CI) == "julia.call")


### PR DESCRIPTION
Adds LLVM `STATISTIC` macros to `GradientUtils.cpp` to track how many values get cached vs recomputed in the reverse pass. The counters are incremented in `computeMinCache()` at both decision points — when a value must be cached due to single-use needs, and when the min-cut classifies intermediates.

Viewable via `opt -stats`.

Partial fix for #962 (covers cached/recomputed tracking; GPU gradient accumulation, allocation merging, etc. could follow separately).