### PR TITLE
Add BLAS trsv derivative rule

### DIFF
--- a/enzyme/Enzyme/BlasDerivatives.td
+++ b/enzyme/Enzyme/BlasDerivatives.td
@@ -56,6 +56,7 @@ def Rows : MagicInst; // given a transpose, normal rows, normal cols get the tru
 def Concat : MagicInst;
 
 def ShadowNoInc : MagicInst;
+def Dep : MagicInst;
 
 class Binop<string _s, list<string> _tys> {
   string s = _s;
@@ -670,6 +671,45 @@ def trtrs : CallBlasPattern<(Op $layout, $uplo, $trans, $diag, $n, $nrhs, $A, $l
                       ),
                   /* b     */ (BlasCall<"trtrs"> $layout, $uplo, transpose<"trans">, $diag, $n, $nrhs, $A, (ld $A, Char<"N">, $lda, $n, $n), (Shadow $B), Alloca<1>),
                   ]
+                  >;
+
+def trsv : CallBlasPattern<(Op $layout, $uplo, $trans, $diag, $n, $A, $lda, $x, $incx),
+                  ["x"],
+                  [cblas_layout, uplo, trans, diag, len, mld<["uplo", "n", "n"]>, vinc<["n"]>],
+                  [
+                  /* A     */
+                    (Seq<["tri", "triangular", "n"], [], 1>
+                      (BlasCall<"lacpy"> $layout, $uplo, $n, $n, (Shadow $A), use<"tri">, $n),
+                      (BlasCall<"ger">
+                        $layout,
+                        $n,
+                        $n,
+                        Constant<"-1">,
+                        (Rows $trans,
+                          (Concat (Shadow $x)),
+                          (Concat $x)),
+                        (Rows $trans,
+                          (Concat $x),
+                          (Concat (Shadow $x))),
+                        use<"tri">, $n),
+
+                      (BlasCall<"copy">
+                          (ISelect (is_nonunit $diag), ConstantInt<0>, $n),
+                          (First (Shadow $A)), (Add $lda, ConstantInt<1>),
+                          use<"tri">, (Add $n, ConstantInt<1>)),
+
+                      (BlasCall<"lacpy"> $layout, $uplo, $n, $n, use<"tri">, $n, (Shadow $A))
+                      ),
+                  /* x     */ (BlasCall<"trsv"> $layout, $uplo, transpose<"trans">, $diag, $n, $A, (ld $A, Char<"N">, $lda, $n, $n), (Shadow $x)),
+                  ]
+                  ,
+                  (Seq<["tmp", "vector", "n"], [], 0>
+                    (BlasCall<"copy"> $n, (Dep (Shadow $A), $x), use<"tmp">, ConstantInt<1>),
+                    (BlasCall<"trmv"> $layout, $uplo, $trans, $diag, $n, (Shadow $A), use<"tmp">, ConstantInt<1>),
+                    (BlasCall<"axpy"> $n, Constant<"-1">, (Dep (Shadow $A), use<"tmp">), ConstantInt<1>, (Shadow $x)),
+                    (BlasCall<"axpy"> (ISelect (is_nonunit $diag), ConstantInt<0>, $n), Constant<"1">, (Dep (Shadow $A), $x), (Shadow $x)),
+                    (BlasCall<"trsv"> $layout, $uplo, $trans, $diag, $n, $A, (ld $A, Char<"N">, $lda, $n, $n), (Shadow $x))
+                  )
                   >;
 
 def spr2 : CallBlasPattern<(Op $layout, $uplo, $n, $alpha, $x, $incx, $y, $incy, $ap),

--- a/enzyme/test/Enzyme/ForwardMode/blas/trsv_f.ll
+++ b/enzyme/test/Enzyme/ForwardMode/blas/trsv_f.ll
@@ -1,0 +1,42 @@
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme -S -enzyme-detect-readthrow=0 | FileCheck %s; fi
+; RUN: %opt < %s %newLoadEnzyme -passes="enzyme" -enzyme-preopt=false -enzyme-detect-readthrow=0 -S | FileCheck %s
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare dso_local void @__enzyme_fwddiff(...)
+
+declare void @dtrsv_64_(i8*, i8*, i8*, i64*, double*, i64*, double*, i64*, i64, i64, i64)
+
+define void @f(double* %A, double* %x) {
+entry:
+  %uplo = alloca i8, align 1
+  %trans = alloca i8, align 1
+  %diag = alloca i8, align 1
+  %n = alloca i64, align 8
+  %lda = alloca i64, align 8
+  %incx = alloca i64, align 8
+  store i8 85, i8* %uplo, align 1
+  store i8 78, i8* %trans, align 1
+  store i8 85, i8* %diag, align 1
+  store i64 4, i64* %n, align 8
+  store i64 4, i64* %lda, align 8
+  store i64 1, i64* %incx, align 8
+  call void @dtrsv_64_(i8* %uplo, i8* %trans, i8* %diag, i64* %n, double* %A, i64* %lda, double* %x, i64* %incx, i64 1, i64 1, i64 1)
+  ret void
+}
+
+define void @active(double* %A, double* %dA, double* %x, double* %dx) {
+entry:
+  call void (...) @__enzyme_fwddiff(void (double*, double*)* @f, metadata !"enzyme_dup", double* %A, double* %dA, metadata !"enzyme_dup", double* %x, double* %dx)
+  ret void
+}
+
+; CHECK-LABEL: define internal void @fwddiffef(
+; CHECK: call void @dtrsv_64_
+; CHECK: call void @dcopy_64_
+; CHECK: call void @dtrmv_64_
+; CHECK: call void @daxpy_64_
+; CHECK: call void @daxpy_64_
+; CHECK: call void @dtrsv_64_
+; CHECK: ret void

--- a/enzyme/test/Enzyme/ReverseMode/blas/trsv_f.ll
+++ b/enzyme/test/Enzyme/ReverseMode/blas/trsv_f.ll
@@ -1,0 +1,41 @@
+; RUN: %opt < %s %newLoadEnzyme -passes="enzyme" -S -enzyme-detect-readthrow=0 | FileCheck %s
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare void @dtrsv_64_(i8*, i8*, i8*, i64*, double*, i64*, double*, i64*, i64, i64, i64)
+
+define void @f(double* %A, double* %x) {
+entry:
+  %uplo = alloca i8, align 1
+  %trans = alloca i8, align 1
+  %diag = alloca i8, align 1
+  %n = alloca i64, align 8
+  %lda = alloca i64, align 8
+  %incx = alloca i64, align 8
+  store i8 85, i8* %uplo, align 1
+  store i8 78, i8* %trans, align 1
+  store i8 78, i8* %diag, align 1
+  store i64 4, i64* %n, align 8
+  store i64 4, i64* %lda, align 8
+  store i64 1, i64* %incx, align 8
+  call void @dtrsv_64_(i8* %uplo, i8* %trans, i8* %diag, i64* %n, double* %A, i64* %lda, double* %x, i64* %incx, i64 1, i64 1, i64 1)
+  ret void
+}
+
+declare void @__enzyme_autodiff(...)
+
+define void @active(double* %A, double* %dA, double* %x, double* %dx) {
+entry:
+  call void (...) @__enzyme_autodiff(void (double*, double*)* @f, metadata !"enzyme_dup", double* %A, double* %dA, metadata !"enzyme_dup", double* %x, double* %dx)
+  ret void
+}
+
+; CHECK: define internal void @diffef(double* %A, double* %"A'", double* %x, double* %"x'")
+; CHECK: call void @dtrsv_64_
+; CHECK: invertentry:
+; CHECK: call void @dtrsv_64_
+; CHECK: call void @dlacpy_64_
+; CHECK: call void @dger_64_
+; CHECK: call void @dcopy_64_
+; CHECK: call void @dlacpy_64_

--- a/enzyme/tools/enzyme-tblgen/blas-tblgen.cpp
+++ b/enzyme/tools/enzyme-tblgen/blas-tblgen.cpp
@@ -951,6 +951,12 @@ void rev_call_arg(bool forward, const DagInit *ruleDag,
         os << "); })";
         return;
       }
+      if (Def->getName() == "Dep") {
+        if (Dag->getNumArgs() != 2)
+          PrintFatalError(pattern.getLoc(), "only 2-arg Dep operands supported");
+        rev_call_arg(forward, Dag, pattern, 1, os, vars);
+        return;
+      }
       if (Def->getName() == "ld") {
         if (Dag->getNumArgs() != 5)
           PrintFatalError(pattern.getLoc(), "only 5-arg ld operands supported");
@@ -1493,7 +1499,7 @@ void rev_call_args(bool forward, Twine argName, const TGPattern &pattern,
     n = 1;
   if (func == "gemm" || func == "syrk" || func == "syr2k" || func == "symm")
     n = 2;
-  if (func == "trmv" || func == "trtrs")
+  if (func == "trmv" || func == "trsv" || func == "trtrs")
     n = 3;
   if (func == "trmm" || func == "trsm")
     n = 4;
@@ -2354,9 +2360,10 @@ void emit_rev_rewrite_rules(const StringMap<TGPattern> &patternMap,
 
   os << "      auto bb_name = Builder2.GetInsertBlock()->getName();\n";
   for (size_t iteri = 0; iteri < activeArgs.size(); iteri++) {
-    // trtrs do in reversed arg order.
-    size_t i = (pattern.getName() != "trtrs") ? iteri
-                                              : (activeArgs.size() - 1 - iteri);
+    // trtrs and trsv solve x cotangent before forming dA.
+    size_t i = (pattern.getName() != "trtrs" && pattern.getName() != "trsv")
+                   ? iteri
+                   : (activeArgs.size() - 1 - iteri);
     StringRef extraCond;
     auto rule = rules[i];
     const size_t actArg = activeArgs[i];


### PR DESCRIPTION
Adds the `def trsv` rule for the real BLAS triangular vector solve, with both forward and reverse mode derivatives. Split out of #2825 per @wsmoses's request to land per-rule PRs with minimal infrastructure churn.

## What's added

- `def trsv` in `BlasDerivatives.td`, following the same reverse-mode shape as `trtrs` (single RHS vector instead of matrix). Forward mode is a 5-call `Seq` using `copy`/`trmv`/`axpy`/`axpy`/`trsv`.
- `def Dep : MagicInst;` (1 line) plus a 6-line passthrough in `rev_call_arg`. The forward rule needs to gate two `axpy` calls and one `copy` on `Shadow $A` activity, but `Shadow $A` is not a direct BLAS argument of those calls. `Dep` wraps an arg so `if_rule_condition_inner` sees the activity dependency without emitting the shadow as a real BLAS argument. No `emit_dag` handler is needed — `Dep` only appears nested inside `BlasCall` args, and `if_rule_condition_inner` already recurses through arbitrary DagInits transparently.
- `trsv` joins `trmv`/`trtrs` in the `n=3` byRef-suffix arity table (three trailing Fortran string-length args for `uplo`/`trans`/`diag`) and in the reversed activeArg iteration order (reverse mode must solve the `x` cotangent before forming `dA`, identical dependency shape to `trtrs`).

## What's intentionally not here

- No changes to `enzyme/Enzyme/Utils.cpp` or `Utils.h`.
- No changes to `trsm`, `potrf`, `potrs`, or the `uplo_to_*`/`side_to_*` matchers.
- No `mat_ld` / `MatAdd` / `side_square` machinery — those belong to follow-up PRs for `trsm`/`potrs`.

## Tests

- New: `test/Enzyme/ForwardMode/blas/trsv_f.ll`, `test/Enzyme/ReverseMode/blas/trsv_f.ll`
- Locally validated against LLVM 16: `ninja LLVMEnzyme-16`, `lit -sv test/Enzyme` (1002 passed, 10 expected-fail; no regressions).

Follow-ups will add `trsm`, `potrs`, and forward-mode rules for `potrf`/etc. as separate PRs.