### PR TITLE
Fix reverse mode for memref.alloca

### DIFF
--- a/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.cpp
@@ -225,8 +225,20 @@ void mlir::enzyme::MGradientUtils::setDiffe(mlir::Value val, mlir::Value toset,
   }
   assert(!isConstantValue(val));
 
+  // Reverse mode also uses invertedPointers for mutable values. For allocation
+  // results, forceAugmentedReturns() installs a placeholder shadow; the
+  // allocation derivative later calls setDiffe with the real shadow, so replace
+  // it here.
+  bool isMutable = cast<AutoDiffTypeInterface>(val.getType()).isMutable();
   if (mode == DerivativeMode::ForwardMode ||
-      mode == DerivativeMode::ForwardModeSplit) {
+      mode == DerivativeMode::ForwardModeSplit || isMutable) {
+    if (isMutable) {
+      // Mutable arguments may already be mapped to a real user-provided shadow
+      // rather than a placeholder. Only replace placeholders here.
+      auto existing = invertedPointers.lookupOrNull(val);
+      if (existing && !existing.getDefiningOp<enzyme::PlaceholderOp>())
+        return;
+    }
     setInvertedPointer(val, toset);
   }
   /*

--- a/enzyme/test/MLIR/ReverseMode/alloca.mlir
+++ b/enzyme/test/MLIR/ReverseMode/alloca.mlir
@@ -1,0 +1,110 @@
+// RUN: %eopt --enzyme %s | FileCheck --implicit-check-not=enzyme.placeholder %s
+
+func.func @foo_flat(%x : f64) -> f64 {
+  %buf = memref.alloca() : memref<f64>
+  memref.store %x, %buf[] : memref<f64>
+  %y = memref.load %buf[] : memref<f64>
+  return %y : f64
+}
+
+func.func @dfoo_flat(%x: f64, %dout : f64) -> f64 {
+  %dx = enzyme.autodiff @foo_flat(%x, %dout) {
+    activity = [#enzyme<activity enzyme_active>],
+    ret_activity = [#enzyme<activity enzyme_activenoneed>]
+  } : (f64, f64) -> (f64)
+  return %dx : f64
+}
+
+// CHECK-LABEL:   func.func private @diffefoo_flat(
+// CHECK-SAME:      %[[X:[^,]+]]: f64,
+// CHECK-SAME:      %[[DOUT:[^)]+]]: f64) -> f64 {
+
+// CHECK:           %[[GX:.+]] = "enzyme.init"() : () -> !enzyme.Gradient<f64>
+// CHECK:           "enzyme.set"(%[[GX]], %{{.*}}) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK:           %[[CS:.+]] = "enzyme.init"() : () -> !enzyme.Cache<memref<f64>>
+// CHECK:           %[[CL:.+]] = "enzyme.init"() : () -> !enzyme.Cache<memref<f64>>
+// CHECK:           %[[GY:.+]] = "enzyme.init"() : () -> !enzyme.Gradient<f64>
+// CHECK:           "enzyme.set"(%[[GY]], %{{.*}}) : (!enzyme.Gradient<f64>, f64) -> ()
+
+// CHECK:           %[[DBUF:.+]] = memref.alloca() : memref<f64>
+// CHECK:           %[[ZERO_INIT:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK:           linalg.fill ins(%[[ZERO_INIT]] : f64) outs(%[[DBUF]] : memref<f64>)
+
+// CHECK:           %[[BUF:.+]] = memref.alloca() : memref<f64>
+// CHECK:           "enzyme.push"(%[[CS]], %[[DBUF]]) : (!enzyme.Cache<memref<f64>>, memref<f64>) -> ()
+// CHECK:           memref.store %[[X]], %[[BUF]][] : memref<f64>
+// CHECK:           "enzyme.push"(%[[CL]], %[[DBUF]]) : (!enzyme.Cache<memref<f64>>, memref<f64>) -> ()
+// CHECK:           memref.load %[[BUF]][] : memref<f64>
+// CHECK:           cf.br ^bb1
+// CHECK:         ^bb1:
+
+// CHECK:           %{{.+}} = "enzyme.get"(%[[GY]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:           arith.addf %{{.+}}, %[[DOUT]] : f64
+// CHECK:           "enzyme.set"(%[[GY]], %{{.*}}) : (!enzyme.Gradient<f64>, f64) -> ()
+
+// CHECK:           %{{.+}} = "enzyme.get"(%[[GY]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:           %[[POPL:.+]] = "enzyme.pop"(%[[CL]]) : (!enzyme.Cache<memref<f64>>) -> memref<f64>
+// CHECK:           memref.load %[[POPL]][] : memref<f64>
+// CHECK:           arith.addf
+// CHECK:           memref.store %{{.+}}, %[[POPL]][] : memref<f64>
+
+// CHECK:           %[[POPS:.+]] = "enzyme.pop"(%[[CS]]) : (!enzyme.Cache<memref<f64>>) -> memref<f64>
+// CHECK:           memref.load %[[POPS]][] : memref<f64>
+// CHECK:           %{{.+}} = "enzyme.get"(%[[GX]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:           arith.addf
+// CHECK:           "enzyme.set"(%[[GX]], %{{.*}}) : (!enzyme.Gradient<f64>, f64) -> ()
+// CHECK:           %[[ZERO_CLEAR:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK:           memref.store %[[ZERO_CLEAR]], %[[POPS]][] : memref<f64>
+
+// CHECK:           %{{.+}} = "enzyme.get"(%[[GX]]) : (!enzyme.Gradient<f64>) -> f64
+// CHECK:           return %{{.+}} : f64
+
+
+// -----
+
+func.func @load_arg(%mem: memref<f64>) -> f64 {
+  %buf = memref.alloca() : memref<f64>
+  %x = memref.load %mem[] : memref<f64>
+  memref.store %x, %buf[] : memref<f64>
+  %y = memref.load %buf[] : memref<f64>
+  return %y : f64
+}
+
+func.func @dload_arg(%mem: memref<f64>, %dmem: memref<f64>, %dout : f64) {
+  enzyme.autodiff @load_arg(%mem, %dmem, %dout) {
+    activity = [#enzyme<activity enzyme_dup>],
+    ret_activity = [#enzyme<activity enzyme_activenoneed>]
+  } : (memref<f64>, memref<f64>, f64) -> ()
+  return
+}
+
+// CHECK-LABEL:   func.func private @diffeload_arg(
+// CHECK-SAME:      %[[MEM:[^,]+]]: memref<f64>,
+// CHECK-SAME:      %[[DMEM:[^,]+]]: memref<f64>,
+// CHECK-SAME:      %[[DOUT:[^)]+]]: f64) {
+// CHECK:           %[[DBUF:.+]] = memref.alloca() : memref<f64>
+// CHECK:           linalg.fill ins(%{{.+}} : f64) outs(%[[DBUF]] : memref<f64>)
+// CHECK:           %[[BUF:.+]] = memref.alloca() : memref<f64>
+// CHECK:           "enzyme.push"(%{{.+}}, %[[DMEM]]) : (!enzyme.Cache<memref<f64>>, memref<f64>) -> ()
+// CHECK:           memref.load %[[MEM]][] : memref<f64>
+// CHECK:           "enzyme.push"(%{{.+}}, %[[DBUF]]) : (!enzyme.Cache<memref<f64>>, memref<f64>) -> ()
+// CHECK:           memref.store %{{.+}}, %[[BUF]][] : memref<f64>
+// CHECK:           "enzyme.push"(%{{.+}}, %[[DBUF]]) : (!enzyme.Cache<memref<f64>>, memref<f64>) -> ()
+// CHECK:           memref.load %[[BUF]][] : memref<f64>
+// CHECK:           arith.addf %{{.+}}, %[[DOUT]] : f64
+// CHECK:           %[[POPL:.+]] = "enzyme.pop"(%{{.+}}) : (!enzyme.Cache<memref<f64>>) -> memref<f64>
+// CHECK:           memref.load %[[POPL]][] : memref<f64>
+// CHECK:           arith.addf
+// CHECK:           memref.store %{{.+}}, %[[POPL]][] : memref<f64>
+// CHECK:           %[[POPS:.+]] = "enzyme.pop"(%{{.+}}) : (!enzyme.Cache<memref<f64>>) -> memref<f64>
+// CHECK:           memref.load %[[POPS]][] : memref<f64>
+// CHECK:           "enzyme.get"
+// CHECK:           arith.addf
+// CHECK:           "enzyme.set"
+// CHECK:           memref.store %{{.+}}, %[[POPS]][] : memref<f64>
+// CHECK:           "enzyme.get"
+// CHECK:           %[[POPD:.+]] = "enzyme.pop"(%{{.+}}) : (!enzyme.Cache<memref<f64>>) -> memref<f64>
+// CHECK:           memref.load %[[POPD]][] : memref<f64>
+// CHECK:           arith.addf
+// CHECK:           memref.store %{{.+}}, %[[POPD]][] : memref<f64>
+// CHECK:           return


### PR DESCRIPTION
1. use `scf.parallel + memref.store/memref.dim` to replace `linalg.fill`
2. substitue the `enzyme.placeholder` with real shadow

The key issue for memref.alloca is: the mutable type's enzyme.placeholder does not be subtitute by the real shadow in reverse mode.

The output before fix:

```
module {
  func.func @foo_flat(%arg0: f64) -> f64 {
    %alloca = memref.alloca() : memref<f64>
    memref.store %arg0, %alloca[] : memref<f64>
    %0 = memref.load %alloca[] : memref<f64>
    return %0 : f6 }
  func.func @dfoo_flat(%arg0: f64, %arg1: f64) -> f64 {
    %0 = call @diffefoo_flat(%arg0, %arg1) : (f64, f64) -> f64
    return %0 : f64
  }
  func.func private @diffefoo_flat(%arg0: f64, %arg1: f64) -> f64 {
    %0 = "enzyme.init"() : () -> !enzyme.Gradient<f64>
    %cst = arith.constant 0.000000e+00 : f64
    "enzyme.set"(%0, %cst) : (!enzyme.Gradient<f64>, f64) -> ()
    %1 = "enzyme.init"() : () -> !enzyme.Cache<memref<f64>>
    %2 = "enzyme.init"() : () -> !enzyme.Cache<memref<f64>>
    %3 = "enzyme.init"() : () -> !enzyme.Gradient<f64>
    %cst_0 = arith.constant 0.000000e+00 : f64
    "enzyme.set"(%3, %cst_0) : (!enzyme.Gradient<f64>, f64) -> ()
    %4 = "enzyme.placeholder"() : () -> memref<f64>
    %alloca = memref.alloca() : memref<f64>
    %cst_1 = arith.constant 0.000000e+00 : f64
    memref.store %cst_1, %alloca[] : memref<f64>
    %alloca_2 = memref.alloca() : memref<f64>
    "enzyme.push"(%1, %4) : (!enzyme.Cache<memref<f64>>, memref<f64>) -> ()
    memref.store %arg0, %alloca_2[] : memref<f64>
    "enzyme.push"(%2, %4) : (!enzyme.Cache<memref<f64>>, memref<f64>) -> ()
    %5 = memref.load %alloca_2[] : memref<f64>
    cf.br ^bb1
  ^bb1:  // pred: ^bb0
    %6 = "enzyme.get"(%3) : (!enzyme.Gradient<f64>) -> f64
    %7 = arith.addf %6, %arg1 : f64
    "enzyme.set"(%3, %7) : (!enzyme.Gradient<f64>, f64) -> ()
    %8 = "enzyme.get"(%3) : (!enzyme.Gradient<f64>) -> f64
    %9 = "enzyme.pop"(%2) : (!enzyme.Cache<memref<f64>>) -> memref<f64>
    %10 = memref.load %9[] : memref<f64>
    %11 = arith.addf %10, %8 : f64
    memref.store %11, %9[] : memref<f64>
    %12 = "enzyme.pop"(%1) : (!enzyme.Cache<memref<f64>>) -> memref<f64>
    %13 = memref.load %12[] : memref<f64>
    %14 = "enzyme.get"(%0) : (!enzyme.Gradient<f64>) -> f64
    %15 = arith.addf %14, %13 : f64
    "enzyme.set"(%0, %15) : (!enzyme.Gradient<f64>, f64) -> ()
    %cst_3 = arith.constant 0.000000e+00 : f64
    memref.store %cst_3, %12[] : memref<f64>
    %16 = "enzyme.get"(%0) : (!enzyme.Gradient<f64>) -> f64
    return %16 : f64
  }
}
```
