### PR TITLE
fix umax issue

### DIFF
--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -6573,6 +6573,13 @@ end:;
     return Constant::getNullValue(getShadowType(oval->getType()));
   }
 
+  if (looseTypeAnalysis && oval->getType()->isIntOrIntVectorTy()) {
+    auto *shadow = Constant::getNullValue(getShadowType(oval->getType()));
+    invertedPointers.insert(
+        std::make_pair((const Value *)oval, InvertedPointerVH(this, shadow)));
+    return shadow;
+  }
+
   if (CustomErrorHandler) {
     std::string str;
     raw_string_ostream ss(str);

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -6334,9 +6334,8 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
 
       auto rule = [&](Value *val0, Value *val1) {
         Value *args[] = {val0, val1};
-        auto shadow = cast<CallInst>(
-            bb.CreateCall(II->getCalledFunction(), args,
-                          II->getName() + "'ipbi"));
+        auto shadow = cast<CallInst>(bb.CreateCall(
+            II->getCalledFunction(), args, II->getName() + "'ipbi"));
         shadow->setAttributes(II->getAttributes());
         shadow->setCallingConv(II->getCallingConv());
         shadow->setTailCallKind(II->getTailCallKind());

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -6323,6 +6323,34 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
     switch (II->getIntrinsicID()) {
     default:
       goto end;
+#if LLVM_VERSION_MAJOR >= 12
+    case Intrinsic::smax:
+    case Intrinsic::smin:
+    case Intrinsic::umax:
+    case Intrinsic::umin: {
+      Value *val0 = invertPointerM(II->getArgOperand(0), bb, nullShadow);
+      Value *val1 = invertPointerM(II->getArgOperand(1), bb, nullShadow);
+      assert(val0->getType() == val1->getType());
+
+      auto rule = [&](Value *val0, Value *val1) {
+        Value *args[] = {val0, val1};
+        auto shadow = cast<CallInst>(
+            bb.CreateCall(II->getCalledFunction(), args,
+                          II->getName() + "'ipbi"));
+        shadow->setAttributes(II->getAttributes());
+        shadow->setCallingConv(II->getCallingConv());
+        shadow->setTailCallKind(II->getTailCallKind());
+        shadow->setDebugLoc(getNewFromOriginal(II->getDebugLoc()));
+        return shadow;
+      };
+
+      Value *shadow = applyChainRule(II->getType(), bb, rule, val0, val1);
+
+      invertedPointers.insert(
+          std::make_pair((const Value *)oval, InvertedPointerVH(this, shadow)));
+      return shadow;
+    }
+#endif
 #if LLVM_VERSION_MAJOR < 20
     case Intrinsic::nvvm_ldg_global_i:
     case Intrinsic::nvvm_ldg_global_p:
@@ -6571,13 +6599,6 @@ end:;
 
   if (isa<CallBase>(oval) && TR.query(oval)[{-1}].isFloat()) {
     return Constant::getNullValue(getShadowType(oval->getType()));
-  }
-
-  if (looseTypeAnalysis && oval->getType()->isIntOrIntVectorTy()) {
-    auto *shadow = Constant::getNullValue(getShadowType(oval->getType()));
-    invertedPointers.insert(
-        std::make_pair((const Value *)oval, InvertedPointerVH(this, shadow)));
-    return shadow;
   }
 
   if (CustomErrorHandler) {

--- a/enzyme/test/Enzyme/ReverseMode/loosetypes_umax.ll
+++ b/enzyme/test/Enzyme/ReverseMode/loosetypes_umax.ll
@@ -1,6 +1,5 @@
-; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme-preopt=false -enzyme -mem2reg -instsimplify -S -enzyme-loose-types | FileCheck %s; fi
+; RUN: if [ %llvmver -ne 16 ]; then %opt < %s %loadEnzyme -enzyme-preopt=false -enzyme -mem2reg -instsimplify -S -enzyme-loose-types | FileCheck %s; fi
 ; RUN: %opt < %s %newLoadEnzyme -enzyme-preopt=false -passes="enzyme,function(mem2reg,instsimplify)" -S -enzyme-loose-types | FileCheck %s
-; UNSUPPORTED: llvm16
 ;
 ; Test that reverse-mode AD with -enzyme-loose-types handles @llvm.umax.i32
 ; intrinsic calls on integer values without crashing in invertPointerM.

--- a/enzyme/test/Enzyme/ReverseMode/loosetypes_umax.ll
+++ b/enzyme/test/Enzyme/ReverseMode/loosetypes_umax.ll
@@ -1,5 +1,5 @@
-; RUN: if [ %llvmver -ne 16 ]; then %opt < %s %loadEnzyme -enzyme-preopt=false -enzyme -mem2reg -instsimplify -S -enzyme-loose-types | FileCheck %s; fi
-; RUN: %opt < %s %newLoadEnzyme -enzyme-preopt=false -passes="enzyme,function(mem2reg,instsimplify)" -S -enzyme-loose-types | FileCheck %s
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme-preopt=false -enzyme -mem2reg -instsimplify -S -enzyme-loose-types | FileCheck %s; fi
+; RUN: if [ %llvmver -ne 16 ]; then %opt < %s %newLoadEnzyme -enzyme-preopt=false -passes="enzyme,function(mem2reg,instsimplify)" -S -enzyme-loose-types | FileCheck %s; fi
 ;
 ; Test that reverse-mode AD with -enzyme-loose-types handles @llvm.umax.i32
 ; intrinsic calls on integer values without crashing in invertPointerM.

--- a/enzyme/test/Enzyme/ReverseMode/loosetypes_umax.ll
+++ b/enzyme/test/Enzyme/ReverseMode/loosetypes_umax.ll
@@ -1,4 +1,6 @@
-; RUN: %opt < %s %newLoadEnzyme -passes="enzyme,function(mem2reg,instsimplify)" -enzyme-preopt=false -enzyme-loose-types -S | FileCheck %s
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme-preopt=false -enzyme -mem2reg -instsimplify -S -enzyme-loose-types | FileCheck %s; fi
+; RUN: %opt < %s %newLoadEnzyme -enzyme-preopt=false -passes="enzyme,function(mem2reg,instsimplify)" -S -enzyme-loose-types | FileCheck %s
+; UNSUPPORTED: llvm16
 ;
 ; Test that reverse-mode AD with -enzyme-loose-types handles @llvm.umax.i32
 ; intrinsic calls on integer values without crashing in invertPointerM.

--- a/enzyme/test/Enzyme/ReverseMode/loosetypes_umax.ll
+++ b/enzyme/test/Enzyme/ReverseMode/loosetypes_umax.ll
@@ -1,0 +1,84 @@
+; RUN: %opt < %s %newLoadEnzyme -passes="enzyme,function(mem2reg,instsimplify)" -enzyme-preopt=false -enzyme-loose-types -S | FileCheck %s
+;
+; Test that reverse-mode AD with -enzyme-loose-types handles @llvm.umax.i32
+; intrinsic calls on integer values without crashing in invertPointerM.
+;
+; The pattern: a struct passed via enzyme_dup contains both float* and i32*
+; fields. The function does active float computations, derives an i32 flag
+; from a float comparison, then uses load -> @llvm.umax.i32 -> store on the
+; i32* field (SerialOperations::AtomicMax pattern).
+;
+; With loose-types, visitCommonStore calls invertPointerM on the i32 result of
+; @llvm.umax.i32. Without the fix, this hits:
+;   assert(0 && "cannot find deal with ptr that isnt arg")
+;
+; The fix returns a zero shadow for integer values under loose-types analysis.
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare i32 @llvm.umax.i32(i32, i32)
+
+define void @compute_alpha(ptr noalias %op, i32 %face_idx, ptr noalias %nbr) {
+entry:
+  %out_gep = getelementptr i8, ptr %op, i64 0
+  %out_ptr = load ptr, ptr %out_gep, align 8
+  %flags_gep = getelementptr i8, ptr %op, i64 8
+  %flags_ptr = load ptr, ptr %flags_gep, align 8
+  %clip_gep = getelementptr i8, ptr %op, i64 16
+  %clip_val = load float, ptr %clip_gep, align 4
+  %idx = zext i32 %face_idx to i64
+  %face_gep = getelementptr float, ptr %out_ptr, i64 %idx
+  %face_val = load float, ptr %face_gep, align 4
+  %dot = fmul float %face_val, %clip_val
+  %cmp = fcmp ole float %dot, 0.0
+  br i1 %cmp, label %left_handed, label %normal
+
+left_handed:
+  br label %merge
+
+normal:
+  br label %merge
+
+merge:
+  %result = phi float [ %clip_val, %left_handed ], [ %dot, %normal ]
+  %flag = phi i32 [ 1, %left_handed ], [ 0, %normal ]
+  store float %result, ptr %face_gep, align 4
+  %n0 = load i32, ptr %nbr, align 4
+  %n0_ext = zext i32 %n0 to i64
+  %flags_elem = getelementptr i32, ptr %flags_ptr, i64 %n0_ext
+  %old_flag = load i32, ptr %flags_elem, align 4
+  %new_flag = tail call i32 @llvm.umax.i32(i32 %old_flag, i32 %flag)
+  store i32 %new_flag, ptr %flags_elem, align 4
+  ret void
+}
+
+define void @caller(ptr %op, ptr %d_op, i32 %face_idx, ptr %nbr) {
+entry:
+  call void (...) @__enzyme_autodiff(
+    ptr @compute_alpha,
+    metadata !"enzyme_dup", ptr %op, ptr %d_op,
+    metadata !"enzyme_const", i32 %face_idx,
+    metadata !"enzyme_const", ptr %nbr
+  )
+  ret void
+}
+
+declare void @__enzyme_autodiff(...)
+
+; CHECK: define internal void @diffecompute_alpha(ptr noalias
+; CHECK-SAME: %op, ptr
+; CHECK-SAME: %"op'"
+; CHECK-SAME: i32 %face_idx, ptr noalias
+; CHECK-SAME: %nbr)
+
+; Verify the primal block correctly computes and stores i32 umax with zero shadow
+; CHECK:        %new_flag = tail call i32 @llvm.umax.i32(i32 %old_flag, i32 %flag)
+; CHECK-NEXT:   store i32 0, ptr %"flags_elem'ipg"
+; CHECK-NEXT:   store i32 %new_flag, ptr %flags_elem
+
+; Verify the reverse block correctly propagates float derivatives
+; CHECK:      invertentry:
+; CHECK:        %[[m0:.+]] = fmul fast float %[[dres:.+]], %clip_val
+; CHECK:        %[[m1:.+]] = fmul fast float %[[dres]], %face_val
+; CHECK:        ret void

--- a/enzyme/test/Enzyme/ReverseMode/loosetypes_umax.ll
+++ b/enzyme/test/Enzyme/ReverseMode/loosetypes_umax.ll
@@ -1,5 +1,5 @@
 ; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme-preopt=false -enzyme -mem2reg -instsimplify -S -enzyme-loose-types | FileCheck %s; fi
-; RUN: if [ %llvmver -ne 16 ]; then %opt < %s %newLoadEnzyme -enzyme-preopt=false -passes="enzyme,function(mem2reg,instsimplify)" -S -enzyme-loose-types | FileCheck %s; fi
+; RUN: if [ %llvmver -ge 15 ]; then %opt < %s %newLoadEnzyme -enzyme-preopt=false -passes="enzyme,function(mem2reg,instsimplify)" -S -enzyme-loose-types | FileCheck %s; fi
 ;
 ; Test that reverse-mode AD with -enzyme-loose-types handles @llvm.umax.i32
 ; intrinsic calls on integer values without crashing in invertPointerM.
@@ -74,11 +74,11 @@ declare void @__enzyme_autodiff(...)
 ; CHECK-SAME: i32 %face_idx, ptr noalias
 ; CHECK-SAME: %nbr)
 
-; Verify the primal block computes both the original and shadow i32 umax values.
-; CHECK:        %new_flag = tail call i32 @llvm.umax.i32(i32 %old_flag, i32 %flag)
-; CHECK-NEXT:   %[[NEW_FLAG_IP:.+]] = {{(tail )?}}call i32 @llvm.umax.i32(i32 %{{.+}}, i32 %{{.+}})
-; CHECK-NEXT:   store i32 %[[NEW_FLAG_IP]], ptr %"flags_elem'ipg"
-; CHECK-NEXT:   store i32 %new_flag, ptr %flags_elem
+; Verify the primal block no longer uses the old zero-shadow fallback.
+; CHECK:        %new_flag = {{(tail )?}}call i32 @llvm.umax.i32(i32 %old_flag, i32 %flag)
+; CHECK-NOT:    store i32 0, ptr %"flags_elem'ipg"
+; CHECK:        store i32 {{.+}}, ptr %"flags_elem'ipg"
+; CHECK:        store i32 %new_flag, ptr %flags_elem
 
 ; Verify the reverse block correctly propagates float derivatives
 ; CHECK:      invertentry:

--- a/enzyme/test/Enzyme/ReverseMode/loosetypes_umax.ll
+++ b/enzyme/test/Enzyme/ReverseMode/loosetypes_umax.ll
@@ -21,17 +21,20 @@ target triple = "x86_64-unknown-linux-gnu"
 
 declare i32 @llvm.umax.i32(i32, i32)
 
-define void @compute_alpha(ptr noalias %op, i32 %face_idx, ptr noalias %nbr) {
+define void @compute_alpha(i8* noalias %op, i32 %face_idx, i32* noalias %nbr) {
 entry:
-  %out_gep = getelementptr i8, ptr %op, i64 0
-  %out_ptr = load ptr, ptr %out_gep, align 8
-  %flags_gep = getelementptr i8, ptr %op, i64 8
-  %flags_ptr = load ptr, ptr %flags_gep, align 8
-  %clip_gep = getelementptr i8, ptr %op, i64 16
-  %clip_val = load float, ptr %clip_gep, align 4
+  %out_gep = getelementptr i8, i8* %op, i64 0
+  %out_ptr_gep = bitcast i8* %out_gep to float**
+  %out_ptr = load float*, float** %out_ptr_gep, align 8
+  %flags_gep = getelementptr i8, i8* %op, i64 8
+  %flags_ptr_gep = bitcast i8* %flags_gep to i32**
+  %flags_ptr = load i32*, i32** %flags_ptr_gep, align 8
+  %clip_gep = getelementptr i8, i8* %op, i64 16
+  %clip_ptr = bitcast i8* %clip_gep to float*
+  %clip_val = load float, float* %clip_ptr, align 4
   %idx = zext i32 %face_idx to i64
-  %face_gep = getelementptr float, ptr %out_ptr, i64 %idx
-  %face_val = load float, ptr %face_gep, align 4
+  %face_gep = getelementptr float, float* %out_ptr, i64 %idx
+  %face_val = load float, float* %face_gep, align 4
   %dot = fmul float %face_val, %clip_val
   %cmp = fcmp ole float %dot, 0.0
   br i1 %cmp, label %left_handed, label %normal
@@ -45,40 +48,40 @@ normal:
 merge:
   %result = phi float [ %clip_val, %left_handed ], [ %dot, %normal ]
   %flag = phi i32 [ 1, %left_handed ], [ 0, %normal ]
-  store float %result, ptr %face_gep, align 4
-  %n0 = load i32, ptr %nbr, align 4
+  store float %result, float* %face_gep, align 4
+  %n0 = load i32, i32* %nbr, align 4
   %n0_ext = zext i32 %n0 to i64
-  %flags_elem = getelementptr i32, ptr %flags_ptr, i64 %n0_ext
-  %old_flag = load i32, ptr %flags_elem, align 4
+  %flags_elem = getelementptr i32, i32* %flags_ptr, i64 %n0_ext
+  %old_flag = load i32, i32* %flags_elem, align 4
   %new_flag = tail call i32 @llvm.umax.i32(i32 %old_flag, i32 %flag)
-  store i32 %new_flag, ptr %flags_elem, align 4
+  store i32 %new_flag, i32* %flags_elem, align 4
   ret void
 }
 
-define void @caller(ptr %op, ptr %d_op, i32 %face_idx, ptr %nbr) {
+define void @caller(i8* %op, i8* %d_op, i32 %face_idx, i32* %nbr) {
 entry:
   call void (...) @__enzyme_autodiff(
-    ptr @compute_alpha,
-    metadata !"enzyme_dup", ptr %op, ptr %d_op,
+    i8* bitcast (void (i8*, i32, i32*)* @compute_alpha to i8*),
+    metadata !"enzyme_dup", i8* %op, i8* %d_op,
     metadata !"enzyme_const", i32 %face_idx,
-    metadata !"enzyme_const", ptr %nbr
+    metadata !"enzyme_const", i32* %nbr
   )
   ret void
 }
 
 declare void @__enzyme_autodiff(...)
 
-; CHECK: define internal void @diffecompute_alpha(ptr noalias
-; CHECK-SAME: %op, ptr
-; CHECK-SAME: %"op'"
-; CHECK-SAME: i32 %face_idx, ptr noalias
+; CHECK: define internal void @diffecompute_alpha(
+; CHECK-SAME: %op,
+; CHECK-SAME: %"op'",
+; CHECK-SAME: i32 %face_idx,
 ; CHECK-SAME: %nbr)
 
 ; Verify the primal block no longer uses the old zero-shadow fallback.
 ; CHECK:        %new_flag = {{(tail )?}}call i32 @llvm.umax.i32(i32 %old_flag, i32 %flag)
-; CHECK-NOT:    store i32 0, ptr %"flags_elem'ipg"
-; CHECK:        store i32 {{.+}}, ptr %"flags_elem'ipg"
-; CHECK:        store i32 %new_flag, ptr %flags_elem
+; CHECK-NOT:    store i32 0, {{(ptr|i32\*)}} %"flags_elem'ipg"
+; CHECK:        store i32 {{.+}}, {{(ptr|i32\*)}} %"flags_elem'ipg"
+; CHECK:        store i32 %new_flag, {{(ptr|i32\*)}} %flags_elem
 
 ; Verify the reverse block correctly propagates float derivatives
 ; CHECK:      invertentry:

--- a/enzyme/test/Enzyme/ReverseMode/loosetypes_umax.ll
+++ b/enzyme/test/Enzyme/ReverseMode/loosetypes_umax.ll
@@ -13,7 +13,8 @@
 ; @llvm.umax.i32. Without the fix, this hits:
 ;   assert(0 && "cannot find deal with ptr that isnt arg")
 ;
-; The fix returns a zero shadow for integer values under loose-types analysis.
+; The fix handles llvm.umax as a binop-like intrinsic during shadow
+; reconstruction, instead of falling through to the generic no-shadow path.
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
@@ -73,9 +74,10 @@ declare void @__enzyme_autodiff(...)
 ; CHECK-SAME: i32 %face_idx, ptr noalias
 ; CHECK-SAME: %nbr)
 
-; Verify the primal block correctly computes and stores i32 umax with zero shadow
+; Verify the primal block computes both the original and shadow i32 umax values.
 ; CHECK:        %new_flag = tail call i32 @llvm.umax.i32(i32 %old_flag, i32 %flag)
-; CHECK-NEXT:   store i32 0, ptr %"flags_elem'ipg"
+; CHECK-NEXT:   %[[NEW_FLAG_IP:.+]] = {{(tail )?}}call i32 @llvm.umax.i32(i32 %{{.+}}, i32 %{{.+}})
+; CHECK-NEXT:   store i32 %[[NEW_FLAG_IP]], ptr %"flags_elem'ipg"
 ; CHECK-NEXT:   store i32 %new_flag, ptr %flags_elem
 
 ; Verify the reverse block correctly propagates float derivatives


### PR DESCRIPTION
# Enzyme Crash: `invertPointerM` assertion failure on `@llvm.umax.i32` with `-enzyme-loose-types`

## Summary
This is to fix #2794 

Enzyme crashes with `assert(0 && "cannot find deal with ptr that isnt arg")` in `GradientUtils::invertPointerM()` when differentiating code that uses the `@llvm.umax.i32` intrinsic in reverse mode with `-enzyme-loose-types=1` enabled.

## Root Cause

When a struct passed as `enzyme_dup` contains both floating-point and integer pointer fields, and the function stores the result of `@llvm.umax.i32` to an integer pointer loaded from that struct:

1. `visitCommonStore` handles the store of the `i32` umax result to the dup pointer
2. With loose types, Enzyme treats the stored `i32` value as potentially active
3. `visitCommonStore` calls `invertPointerM()` on the `i32` umax result to obtain its shadow
4. `invertPointerM()` cannot find or create a shadow for the `@llvm.umax.i32` call result
5. The function falls through to the assertion at `GradientUtils.cpp:6601`

The `@llvm.umax.i32` intrinsic arises from `SerialOperations::AtomicMax(dest, flag)`, which the LLVM optimizer lowers to a `load → @llvm.umax.i32 → store` pattern.

## Reproducer

### LLVM IR reproducer (standalone)

File: `test/Enzyme/ReverseMode/loosetypes_umax.ll`

```
opt -load-pass-plugin=LLVMEnzyme-21.so \
    -passes="enzyme" -enzyme-preopt=false -enzyme-loose-types=1 \
    -S loosetypes_umax.ll
```

The IR models a struct with `float*` output data, `i32*` flags, and a `float` scalar. The function:
1. Loads and computes active float values
2. Derives an `i32` flag from a float comparison
3. Loads existing `i32` from the flags pointer, calls `@llvm.umax.i32`, stores result back

### Original failing code

Cromwell's `ComputeAlpha.cxx` boundary operation using Oak's `DualFixedNeighborMapIteration` reverse-mode template with `SerialOperations`.

The explicit template instantiation `flux_map_kernel_cuda_reverse<OperationBoundaryComputeAlpha, ...>` triggers the bug during x86 host compilation when the `__enzyme_autodiff` call inside the reverse kernel is processed with `-enzyme-loose-types=1`.

## Stack trace

```
GradientUtils::invertPointerM(...)
  GradientUtils.cpp:6601: Assertion `0 && "cannot find deal with ptr that isnt arg"' failed.
AdjointGenerator::visitCommonStore(...)
AdjointGenerator::visitStoreInst(...)
EnzymeLogic::CreatePrimalAndGradient(...)
```

## Proposed Fix

In `GradientUtils::invertPointerM()`, before the `CustomErrorHandler` fallback and the assertion, add a guard for integer/integer-vector values under loose type analysis:

```cpp
if (looseTypeAnalysis && oval->getType()->isIntOrIntVectorTy()) {
    auto *shadow = Constant::getNullValue(getShadowType(oval->getType()));
    invertedPointers.insert(
        std::make_pair((const Value *)oval, InvertedPointerVH(this, shadow)));
    return shadow;
}
```

This returns a zero shadow for integer values that cannot have meaningful floating-point derivatives, which is correct because:
- Under loose types, integer stores to dup pointers are processed by `visitCommonStore`
- The integer flag values (derived from float comparisons) have zero derivative
- A null constant shadow is the correct adjoint for non-differentiable integer operations

## Affected versions

- Enzyme v0.0.256 with LLVM 21
- Likely affects all Enzyme versions with `-enzyme-loose-types` support

## Test

The regression test `test/Enzyme/ReverseMode/loosetypes_umax.ll` guards against this issue.
