### PR TITLE
MLIR: register ReverseAutoDiffOpInterface for llvm.insertvalue/extractvalue

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
@@ -218,7 +218,7 @@ struct ExtractValueOpInterfaceReverse
 
     auto containerIface = dyn_cast<AutoDiffTypeInterface>(container.getType());
     if (!containerIface)
-      return success();
+      return failure();
 
     if (!gutils->isConstantValue(evOp)) {
       Value gradient = gutils->diffe(evOp, builder);
@@ -257,7 +257,7 @@ struct InsertValueOpInterfaceReverse
 
     auto resultIface = dyn_cast<AutoDiffTypeInterface>(ivOp.getType());
     if (!resultIface)
-      return success();
+      return failure();
 
     if (!gutils->isConstantValue(ivOp)) {
       Value gradient = gutils->diffe(ivOp, builder);

--- a/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
@@ -217,8 +217,10 @@ struct ExtractValueOpInterfaceReverse
     Value container = evOp.getContainer();
 
     auto containerIface = dyn_cast<AutoDiffTypeInterface>(container.getType());
-    if (!containerIface)
+    if (!containerIface) {
+      gutils->zeroDiffe(evOp, builder);
       return failure();
+    }
 
     if (!gutils->isConstantValue(evOp)) {
       Value gradient = gutils->diffe(evOp, builder);
@@ -256,8 +258,10 @@ struct InsertValueOpInterfaceReverse
     Value value = ivOp.getValue();
 
     auto resultIface = dyn_cast<AutoDiffTypeInterface>(ivOp.getType());
-    if (!resultIface)
+    if (!resultIface) {
+      gutils->zeroDiffe(ivOp, builder);
       return failure();
+    }
 
     if (!gutils->isConstantValue(ivOp)) {
       Value gradient = gutils->diffe(ivOp, builder);

--- a/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
@@ -216,19 +216,21 @@ struct ExtractValueOpInterfaceReverse
     auto evOp = cast<LLVM::ExtractValueOp>(op);
     Value container = evOp.getContainer();
 
-    auto containerIface =
-        dyn_cast<AutoDiffTypeInterface>(container.getType());
+    auto containerIface = dyn_cast<AutoDiffTypeInterface>(container.getType());
     if (!containerIface)
       return success();
 
-    if (!gutils->isConstantValue(evOp) && !gutils->isConstantValue(container)) {
+    if (!gutils->isConstantValue(evOp)) {
       Value gradient = gutils->diffe(evOp, builder);
+      gutils->zeroDiffe(evOp, builder);
       // Create a zero aggregate matching the container type, then insert the
       // gradient at the extracted position.
-      Value zero = containerIface.createNullValue(builder, op->getLoc());
-      Value grad = LLVM::InsertValueOp::create(builder, op->getLoc(), zero,
-                                                gradient, evOp.getPosition());
-      gutils->addToDiffe(container, grad, builder);
+      if (!gutils->isConstantValue(container)) {
+        Value zero = containerIface.createNullValue(builder, op->getLoc());
+        Value grad = LLVM::InsertValueOp::create(builder, op->getLoc(), zero,
+                                                 gradient, evOp.getPosition());
+        gutils->addToDiffe(container, grad, builder);
+      }
     }
 
     return success();
@@ -259,6 +261,7 @@ struct InsertValueOpInterfaceReverse
 
     if (!gutils->isConstantValue(ivOp)) {
       Value gradient = gutils->diffe(ivOp, builder);
+      gutils->zeroDiffe(ivOp, builder);
 
       // Propagate gradient to the inserted value: extract from the result
       // gradient at the insertion position.
@@ -272,10 +275,10 @@ struct InsertValueOpInterfaceReverse
       // Propagate gradient to the container: zero out the inserted position
       // in the result gradient, then add to the container gradient.
       if (!gutils->isConstantValue(container)) {
-        Value zeroVal = valIface
-                            ? valIface.createNullValue(builder, op->getLoc())
-                            : LLVM::ZeroOp::create(builder, op->getLoc(),
-                                                    value.getType());
+        Value zeroVal =
+            valIface
+                ? valIface.createNullValue(builder, op->getLoc())
+                : LLVM::ZeroOp::create(builder, op->getLoc(), value.getType());
         Value containerGrad = LLVM::InsertValueOp::create(
             builder, op->getLoc(), gradient, zeroVal, ivOp.getPosition());
         gutils->addToDiffe(container, containerGrad, builder);

--- a/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
@@ -217,10 +217,8 @@ struct ExtractValueOpInterfaceReverse
     Value container = evOp.getContainer();
 
     auto containerIface = dyn_cast<AutoDiffTypeInterface>(container.getType());
-    if (!containerIface) {
-      gutils->zeroDiffe(evOp, builder);
+    if (!containerIface)
       return failure();
-    }
 
     if (!gutils->isConstantValue(evOp)) {
       Value gradient = gutils->diffe(evOp, builder);
@@ -258,10 +256,8 @@ struct InsertValueOpInterfaceReverse
     Value value = ivOp.getValue();
 
     auto resultIface = dyn_cast<AutoDiffTypeInterface>(ivOp.getType());
-    if (!resultIface) {
-      gutils->zeroDiffe(ivOp, builder);
+    if (!resultIface)
       return failure();
-    }
 
     if (!gutils->isConstantValue(ivOp)) {
       Value gradient = gutils->diffe(ivOp, builder);

--- a/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
@@ -207,6 +207,93 @@ struct StoreOpInterfaceReverse
                           MGradientUtilsReverse *gutils) const {}
 };
 
+struct ExtractValueOpInterfaceReverse
+    : public ReverseAutoDiffOpInterface::ExternalModel<
+          ExtractValueOpInterfaceReverse, LLVM::ExtractValueOp> {
+  LogicalResult createReverseModeAdjoint(Operation *op, OpBuilder &builder,
+                                         MGradientUtilsReverse *gutils,
+                                         SmallVector<Value> caches) const {
+    auto evOp = cast<LLVM::ExtractValueOp>(op);
+    Value container = evOp.getContainer();
+
+    auto containerIface =
+        dyn_cast<AutoDiffTypeInterface>(container.getType());
+    if (!containerIface)
+      return success();
+
+    if (!gutils->isConstantValue(evOp) && !gutils->isConstantValue(container)) {
+      Value gradient = gutils->diffe(evOp, builder);
+      // Create a zero aggregate matching the container type, then insert the
+      // gradient at the extracted position.
+      Value zero = containerIface.createNullValue(builder, op->getLoc());
+      Value grad = LLVM::InsertValueOp::create(builder, op->getLoc(), zero,
+                                                gradient, evOp.getPosition());
+      gutils->addToDiffe(container, grad, builder);
+    }
+
+    return success();
+  }
+
+  SmallVector<Value> cacheValues(Operation *op,
+                                 MGradientUtilsReverse *gutils) const {
+    return {};
+  }
+
+  void createShadowValues(Operation *op, OpBuilder &builder,
+                          MGradientUtilsReverse *gutils) const {}
+};
+
+struct InsertValueOpInterfaceReverse
+    : public ReverseAutoDiffOpInterface::ExternalModel<
+          InsertValueOpInterfaceReverse, LLVM::InsertValueOp> {
+  LogicalResult createReverseModeAdjoint(Operation *op, OpBuilder &builder,
+                                         MGradientUtilsReverse *gutils,
+                                         SmallVector<Value> caches) const {
+    auto ivOp = cast<LLVM::InsertValueOp>(op);
+    Value container = ivOp.getContainer();
+    Value value = ivOp.getValue();
+
+    auto resultIface = dyn_cast<AutoDiffTypeInterface>(ivOp.getType());
+    if (!resultIface)
+      return success();
+
+    if (!gutils->isConstantValue(ivOp)) {
+      Value gradient = gutils->diffe(ivOp, builder);
+
+      // Propagate gradient to the inserted value: extract from the result
+      // gradient at the insertion position.
+      auto valIface = dyn_cast<AutoDiffTypeInterface>(value.getType());
+      if (valIface && !gutils->isConstantValue(value)) {
+        Value valGrad = LLVM::ExtractValueOp::create(
+            builder, op->getLoc(), gradient, ivOp.getPosition());
+        gutils->addToDiffe(value, valGrad, builder);
+      }
+
+      // Propagate gradient to the container: zero out the inserted position
+      // in the result gradient, then add to the container gradient.
+      if (!gutils->isConstantValue(container)) {
+        Value zeroVal = valIface
+                            ? valIface.createNullValue(builder, op->getLoc())
+                            : LLVM::ZeroOp::create(builder, op->getLoc(),
+                                                    value.getType());
+        Value containerGrad = LLVM::InsertValueOp::create(
+            builder, op->getLoc(), gradient, zeroVal, ivOp.getPosition());
+        gutils->addToDiffe(container, containerGrad, builder);
+      }
+    }
+
+    return success();
+  }
+
+  SmallVector<Value> cacheValues(Operation *op,
+                                 MGradientUtilsReverse *gutils) const {
+    return {};
+  }
+
+  void createShadowValues(Operation *op, OpBuilder &builder,
+                          MGradientUtilsReverse *gutils) const {}
+};
+
 std::optional<Value> findPtrSize(Value ptr) {
   if (auto allocOp = ptr.getDefiningOp<llvm_ext::AllocOp>())
     return allocOp.getSize();
@@ -373,6 +460,10 @@ void mlir::enzyme::registerLLVMDialectAutoDiffInterface(
     LLVM::LoadOp::attachInterface<LoadOpInterfaceReverse>(*context);
     LLVM::StoreOp::attachInterface<StoreOpInterfaceReverse>(*context);
     LLVM::GEPOp::attachInterface<GEPOpInterfaceReverse>(*context);
+    LLVM::ExtractValueOp::attachInterface<ExtractValueOpInterfaceReverse>(
+        *context);
+    LLVM::InsertValueOp::attachInterface<InsertValueOpInterfaceReverse>(
+        *context);
     LLVM::UnreachableOp::template attachInterface<
         detail::NoopRevAutoDiffInterface<LLVM::UnreachableOp>>(*context);
     LLVM::LLVMFuncOp::attachInterface<AutoDiffLLVMFuncOpFunctionInterface>(

--- a/enzyme/test/MLIR/ReverseMode/llvm_insertvalue_extractvalue.mlir
+++ b/enzyme/test/MLIR/ReverseMode/llvm_insertvalue_extractvalue.mlir
@@ -1,0 +1,50 @@
+// RUN: %eopt --outline-enzyme-regions --enzyme %s | FileCheck %s
+
+// Test reverse mode AD for llvm.extractvalue on active (f64) struct elements.
+// See https://github.com/EnzymeAD/Enzyme/issues/2811
+llvm.func @extract(%s: !llvm.struct<(f64, f64)>, %seed: f64)
+                  -> !llvm.struct<(f64, f64)> {
+  %g = enzyme.autodiff_region(%s, %seed) {
+  ^bb0(%a_s: !llvm.struct<(f64, f64)>):
+    %f0 = llvm.extractvalue %a_s[0] : !llvm.struct<(f64, f64)>
+    %f1 = llvm.extractvalue %a_s[1] : !llvm.struct<(f64, f64)>
+    %m  = arith.mulf %f0, %f1 : f64
+    enzyme.yield %m : f64
+  } attributes {
+    activity = [#enzyme<activity enzyme_active>],
+    ret_activity = [#enzyme<activity enzyme_activenoneed>],
+    fn = "compute_extract"
+  } : (!llvm.struct<(f64, f64)>, f64) -> !llvm.struct<(f64, f64)>
+  llvm.return %g : !llvm.struct<(f64, f64)>
+}
+
+// CHECK-LABEL: func.func private @diffeextract_to_diff0
+// CHECK-SAME: (%arg0: !llvm.struct<(f64, f64)>, %arg1: f64) -> !llvm.struct<(f64, f64)>
+// CHECK:        llvm.extractvalue
+// CHECK:        llvm.insertvalue
+// CHECK:        return
+
+// -----
+
+// Test reverse mode AD for llvm.insertvalue on active (f64) struct elements.
+// See https://github.com/EnzymeAD/Enzyme/issues/2812
+llvm.func @insert(%x: f64, %seed: !llvm.struct<(f64, f64)>) -> f64 {
+  %g = enzyme.autodiff_region(%x, %seed) {
+  ^bb0(%a_x: f64):
+    %z  = llvm.mlir.constant(0.0 : f64) : f64
+    %u  = llvm.mlir.undef : !llvm.struct<(f64, f64)>
+    %s0 = llvm.insertvalue %a_x, %u[0]  : !llvm.struct<(f64, f64)>
+    %s1 = llvm.insertvalue %z,   %s0[1] : !llvm.struct<(f64, f64)>
+    enzyme.yield %s1 : !llvm.struct<(f64, f64)>
+  } attributes {
+    activity = [#enzyme<activity enzyme_active>],
+    ret_activity = [#enzyme<activity enzyme_activenoneed>],
+    fn = "compute_insert"
+  } : (f64, !llvm.struct<(f64, f64)>) -> f64
+  llvm.return %g : f64
+}
+
+// CHECK-LABEL: func.func private @diffeinsert_to_diff0
+// CHECK-SAME: (%arg0: f64, %arg1: !llvm.struct<(f64, f64)>) -> f64
+// CHECK:        llvm.extractvalue
+// CHECK:        return

--- a/enzyme/test/MLIR/ReverseMode/llvm_insertvalue_extractvalue.mlir
+++ b/enzyme/test/MLIR/ReverseMode/llvm_insertvalue_extractvalue.mlir
@@ -1,19 +1,20 @@
-// RUN: %eopt --outline-enzyme-regions --enzyme %s | FileCheck %s
+// RUN: %eopt --enzyme %s | FileCheck %s
 
 // Test reverse mode AD for llvm.extractvalue on active (f64) struct elements.
 // See https://github.com/EnzymeAD/Enzyme/issues/2811
+
+func.func @extract_to_diff0(%arg0: !llvm.struct<(f64, f64)>) -> f64 {
+  %f0 = llvm.extractvalue %arg0[0] : !llvm.struct<(f64, f64)>
+  %f1 = llvm.extractvalue %arg0[1] : !llvm.struct<(f64, f64)>
+  %m  = arith.mulf %f0, %f1 : f64
+  return %m : f64
+}
+
 llvm.func @extract(%s: !llvm.struct<(f64, f64)>, %seed: f64)
                   -> !llvm.struct<(f64, f64)> {
-  %g = enzyme.autodiff_region(%s, %seed) {
-  ^bb0(%a_s: !llvm.struct<(f64, f64)>):
-    %f0 = llvm.extractvalue %a_s[0] : !llvm.struct<(f64, f64)>
-    %f1 = llvm.extractvalue %a_s[1] : !llvm.struct<(f64, f64)>
-    %m  = arith.mulf %f0, %f1 : f64
-    enzyme.yield %m : f64
-  } attributes {
+  %g = enzyme.autodiff @extract_to_diff0(%s, %seed) {
     activity = [#enzyme<activity enzyme_active>],
-    ret_activity = [#enzyme<activity enzyme_activenoneed>],
-    fn = "compute_extract"
+    ret_activity = [#enzyme<activity enzyme_activenoneed>]
   } : (!llvm.struct<(f64, f64)>, f64) -> !llvm.struct<(f64, f64)>
   llvm.return %g : !llvm.struct<(f64, f64)>
 }
@@ -39,18 +40,19 @@ llvm.func @extract(%s: !llvm.struct<(f64, f64)>, %seed: f64)
 
 // Test reverse mode AD for llvm.insertvalue on active (f64) struct elements.
 // See https://github.com/EnzymeAD/Enzyme/issues/2812
+
+func.func @insert_to_diff0(%arg0: f64) -> !llvm.struct<(f64, f64)> {
+  %z  = llvm.mlir.constant(0.0 : f64) : f64
+  %u  = llvm.mlir.undef : !llvm.struct<(f64, f64)>
+  %s0 = llvm.insertvalue %arg0, %u[0]  : !llvm.struct<(f64, f64)>
+  %s1 = llvm.insertvalue %z,   %s0[1] : !llvm.struct<(f64, f64)>
+  return %s1 : !llvm.struct<(f64, f64)>
+}
+
 llvm.func @insert(%x: f64, %seed: !llvm.struct<(f64, f64)>) -> f64 {
-  %g = enzyme.autodiff_region(%x, %seed) {
-  ^bb0(%a_x: f64):
-    %z  = llvm.mlir.constant(0.0 : f64) : f64
-    %u  = llvm.mlir.undef : !llvm.struct<(f64, f64)>
-    %s0 = llvm.insertvalue %a_x, %u[0]  : !llvm.struct<(f64, f64)>
-    %s1 = llvm.insertvalue %z,   %s0[1] : !llvm.struct<(f64, f64)>
-    enzyme.yield %s1 : !llvm.struct<(f64, f64)>
-  } attributes {
+  %g = enzyme.autodiff @insert_to_diff0(%x, %seed) {
     activity = [#enzyme<activity enzyme_active>],
-    ret_activity = [#enzyme<activity enzyme_activenoneed>],
-    fn = "compute_insert"
+    ret_activity = [#enzyme<activity enzyme_activenoneed>]
   } : (f64, !llvm.struct<(f64, f64)>) -> f64
   llvm.return %g : f64
 }

--- a/enzyme/test/MLIR/ReverseMode/llvm_insertvalue_extractvalue.mlir
+++ b/enzyme/test/MLIR/ReverseMode/llvm_insertvalue_extractvalue.mlir
@@ -1,61 +1,63 @@
-// RUN: %eopt --outline-enzyme-regions --enzyme %s | FileCheck %s
+// RUN: %eopt --enzyme %s | FileCheck %s
 
 // Test reverse mode AD for llvm.extractvalue on active (f64) struct elements.
 // See https://github.com/EnzymeAD/Enzyme/issues/2811
+
+func.func @extract_to_diff0(%arg0: !llvm.struct<(f64, f64)>) -> f64 {
+  %f0 = llvm.extractvalue %arg0[0] : !llvm.struct<(f64, f64)>
+  %f1 = llvm.extractvalue %arg0[1] : !llvm.struct<(f64, f64)>
+  %m  = arith.mulf %f0, %f1 : f64
+  return %m : f64
+}
+
 llvm.func @extract(%s: !llvm.struct<(f64, f64)>, %seed: f64)
                   -> !llvm.struct<(f64, f64)> {
-  %g = enzyme.autodiff_region(%s, %seed) {
-  ^bb0(%a_s: !llvm.struct<(f64, f64)>):
-    %f0 = llvm.extractvalue %a_s[0] : !llvm.struct<(f64, f64)>
-    %f1 = llvm.extractvalue %a_s[1] : !llvm.struct<(f64, f64)>
-    %m  = arith.mulf %f0, %f1 : f64
-    enzyme.yield %m : f64
-  } attributes {
+  %g = enzyme.autodiff @extract_to_diff0(%s, %seed) {
     activity = [#enzyme<activity enzyme_active>],
-    ret_activity = [#enzyme<activity enzyme_activenoneed>],
-    fn = "compute_extract"
+    ret_activity = [#enzyme<activity enzyme_activenoneed>]
   } : (!llvm.struct<(f64, f64)>, f64) -> !llvm.struct<(f64, f64)>
   llvm.return %g : !llvm.struct<(f64, f64)>
 }
 
-// CHECK-LABEL: func.func private @diffecompute_extract
+// CHECK-LABEL: func.func private @diffeextract_to_diff0
 // CHECK-SAME: (%arg0: !llvm.struct<(f64, f64)>, %arg1: f64) -> !llvm.struct<(f64, f64)>
-// CHECK-NEXT:   %[[V0:.+]] = llvm.extractvalue %arg0[0] : !llvm.struct<(f64, f64)>
-// CHECK-NEXT:   %[[V1:.+]] = llvm.extractvalue %arg0[1] : !llvm.struct<(f64, f64)>
-// CHECK-NEXT:   %[[V2:.+]] = arith.mulf %[[V1]], %arg1 : f64
-// CHECK-NEXT:   %[[V3:.+]] = arith.mulf %[[V0]], %arg1 : f64
-// CHECK-NEXT:   %[[Z0:.+]] = llvm.mlir.poison : !llvm.struct<(f64, f64)>
-// CHECK-NEXT:   %[[Z1:.+]] = arith.constant 0.000000e+00 : f64
-// CHECK-NEXT:   %[[IV0:.+]] = llvm.insertvalue %[[Z1]], %[[Z0]][0] : !llvm.struct<(f64, f64)>
-// CHECK-NEXT:   %[[IV1:.+]] = llvm.insertvalue %[[V2]], %[[IV0]][1] : !llvm.struct<(f64, f64)>
-// CHECK-NEXT:   %[[Z2:.+]] = llvm.mlir.poison : !llvm.struct<(f64, f64)>
-// CHECK-NEXT:   %[[Z3:.+]] = arith.constant 0.000000e+00 : f64
-// CHECK-NEXT:   %[[IV2:.+]] = llvm.insertvalue %[[V3]], %[[Z2]][0] : !llvm.struct<(f64, f64)>
-// CHECK-NEXT:   %[[IV3:.+]] = llvm.insertvalue %[[Z3]], %[[IV2]][1] : !llvm.struct<(f64, f64)>
-// CHECK-NEXT:   %[[ADD:.+]] = enzyme.foadd %[[IV1]], %[[IV3]]
-// CHECK-NEXT:   return %[[ADD]] : !llvm.struct<(f64, f64)>
+// CHECK-DAG:    %[[V0:.+]] = llvm.extractvalue %arg0[0] : !llvm.struct<(f64, f64)>
+// CHECK-DAG:    %[[V1:.+]] = llvm.extractvalue %arg0[1] : !llvm.struct<(f64, f64)>
+// CHECK-DAG:    %[[V2:.+]] = arith.mulf %[[V1]], %arg1 : f64
+// CHECK-DAG:    %[[V3:.+]] = arith.mulf %[[V0]], %arg1 : f64
+// CHECK-DAG:    %[[Z0:.+]] = llvm.mlir.poison : !llvm.struct<(f64, f64)>
+// CHECK-DAG:    %[[Z1:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-DAG:    %[[IV0:.+]] = llvm.insertvalue %[[Z1]], %[[Z0]][0] : !llvm.struct<(f64, f64)>
+// CHECK-DAG:    %[[IV1:.+]] = llvm.insertvalue %[[V2]], %[[IV0]][1] : !llvm.struct<(f64, f64)>
+// CHECK-DAG:    %[[Z2:.+]] = llvm.mlir.poison : !llvm.struct<(f64, f64)>
+// CHECK-DAG:    %[[Z3:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-DAG:    %[[IV2:.+]] = llvm.insertvalue %[[V3]], %[[Z2]][0] : !llvm.struct<(f64, f64)>
+// CHECK-DAG:    %[[IV3:.+]] = llvm.insertvalue %[[Z3]], %[[IV2]][1] : !llvm.struct<(f64, f64)>
+// CHECK-DAG:    %[[ADD:.+]] = enzyme.foadd %[[IV1]], %[[IV3]]
+// CHECK:        return %[[ADD]] : !llvm.struct<(f64, f64)>
 
 // -----
 
 // Test reverse mode AD for llvm.insertvalue on active (f64) struct elements.
 // See https://github.com/EnzymeAD/Enzyme/issues/2812
+
+func.func @insert_to_diff0(%arg0: f64) -> !llvm.struct<(f64, f64)> {
+  %z  = llvm.mlir.constant(0.0 : f64) : f64
+  %u  = llvm.mlir.undef : !llvm.struct<(f64, f64)>
+  %s0 = llvm.insertvalue %arg0, %u[0]  : !llvm.struct<(f64, f64)>
+  %s1 = llvm.insertvalue %z,   %s0[1] : !llvm.struct<(f64, f64)>
+  return %s1 : !llvm.struct<(f64, f64)>
+}
+
 llvm.func @insert(%x: f64, %seed: !llvm.struct<(f64, f64)>) -> f64 {
-  %g = enzyme.autodiff_region(%x, %seed) {
-  ^bb0(%a_x: f64):
-    %z  = llvm.mlir.constant(0.0 : f64) : f64
-    %u  = llvm.mlir.undef : !llvm.struct<(f64, f64)>
-    %s0 = llvm.insertvalue %a_x, %u[0]  : !llvm.struct<(f64, f64)>
-    %s1 = llvm.insertvalue %z,   %s0[1] : !llvm.struct<(f64, f64)>
-    enzyme.yield %s1 : !llvm.struct<(f64, f64)>
-  } attributes {
+  %g = enzyme.autodiff @insert_to_diff0(%x, %seed) {
     activity = [#enzyme<activity enzyme_active>],
-    ret_activity = [#enzyme<activity enzyme_activenoneed>],
-    fn = "compute_insert"
+    ret_activity = [#enzyme<activity enzyme_activenoneed>]
   } : (f64, !llvm.struct<(f64, f64)>) -> f64
   llvm.return %g : f64
 }
 
-// CHECK-LABEL: func.func private @diffecompute_insert
+// CHECK-LABEL: func.func private @diffeinsert_to_diff0
 // CHECK-SAME: (%arg0: f64, %arg1: !llvm.struct<(f64, f64)>) -> f64
-// CHECK-NEXT:   %[[EV:.+]] = llvm.extractvalue %arg1[0] : !llvm.struct<(f64, f64)>
-// CHECK-NEXT:   return %[[EV]] : f64
+// CHECK-DAG:    %[[EV:.+]] = llvm.extractvalue %arg1[0] : !llvm.struct<(f64, f64)>
+// CHECK:        return %[[EV]] : f64

--- a/enzyme/test/MLIR/ReverseMode/llvm_insertvalue_extractvalue.mlir
+++ b/enzyme/test/MLIR/ReverseMode/llvm_insertvalue_extractvalue.mlir
@@ -20,9 +20,20 @@ llvm.func @extract(%s: !llvm.struct<(f64, f64)>, %seed: f64)
 
 // CHECK-LABEL: func.func private @diffeextract_to_diff0
 // CHECK-SAME: (%arg0: !llvm.struct<(f64, f64)>, %arg1: f64) -> !llvm.struct<(f64, f64)>
-// CHECK:        llvm.extractvalue
-// CHECK:        llvm.insertvalue
-// CHECK:        return
+// CHECK-DAG:    %[[V0:.+]] = llvm.extractvalue %arg0[0] : !llvm.struct<(f64, f64)>
+// CHECK-DAG:    %[[V1:.+]] = llvm.extractvalue %arg0[1] : !llvm.struct<(f64, f64)>
+// CHECK-DAG:    %[[V2:.+]] = arith.mulf %[[V1]], %arg1 : f64
+// CHECK-DAG:    %[[V3:.+]] = arith.mulf %[[V0]], %arg1 : f64
+// CHECK-DAG:    %[[Z0:.+]] = llvm.mlir.poison : !llvm.struct<(f64, f64)>
+// CHECK-DAG:    %[[Z1:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-DAG:    %[[IV0:.+]] = llvm.insertvalue %[[Z1]], %[[Z0]][0] : !llvm.struct<(f64, f64)>
+// CHECK-DAG:    %[[IV1:.+]] = llvm.insertvalue %[[V2]], %[[IV0]][1] : !llvm.struct<(f64, f64)>
+// CHECK-DAG:    %[[Z2:.+]] = llvm.mlir.poison : !llvm.struct<(f64, f64)>
+// CHECK-DAG:    %[[Z3:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-DAG:    %[[IV2:.+]] = llvm.insertvalue %[[V3]], %[[Z2]][0] : !llvm.struct<(f64, f64)>
+// CHECK-DAG:    %[[IV3:.+]] = llvm.insertvalue %[[Z3]], %[[IV2]][1] : !llvm.struct<(f64, f64)>
+// CHECK-DAG:    %[[ADD:.+]] = enzyme.foadd %[[IV1]], %[[IV3]]
+// CHECK:        return %[[ADD]] : !llvm.struct<(f64, f64)>
 
 // -----
 
@@ -46,5 +57,5 @@ llvm.func @insert(%x: f64, %seed: !llvm.struct<(f64, f64)>) -> f64 {
 
 // CHECK-LABEL: func.func private @diffeinsert_to_diff0
 // CHECK-SAME: (%arg0: f64, %arg1: !llvm.struct<(f64, f64)>) -> f64
-// CHECK:        llvm.extractvalue
-// CHECK:        return
+// CHECK-DAG:    %[[EV:.+]] = llvm.extractvalue %arg1[0] : !llvm.struct<(f64, f64)>
+// CHECK:        return %[[EV]] : f64

--- a/enzyme/test/MLIR/ReverseMode/llvm_insertvalue_extractvalue.mlir
+++ b/enzyme/test/MLIR/ReverseMode/llvm_insertvalue_extractvalue.mlir
@@ -21,20 +21,49 @@ llvm.func @extract(%s: !llvm.struct<(f64, f64)>, %seed: f64)
 
 // CHECK-LABEL: func.func private @diffeextract_to_diff0
 // CHECK-SAME: (%arg0: !llvm.struct<(f64, f64)>, %arg1: f64) -> !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[V0:.+]] = llvm.extractvalue %arg0[0] : !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[V1:.+]] = llvm.extractvalue %arg0[1] : !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[V2:.+]] = arith.mulf %[[V1]], %arg1 : f64
-// CHECK-DAG:    %[[V3:.+]] = arith.mulf %[[V0]], %arg1 : f64
-// CHECK-DAG:    %[[Z0:.+]] = llvm.mlir.poison : !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[Z1:.+]] = arith.constant 0.000000e+00 : f64
-// CHECK-DAG:    %[[IV0:.+]] = llvm.insertvalue %[[Z1]], %[[Z0]][0] : !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[IV1:.+]] = llvm.insertvalue %[[V2]], %[[IV0]][1] : !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[Z2:.+]] = llvm.mlir.poison : !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[Z3:.+]] = arith.constant 0.000000e+00 : f64
-// CHECK-DAG:    %[[IV2:.+]] = llvm.insertvalue %[[V3]], %[[Z2]][0] : !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[IV3:.+]] = llvm.insertvalue %[[Z3]], %[[IV2]][1] : !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[ADD:.+]] = enzyme.foadd %[[IV1]], %[[IV3]]
-// CHECK:        return %[[ADD]] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[GINIT:.+]] = "enzyme.init"() : () -> !enzyme.Gradient<!llvm.struct<(f64, f64)>>
+// CHECK-NEXT:   %[[P0:.+]] = llvm.mlir.poison : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[CST0:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:   %[[S0:.+]] = llvm.insertvalue %[[CST0]], %[[P0]][0] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[CST1:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:   %[[S1:.+]] = llvm.insertvalue %[[CST1]], %[[S0]][1] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   "enzyme.set"(%[[GINIT]], %[[S1]]) : (!enzyme.Gradient<!llvm.struct<(f64, f64)>>, !llvm.struct<(f64, f64)>) -> ()
+// CHECK-NEXT:   %[[G0:.+]] = "enzyme.init"() : () -> !enzyme.Gradient<f64>
+// CHECK-NEXT:   %[[CST2:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:   "enzyme.set"(%[[G0]], %[[CST2]]) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK-NEXT:   %[[G1:.+]] = "enzyme.init"() : () -> !enzyme.Gradient<f64>
+// CHECK-NEXT:   %[[CST3:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:   "enzyme.set"(%[[G1]], %[[CST3]]) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK-NEXT:   %[[C0:.+]] = "enzyme.init"() : () -> !enzyme.Cache<f64>
+// CHECK-NEXT:   %[[C1:.+]] = "enzyme.init"() : () -> !enzyme.Cache<f64>
+// CHECK-NEXT:   %[[GMUL:.+]] = "enzyme.init"() : () -> !enzyme.Gradient<f64>
+// CHECK-NEXT:   %[[CST4:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:   "enzyme.set"(%[[GMUL]], %[[CST4]]) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK-NEXT:   %[[EV0:.+]] = llvm.extractvalue %arg0[0] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[EV1:.+]] = llvm.extractvalue %arg0[1] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   "enzyme.push"(%[[C1]], %[[EV0]]) : (!enzyme.Cache<f64>, f64) -> ()
+// CHECK-NEXT:   "enzyme.push"(%[[C0]], %[[EV1]]) : (!enzyme.Cache<f64>, f64) -> ()
+// CHECK-NEXT:   %[[MUL:.+]] = arith.mulf %[[EV0]], %[[EV1]] : f64
+// CHECK-NEXT:   cf.br ^bb1
+// CHECK-NEXT: ^bb1:
+// CHECK-NEXT:   %[[GETM:.+]] = "enzyme.get"(%[[GMUL]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK-NEXT:   %[[SUM:.+]] = arith.addf %[[GETM]], %arg1 : f64
+// CHECK-NEXT:   "enzyme.set"(%[[GMUL]], %[[SUM]]) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK-NEXT:   %[[DRES:.+]] = "enzyme.get"(%[[GMUL]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK-NEXT:   %[[CST5:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:   "enzyme.set"(%[[GMUL]], %[[CST5]]) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK-NEXT:   %[[POP0:.+]] = "enzyme.pop"(%[[C1]]) : (!enzyme.Cache<f64>) -> f64
+// CHECK-NEXT:   %[[POP1:.+]] = "enzyme.pop"(%[[C0]]) : (!enzyme.Cache<f64>) -> f64
+// CHECK-NEXT:   %[[MUL0:.+]] = arith.mulf %[[DRES]], %[[POP1]] : f64
+// CHECK-NEXT:   %[[GET1:.+]] = "enzyme.get"(%[[G1]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK-NEXT:   %[[ADD0:.+]] = arith.addf %[[GET1]], %[[MUL0]] : f64
+// CHECK-NEXT:   "enzyme.set"(%[[G1]], %[[ADD0]]) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK-NEXT:   %[[MUL1:.+]] = arith.mulf %[[DRES]], %[[POP0]] : f64
+// CHECK-NEXT:   %[[GET0:.+]] = "enzyme.get"(%[[G0]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK-NEXT:   %[[ADD1:.+]] = arith.addf %[[GET0]], %[[MUL1]] : f64
+// CHECK-NEXT:   "enzyme.set"(%[[G0]], %[[ADD1]]) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK:        return %{{.+}} : !llvm.struct<(f64, f64)>
+// CHECK-NEXT: }
 
 // -----
 
@@ -59,5 +88,39 @@ llvm.func @insert(%x: f64, %seed: !llvm.struct<(f64, f64)>) -> f64 {
 
 // CHECK-LABEL: func.func private @diffeinsert_to_diff0
 // CHECK-SAME: (%arg0: f64, %arg1: !llvm.struct<(f64, f64)>) -> f64
-// CHECK-DAG:    %[[EV:.+]] = llvm.extractvalue %arg1[0] : !llvm.struct<(f64, f64)>
-// CHECK:        return %[[EV]] : f64
+// CHECK-NEXT:   %[[G0:.+]] = "enzyme.init"() : () -> !enzyme.Gradient<f64>
+// CHECK-NEXT:   %[[CST0:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:   "enzyme.set"(%[[G0]], %[[CST0]]) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK-NEXT:   %[[GS0:.+]] = "enzyme.init"() : () -> !enzyme.Gradient<!llvm.struct<(f64, f64)>>
+// CHECK-NEXT:   %[[P0:.+]] = llvm.mlir.poison : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[Z0:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:   %[[S0:.+]] = llvm.insertvalue %[[Z0]], %[[P0]][0] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[Z1:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:   %[[S1:.+]] = llvm.insertvalue %[[Z1]], %[[S0]][1] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   "enzyme.set"(%[[GS0]], %[[S1]]) : (!enzyme.Gradient<!llvm.struct<(f64, f64)>>, !llvm.struct<(f64, f64)>) -> ()
+// CHECK-NEXT:   %[[GS1:.+]] = "enzyme.init"() : () -> !enzyme.Gradient<!llvm.struct<(f64, f64)>>
+// CHECK-NEXT:   %[[P1:.+]] = llvm.mlir.poison : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[Z2:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:   %[[S2:.+]] = llvm.insertvalue %[[Z2]], %[[P1]][0] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[Z3:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:   %[[S3:.+]] = llvm.insertvalue %[[Z3]], %[[S2]][1] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   "enzyme.set"(%[[GS1]], %[[S3]]) : (!enzyme.Gradient<!llvm.struct<(f64, f64)>>, !llvm.struct<(f64, f64)>) -> ()
+// CHECK-NEXT:   %[[CNST:.+]] = llvm.mlir.constant(0.000000e+00 : f64) : f64
+// CHECK-NEXT:   %[[UNDEF:.+]] = llvm.mlir.undef : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[IV0:.+]] = llvm.insertvalue %arg0, %[[UNDEF]][0] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[IV1:.+]] = llvm.insertvalue %[[CNST]], %[[IV0]][1] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   cf.br ^bb1
+// CHECK-NEXT: ^bb1:
+// CHECK-NEXT:   %[[GETS1:.+]] = "enzyme.get"(%[[GS1]]) : (!enzyme.Gradient<!llvm.struct<(f64, f64)>>) -> !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[P2:.+]] = llvm.mlir.poison : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[EV0:.+]] = llvm.extractvalue %[[GETS1]][0] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[EV1:.+]] = llvm.extractvalue %arg1[0] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[ADD0:.+]] = arith.addf %[[EV0]], %[[EV1]] : f64
+// CHECK-NEXT:   %[[INS0:.+]] = llvm.insertvalue %[[ADD0]], %[[P2]][0] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[EV2:.+]] = llvm.extractvalue %[[GETS1]][1] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[EV3:.+]] = llvm.extractvalue %arg1[1] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[ADD1:.+]] = arith.addf %[[EV2]], %[[EV3]] : f64
+// CHECK-NEXT:   %[[INS1:.+]] = llvm.insertvalue %[[ADD1]], %[[INS0]][1] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   "enzyme.set"(%[[GS1]], %[[INS1]]) : (!enzyme.Gradient<!llvm.struct<(f64, f64)>>, !llvm.struct<(f64, f64)>) -> ()
+// CHECK:        return %{{.+}} : f64
+// CHECK-NEXT: }

--- a/enzyme/test/MLIR/ReverseMode/llvm_insertvalue_extractvalue.mlir
+++ b/enzyme/test/MLIR/ReverseMode/llvm_insertvalue_extractvalue.mlir
@@ -1,63 +1,61 @@
-// RUN: %eopt --enzyme %s | FileCheck %s
+// RUN: %eopt --outline-enzyme-regions --enzyme %s | FileCheck %s
 
 // Test reverse mode AD for llvm.extractvalue on active (f64) struct elements.
 // See https://github.com/EnzymeAD/Enzyme/issues/2811
-
-func.func @extract_to_diff0(%arg0: !llvm.struct<(f64, f64)>) -> f64 {
-  %f0 = llvm.extractvalue %arg0[0] : !llvm.struct<(f64, f64)>
-  %f1 = llvm.extractvalue %arg0[1] : !llvm.struct<(f64, f64)>
-  %m  = arith.mulf %f0, %f1 : f64
-  return %m : f64
-}
-
 llvm.func @extract(%s: !llvm.struct<(f64, f64)>, %seed: f64)
                   -> !llvm.struct<(f64, f64)> {
-  %g = enzyme.autodiff @extract_to_diff0(%s, %seed) {
+  %g = enzyme.autodiff_region(%s, %seed) {
+  ^bb0(%a_s: !llvm.struct<(f64, f64)>):
+    %f0 = llvm.extractvalue %a_s[0] : !llvm.struct<(f64, f64)>
+    %f1 = llvm.extractvalue %a_s[1] : !llvm.struct<(f64, f64)>
+    %m  = arith.mulf %f0, %f1 : f64
+    enzyme.yield %m : f64
+  } attributes {
     activity = [#enzyme<activity enzyme_active>],
-    ret_activity = [#enzyme<activity enzyme_activenoneed>]
+    ret_activity = [#enzyme<activity enzyme_activenoneed>],
+    fn = "compute_extract"
   } : (!llvm.struct<(f64, f64)>, f64) -> !llvm.struct<(f64, f64)>
   llvm.return %g : !llvm.struct<(f64, f64)>
 }
 
-// CHECK-LABEL: func.func private @diffeextract_to_diff0
+// CHECK-LABEL: func.func private @diffecompute_extract
 // CHECK-SAME: (%arg0: !llvm.struct<(f64, f64)>, %arg1: f64) -> !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[V0:.+]] = llvm.extractvalue %arg0[0] : !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[V1:.+]] = llvm.extractvalue %arg0[1] : !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[V2:.+]] = arith.mulf %[[V1]], %arg1 : f64
-// CHECK-DAG:    %[[V3:.+]] = arith.mulf %[[V0]], %arg1 : f64
-// CHECK-DAG:    %[[Z0:.+]] = llvm.mlir.poison : !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[Z1:.+]] = arith.constant 0.000000e+00 : f64
-// CHECK-DAG:    %[[IV0:.+]] = llvm.insertvalue %[[Z1]], %[[Z0]][0] : !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[IV1:.+]] = llvm.insertvalue %[[V2]], %[[IV0]][1] : !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[Z2:.+]] = llvm.mlir.poison : !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[Z3:.+]] = arith.constant 0.000000e+00 : f64
-// CHECK-DAG:    %[[IV2:.+]] = llvm.insertvalue %[[V3]], %[[Z2]][0] : !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[IV3:.+]] = llvm.insertvalue %[[Z3]], %[[IV2]][1] : !llvm.struct<(f64, f64)>
-// CHECK-DAG:    %[[ADD:.+]] = enzyme.foadd %[[IV1]], %[[IV3]]
-// CHECK:        return %[[ADD]] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[V0:.+]] = llvm.extractvalue %arg0[0] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[V1:.+]] = llvm.extractvalue %arg0[1] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[V2:.+]] = arith.mulf %[[V1]], %arg1 : f64
+// CHECK-NEXT:   %[[V3:.+]] = arith.mulf %[[V0]], %arg1 : f64
+// CHECK-NEXT:   %[[Z0:.+]] = llvm.mlir.poison : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[Z1:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:   %[[IV0:.+]] = llvm.insertvalue %[[Z1]], %[[Z0]][0] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[IV1:.+]] = llvm.insertvalue %[[V2]], %[[IV0]][1] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[Z2:.+]] = llvm.mlir.poison : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[Z3:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:   %[[IV2:.+]] = llvm.insertvalue %[[V3]], %[[Z2]][0] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[IV3:.+]] = llvm.insertvalue %[[Z3]], %[[IV2]][1] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   %[[ADD:.+]] = enzyme.foadd %[[IV1]], %[[IV3]]
+// CHECK-NEXT:   return %[[ADD]] : !llvm.struct<(f64, f64)>
 
 // -----
 
 // Test reverse mode AD for llvm.insertvalue on active (f64) struct elements.
 // See https://github.com/EnzymeAD/Enzyme/issues/2812
-
-func.func @insert_to_diff0(%arg0: f64) -> !llvm.struct<(f64, f64)> {
-  %z  = llvm.mlir.constant(0.0 : f64) : f64
-  %u  = llvm.mlir.undef : !llvm.struct<(f64, f64)>
-  %s0 = llvm.insertvalue %arg0, %u[0]  : !llvm.struct<(f64, f64)>
-  %s1 = llvm.insertvalue %z,   %s0[1] : !llvm.struct<(f64, f64)>
-  return %s1 : !llvm.struct<(f64, f64)>
-}
-
 llvm.func @insert(%x: f64, %seed: !llvm.struct<(f64, f64)>) -> f64 {
-  %g = enzyme.autodiff @insert_to_diff0(%x, %seed) {
+  %g = enzyme.autodiff_region(%x, %seed) {
+  ^bb0(%a_x: f64):
+    %z  = llvm.mlir.constant(0.0 : f64) : f64
+    %u  = llvm.mlir.undef : !llvm.struct<(f64, f64)>
+    %s0 = llvm.insertvalue %a_x, %u[0]  : !llvm.struct<(f64, f64)>
+    %s1 = llvm.insertvalue %z,   %s0[1] : !llvm.struct<(f64, f64)>
+    enzyme.yield %s1 : !llvm.struct<(f64, f64)>
+  } attributes {
     activity = [#enzyme<activity enzyme_active>],
-    ret_activity = [#enzyme<activity enzyme_activenoneed>]
+    ret_activity = [#enzyme<activity enzyme_activenoneed>],
+    fn = "compute_insert"
   } : (f64, !llvm.struct<(f64, f64)>) -> f64
   llvm.return %g : f64
 }
 
-// CHECK-LABEL: func.func private @diffeinsert_to_diff0
+// CHECK-LABEL: func.func private @diffecompute_insert
 // CHECK-SAME: (%arg0: f64, %arg1: !llvm.struct<(f64, f64)>) -> f64
-// CHECK-DAG:    %[[EV:.+]] = llvm.extractvalue %arg1[0] : !llvm.struct<(f64, f64)>
-// CHECK:        return %[[EV]] : f64
+// CHECK-NEXT:   %[[EV:.+]] = llvm.extractvalue %arg1[0] : !llvm.struct<(f64, f64)>
+// CHECK-NEXT:   return %[[EV]] : f64


### PR DESCRIPTION
Fixes #2811 and #2812.

llvm.extractvalue and llvm.insertvalue were missing reverse-mode AD interface registrations, causing "could not compute the adjoint" errors when differentiating functions that use struct value operations.

ExtractValue reverse rule: `d(container) += insertvalue(zeros, d(res), position)`

InsertValue reverse rule: `d(val) += extractvalue(d(res), position)` and `d(container) += insertvalue(d(res), zero(val), position)`

Both implementations include AutoDiffTypeInterface guards for non-differentiable types and handle partial activity correctly.

Test: `enzyme/test/MLIR/ReverseMode/llvm_insertvalue_extractvalue.mlir` — verifies both extractvalue and insertvalue reverse-mode adjoints produce correct gradient propagation.