### PR TITLE
Create Fortran bindings module

### DIFF
--- a/enzyme/CMakeLists.txt
+++ b/enzyme/CMakeLists.txt
@@ -34,9 +34,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 option(ENZYME_ENABLE_PLUGINS "Enable Clang/LLD/Opt plugins" ON)
 option(ENZYME_ENABLE_BENCHMARKS "Enable benchmarks" OFF)
 option(ENZYME_BC_LOADER "Enable bitcode loader" ON)
+option(ENZYME_FORTRAN "Build Enzyme Fortran bindings" OFF)
 option(ENZYME_CLANG "Build enzyme clang plugin" ON)
 option(ENZYME_FLANG "Build enzyme flang symlink" OFF)
 option(ENZYME_MLIR "Build enzyme mlir plugin" OFF)
+option(ENZYME_IFX "Enable enzyme support for the Intel Fortran compiler IFX" OFF)
 option(ENZYME_IFX "Enable enzyme support for the Intel Fortran compiler IFX" OFF)
 option(ENZYME_EXTERNAL_SHARED_LIB "Build external shared library" OFF)
 option(ENZYME_APPLE_DYNAMIC_LOOKUP
@@ -299,7 +301,9 @@ endif()
 if (ENZYME_ENABLE_PLUGINS)
     add_subdirectory(test)
 endif()
-add_subdirectory(Fortran)
+if (ENZYME_FORTRAN)
+    add_subdirectory(Fortran)
+endif()
 
 # The benchmarks data are not in git-exported source archives to minimize size.
 # Only add the benchmarks if the directory exists.

--- a/enzyme/CMakeLists.txt
+++ b/enzyme/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
-project(Enzyme LANGUAGES C CXX Fortran)
+project(Enzyme)
 
 include(CMakePackageConfigHelpers)
 include(CheckIncludeFile)

--- a/enzyme/CMakeLists.txt
+++ b/enzyme/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
-project(Enzyme)
+project(Enzyme LANGUAGES C CXX Fortran)
 
 include(CMakePackageConfigHelpers)
 include(CheckIncludeFile)
@@ -299,6 +299,7 @@ endif()
 if (ENZYME_ENABLE_PLUGINS)
     add_subdirectory(test)
 endif()
+add_subdirectory(Fortran)
 
 # The benchmarks data are not in git-exported source archives to minimize size.
 # Only add the benchmarks if the directory exists.

--- a/enzyme/Fortran/CMakeLists.txt
+++ b/enzyme/Fortran/CMakeLists.txt
@@ -1,0 +1,25 @@
+include(FortranCInterface)
+FortranCInterface_VERIFY(QUIET)
+
+add_library(EnzymeFortran enzyme_mod.f90)
+
+# Install library, create target file
+install(
+  TARGETS EnzymeFortran
+  EXPORT EnzymeFortranTargets
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  PRIVATE_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  INCLUDES
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/EnzymeFortran)
+
+# Install Fortran module file
+if(NOT DEFINED CMAKE_INSTALL_MODULEDIR)
+  set(
+    CMAKE_INSTALL_MODULEDIR
+    "${CMAKE_INSTALL_INCLUDEDIR}/EnzymeFortran"
+    CACHE STRING "Directory in prefix to install generated module files"
+  )
+endif()
+install(FILES "${CMAKE_Fortran_MODULE_DIRECTORY}/enzyme_mod.mod"
+        DESTINATION "${CMAKE_INSTALL_MODULEDIR}")

--- a/enzyme/Fortran/CMakeLists.txt
+++ b/enzyme/Fortran/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(FortranCInterface)
 FortranCInterface_VERIFY(QUIET)
 
-add_library(EnzymeFortran enzyme_mod.f90)
+add_library(EnzymeFortran enzyme.f90)
 
 # Install library, create target file
 install(
@@ -21,5 +21,5 @@ if(NOT DEFINED CMAKE_INSTALL_MODULEDIR)
     CACHE STRING "Directory in prefix to install generated module files"
   )
 endif()
-install(FILES "${CMAKE_Fortran_MODULE_DIRECTORY}/enzyme_mod.mod"
+install(FILES "${CMAKE_Fortran_MODULE_DIRECTORY}/enzyme.mod"
         DESTINATION "${CMAKE_INSTALL_MODULEDIR}")

--- a/enzyme/Fortran/CMakeLists.txt
+++ b/enzyme/Fortran/CMakeLists.txt
@@ -1,3 +1,4 @@
+enable_language(Fortran)
 include(FortranCInterface)
 FortranCInterface_VERIFY(QUIET)
 

--- a/enzyme/Fortran/enzyme.f90
+++ b/enzyme/Fortran/enzyme.f90
@@ -1,4 +1,4 @@
-! ===- enzyme_mod.f90 - Fortran bindings for Enzyme -----------------------=== !
+! ===- enzyme.f90 - Fortran bindings for Enzyme ---------------------------=== !
 !
 !                              Enzyme Project
 !
@@ -20,7 +20,7 @@
 !  This file provides Fortran bindings for Enzyme.
 !
 ! ===----------------------------------------------------------------------=== !
-module enzyme_mod
+module enzyme
   use iso_c_binding, only: c_int
   implicit none
   private
@@ -33,4 +33,4 @@ module enzyme_mod
   integer(c_int), public, bind(C, name="enzyme_scalar")    :: enzyme_scalar
   integer(c_int), public, bind(C, name="enzyme_width")     :: enzyme_width
   integer(c_int), public, bind(C, name="enzyme_vector")    :: enzyme_vector
-end module enzyme_mod
+end module enzyme

--- a/enzyme/Fortran/enzyme_mod.f90
+++ b/enzyme/Fortran/enzyme_mod.f90
@@ -1,0 +1,36 @@
+! ===- enzyme_mod.f90 - Fortran bindings for Enzyme -----------------------=== !
+!
+!                              Enzyme Project
+!
+!  Part of the Enzyme Project, under the Apache License v2.0 with LLVM
+!  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+!  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+!  If using this code in an academic setting, please cite the following:
+!  @misc{enzymeGithub,
+!   author = {William S. Moses and Valentin Churavy},
+!   title = {Enzyme: High Performance Automatic Differentiation of LLVM},
+!   year = {2020},
+!   howpublished = {\url{https://github.com/wsmoses/Enzyme}},
+!   note = {commit xxxxxxx}
+!  }
+!
+! ===----------------------------------------------------------------------=== !
+!
+!  This file provides Fortran bindings for Enzyme.
+!
+! ===----------------------------------------------------------------------=== !
+module enzyme_mod
+  use iso_c_binding, only: c_int
+  implicit none
+  private
+
+  ! Bindings for activity descriptors
+  integer(c_int), public, bind(C, name="enzyme_const")     :: enzyme_const
+  integer(c_int), public, bind(C, name="enzyme_dup")       :: enzyme_dup
+  integer(c_int), public, bind(C, name="enzyme_dupnoneed") :: enzyme_dupnoneed
+  integer(c_int), public, bind(C, name="enzyme_out")       :: enzyme_out
+  integer(c_int), public, bind(C, name="enzyme_scalar")    :: enzyme_scalar
+  integer(c_int), public, bind(C, name="enzyme_width")     :: enzyme_width
+  integer(c_int), public, bind(C, name="enzyme_vector")    :: enzyme_vector
+end module enzyme_mod


### PR DESCRIPTION
Closes #2805

Thanks to @isaacaka for figuring out how to make use of activity descriptors in Fortran: bind to those that Enzyme picks up in C. To avoid users having to know how to do Fortran-C binding, we thought it would be beneficial to create a Fortran module containing these for convenience. There will likely be other things that come up that we can add to the module later in the project.

To use these descriptors in Fortran, import them with
```fortran
use enzyme_mod, only: enzyme_const, enzyme_dup
```
or just
```fortran
use enzyme_mod
```

## Checklist

- [x] Add a Fortran module into the repo containing these bindings
- [x] Hook it up in the build system