### PR TITLE
IFX bugfix (take 3)

### DIFF
--- a/enzyme/test/Fortran/ForwardMode/allocatableArraySimple_with_bindings.f90
+++ b/enzyme/test/Fortran/ForwardMode/allocatableArraySimple_with_bindings.f90
@@ -8,24 +8,7 @@
 !       For it to work with the ifx compiler we will need to figure out how to
 !       handle the indirection involved in the enzyme_fwddiff binding
 
-module AD
-    implicit none
-
-    contains
-
-    ! TODO: Switch to assumed shape implementation once
-    !       https://github.com/EnzymeAD/Enzyme/issues/2820
-    !       has been addressed
-    subroutine selectFirst(n, x, y)
-        integer, intent(in) :: n
-        real, intent(in) :: x(n)
-        real, intent(inout) :: y
-        y = x(1)
-    end subroutine
-end module
-
 program app
-    use AD, only: selectFirst
     use enzyme, only: enzyme_const, enzyme_dup, enzyme_fwddiff
     implicit none
     integer :: n
@@ -49,6 +32,19 @@ program app
     print *, int(dx(2))
     print *, int(dx(3))
     print *, int(dy)
+
+contains
+
+    ! TODO: Switch to assumed shape implementation once
+    !       https://github.com/EnzymeAD/Enzyme/issues/2820
+    !       has been addressed
+    subroutine selectFirst(n, x, y)
+        integer, intent(in) :: n
+        real, intent(in) :: x(n)
+        real, intent(inout) :: y
+        y = x(1)
+    end subroutine
+
 end program
 
 

--- a/enzyme/test/Fortran/ForwardMode/allocatableArraySimple_with_bindings.f90
+++ b/enzyme/test/Fortran/ForwardMode/allocatableArraySimple_with_bindings.f90
@@ -1,7 +1,8 @@
-! RUN: if [[ %fc != ifx ]]; then %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O0 -S -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s; fi
-! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O1 -S -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O2 -S -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O3 -S -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
+! REQUIRES: fortran
+! RUN: if [[ %fc != ifx ]]; then %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s; fi
+! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
 
 ! NOTE: This test is only configured to run with the flang compiler at -O0
 !       For it to work with the ifx compiler we will need to figure out how to

--- a/enzyme/test/Fortran/ForwardMode/allocatableArraySimple_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ForwardMode/allocatableArraySimple_with_explicit_interface.f90
@@ -1,8 +1,9 @@
+! REQUIRES: fortran
 ! REQUIRES: ifx
-! RUN: %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O0 -S -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O1 -S -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O2 -S -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O3 -S -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O0 -c %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O1 -c %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
 
 ! NOTE: This test is only configured to run with the ifx compiler
 !       For it to work with the flang compiler we will need to address

--- a/enzyme/test/Fortran/ForwardMode/allocatableArraySimple_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ForwardMode/allocatableArraySimple_with_explicit_interface.f90
@@ -9,7 +9,7 @@
 !       For it to work with the flang compiler we will need to address
 !       https://github.com/EnzymeAD/Enzyme/issues/2820
 
-module AD
+module selectFirstForward
     implicit none
     interface
         subroutine selectFirst__enzyme_fwddiff(fnc, x, dx, y, dy)
@@ -37,7 +37,7 @@ module AD
 end module
 
 program app
-    use AD
+    use selectFirstForward, only: selectFirst, selectFirst__enzyme_fwddiff
     implicit none
     real, allocatable :: x(:), dx(:)
     real :: y, dy

--- a/enzyme/test/Fortran/ReverseMode/allocatableArraySimple_with_bindings.f90
+++ b/enzyme/test/Fortran/ReverseMode/allocatableArraySimple_with_bindings.f90
@@ -1,8 +1,8 @@
 ! REQUIRES: fortran
-! RUN: if [[ %fc != ifx ]]; then %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O0 -S -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s; fi
-! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O1 -S -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O2 -S -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O3 -S -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: if [[ %fc != ifx ]]; then %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s; fi
+! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
 
 ! NOTE: This test is only configured to run with the flang compiler at -O0
 !       For it to work with the ifx compiler we will need to figure out how to

--- a/enzyme/test/Fortran/ReverseMode/allocatableArraySimple_with_bindings.f90
+++ b/enzyme/test/Fortran/ReverseMode/allocatableArraySimple_with_bindings.f90
@@ -8,24 +8,7 @@
 !       For it to work with the ifx compiler we will need to figure out how to
 !       handle the indirection involved in the enzyme_autodiff binding
 
-module AD
-    implicit none
-
-    contains
-
-    ! TODO: Switch to assumed shape implementation once
-    !       https://github.com/EnzymeAD/Enzyme/issues/2820
-    !       has been addressed
-    subroutine selectFirst(n, x, y)
-        integer, intent(in) :: n
-        real, intent(in) :: x(n)
-        real, intent(inout) :: y
-        y = x(1)
-    end subroutine
-end module
-
 program app
-    use AD, only: selectFirst
     use enzyme, only: enzyme_const, enzyme_dup, enzyme_autodiff
     implicit none
     integer :: n
@@ -49,6 +32,19 @@ program app
     print *, int(dx(2))
     print *, int(dx(3))
     print *, int(dy)
+
+contains
+
+    ! TODO: Switch to assumed shape implementation once
+    !       https://github.com/EnzymeAD/Enzyme/issues/2820
+    !       has been addressed
+    subroutine selectFirst(n, x, y)
+        integer, intent(in) :: n
+        real, intent(in) :: x(n)
+        real, intent(inout) :: y
+        y = x(1)
+    end subroutine
+
 end program
 
 

--- a/enzyme/test/Fortran/ReverseMode/allocatableArraySimple_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ReverseMode/allocatableArraySimple_with_explicit_interface.f90
@@ -1,8 +1,9 @@
+! REQUIRES: fortran
 ! REQUIRES: ifx
-! RUN: %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O0 -S -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O1 -S -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O2 -S -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O3 -S -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O0 -c  %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O1 -c  %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c  %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c  %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
 
 ! NOTE: This test is only configured to run with the ifx compiler
 !       For it to work with the flang compiler we will need to address

--- a/enzyme/test/Fortran/ReverseMode/allocatableArraySimple_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ReverseMode/allocatableArraySimple_with_explicit_interface.f90
@@ -9,7 +9,7 @@
 !       For it to work with the flang compiler we will need to address
 !       https://github.com/EnzymeAD/Enzyme/issues/2820
 
-module AD
+module selectFirstReverse
     implicit none
     interface
         subroutine selectFirst__enzyme_autodiff(fnc, x, dx, y, dy)
@@ -37,7 +37,7 @@ module AD
 end module
 
 program app
-    use AD
+    use selectFirstReverse, only: selectFirst, selectFirst__enzyme_autodiff
     implicit none
     real, allocatable :: x(:), dx(:)
     real :: y, dy

--- a/enzyme/test/Fortran/ReverseMode/square_with_bindings.f90
+++ b/enzyme/test/Fortran/ReverseMode/square_with_bindings.f90
@@ -8,17 +8,8 @@
 !       For it to work with the ifx compiler we will need to figure out how to
 !       handle the indirection involved in the enzyme_autodiff binding
 
-module math
-contains
-    real function square( x )
-        real, intent(in) :: x
-        square = x**2
-    end function
-end module math
-
 program app
     use enzyme, only: enzyme_autodiff
-    use math, only: square
     implicit none
     real :: x, dx
 
@@ -29,6 +20,14 @@ program app
     call enzyme_autodiff(square, x, dx)
 
     print *, dx
+
+contains
+
+    real function square( x )
+        real, intent(in) :: x
+        square = x**2
+    end function
+
 end program app
 
 ! CHECK: 9

--- a/enzyme/test/Fortran/ReverseMode/square_with_bindings.f90
+++ b/enzyme/test/Fortran/ReverseMode/square_with_bindings.f90
@@ -1,7 +1,8 @@
-! RUN: if [[ %fc != ifx ]]; then %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O0 -S -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s; fi
-! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O1 -S -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O2 -S -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O3 -S -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
+! REQUIRES: fortran
+! RUN: if [[ %fc != ifx ]]; then %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s; fi
+! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
 
 ! NOTE: This test is only configured to run with the flang compiler at -O0
 !       For it to work with the ifx compiler we will need to figure out how to

--- a/enzyme/test/Fortran/ReverseMode/square_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ReverseMode/square_with_explicit_interface.f90
@@ -1,7 +1,8 @@
-! RUN: %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O0 -S -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O1 -S -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O2 -S -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O3 -S -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
+! REQUIRES: fortran
+! RUN: %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
 
 module math
     interface

--- a/enzyme/test/Fortran/ReverseMode/square_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ReverseMode/square_with_explicit_interface.f90
@@ -4,7 +4,7 @@
 ! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
 ! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
 
-module math
+module squareForward
     interface
         subroutine square__enzyme_autodiff(fn, x, dx)
         interface
@@ -22,10 +22,10 @@ contains
         real, intent(in) :: x
         square = x**2
     end function
-end module math
+end module
 
 program app
-    use math
+    use squareForward, only: square, square__enzyme_autodiff
     implicit none
     real :: x, dx
 


### PR DESCRIPTION
Closes #2902 
Based off what I arrived at in #2904

Okay I think I've got the fix for the error reported as well as some other intermittent ones.

The error reported was occurring because the same Fortran module name was being used in different tests, leading to conflicting `.mod` files with the same name.

Other errors are (I think) fixed by avoiding the second `opt` step.

I also ensured `REQUIRES: fortran` is always used (to get the right LLVM version checking) and dropped some unnecessary `%loadFortran` statements in tests that don't use the bindings.