### PR TITLE
Preserve full shadow memtransfers

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -3653,6 +3653,10 @@ public:
       }
     }
 
+    if (size != 0) {
+      toIterate.emplace_back(nullptr, 0, size);
+    }
+
     for (auto &&[floatTy_ref, seg_start_ref, seg_size_ref] : toIterate) {
       auto floatTy = floatTy_ref;
       auto seg_start = seg_start_ref;

--- a/enzyme/test/Enzyme/ReverseMode/full-shadow-memcpy.ll
+++ b/enzyme/test/Enzyme/ReverseMode/full-shadow-memcpy.ll
@@ -1,0 +1,32 @@
+; RUN: %opt < %s %newLoadEnzyme -enzyme-preopt=false -passes="enzyme" -S | FileCheck %s
+
+%State = type { ptr, double, ptr, double }
+
+define void @scatter(ptr byval(%State) align 8 %arg) {
+entry:
+  %local = alloca %State, align 8
+  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %local, ptr align 8 %arg, i64 32, i1 false)
+  %out.gep = getelementptr inbounds %State, ptr %local, i32 0, i32 0
+  %out = load ptr, ptr %out.gep, align 8
+  %scale.gep = getelementptr inbounds %State, ptr %local, i32 0, i32 1
+  %scale = load double, ptr %scale.gep, align 8
+  %in.gep = getelementptr inbounds %State, ptr %local, i32 0, i32 2
+  %in = load ptr, ptr %in.gep, align 8
+  %x = load double, ptr %in, align 8
+  %res = fmul double %x, %scale
+  store double %res, ptr %out, align 8
+  ret void
+}
+
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1)
+
+define void @caller(ptr %arg, ptr %darg) {
+entry:
+  call void (...) @__enzyme_autodiff(void (ptr)* @scatter, ptr %arg, ptr %darg)
+  ret void
+}
+
+declare void @__enzyme_autodiff(...)
+
+; CHECK: define internal void @diffescatter(ptr byval(%State) align 8 %arg, ptr align 8 %"arg'")
+; CHECK: call void @llvm.memcpy.p0.p0.i64(ptr align 8 %{{.*}}, ptr align 8 %"arg'", i64 32, i1 false)


### PR DESCRIPTION
## problem
Enzyme was zero-initializing a shadow copy of a struct and then copying only selected active slices from the source shadow. The reverse pass later needed pointer fields from the copied shadow object, but those fields stayed null. The fix preserves a full shadow memtransfer for nonzero memtransfers, so inactive pointer fields remain initialized while existing sliced updates can still run.

## Summary
- Preserve the full shadow memtransfer when Enzyme also emits sliced shadow updates, so inactive fields in copied aggregates remain initialized.
- Add a reverse-mode IR regression test covering a copied aggregate with pointer and active scalar fields.

## Test plan
- Built `LLVMEnzyme-19.so` and `ClangEnzyme-19.so` against the Conan LLVM 19.1.7 package.
- Ran the new standalone IR repro through `opt`; confirmed the full 32-byte shadow copy is absent without the fix and present with the fix.
- Ran Cromwell `TestAdjoint.UnitTestAdjointKW` with the minimal fix; it passed.

#2629 