### PR TITLE
fix the fictiousPHI crash issue

### DIFF
--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -8659,6 +8659,27 @@ void GradientUtils::eraseFictiousPHIs() {
   for (auto pair : phis) {
     auto pp = pair.first;
     if (pp->getNumUses() != 0) {
+      // If the original instruction was a malloc with enzyme_fromstack,
+      // the allocation is needed but was incorrectly replaced by a
+      // fictiousPHI. Restore it as a stack allocation (alloca).
+      if (auto *origCall = dyn_cast<CallInst>(pair.second)) {
+        if (auto MD = hasMetadata(origCall, "enzyme_fromstack")) {
+          IRBuilder<> B(&newFunc->getEntryBlock().front());
+          Value *Size = getNewFromOriginal(origCall->getArgOperand(0));
+          Type *elTy = Type::getInt8Ty(origCall->getContext());
+          Value *replacement = B.CreateAlloca(elTy, Size);
+          auto Alignment =
+              cast<ConstantInt>(
+                  cast<ConstantAsMetadata>(MD->getOperand(0))->getValue())
+                  ->getLimitedValue();
+          if (Alignment) {
+            cast<AllocaInst>(replacement)->setAlignment(Align(Alignment));
+          }
+          pp->replaceAllUsesWith(replacement);
+          erase(pp);
+          continue;
+        }
+      }
       if (CustomErrorHandler) {
         std::string str;
         raw_string_ostream ss(str);


### PR DESCRIPTION
This is to fix the issue #2700 

The crash was in [GradientUtils::eraseFictiousPHIs()]— a fictiousPHI created for a [malloc] with !enzyme_fromstack metadata still had live uses (GEPs and loads accessing the 3 float elements of a [std::array<float,3>], causing the assertion [pp->getNumUses() == 0] to fire.

Root cause: When Enzyme decided the primal allocation wasn't needed in reverse mode, it replaced the malloc call with a fictiousPHI placeholder. However, [restoreCache()](which normally resolves fictiousPHIs for enzyme_fromstack mallocs by creating stack allocations) didn't process this particular PHI — likely because the allocation was in an inner function (InverseQuery) and the cache restoration logic didn't cover this case.

Fix: In [eraseFictiousPHIs()], before asserting that a fictiousPHI has no uses, check if the original instruction was a [malloc] with enzyme_fromstack metadata. If so, create a proper stack allocation (alloca) in the entry block with the correct size and alignment, and replace the PHI's uses with it. This mirrors the same enzyme_fromstack handling done elsewhere in the codebase (e.g., at GradientUtils.cpp).