### PR TITLE
fix syntax of bazel workflow

### DIFF
--- a/.github/workflows/enzyme-bazel.yml
+++ b/.github/workflows/enzyme-bazel.yml
@@ -40,11 +40,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          - linux-x86-n2-32
-        build:
-          - Release
-        llbuild:
-          - Release
+        build: ["Release"]
+        llbuild: ["Release"]
+        os: [ubuntu-22.04]
     timeout-minutes: 500 
 
     container:


### PR DESCRIPTION
recent changes in upstream LLVM have broken bazel build of Enzyme. check out https://github.com/llvm/llvm-project/pull/197316

although bazel workflow should have detected it when that pr was merged, it wasn't because the workflow is broken