### PR TITLE
update rust sha in CI

### DIFF
--- a/.github/workflows/enzyme-rust.yml
+++ b/.github/workflows/enzyme-rust.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [linux-x86-n2-32]
-        commit: [b2ee1b333aea9951c3eefa4967098cc763de59ca]
+        commit: [cb40c25f6aebb637163d26bf76a680ed6e5d1eda]
     
     timeout-minutes: 90
 


### PR DESCRIPTION
related: https://github.com/EnzymeAD/Enzyme/pull/2802#issuecomment-4374551075

new sha is from 2026/05/04