### PR TITLE
Add external context accessor to type analysis

### DIFF
--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -947,6 +947,11 @@ const char *EnzymeTypeAnalyzerToString(void *src) {
   return cstr;
 }
 
+void *EnzymeTypeAnalyzerGetExternalContext(void *src) {
+  auto TA = (TypeAnalyzer *)src;
+  return TA->interprocedural.Logic.ExternalContext;
+}
+
 const char *EnzymeGradientUtilsInvertedPointersToString(GradientUtils *gutils,
                                                         void *src) {
   std::string str;

--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -947,9 +947,9 @@ const char *EnzymeTypeAnalyzerToString(void *src) {
   return cstr;
 }
 
-void *EnzymeTypeAnalyzerGetExternalContext(void *src) {
+EnzymeLogicRef EnzymeTypeAnalyzerGetLogic(void *src) {
   auto TA = (TypeAnalyzer *)src;
-  return TA->interprocedural.Logic.ExternalContext;
+  return (EnzymeLogicRef)&TA->interprocedural.Logic;
 }
 
 const char *EnzymeGradientUtilsInvertedPointersToString(GradientUtils *gutils,

--- a/enzyme/Enzyme/CApi.h
+++ b/enzyme/Enzyme/CApi.h
@@ -242,6 +242,7 @@ LLVMValueRef EnzymeGradientUtilsNewFromOriginal(GradientUtils *gutils,
 
 // TODO: Other API functions that are defined in CApi.cpp for GradientUtils
 void *EnzymeGradientUtilsGetExternalContext(GradientUtils *gutils);
+void *EnzymeTypeAnalyzerGetExternalContext(void *analyzer);
 EnzymeLogicRef EnzymeGradientUtilsGetLogic(GradientUtils *gutils);
 uint8_t EnzymeGradientUtilsGetAtomicAdd(GradientUtils *gutils);
 

--- a/enzyme/Enzyme/CApi.h
+++ b/enzyme/Enzyme/CApi.h
@@ -242,7 +242,7 @@ LLVMValueRef EnzymeGradientUtilsNewFromOriginal(GradientUtils *gutils,
 
 // TODO: Other API functions that are defined in CApi.cpp for GradientUtils
 void *EnzymeGradientUtilsGetExternalContext(GradientUtils *gutils);
-void *EnzymeTypeAnalyzerGetExternalContext(void *analyzer);
+EnzymeLogicRef EnzymeTypeAnalyzerGetLogic(void *analyzer);
 EnzymeLogicRef EnzymeGradientUtilsGetLogic(GradientUtils *gutils);
 uint8_t EnzymeGradientUtilsGetAtomicAdd(GradientUtils *gutils);
 


### PR DESCRIPTION
To remove the last uses of `enzyme_extract_world` in https://github.com/EnzymeAD/Enzyme.jl/pull/2643 
