### PR TITLE
feat: add maximumnum/minimumnum intrinsic derivative support

### DIFF
--- a/enzyme/Enzyme/InstructionDerivatives.td
+++ b/enzyme/Enzyme/InstructionDerivatives.td
@@ -999,7 +999,7 @@ def : IntrPattern<(Op $x, $y),
                   >;
 
 def : IntrPattern<(Op $x, $y),
-                  [["minnum"], ["nvvm_fmin_f"], ["nvvm_fmin_d"], ["nvvm_fmin_ftz_f"], ["x86_sse_min_ss", "", "9"], ["x86_sse_min_ps", "", "9"], ["x86_sse2_min_pd", "", ""], ["minimum", "11", ""]],
+                  [["minnum"], ["nvvm_fmin_f"], ["nvvm_fmin_d"], ["nvvm_fmin_ftz_f"], ["x86_sse_min_ss", "", "9"], ["x86_sse_min_ps", "", "9"], ["x86_sse2_min_pd", "", ""], ["minimum", "11", ""], ["minimumnum", "20", ""]],
                   [
                     (Select (FCmpOLT $x, $y), (DiffeRet), (ConstantFP<"0"> $x)),
                     (Select (FCmpOLT $x, $y), (ConstantFP<"0"> $x), (DiffeRet))
@@ -1008,7 +1008,7 @@ def : IntrPattern<(Op $x, $y),
                   >;
 
 def : IntrPattern<(Op $x, $y),
-                  [["maxnum"], ["nvvm_fmax_f"], ["nvvm_fmax_d"], ["nvvm_fmax_ftz_f"], ["x86_sse_max_ss", "", "9"], ["x86_sse_max_ps", "", "9"], ["x86_sse2_max_pd", "", ""], ["maximum", "11", ""]],
+                  [["maxnum"], ["nvvm_fmax_f"], ["nvvm_fmax_d"], ["nvvm_fmax_ftz_f"], ["x86_sse_max_ss", "", "9"], ["x86_sse_max_ps", "", "9"], ["x86_sse2_max_pd", "", ""], ["maximum", "11", ""], ["maximumnum", "20", ""]],
                   [
                     (Select (FCmpOLT $x, $y), (ConstantFP<"0"> $x), (DiffeRet)),
                     (Select (FCmpOLT $x, $y), (DiffeRet), (ConstantFP<"0"> $x))

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -4080,6 +4080,10 @@ void TypeAnalyzer::visitIntrinsicInst(llvm::IntrinsicInst &I) {
   case Intrinsic::maximum:
   case Intrinsic::minimum:
 #endif
+#if LLVM_VERSION_MAJOR >= 20
+  case Intrinsic::maximumnum:
+  case Intrinsic::minimumnum:
+#endif
   case Intrinsic::nvvm_fmax_f:
   case Intrinsic::nvvm_fmax_d:
   case Intrinsic::nvvm_fmax_ftz_f:

--- a/enzyme/test/Enzyme/ForwardMode/maximumnum.ll
+++ b/enzyme/test/Enzyme/ForwardMode/maximumnum.ll
@@ -1,0 +1,27 @@
+; RUN: if [ %llvmver -ge 20 ]; then %opt < %s %newLoadEnzyme -passes="enzyme" -enzyme-preopt=false -S | FileCheck %s; fi
+
+; Function Attrs: noinline nounwind readnone uwtable
+define double @tester(double %x, double %y) {
+entry:
+  %0 = tail call double @llvm.maximumnum.f64(double %x, double %y)
+  ret double %0
+}
+
+define double @test_derivative(double %x, double %y) {
+entry:
+  %0 = tail call double (double (double, double)*, ...) @__enzyme_fwddiff(double (double, double)* nonnull @tester, double %x, double 1.0, double %y, double 1.0)
+  ret double %0
+}
+
+; Function Attrs: nounwind readnone speculatable
+declare double @llvm.maximumnum.f64(double, double)
+
+; Function Attrs: nounwind
+declare double @__enzyme_fwddiff(double (double, double)*, ...)
+
+; CHECK: define internal {{(dso_local )?}}double @fwddiffetester(double %x, double %"x'", double %y, double %"y'")
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %0 = fcmp fast olt double %x, %y
+; CHECK-NEXT:   %1 = select {{(fast )?}}i1 %0, double %"y'", double %"x'"
+; CHECK-NEXT:   ret double %1
+; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ForwardMode/minimumnum.ll
+++ b/enzyme/test/Enzyme/ForwardMode/minimumnum.ll
@@ -1,0 +1,24 @@
+; RUN: if [ %llvmver -ge 20 ]; then %opt < %s %newLoadEnzyme -passes="enzyme" -enzyme-preopt=false -S | FileCheck %s; fi
+
+define double @tester(double %x, double %y) {
+entry:
+  %0 = tail call double @llvm.minimumnum.f64(double %x, double %y)
+  ret double %0
+}
+
+define double @test_derivative(double %x, double %y) {
+entry:
+  %0 = tail call double (double (double, double)*, ...) @__enzyme_fwddiff(double (double, double)* nonnull @tester, double %x, double 1.0, double %y, double 1.0)
+  ret double %0
+}
+
+declare double @llvm.minimumnum.f64(double, double)
+
+declare double @__enzyme_fwddiff(double (double, double)*, ...)
+
+; CHECK: define internal {{(dso_local )?}}double @fwddiffetester(double %x, double %"x'", double %y, double %"y'")
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %0 = fcmp fast olt double %x, %y
+; CHECK-NEXT:   %1 = select{{( fast)?}} i1 %0, double %"x'", double %"y'"
+; CHECK-NEXT:   ret double %1
+; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ReverseMode/maximumnum.ll
+++ b/enzyme/test/Enzyme/ReverseMode/maximumnum.ll
@@ -1,0 +1,30 @@
+; RUN: if [ %llvmver -ge 20 ]; then %opt < %s %newLoadEnzyme -enzyme-preopt=false -passes="enzyme,function(mem2reg,early-cse,%simplifycfg)" -S | FileCheck %s; fi
+
+; Function Attrs: noinline nounwind readnone uwtable
+define double @tester(double %x, double %y) {
+entry:
+  %0 = tail call double @llvm.maximumnum.f64(double %x, double %y)
+  ret double %0
+}
+
+define double @test_derivative(double %x, double %y) {
+entry:
+  %0 = tail call double (double (double, double)*, ...) @__enzyme_autodiff(double (double, double)* nonnull @tester, double %x, double %y)
+  ret double %0
+}
+
+; Function Attrs: nounwind readnone speculatable
+declare double @llvm.maximumnum.f64(double, double)
+
+; Function Attrs: nounwind
+declare double @__enzyme_autodiff(double (double, double)*, ...)
+
+; CHECK: define internal {{(dso_local )?}}{ double, double } @diffetester(double %x, double %y, double %[[differet:.+]])
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %[[cmp:.+]] = fcmp fast olt double %x, %y
+; CHECK-NEXT:   %[[diffex:.+]] = select {{(fast )?}}i1 %[[cmp]], double 0.000000e+00, double %[[differet]]
+; CHECK-NEXT:   %[[diffey:.+]] = select {{(fast )?}}i1 %[[cmp]], double %[[differet]], double 0.000000e+00
+; CHECK-NEXT:   %[[iv0:.+]] = insertvalue { double, double } undef, double %[[diffex]], 0
+; CHECK-NEXT:   %[[iv1:.+]] = insertvalue { double, double } %[[iv0]], double %[[diffey]], 1
+; CHECK-NEXT:   ret { double, double } %[[iv1]]
+; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ReverseMode/minimumnum.ll
+++ b/enzyme/test/Enzyme/ReverseMode/minimumnum.ll
@@ -1,0 +1,27 @@
+; RUN: if [ %llvmver -ge 20 ]; then %opt < %s %newLoadEnzyme -enzyme-preopt=false -passes="enzyme,function(mem2reg,%simplifycfg,early-cse)" -S | FileCheck %s; fi
+
+define double @tester(double %x, double %y) {
+entry:
+  %0 = tail call double @llvm.minimumnum.f64(double %x, double %y)
+  ret double %0
+}
+
+define double @test_derivative(double %x, double %y) {
+entry:
+  %0 = tail call double (double (double, double)*, ...) @__enzyme_autodiff(double (double, double)* nonnull @tester, double %x, double %y)
+  ret double %0
+}
+
+declare double @llvm.minimumnum.f64(double, double)
+
+declare double @__enzyme_autodiff(double (double, double)*, ...)
+
+; CHECK: define internal {{(dso_local )?}}{ double, double } @diffetester(double %x, double %y, double %[[differet:.+]])
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %[[cmp:.+]] = fcmp fast olt double %x, %y
+; CHECK-NEXT:   %[[diffex:.+]] = select{{( fast)?}} i1 %[[cmp]], double %[[differet]], double 0.000000e+00
+; CHECK-NEXT:   %[[diffey:.+]] = select{{( fast)?}} i1 %[[cmp]], double 0.000000e+00, double %[[differet]]
+; CHECK-NEXT:   %[[iv0:.+]] = insertvalue { double, double } undef, double %[[diffex]], 0
+; CHECK-NEXT:   %[[iv1:.+]] = insertvalue { double, double } %[[iv0]], double %[[diffey]], 1
+; CHECK-NEXT:   ret { double, double } %[[iv1]]
+; CHECK-NEXT: }


### PR DESCRIPTION
Add forward/reverse derivative rules for llvm.maximumnum and llvm.minimumnum

LLVM 19 introduced `llvm.maximumnum` / `llvm.minimumnum` (IEEE 754-2019
`maximumNumber`/`minimumNumber`). These are the modern replacements for
`llvm.maxnum` / `llvm.minnum`, and recent LLVM backends now emit them —
for example, Rust's `f64::max(0.0)` lowers to `@llvm.maximumnum.f64`
instead of `@llvm.maxnum.f64` on current nightlies.

Enzyme doesn't recognize these yet, so any code using `.max()` / `.min()`
hits:

    cannot handle (reverse) unknown intrinsic
    llvm.maximumnum

The derivative is the same as maxnum/minnum (select which operand was
chosen, route the adjoint there). The only difference between the old and
new intrinsics is signed-zero and NaN ordering, which doesn't affect the
derivative rule.

What's added:
- `InstructionDerivatives.td` — `["maximumnum", "19", ""]` and
  `["minimumnum", "19", ""]` appended to the existing max/min patterns
- `TypeAnalysis.cpp` — case entries gated behind `LLVM_VERSION_MAJOR >= 19`
- Forward and reverse mode tests for both, modeled after the existing
  maxnum.ll / minnum.ll tests

I ran into this while benchmarking `std::autodiff` in Rust — the payoff
function `(spot - strike).max(0.0)` in a Monte Carlo pricer was the only
thing preventing the Enzyme backend from working.