### PR TITLE
Handle gc-transition bundle from Julia v1.12

### DIFF
--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -260,10 +260,8 @@ bool GradientUtils::usedInRooting(const llvm::CallBase *orig,
   orig->getOperandBundlesAsDefs(OrigDefs);
   SmallVector<OperandBundleDef, 2> Defs;
   for (auto bund : OrigDefs) {
-    if (bund.getTag() == "gc-transition")
-      continue;
-    // Only handle jl_roots tag (for now).
-    if (bund.getTag() != "jl_roots") {
+    // Only handle jl_roots & gc-transition tags (for now).
+    if (bund.getTag() != "jl_roots" && bund.getTag() != "gc-transition") {
       errs() << "unsupported tag " << bund.getTag() << " for " << *orig << "\n";
       llvm_unreachable("unsupported tag");
     }
@@ -305,52 +303,43 @@ GradientUtils::getInvertedBundles(CallInst *orig, ArrayRef<ValueType> types,
   orig->getOperandBundlesAsDefs(OrigDefs);
   SmallVector<OperandBundleDef, 2> Defs;
   for (auto bund : OrigDefs) {
-    // Only handle jl_roots tag i & gc-transition (for now).
-    if (bund.getTag() == "jl_roots") {
-      SmallVector<Value *, 2> bunds;
-      // In the future we can reduce the number of roots
-      // we preserve by identifying which operands they
-      // correspond to. For now, fall back and preserve all
-      // primals and shadows
-      // assert(bund.inputs().size() == types.size());
-      for (auto inp : bund.inputs()) {
-        bool anyPrimal = false;
-        bool anyShadow = false;
-        for (auto ty : types) {
-          if (ty == ValueType::Primal || ty == ValueType::Both)
-            anyPrimal = true;
-          if (ty == ValueType::Shadow || ty == ValueType::Both)
-            anyShadow = true;
-        }
-
-        if (anyPrimal) {
-          Value *newv = getNewFromOriginal(inp);
-          if (lookup)
-            newv = lookupM(newv, Builder2, available);
-          bunds.push_back(newv);
-        }
-        if (anyShadow && !isConstantValue(inp)) {
-          Value *shadow = invertPointerM(inp, Builder2);
-          if (lookup)
-            shadow = lookupM(shadow, Builder2);
-          bunds.push_back(shadow);
-        }
-      }
-      Defs.push_back(OperandBundleDef(bund.getTag().str(), bunds));
-    } else if (bund.getTag() == "gc-transition"){
-      // carries only primal
-      SmallVector<Value *, 2> bunds;
-      for (auto inp : bund.inputs()) {
-          Value *newv = getNewFromOriginal(inp);
-          if (lookup)
-            newv = lookupM(newv, Builder2, available);
-          bunds.push_back(newv);
-      }
-      Defs.push_back(OperandBundleDef(bund.getTag().str(), bunds));
-    } else {
-      errs() << "unsupported tag " << bund.getTag() << " for " << *orig << "\n";
+    // Only handle jl_roots & gc-transition tags (for now).
+    StringRef tag = bund.getTag();
+    if (tag != "jl_roots" && tag != "gc-transition") {
+      errs() << "unsupported tag " << tag << " for " << *orig << "\n";
       llvm_unreachable("unsupported tag");
     }
+
+    // In the future we can reduce the number of roots
+    // we preserve by identifying which operands they
+    // correspond to. For now, fall back and preserve all
+    // primals and shadows
+    // assert(bund.inputs().size() == types.size());
+    bool anyPrimal = false;
+    bool anyShadow = false;
+    for (auto ty : types) {
+      if (ty == ValueType::Primal || ty == ValueType::Both)
+        anyPrimal = true;
+      if (ty == ValueType::Shadow || ty == ValueType::Both)
+        anyShadow = true;
+    }
+
+    SmallVector<Value *, 2> bunds;
+    for (auto inp : bund.inputs()) {
+      if (anyPrimal) {
+        Value *newv = getNewFromOriginal(inp);
+        if (lookup)
+          newv = lookupM(newv, Builder2, available);
+        bunds.push_back(newv);
+      }
+      if (anyShadow && !isConstantValue(inp)) {
+        Value *shadow = invertPointerM(inp, Builder2);
+        if (lookup)
+          shadow = lookupM(shadow, Builder2);
+        bunds.push_back(shadow);
+      }
+    }
+    Defs.push_back(OperandBundleDef(tag.str(), bunds));
   }
   return Defs;
 }

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -310,36 +310,47 @@ GradientUtils::getInvertedBundles(CallInst *orig, ArrayRef<ValueType> types,
       llvm_unreachable("unsupported tag");
     }
 
-    // In the future we can reduce the number of roots
-    // we preserve by identifying which operands they
-    // correspond to. For now, fall back and preserve all
-    // primals and shadows
-    // assert(bund.inputs().size() == types.size());
-    bool anyPrimal = false;
-    bool anyShadow = false;
-    for (auto ty : types) {
-      if (ty == ValueType::Primal || ty == ValueType::Both)
-        anyPrimal = true;
-      if (ty == ValueType::Shadow || ty == ValueType::Both)
-        anyShadow = true;
-    }
+    if (tag == "jl_roots") {
+      // In the future we can reduce the number of roots
+      // we preserve by identifying which operands they
+      // correspond to. For now, fall back and preserve all
+      // primals and shadows
+      // assert(bund.inputs().size() == types.size());
+      bool anyPrimal = false;
+      bool anyShadow = false;
+      for (auto ty : types) {
+        if (ty == ValueType::Primal || ty == ValueType::Both)
+          anyPrimal = true;
+        if (ty == ValueType::Shadow || ty == ValueType::Both)
+          anyShadow = true;
+      }
 
-    SmallVector<Value *, 2> bunds;
-    for (auto inp : bund.inputs()) {
-      if (anyPrimal) {
+      SmallVector<Value *, 2> bunds;
+      for (auto inp : bund.inputs()) {
+        if (anyPrimal) {
+          Value *newv = getNewFromOriginal(inp);
+          if (lookup)
+            newv = lookupM(newv, Builder2, available);
+          bunds.push_back(newv);
+        }
+        if (anyShadow && !isConstantValue(inp)) {
+          Value *shadow = invertPointerM(inp, Builder2);
+          if (lookup)
+            shadow = lookupM(shadow, Builder2);
+          bunds.push_back(shadow);
+        }
+      }
+      Defs.push_back(OperandBundleDef(tag.str(), bunds));
+    } else {
+      SmallVector<Value *, 2> bunds;
+      for (auto inp : bund.inputs()) {
         Value *newv = getNewFromOriginal(inp);
         if (lookup)
           newv = lookupM(newv, Builder2, available);
         bunds.push_back(newv);
       }
-      if (anyShadow && !isConstantValue(inp)) {
-        Value *shadow = invertPointerM(inp, Builder2);
-        if (lookup)
-          shadow = lookupM(shadow, Builder2);
-        bunds.push_back(shadow);
-      }
+      Defs.push_back(OperandBundleDef(tag.str(), bunds));
     }
-    Defs.push_back(OperandBundleDef(tag.str(), bunds));
   }
   return Defs;
 }

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -261,19 +261,8 @@ bool GradientUtils::usedInRooting(const llvm::CallBase *orig,
   SmallVector<OperandBundleDef, 2> Defs;
   for (auto bund : OrigDefs) {
     // Only handle jl_roots & gc-transition tags (for now).
-    if (bund.getTag() != "jl_roots" && bund.getTag() != "gc-transition") {
-      errs() << "unsupported tag " << bund.getTag() << " for " << *orig << "\n";
-      llvm_unreachable("unsupported tag");
-    }
-
-    // In the future we can reduce the number of roots
-    // we preserve by identifying which operands they
-    // correspond to. For now, fall back and preserve all
-    // primals and shadows
-    // assert(bund.inputs().size() == types.size());
-    for (auto inp : bund.inputs()) {
-      if (inp != val)
-        continue;
+    StringRef tag = bund.getTag();
+    if (tag == "jl_roots") {
       bool anyPrimal = false;
       bool anyShadow = false;
       for (auto ty : types) {
@@ -283,10 +272,31 @@ bool GradientUtils::usedInRooting(const llvm::CallBase *orig,
           anyShadow = true;
       }
 
-      if (anyPrimal && !shadow)
+      // In the future we can reduce the number of roots
+      // we preserve by identifying which operands they
+      // correspond to. For now, fall back and preserve all
+      // primals and shadows
+      // assert(bund.inputs().size() == types.size());
+      for (auto inp : bund.inputs()) {
+        if (inp != val)
+          continue;
+
+        if (anyPrimal && !shadow)
+          return true;
+        if (anyShadow && shadow)
+          return true;
+      }
+    } else if (tag == "gc-transition") {
+      if (shadow)
+        continue;
+      for (auto inp : bund.inputs()) {
+        if (inp != val)
+          continue;
         return true;
-      if (anyShadow && shadow)
-        return true;
+      }
+    } else {
+      errs() << "unsupported tag " << bund.getTag() << " for " << *orig << "\n";
+      llvm_unreachable("unsupported tag");
     }
   }
   return false;
@@ -305,11 +315,6 @@ GradientUtils::getInvertedBundles(CallInst *orig, ArrayRef<ValueType> types,
   for (auto bund : OrigDefs) {
     // Only handle jl_roots & gc-transition tags (for now).
     StringRef tag = bund.getTag();
-    if (tag != "jl_roots" && tag != "gc-transition") {
-      errs() << "unsupported tag " << tag << " for " << *orig << "\n";
-      llvm_unreachable("unsupported tag");
-    }
-
     if (tag == "jl_roots") {
       // In the future we can reduce the number of roots
       // we preserve by identifying which operands they
@@ -341,7 +346,7 @@ GradientUtils::getInvertedBundles(CallInst *orig, ArrayRef<ValueType> types,
         }
       }
       Defs.push_back(OperandBundleDef(tag.str(), bunds));
-    } else {
+    } else if (tag == "gc-transition") {
       SmallVector<Value *, 2> bunds;
       for (auto inp : bund.inputs()) {
         Value *newv = getNewFromOriginal(inp);
@@ -350,6 +355,9 @@ GradientUtils::getInvertedBundles(CallInst *orig, ArrayRef<ValueType> types,
         bunds.push_back(newv);
       }
       Defs.push_back(OperandBundleDef(tag.str(), bunds));
+    } else {
+      errs() << "unsupported tag " << tag << " for " << *orig << "\n";
+      llvm_unreachable("unsupported tag");
     }
   }
   return Defs;

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -260,6 +260,8 @@ bool GradientUtils::usedInRooting(const llvm::CallBase *orig,
   orig->getOperandBundlesAsDefs(OrigDefs);
   SmallVector<OperandBundleDef, 2> Defs;
   for (auto bund : OrigDefs) {
+    if (bund.getTag() == "gc-transition")
+      continue;
     // Only handle jl_roots tag (for now).
     if (bund.getTag() != "jl_roots") {
       errs() << "unsupported tag " << bund.getTag() << " for " << *orig << "\n";
@@ -303,41 +305,52 @@ GradientUtils::getInvertedBundles(CallInst *orig, ArrayRef<ValueType> types,
   orig->getOperandBundlesAsDefs(OrigDefs);
   SmallVector<OperandBundleDef, 2> Defs;
   for (auto bund : OrigDefs) {
-    // Only handle jl_roots tag (for now).
-    if (bund.getTag() != "jl_roots") {
+    // Only handle jl_roots tag i & gc-transition (for now).
+    if (bund.getTag() == "jl_roots") {
+      SmallVector<Value *, 2> bunds;
+      // In the future we can reduce the number of roots
+      // we preserve by identifying which operands they
+      // correspond to. For now, fall back and preserve all
+      // primals and shadows
+      // assert(bund.inputs().size() == types.size());
+      for (auto inp : bund.inputs()) {
+        bool anyPrimal = false;
+        bool anyShadow = false;
+        for (auto ty : types) {
+          if (ty == ValueType::Primal || ty == ValueType::Both)
+            anyPrimal = true;
+          if (ty == ValueType::Shadow || ty == ValueType::Both)
+            anyShadow = true;
+        }
+
+        if (anyPrimal) {
+          Value *newv = getNewFromOriginal(inp);
+          if (lookup)
+            newv = lookupM(newv, Builder2, available);
+          bunds.push_back(newv);
+        }
+        if (anyShadow && !isConstantValue(inp)) {
+          Value *shadow = invertPointerM(inp, Builder2);
+          if (lookup)
+            shadow = lookupM(shadow, Builder2);
+          bunds.push_back(shadow);
+        }
+      }
+      Defs.push_back(OperandBundleDef(bund.getTag().str(), bunds));
+    } else if (bund.getTag() == "gc-transition"){
+      // carries only primal
+      SmallVector<Value *, 2> bunds;
+      for (auto inp : bund.inputs()) {
+          Value *newv = getNewFromOriginal(inp);
+          if (lookup)
+            newv = lookupM(newv, Builder2, available);
+          bunds.push_back(newv);
+      }
+      Defs.push_back(OperandBundleDef(bund.getTag().str(), bunds));
+    } else {
       errs() << "unsupported tag " << bund.getTag() << " for " << *orig << "\n";
       llvm_unreachable("unsupported tag");
     }
-    SmallVector<Value *, 2> bunds;
-    // In the future we can reduce the number of roots
-    // we preserve by identifying which operands they
-    // correspond to. For now, fall back and preserve all
-    // primals and shadows
-    // assert(bund.inputs().size() == types.size());
-    for (auto inp : bund.inputs()) {
-      bool anyPrimal = false;
-      bool anyShadow = false;
-      for (auto ty : types) {
-        if (ty == ValueType::Primal || ty == ValueType::Both)
-          anyPrimal = true;
-        if (ty == ValueType::Shadow || ty == ValueType::Both)
-          anyShadow = true;
-      }
-
-      if (anyPrimal) {
-        Value *newv = getNewFromOriginal(inp);
-        if (lookup)
-          newv = lookupM(newv, Builder2, available);
-        bunds.push_back(newv);
-      }
-      if (anyShadow && !isConstantValue(inp)) {
-        Value *shadow = invertPointerM(inp, Builder2);
-        if (lookup)
-          shadow = lookupM(shadow, Builder2);
-        bunds.push_back(shadow);
-      }
-    }
-    Defs.push_back(OperandBundleDef(bund.getTag().str(), bunds));
   }
   return Defs;
 }


### PR DESCRIPTION
Handle the new gc-transition bundle from Julia 1.12.

It signifies that a function call is potentially blocking and does not interact with the Julia runtime,
and that it is thus safe to run GC during it. 

Fixes:

- https://github.com/EnzymeAD/Enzyme.jl/issues/2139#issuecomment-4763197828
- https://github.com/EnzymeAD/Enzyme.jl/issues/3235
- https://github.com/EnzymeAD/Enzyme.jl/issues/3195
