### PR TITLE
Allow setting strict-alias defaults at config time

### DIFF
--- a/enzyme/CMakeLists.txt
+++ b/enzyme/CMakeLists.txt
@@ -46,6 +46,15 @@ option(ENZYME_APPLE_DYNAMIC_LOOKUP
 option(ENZYME_STATIC_LIB "Build static library" OFF)
 option(ENZYME_WARN_COMPILER "Warn if enzyme detects potentially incompatible compiler" ON)
 option(ENZYME_ENABLE_REACTANT "Build support library for Reactant C++ frontend" OFF)
+option(
+  ENZYME_DEFAULT_STRICT_ALIASING
+  "Default -enzyme-strict-aliasing to true"
+  ON
+)
+add_compile_definitions(
+  ENZYME_DEFAULT_STRICT_ALIASING=$<BOOL:${ENZYME_DEFAULT_STRICT_ALIASING}>
+)
+
 set(ENZYME_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(ENZYME_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(Fortran_COMPILER ${CMAKE_Fortran_COMPILER})

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -71,6 +71,10 @@
 
 using namespace llvm;
 
+#ifndef ENZYME_DEFAULT_STRICT_ALIASING
+#define ENZYME_DEFAULT_STRICT_ALIASING 1
+#endif
+
 extern "C" {
 /// Maximum offset for type trees to keep
 llvm::cl::opt<int> MaxIntOffset("enzyme-max-int-offset", cl::init(100),
@@ -90,8 +94,8 @@ llvm::cl::opt<bool> RustTypeRules("enzyme-rust-type", cl::init(false),
                                   cl::desc("Enable rust-specific type rules"));
 
 llvm::cl::opt<bool> EnzymeStrictAliasing(
-    "enzyme-strict-aliasing", cl::init(true), cl::Hidden,
-    cl::desc("Assume strict aliasing of types / type stability"));
+    "enzyme-strict-aliasing", cl::init(ENZYME_DEFAULT_STRICT_ALIASING != 0),
+    cl::Hidden, cl::desc("Assume strict aliasing of types / type stability"));
 }
 
 const llvm::StringMap<llvm::Intrinsic::ID> LIBM_FUNCTIONS = {


### PR DESCRIPTION
Whether or not some IR is valid or not under strict-aliasing is determined by the language. Rust does not have the concept, so we want to set the default to false in https://github.com/EnzymeAD/Enzyme/blob/41b6c734483d62764381194aeb15b8690f8c99ee/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp#L93

It doesn't matter for rustc driven builds, but every debug build has to specify `-enzyme-strict-aliasing=0` by hand, which doesn't make sense.
@copilot add a cmake option (default off) to change the default of strict-aliasing from true to false, so that rust people loading enzyme via opt stop running into it.

Enzyme was unwilling to accept it in https://github.com/EnzymeAD/Enzyme/issues/2885, but I care more about the concrete benefit to Rust devs willing to spend time debugging Enzyme, than about a potential future person downloading Enzyme via rustup, and then being confused that it used cmake to tune defaults in favour of Rust.