### PR TITLE
Add rev mode support for `memref.alloca_scope`

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
@@ -274,7 +274,7 @@ public:
     if (!eltIface || eltIface.isMutable())
       return failure();
     Value zero = eltIface.createNullValue(builder, loc);
-    
+
     if (MT.getRank() == 0) {
       memref::StoreOp::create(builder, loc, zero, val, ValueRange{});
       return success();
@@ -287,15 +287,16 @@ public:
     SmallVector<Value> steps(MT.getRank(), c1);
     SmallVector<Value> ubs;
     for (auto [i, d] : llvm::enumerate(MT.getShape())) {
-      ubs.push_back(d == ShapedType::kDynamic
-          ? memref::DimOp::create(builder, loc, val, i).getResult()
-          : arith::ConstantIndexOp::create(builder, loc, d).getResult());
+      ubs.push_back(
+          d == ShapedType::kDynamic
+              ? memref::DimOp::create(builder, loc, val, i).getResult()
+              : arith::ConstantIndexOp::create(builder, loc, d).getResult());
     }
 
     scf::ParallelOp::create(builder, loc, lbs, ubs, steps,
-        [&](OpBuilder &b, Location l, ValueRange ivs) {
-          memref::StoreOp::create(b, l, zero, val, ivs);
-        });
+                            [&](OpBuilder &b, Location l, ValueRange ivs) {
+                              memref::StoreOp::create(b, l, zero, val, ivs);
+                            });
     return success();
   }
 

--- a/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
@@ -244,8 +244,7 @@ struct AllocaScopeOpInterfaceReverse
       gutils->zeroDiffe(v, builder);
     }
 
-    auto newScope =
-        cast<memref::AllocaScopeOp>(gutils->getNewFromOriginal(op));
+    auto newScope = cast<memref::AllocaScopeOp>(gutils->getNewFromOriginal(op));
     newScope->moveBefore(builder.getInsertionBlock(),
                          builder.getInsertionPoint());
 

--- a/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
@@ -220,19 +220,41 @@ struct AllocaScopeOpInterfaceReverse
       }
     }
 
-    auto revScope =
-        memref::AllocaScopeOp::create(builder, op->getLoc(), TypeRange());
-    Block *revBody = builder.createBlock(&revScope.getBodyRegion());
-    OpBuilder bodyBuilder(revBody, revBody->end());
-    memref::AllocaScopeReturnOp::create(bodyBuilder, op->getLoc(),
-                                        ValueRange());
-    bodyBuilder.setInsertionPoint(revBody->getTerminator());
+    Region &scopeRegion = scopeOp.getBodyRegion();
+    SmallVector<Value> capturedInputs;
+    scopeRegion.walk([&](Operation *inner) {
+      for (Value operand : inner->getOperands()) {
+        Region *defRegion = operand.getParentRegion();
+        if (!defRegion || scopeRegion.isAncestor(defRegion))
+          continue;
+        if (gutils->isConstantValue(operand))
+          continue;
+        auto iface = dyn_cast<AutoDiffTypeInterface>(operand.getType());
+        if (!iface || iface.isMutable())
+          continue;
+        if (!llvm::is_contained(capturedInputs, operand))
+          capturedInputs.push_back(operand);
+      }
+    });
+
+    SmallVector<Value> capturedPre;
+    capturedPre.reserve(capturedInputs.size());
+    for (Value v : capturedInputs) {
+      capturedPre.push_back(gutils->diffe(v, builder));
+      gutils->zeroDiffe(v, builder);
+    }
+
+    auto newScope =
+        cast<memref::AllocaScopeOp>(gutils->getNewFromOriginal(op));
+    newScope->moveBefore(builder.getInsertionBlock(),
+                         builder.getInsertionPoint());
+
+    Block &newBody = newScope.getBodyRegion().front();
+    OpBuilder bodyBuilder(newBody.getTerminator());
 
     Block &oldBody = scopeOp.getBodyRegion().front();
     bool valid = true;
 
-    // Values defined in the scoped region cannot be used outside it. Reset
-    // their adjoints before propagating gradients through the scoped body.
     for (Operation &innerOp : oldBody.getOperations()) {
       for (Value result : innerOp.getResults()) {
         if (!gutils->isConstantValue(result)) {
@@ -253,14 +275,59 @@ struct AllocaScopeOpInterfaceReverse
       if (!gutils->isConstantValue(operand))
         gutils->addToDiffe(operand, incomingGradients[incomingIdx],
                            bodyBuilder);
-      ++incomingIdx;
+      incomingIdx++;
     }
 
     auto first = oldBody.rbegin();
-    ++first;
+    first++;
 
-    for (auto it = first; it != oldBody.rend(); ++it) {
+    for (auto it = first; it != oldBody.rend(); it++) {
       valid &= gutils->Logic.visitChild(&*it, bodyBuilder, gutils).succeeded();
+    }
+
+    if (capturedInputs.empty())
+      return success(valid);
+
+    SmallVector<Value> contributions;
+    contributions.reserve(capturedInputs.size());
+    for (Value v : capturedInputs)
+      contributions.push_back(gutils->diffe(v, bodyBuilder));
+
+    unsigned numPrimal = newScope->getNumResults();
+    Operation *bodyTerm = newBody.getTerminator();
+    SmallVector<Value> retVals(bodyTerm->getOperands().begin(),
+                               bodyTerm->getOperands().end());
+    retVals.append(contributions.begin(), contributions.end());
+
+    SmallVector<Type> newResultTypes(newScope->getResultTypes().begin(),
+                                     newScope->getResultTypes().end());
+    for (Value v : capturedInputs)
+      newResultTypes.push_back(gutils->getShadowType(v.getType()));
+
+    OpBuilder scopeBuilder(newScope);
+    auto extScope = memref::AllocaScopeOp::create(scopeBuilder, op->getLoc(),
+                                                  newResultTypes);
+    extScope.getBodyRegion().takeBody(newScope.getBodyRegion());
+
+    Block &extBody = extScope.getBodyRegion().front();
+    Operation *movedTerm = extBody.getTerminator();
+    OpBuilder termBuilder(movedTerm);
+    memref::AllocaScopeReturnOp::create(termBuilder, movedTerm->getLoc(),
+                                        retVals);
+    gutils->erase(movedTerm);
+
+    for (unsigned i = 0; i < numPrimal; ++i) {
+      newScope->getResult(i).replaceAllUsesWith(extScope.getResult(i));
+      gutils->originalToNewFn.map(scopeOp->getResult(i), extScope.getResult(i));
+    }
+    gutils->erase(newScope);
+
+    builder.setInsertionPointAfter(extScope);
+    for (auto indexed : llvm::enumerate(capturedInputs)) {
+      Value v = indexed.value();
+      gutils->setDiffe(v, capturedPre[indexed.index()], builder);
+      gutils->addToDiffe(v, extScope.getResult(numPrimal + indexed.index()),
+                         builder);
     }
 
     return success(valid);

--- a/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
@@ -200,6 +200,81 @@ struct SubViewOpInterfaceReverse
   }
 };
 
+struct AllocaScopeOpInterfaceReverse
+    : public ReverseAutoDiffOpInterface::ExternalModel<
+          AllocaScopeOpInterfaceReverse, memref::AllocaScopeOp> {
+  LogicalResult createReverseModeAdjoint(Operation *op, OpBuilder &builder,
+                                         MGradientUtilsReverse *gutils,
+                                         SmallVector<Value> caches) const {
+    auto scopeOp = cast<memref::AllocaScopeOp>(op);
+
+    SmallVector<bool> resultsActive(scopeOp->getNumResults(), false);
+    SmallVector<Value> incomingGradients;
+    incomingGradients.reserve(scopeOp->getNumResults());
+    for (OpResult result : scopeOp->getResults()) {
+      bool active = !gutils->isConstantValue(result);
+      resultsActive[result.getResultNumber()] = active;
+      if (active) {
+        incomingGradients.push_back(gutils->diffe(result, builder));
+        gutils->zeroDiffe(result, builder);
+      }
+    }
+
+    auto revScope =
+        memref::AllocaScopeOp::create(builder, op->getLoc(), TypeRange());
+    Block *revBody = builder.createBlock(&revScope.getBodyRegion());
+    OpBuilder bodyBuilder(revBody, revBody->end());
+    memref::AllocaScopeReturnOp::create(bodyBuilder, op->getLoc(),
+                                        ValueRange());
+    bodyBuilder.setInsertionPoint(revBody->getTerminator());
+
+    Block &oldBody = scopeOp.getBodyRegion().front();
+    bool valid = true;
+
+    // Values defined in the scoped region cannot be used outside it. Reset their
+    // adjoints before propagating gradients through the scoped body.
+    for (Operation &innerOp : oldBody.getOperations()) {
+      for (Value result : innerOp.getResults()) {
+        if (!gutils->isConstantValue(result)) {
+          auto iface = dyn_cast<AutoDiffTypeInterface>(result.getType());
+          if (iface && !iface.isMutable())
+            gutils->zeroDiffe(result, bodyBuilder);
+        }
+      }
+    }
+
+    Operation *term = oldBody.getTerminator();
+    unsigned incomingIdx = 0;
+    for (auto indexedOperand : llvm::enumerate(term->getOperands())) {
+      if (!resultsActive[indexedOperand.index()])
+        continue;
+
+      Value operand = indexedOperand.value();
+      if (!gutils->isConstantValue(operand))
+        gutils->addToDiffe(operand, incomingGradients[incomingIdx],
+                           bodyBuilder);
+      ++incomingIdx;
+    }
+
+    auto first = oldBody.rbegin();
+    ++first;
+
+    for (auto it = first; it != oldBody.rend(); ++it) {
+      valid &= gutils->Logic.visitChild(&*it, bodyBuilder, gutils).succeeded();
+    }
+
+    return success(valid);
+  }
+
+  SmallVector<Value> cacheValues(Operation *op,
+                                 MGradientUtilsReverse *gutils) const {
+    return SmallVector<Value>();
+  }
+
+  void createShadowValues(Operation *op, OpBuilder &builder,
+                          MGradientUtilsReverse *gutils) const {}
+};
+
 class MemRefClonableTypeInterface
     : public ClonableTypeInterface::ExternalModel<MemRefClonableTypeInterface,
                                                   MemRefType> {
@@ -315,5 +390,7 @@ void mlir::enzyme::registerMemRefDialectAutoDiffInterface(
     memref::LoadOp::attachInterface<LoadOpInterfaceReverse>(*context);
     memref::StoreOp::attachInterface<StoreOpInterfaceReverse>(*context);
     memref::SubViewOp::attachInterface<SubViewOpInterfaceReverse>(*context);
+    memref::AllocaScopeOp::attachInterface<AllocaScopeOpInterfaceReverse>(
+        *context);
   });
 }

--- a/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
@@ -231,8 +231,8 @@ struct AllocaScopeOpInterfaceReverse
     Block &oldBody = scopeOp.getBodyRegion().front();
     bool valid = true;
 
-    // Values defined in the scoped region cannot be used outside it. Reset their
-    // adjoints before propagating gradients through the scoped body.
+    // Values defined in the scoped region cannot be used outside it. Reset
+    // their adjoints before propagating gradients through the scoped body.
     for (Operation &innerOp : oldBody.getOperations()) {
       for (Value result : innerOp.getResults()) {
         if (!gutils->isConstantValue(result)) {

--- a/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
@@ -18,12 +18,9 @@
 #include "Interfaces/GradientUtilsReverse.h"
 
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/Support/LogicalResult.h"
-
-// TODO: We need a way to zero out a memref (which linalg.fill does), but
-// ideally we wouldn't depend on the linalg dialect.
-#include "mlir/Dialect/Linalg/IR/Linalg.h"
 
 using namespace mlir;
 using namespace mlir::enzyme;
@@ -273,14 +270,32 @@ public:
   LogicalResult zeroInPlace(Type self, OpBuilder &builder, Location loc,
                             Value val) const {
     auto MT = cast<MemRefType>(self);
-    if (auto iface = dyn_cast<AutoDiffTypeInterface>(MT.getElementType())) {
-      if (!iface.isMutable()) {
-        Value zero = iface.createNullValue(builder, loc);
-        linalg::FillOp::create(builder, loc, zero, val);
-      }
-    } else {
+    auto eltIface = dyn_cast<AutoDiffTypeInterface>(MT.getElementType());
+    if (!eltIface || eltIface.isMutable())
       return failure();
+    Value zero = eltIface.createNullValue(builder, loc);
+    
+    if (MT.getRank() == 0) {
+      memref::StoreOp::create(builder, loc, zero, val, ValueRange{});
+      return success();
     }
+
+    Value c0 = arith::ConstantIndexOp::create(builder, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(builder, loc, 1);
+
+    SmallVector<Value> lbs(MT.getRank(), c0);
+    SmallVector<Value> steps(MT.getRank(), c1);
+    SmallVector<Value> ubs;
+    for (auto [i, d] : llvm::enumerate(MT.getShape())) {
+      ubs.push_back(d == ShapedType::kDynamic
+          ? memref::DimOp::create(builder, loc, val, i).getResult()
+          : arith::ConstantIndexOp::create(builder, loc, d).getResult());
+    }
+
+    scf::ParallelOp::create(builder, loc, lbs, ubs, steps,
+        [&](OpBuilder &b, Location l, ValueRange ivs) {
+          memref::StoreOp::create(b, l, zero, val, ivs);
+        });
     return success();
   }
 

--- a/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.cpp
@@ -223,8 +223,12 @@ void mlir::enzyme::MGradientUtils::setDiffe(mlir::Value val, mlir::Value toset,
   }
   assert(!isConstantValue(val));
 
+  bool isMutable = false;
+  if (auto iface = dyn_cast<AutoDiffTypeInterface>(val.getType()))
+    isMutable = iface.isMutable();
+
   if (mode == DerivativeMode::ForwardMode ||
-      mode == DerivativeMode::ForwardModeSplit) {
+      mode == DerivativeMode::ForwardModeSplit || isMutable) {
     setInvertedPointer(val, toset);
   }
   /*
@@ -240,11 +244,13 @@ void mlir::enzyme::MGradientUtils::setDiffe(mlir::Value val, mlir::Value toset,
 
 void mlir::enzyme::MGradientUtils::setInvertedPointer(Value val, Value toset) {
   assert(getShadowType(val.getType()) == toset.getType());
-  auto found = invertedPointers.lookupOrNull(val);
-  assert(found != nullptr);
-  auto placeholder = found.getDefiningOp<enzyme::PlaceholderOp>();
-  placeholder.replaceAllUsesWith(toset);
-  erase(placeholder);
+  
+  if (auto found = invertedPointers.lookupOrNull(val)) {
+    if (auto placeholder = found.getDefiningOp<enzyme::PlaceholderOp>()) {
+      placeholder.replaceAllUsesWith(toset);
+      erase(placeholder);
+    }
+  }
   invertedPointers.map(val, toset);
 }
 

--- a/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.cpp
@@ -244,7 +244,7 @@ void mlir::enzyme::MGradientUtils::setDiffe(mlir::Value val, mlir::Value toset,
 
 void mlir::enzyme::MGradientUtils::setInvertedPointer(Value val, Value toset) {
   assert(getShadowType(val.getType()) == toset.getType());
-  
+
   if (auto found = invertedPointers.lookupOrNull(val)) {
     if (auto placeholder = found.getDefiningOp<enzyme::PlaceholderOp>()) {
       placeholder.replaceAllUsesWith(toset);

--- a/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.cpp
@@ -244,13 +244,11 @@ void mlir::enzyme::MGradientUtils::setDiffe(mlir::Value val, mlir::Value toset,
 
 void mlir::enzyme::MGradientUtils::setInvertedPointer(Value val, Value toset) {
   assert(getShadowType(val.getType()) == toset.getType());
-
-  if (auto found = invertedPointers.lookupOrNull(val)) {
-    if (auto placeholder = found.getDefiningOp<enzyme::PlaceholderOp>()) {
-      placeholder.replaceAllUsesWith(toset);
-      erase(placeholder);
-    }
-  }
+  auto found = invertedPointers.lookupOrNull(val);
+  assert(found != nullptr);
+  auto placeholder = found.getDefiningOp<enzyme::PlaceholderOp>();
+  placeholder.replaceAllUsesWith(toset);
+  erase(placeholder);
   invertedPointers.map(val, toset);
 }
 

--- a/enzyme/test/MLIR/ReverseMode/alloca.mlir
+++ b/enzyme/test/MLIR/ReverseMode/alloca.mlir
@@ -1,4 +1,4 @@
-// RUN: %eopt --split-input-file --enzyme --canonicalize --remove-unnecessary-enzyme-ops --enzyme-simplify-math %s | FileCheck %s
+// RUN: %eopt --enzyme %s | FileCheck %s
 
 func.func @foo_flat(%x : f64) -> f64 {
   %buf = memref.alloca() : memref<f64>
@@ -18,12 +18,45 @@ func.func @dfoo_flat(%x: f64, %dout : f64) -> f64 {
 // CHECK-LABEL:   func.func private @diffefoo_flat(
 // CHECK-SAME:      %[[X:[^,]+]]: f64,
 // CHECK-SAME:      %[[DOUT:[^)]+]]: f64) -> f64 {
-// A shadow memref.alloca must be created and zero-initialized so the
-// reverse-mode adjoint can accumulate gradients into it.
-// CHECK-DAG:       %[[ZERO:.*]] = arith.constant 0.000000e+00 : f64
-// CHECK-DAG:       %[[DBUF:.*]] = memref.alloca() : memref<f64>
-// CHECK:           memref.store %[[ZERO]], %[[DBUF]][] : memref<f64>
-// No leftover placeholders should survive the differentiation.
+
+// CHECK:           %[[GX:.+]] = "enzyme.init"() : () -> !enzyme.Gradient<f64>
+// CHECK:           "enzyme.set"(%[[GX]], %{{.*}}) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK:           %[[CS:.+]] = "enzyme.init"() : () -> !enzyme.Cache<memref<f64>>
+// CHECK:           %[[CL:.+]] = "enzyme.init"() : () -> !enzyme.Cache<memref<f64>>
+// CHECK:           %[[GY:.+]] = "enzyme.init"() : () -> !enzyme.Gradient<f64>
+// CHECK:           "enzyme.set"(%[[GY]], %{{.*}}) : (!enzyme.Gradient<f64>, f64) -> ()
+
+// CHECK:           %[[DBUF:.+]] = memref.alloca() : memref<f64>
+// CHECK:           %[[ZERO_INIT:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK:           memref.store %[[ZERO_INIT]], %[[DBUF]][] : memref<f64>
+
+// CHECK:           %[[BUF:.+]] = memref.alloca() : memref<f64>
+// CHECK:           "enzyme.push"(%[[CS]], %[[DBUF]]) : (!enzyme.Cache<memref<f64>>, memref<f64>) -> ()
+// CHECK:           memref.store %[[X]], %[[BUF]][] : memref<f64>
+// CHECK:           "enzyme.push"(%[[CL]], %[[DBUF]]) : (!enzyme.Cache<memref<f64>>, memref<f64>) -> ()
+// CHECK:           memref.load %[[BUF]][] : memref<f64>
+// CHECK:           cf.br ^bb1
+// CHECK:         ^bb1:
+
+// CHECK:           %{{.+}} = "enzyme.get"(%[[GY]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:           arith.addf %{{.+}}, %[[DOUT]] : f64
+// CHECK:           "enzyme.set"(%[[GY]], %{{.*}}) : (!enzyme.Gradient<f64>, f64) -> ()
+
+// CHECK:           %{{.+}} = "enzyme.get"(%[[GY]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:           %[[POPL:.+]] = "enzyme.pop"(%[[CL]]) : (!enzyme.Cache<memref<f64>>) -> memref<f64>
+// CHECK:           memref.load %[[POPL]][] : memref<f64>
+// CHECK:           arith.addf
+// CHECK:           memref.store %{{.+}}, %[[POPL]][] : memref<f64>
+
+// CHECK:           %[[POPS:.+]] = "enzyme.pop"(%[[CS]]) : (!enzyme.Cache<memref<f64>>) -> memref<f64>
+// CHECK:           memref.load %[[POPS]][] : memref<f64>
+// CHECK:           %{{.+}} = "enzyme.get"(%[[GX]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:           arith.addf
+// CHECK:           "enzyme.set"(%[[GX]], %{{.*}}) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK:           %[[ZERO_CLEAR:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK:           memref.store %[[ZERO_CLEAR]], %[[POPS]][] : memref<f64>
+
+// CHECK:           %{{.+}} = "enzyme.get"(%[[GX]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:           return %{{.+}} : f64
+
 // CHECK-NOT:       enzyme.placeholder
-// The function ultimately returns the gradient w.r.t. x (= dout).
-// CHECK:           return %{{.*}} : f64

--- a/enzyme/test/MLIR/ReverseMode/alloca.mlir
+++ b/enzyme/test/MLIR/ReverseMode/alloca.mlir
@@ -1,0 +1,29 @@
+// RUN: %eopt --split-input-file --enzyme --canonicalize --remove-unnecessary-enzyme-ops --enzyme-simplify-math %s | FileCheck %s
+
+func.func @foo_flat(%x : f64) -> f64 {
+  %buf = memref.alloca() : memref<f64>
+  memref.store %x, %buf[] : memref<f64>
+  %y = memref.load %buf[] : memref<f64>
+  return %y : f64
+}
+
+func.func @dfoo_flat(%x: f64, %dout : f64) -> f64 {
+  %dx = enzyme.autodiff @foo_flat(%x, %dout) {
+    activity = [#enzyme<activity enzyme_active>],
+    ret_activity = [#enzyme<activity enzyme_activenoneed>]
+  } : (f64, f64) -> (f64)
+  return %dx : f64
+}
+
+// CHECK-LABEL:   func.func private @diffefoo_flat(
+// CHECK-SAME:      %[[X:[^,]+]]: f64,
+// CHECK-SAME:      %[[DOUT:[^)]+]]: f64) -> f64 {
+// A shadow memref.alloca must be created and zero-initialized so the
+// reverse-mode adjoint can accumulate gradients into it.
+// CHECK-DAG:       %[[ZERO:.*]] = arith.constant 0.000000e+00 : f64
+// CHECK-DAG:       %[[DBUF:.*]] = memref.alloca() : memref<f64>
+// CHECK:           memref.store %[[ZERO]], %[[DBUF]][] : memref<f64>
+// No leftover placeholders should survive the differentiation.
+// CHECK-NOT:       enzyme.placeholder
+// The function ultimately returns the gradient w.r.t. x (= dout).
+// CHECK:           return %{{.*}} : f64

--- a/enzyme/test/MLIR/ReverseMode/alloca_scope.mlir
+++ b/enzyme/test/MLIR/ReverseMode/alloca_scope.mlir
@@ -1,0 +1,94 @@
+// RUN: %eopt --enzyme --canonicalize --remove-unnecessary-enzyme-ops --enzyme-simplify-math %s | FileCheck %s
+
+func.func private @scope_overwrite(%x: memref<f32>) {
+  memref.alloca_scope {
+    %val = memref.load %x[] : memref<f32>
+    %cos = math.cos %val : f32
+    memref.store %cos, %x[] : memref<f32>
+  }
+  return
+}
+
+func.func @dscope_overwrite(%x: memref<f32>, %dx: memref<f32>) {
+  enzyme.autodiff @scope_overwrite(%x, %dx) {
+    activity = [#enzyme<activity enzyme_dup>],
+    ret_activity = []
+  } : (memref<f32>, memref<f32>) -> ()
+  return
+}
+
+func.func private @scope_load_mul(%x: memref<f64>, %c: f64) -> f64 {
+  %r = memref.alloca_scope -> (f64) {
+    %v = memref.load %x[] : memref<f64>
+    %p = arith.mulf %v, %c : f64
+    memref.alloca_scope.return %p : f64
+  }
+  return %r : f64
+}
+
+func.func @dscope_load_mul(%x: memref<f64>, %dx: memref<f64>,
+                           %c: f64, %dout: f64) -> f64 {
+  %res = enzyme.autodiff @scope_load_mul(%x, %dx, %c, %dout) {
+    activity = [#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_active>],
+    ret_activity = [#enzyme<activity enzyme_activenoneed>]
+  } : (memref<f64>, memref<f64>, f64, f64) -> f64
+  return %res : f64
+}
+
+// CHECK-LABEL:   func.func private @diffescope_overwrite(
+// CHECK-SAME:      %[[X:.*]]: memref<f32>,
+// CHECK-SAME:      %[[DX:.*]]: memref<f32>) {
+// CHECK:           %[[ZERO:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[CDX0:.*]] = "enzyme.init"() : () -> !enzyme.Cache<memref<f32>>
+// CHECK:           %[[CVAL:.*]] = "enzyme.init"() : () -> !enzyme.Cache<f32>
+// CHECK:           %[[CDX1:.*]] = "enzyme.init"() : () -> !enzyme.Cache<memref<f32>>
+// CHECK:           memref.alloca_scope  {
+// CHECK:             "enzyme.push"(%[[CDX0]], %[[DX]])
+// CHECK:             %[[V:.*]] = memref.load %[[X]][] : memref<f32>
+// CHECK:             "enzyme.push"(%[[CVAL]], %[[V]])
+// CHECK:             %[[COS:.*]] = math.cos %[[V]] : f32
+// CHECK:             "enzyme.push"(%[[CDX1]], %[[DX]])
+// CHECK:             memref.store %[[COS]], %[[X]][] : memref<f32>
+// CHECK:           }
+// CHECK:           %[[DX_R1:.*]] = "enzyme.pop"(%[[CDX1]])
+// CHECK:           %[[DOUT:.*]] = memref.load %[[DX_R1]][] : memref<f32>
+// CHECK:           memref.store %[[ZERO]], %[[DX_R1]][] : memref<f32>
+// CHECK:           %[[VAL:.*]] = "enzyme.pop"(%[[CVAL]])
+// CHECK:           %[[SIN:.*]] = math.sin %[[VAL]] : f32
+// CHECK:           %[[NEG:.*]] = arith.negf %[[SIN]] : f32
+// CHECK:           %[[GRAD:.*]] = arith.mulf %[[DOUT]], %[[NEG]] : f32
+// CHECK:           %[[DX_R0:.*]] = "enzyme.pop"(%[[CDX0]])
+// CHECK:           %[[OLD:.*]] = memref.load %[[DX_R0]][] : memref<f32>
+// CHECK:           %[[NEW:.*]] = arith.addf %[[OLD]], %[[GRAD]] : f32
+// CHECK:           memref.store %[[NEW]], %[[DX_R0]][] : memref<f32>
+// CHECK:           return
+
+// CHECK-LABEL:   func.func private @diffescope_load_mul(
+// CHECK-SAME:      %[[X:[^,]+]]: memref<f64>,
+// CHECK-SAME:      %[[DX:[^,]+]]: memref<f64>,
+// CHECK-SAME:      %[[C:[^,]+]]: f64,
+// CHECK-SAME:      %[[DOUT:[^)]+]]: f64) -> f64 {
+// CHECK:           %[[CDX:.*]] = "enzyme.init"() : () -> !enzyme.Cache<memref<f64>>
+// CHECK:           %[[GC:.*]] = "enzyme.init"() : () -> !enzyme.Gradient<f64>
+// CHECK:           %[[CC:.*]] = "enzyme.init"() : () -> !enzyme.Cache<f64>
+// CHECK:           %[[CV:.*]] = "enzyme.init"() : () -> !enzyme.Cache<f64>
+// CHECK:           memref.alloca_scope  -> (f64) {
+// CHECK:             "enzyme.push"(%[[CDX]], %[[DX]])
+// CHECK:             %[[V:.*]] = memref.load %[[X]][] : memref<f64>
+// CHECK:             "enzyme.push"(%[[CV]], %[[V]])
+// CHECK:             "enzyme.push"(%[[CC]], %[[C]])
+// CHECK:             %[[P:.*]] = arith.mulf %[[V]], %[[C]] : f64
+// CHECK:             memref.alloca_scope.return %[[P]] : f64
+// CHECK:           }
+// CHECK:           memref.alloca_scope  {
+// CHECK:             %[[V_R:.*]] = "enzyme.pop"(%[[CV]])
+// CHECK:             %[[C_R:.*]] = "enzyme.pop"(%[[CC]])
+// CHECK-DAG:         %[[DC:.*]] = arith.mulf %[[DOUT]], %[[V_R]] : f64
+// CHECK-DAG:         %[[DV:.*]] = arith.mulf %[[DOUT]], %[[C_R]] : f64
+// CHECK:             %[[DX_R:.*]] = "enzyme.pop"(%[[CDX]])
+// CHECK:             %[[OLD:.*]] = memref.load %[[DX_R]][] : memref<f64>
+// CHECK:             %[[NEW:.*]] = arith.addf %[[OLD]], %[[DV]] : f64
+// CHECK:             memref.store %[[NEW]], %[[DX_R]][] : memref<f64>
+// CHECK:           }
+// CHECK:           %[[OUT:.*]] = "enzyme.get"(%[[GC]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:           return %[[OUT]] : f64

--- a/enzyme/test/MLIR/ReverseMode/alloca_scope2.mlir
+++ b/enzyme/test/MLIR/ReverseMode/alloca_scope2.mlir
@@ -10,29 +10,63 @@ func.func @foo(%x : f64) -> f64{
     return %out  : f64
 }
 
-
 func.func @dfoo(%x: f64, %dout : f64) -> f64 {
   %dx = enzyme.autodiff @foo(%x, %dout) {
-    activity = [#enzyme<activity enzyme_active>],
-    ret_activity = [#enzyme<acitivity enzyme_activenoneed>]
-  } : (f64, f64) -> (f64)
-  return %dx : f64
-}
-
-func.func @foo2(%x : f64) -> f64{
-    %cst = arith.constant 0.0000e+00 : f64
-      %buf = memref.alloca() : memref<f64>
-      memref.store %x, %buf[] : memref<f64>
-      %y = memref.load %buf[] : memref<f64>
-      %out = arith.addf %cst, %y : f64
-    return %out  : f64
-}
-
-
-func.func @dfoo2(%x: f64, %dout : f64) -> f64 {
-  %dx = enzyme.autodiff @foo2(%x, %dout) {
     activity = [#enzyme<activity enzyme_active>],
     ret_activity = [#enzyme<activity enzyme_activenoneed>]
   } : (f64, f64) -> (f64)
   return %dx : f64
 }
+
+// CHECK-LABEL:   func.func private @diffefoo(
+// CHECK-SAME:      %[[X:[^,]+]]: f64,
+// CHECK-SAME:      %[[DOUT:[^)]+]]: f64) -> f64 {
+// CHECK:           %[[C0:.*]] = "enzyme.init"() : () -> !enzyme.Cache<memref<f64>>
+// CHECK:           %[[C1:.*]] = "enzyme.init"() : () -> !enzyme.Cache<memref<f64>>
+// CHECK:           %[[G0:.*]] = "enzyme.init"() : () -> !enzyme.Gradient<f64>
+// CHECK:           "enzyme.set"(%[[G0]], %{{.*}}) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK:           %[[G1:.*]] = "enzyme.init"() : () -> !enzyme.Gradient<f64>
+// CHECK:           "enzyme.set"(%[[G1]], %{{.*}}) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK:           %[[G2:.*]] = "enzyme.init"() : () -> !enzyme.Gradient<f64>
+// CHECK:           "enzyme.set"(%[[G2]], %{{.*}}) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK:           cf.br ^bb1
+// CHECK:         ^bb1:
+// CHECK:           %[[T5:.*]] = "enzyme.get"(%[[G2]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:           %[[T6:.*]] = arith.addf %[[T5]], %[[DOUT]] : f64
+// CHECK:           "enzyme.set"(%[[G2]], %[[T6]]) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK:           %[[T7:.*]] = "enzyme.get"(%[[G2]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:           "enzyme.set"(%[[G2]], %{{.*}}) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK:           %[[T8:.*]] = "enzyme.get"(%[[G1]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:           "enzyme.set"(%[[G1]], %{{.*}}) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK:           %[[SCOPE:.*]]:2 = memref.alloca_scope  -> (f64, f64) {
+// CHECK:             %[[ALLOCA:.*]] = memref.alloca() : memref<f64>
+// CHECK:             memref.store %{{.*}}, %[[ALLOCA]][] : memref<f64>
+// CHECK:             %[[ALLOCA5:.*]] = memref.alloca() : memref<f64>
+// CHECK:             "enzyme.push"(%[[C0]], %[[ALLOCA]]) : (!enzyme.Cache<memref<f64>>, memref<f64>) -> ()
+// CHECK:             memref.store %[[X]], %[[ALLOCA5]][] : memref<f64>
+// CHECK:             "enzyme.push"(%[[C1]], %[[ALLOCA]]) : (!enzyme.Cache<memref<f64>>, memref<f64>) -> ()
+// CHECK:             %[[LD:.*]] = memref.load %[[ALLOCA5]][] : memref<f64>
+// CHECK:             "enzyme.set"(%[[G0]], %{{.*}}) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK:             %[[T14:.*]] = "enzyme.get"(%[[G0]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:             %[[T15:.*]] = arith.addf %[[T14]], %[[T7]] : f64
+// CHECK:             "enzyme.set"(%[[G0]], %[[T15]]) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK:             %[[T16:.*]] = "enzyme.get"(%[[G0]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:             %[[POP1:.*]] = "enzyme.pop"(%[[C1]]) : (!enzyme.Cache<memref<f64>>) -> memref<f64>
+// CHECK:             %[[LD18:.*]] = memref.load %[[POP1]][] : memref<f64>
+// CHECK:             %[[T19:.*]] = arith.addf %[[LD18]], %[[T16]] : f64
+// CHECK:             memref.store %[[T19]], %[[POP1]][] : memref<f64>
+// CHECK:             %[[POP0:.*]] = "enzyme.pop"(%[[C0]]) : (!enzyme.Cache<memref<f64>>) -> memref<f64>
+// CHECK:             %[[LD21:.*]] = memref.load %[[POP0]][] : memref<f64>
+// CHECK:             %[[T22:.*]] = "enzyme.get"(%[[G1]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:             %[[T23:.*]] = arith.addf %[[T22]], %[[LD21]] : f64
+// CHECK:             "enzyme.set"(%[[G1]], %[[T23]]) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK:             memref.store %{{.*}}, %[[POP0]][] : memref<f64>
+// CHECK:             %[[T24:.*]] = "enzyme.get"(%[[G1]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:             memref.alloca_scope.return %[[LD]], %[[T24]] : f64, f64
+// CHECK:           }
+// CHECK:           "enzyme.set"(%[[G1]], %[[T8]]) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK:           %[[T10:.*]] = "enzyme.get"(%[[G1]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:           %[[T11:.*]] = arith.addf %[[T10]], %[[SCOPE]]#1 : f64
+// CHECK:           "enzyme.set"(%[[G1]], %[[T11]]) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK:           %[[T12:.*]] = "enzyme.get"(%[[G1]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:           return %[[T12]] : f64

--- a/enzyme/test/MLIR/ReverseMode/alloca_scope2.mlir
+++ b/enzyme/test/MLIR/ReverseMode/alloca_scope2.mlir
@@ -1,0 +1,38 @@
+// RUN: %eopt --enzyme %s | FileCheck %s
+
+func.func @foo(%x : f64) -> f64{
+    %out = memref.alloca_scope -> (f64) {
+      %buf = memref.alloca() : memref<f64>
+      memref.store %x, %buf[] : memref<f64>
+      %y = memref.load %buf[] : memref<f64>
+      memref.alloca_scope.return %y : f64
+    }
+    return %out  : f64
+}
+
+
+func.func @dfoo(%x: f64, %dout : f64) -> f64 {
+  %dx = enzyme.autodiff @foo(%x, %dout) {
+    activity = [#enzyme<activity enzyme_active>],
+    ret_activity = [#enzyme<acitivity enzyme_activenoneed>]
+  } : (f64, f64) -> (f64)
+  return %dx : f64
+}
+
+func.func @foo2(%x : f64) -> f64{
+    %cst = arith.constant 0.0000e+00 : f64
+      %buf = memref.alloca() : memref<f64>
+      memref.store %x, %buf[] : memref<f64>
+      %y = memref.load %buf[] : memref<f64>
+      %out = arith.addf %cst, %y : f64
+    return %out  : f64
+}
+
+
+func.func @dfoo2(%x: f64, %dout : f64) -> f64 {
+  %dx = enzyme.autodiff @foo2(%x, %dout) {
+    activity = [#enzyme<activity enzyme_active>],
+    ret_activity = [#enzyme<activity enzyme_activenoneed>]
+  } : (f64, f64) -> (f64)
+  return %dx : f64
+}


### PR DESCRIPTION
Re-opening the alloca_scope PR in the repo

I dont think this will work if the `alloca_scope` has a `memref.alloca` inside it (caching it will be unsafe across the 2 alloca_scope ops that are emitted)

Something like this will fail

```mlir
func.func @foo(%x : f64) -> f64{
    %out = memref.alloca_scope -> (f64) {
      %buf = memref.alloca() : memref<f64>
      memref.store %x, %buf[] : memref<f64>
      %y = memref.load %buf[] : memref<f64>
      memref.alloca_scope.return %y : f64
    }
    return %out
}

func.func @dfoo(%x, %dout) {
   %dx = enzyme.autodiff @foo(%x,%dout) {act=[active], ret_act=[activenoneed] } 
   return %dx
}
```
The primal is basically
```
out = alloca_scope{
buf[] = x
y = buf[]
return y
}
```
Reverse Mode should give us
```
dy += dout
d(buf) += dy // load
dx += d(buf) // store
d(buf) = 0 //alloca
```

We want this to lower to something like this (need to discuss what the caching should look like, since I dont think we can just push the memref to the cache here)

```
//forward
memref.alloca_scope {
    %buf = memref.alloca() 
    %dbuf = memref.alloca() 
    zero %dbuf
    
    enzyme.push %cache_store %dbuf
    memref.store %x, %buf
    
    enzyme.push %cache_load %dbuf
    %y = memref.load %buf
    
     alloca_scope.return %y
}

//reverse
memref.alloca_scope{
  //terminator
   dy += dout
   //load
   dbuf1 = enzyme.pop %cache_load
   old = memref.load dbuf1
   memref.store  (old + dy), dbuf1 
   //store
   dbuf2 = enzyme.pop %cache_store
   %old2 = memref.load dbuf2
   dx += old2
   
   memref.store 0, dbuf2
}
```

The issue is that the cache push/pop will not be valid across the 2 alloca_scopes here