### PR TITLE
Register memref, linalg dialects

### DIFF
--- a/enzyme/Enzyme/MLIR/Passes/EnzymeMLIRPass.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/EnzymeMLIRPass.cpp
@@ -53,7 +53,8 @@ struct DifferentiatePass
 
     registry.insert<mlir::arith::ArithDialect, mlir::complex::ComplexDialect,
                     mlir::cf::ControlFlowDialect, mlir::tensor::TensorDialect,
-                    mlir::linalg::LinalgDialect, mlir::enzyme::EnzymeDialect>();
+                    mlir::memref::MemRefDialect, mlir::linalg::LinalgDialect,
+                    mlir::enzyme::EnzymeDialect>();
   }
 
   static std::vector<DIFFE_TYPE> mode_from_fn(FunctionOpInterface fn,

--- a/enzyme/Enzyme/MLIR/Passes/Passes.h
+++ b/enzyme/Enzyme/MLIR/Passes/Passes.h
@@ -15,6 +15,8 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 
 #include "Dialect/Dialect.h"
@@ -69,6 +71,14 @@ class LLVMDialect;
 namespace tensor {
 class TensorDialect;
 } // end namespace tensor
+
+namespace linalg {
+class LinalgDialect;
+} // end namespace linalg
+
+namespace memref {
+class MemRefDialect;
+} // end namespace memref
 
 namespace enzyme {
 

--- a/enzyme/Enzyme/MLIR/Passes/Passes.td
+++ b/enzyme/Enzyme/MLIR/Passes/Passes.td
@@ -19,6 +19,8 @@ def DifferentiatePass : Pass<"enzyme"> {
     "cf::ControlFlowDialect",
     "tensor::TensorDialect",
     "enzyme::EnzymeDialect",
+    "linalg::LinalgDialect",
+    "memref::MemRefDialect"
   ];
   let options = [
     Option<
@@ -85,7 +87,9 @@ def DifferentiateWrapperPass : Pass<"enzyme-wrap"> {
     "arith::ArithDialect",
     "complex::ComplexDialect",
     "cf::ControlFlowDialect",
-    "enzyme::EnzymeDialect"
+    "enzyme::EnzymeDialect",
+    "linalg::LinalgDialect",
+    "memref::MemRefDialect"
   ];
   let options = [
     Option<


### PR DESCRIPTION
Register memref and linalg dialects eagerly in ``enzyme`` and ``enzyme-wrap`` passes.
The following is an example where this is needed ([Enzyme explorer version](https://tinyurl.com/2cfkegpd)).
```
module {
  func.func @memref_example(%arg0: f64) -> f64 attributes {llvm.linkage = #llvm.linkage<external>} {
    %c0 = arith.constant 0 : index
    %alloc = memref.alloc() : memref<10xf64>
    memref.store %arg0, %alloc[%c0] : memref<10xf64>
    %1 = memref.load %alloc[%c0] : memref<10xf64>
    return %1 : f64
  }
}
```
Command:
```
enzymemlir-opt "--enzyme-wrap=infn=memref_example outfn=grad_memref_example retTys=enzyme_active argTys=enzyme_dup mode=ReverseModeCombined"
```
Output with main branch:
```
<unknown>:0: error: 'linalg.yield' op created with unregistered dialect. If this is intended, please call allowUnregisteredDialects() on the MLIRContext, or use -allow-unregistered-dialect with the MLIR opt tool used
<unknown>:0: note: see current operation: "linalg.yield"(%arg3) : (f64) -> ()
Compiler returned: 1
```

With the changes in this PR enzyme-wrap succeeds.