### PR TITLE
Account for Fortran assumed shape

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -2642,7 +2642,7 @@ public:
              << " val:" << gutils->isConstantValue(&I)
              << " type: " << TR.query(&I).str() << "\n";
         }
-      ss << "cannot handle unknown binary operator: " << BO << "\n";
+      ss << "derivative of active binary operator not known: " << BO << "\n";
       EmitNoDerivativeError(ss.str(), BO, gutils, Builder2);
     }
 

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -2884,7 +2884,7 @@ public:
     case Instruction::Mul:
     case Instruction::Sub:
     case Instruction::Add: {
-      if (looseTypeAnalysis) {
+      if (looseTypeAnalysis || BO.getType()->isIntOrIntVectorTy()) {
         forwardModeInvertedPointerFallback(BO);
         llvm::errs() << "warning: binary operator is integer and constant: "
                      << BO << "\n";
@@ -2912,7 +2912,7 @@ public:
              << " val:" << gutils->isConstantValue(&I)
              << " type: " << TR.query(&I).str() << "\n";
         }
-      ss << "cannot handle unknown binary operator: " << BO << "\n";
+      ss << "derivative of active binary operator not known: " << BO << "\n";
       auto rval = EmitNoDerivativeError(ss.str(), BO, gutils, Builder2);
       if (!rval)
         rval = Constant::getNullValue(gutils->getShadowType(BO.getType()));

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -2614,7 +2614,7 @@ public:
     case Instruction::Mul:
     case Instruction::Sub:
     case Instruction::Add: {
-      if (looseTypeAnalysis) {
+      if (looseTypeAnalysis || BO.getType()->isIntOrIntVectorTy()) {
         llvm::errs()
             << "warning: binary operator is integer and assumed constant: "
             << BO << "\n";


### PR DESCRIPTION
Closes #2820
Merges into #2837

As documented in the issue, I wasn't able to build the `allocatableArraySimple` example locally. It seemed that Enzyme didn't fully account for assumed shape arrays in Fortran. The small patch in this PR addresses this and I can confirm I can now forward and reverse mode differentiate through things like
```fortran
  subroutine normalise(x, y)
    real, dimension(:), intent(in) :: x
    real, dimension(:), intent(out) :: y
    y(:) = x / sum(x)
  end subroutine normalise
```
which is really nice.

If I understand correctly, the error message I was hitting was slightly misleading so I propose an alternative phrasing.