### PR TITLE
Fix unsound icmp fold for loads from fresh allocations in jl-inst-simplify

### DIFF
--- a/enzyme/Enzyme/JLInstSimplify.cpp
+++ b/enzyme/Enzyme/JLInstSimplify.cpp
@@ -61,7 +61,8 @@ using namespace llvm;
 namespace {
 
 bool jlInstSimplify(llvm::Function &F, TargetLibraryInfo &TLI,
-                    llvm::AAResults &AA, llvm::LoopInfo &LI) {
+                    llvm::AAResults &AA, llvm::LoopInfo &LI,
+                    DominatorTree &DT) {
   bool changed = false;
 
   for (auto &BB : F)
@@ -107,7 +108,7 @@ bool jlInstSimplify(llvm::Function &F, TargetLibraryInfo &TLI,
 
       if (legal) {
         if (auto alias = arePointersGuaranteedNoAlias(
-                TLI, AA, LI, I.getOperand(0), I.getOperand(1), false)) {
+                TLI, AA, DT, LI, I.getOperand(0), I.getOperand(1), false)) {
 
           bool val = *alias;
           auto repval = ICmpInst::isTrueWhenEqual(pred)
@@ -132,13 +133,15 @@ public:
     AU.addRequired<TargetLibraryInfoWrapperPass>();
     AU.addRequired<AAResultsWrapperPass>();
     AU.addRequired<LoopInfoWrapperPass>();
+    AU.addRequired<DominatorTreeWrapperPass>();
   }
 
   bool runOnFunction(Function &F) override {
     auto &TLI = getAnalysis<TargetLibraryInfoWrapperPass>().getTLI(F);
     auto &AA = getAnalysis<AAResultsWrapperPass>().getAAResults();
     auto &LI = getAnalysis<LoopInfoWrapperPass>().getLoopInfo();
-    return jlInstSimplify(F, TLI, AA, LI);
+    auto &DT = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
+    return jlInstSimplify(F, TLI, AA, LI, DT);
   }
 };
 
@@ -159,9 +162,9 @@ JLInstSimplifyNewPM::Result
 JLInstSimplifyNewPM::run(llvm::Function &F,
                          llvm::FunctionAnalysisManager &FAM) {
   bool changed = false;
-  changed = jlInstSimplify(F, FAM.getResult<TargetLibraryAnalysis>(F),
-                           FAM.getResult<AAManager>(F),
-                           FAM.getResult<LoopAnalysis>(F));
+  changed = jlInstSimplify(
+      F, FAM.getResult<TargetLibraryAnalysis>(F), FAM.getResult<AAManager>(F),
+      FAM.getResult<LoopAnalysis>(F), FAM.getResult<DominatorTreeAnalysis>(F));
   return changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }
 llvm::AnalysisKey JLInstSimplifyNewPM::Key;

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -4721,8 +4721,8 @@ arePointersGuaranteedNoAlias(TargetLibraryInfo &TLI, llvm::AAResults &AA,
     }
 
     if (auto ld = dyn_cast<LoadInst>(start)) {
-      auto base = getBaseObject(ld->getOperand(0), /*offsetAllowed*/ false);
-      auto end_base = getBaseObject(end, /*offsetAllowed*/ false);
+      auto base = getBaseObject(ld->getOperand(0), /*offsetAllowed*/ true);
+      auto end_base = getBaseObject(end, /*offsetAllowed*/ true);
       if (isAllocationCall(base, TLI) || isa<AllocaInst>(base)) {
         auto alloc_call = cast<Instruction>(base);
         // Even if the alloc was written into:
@@ -4771,7 +4771,7 @@ arePointersGuaranteedNoAlias(TargetLibraryInfo &TLI, llvm::AAResults &AA,
               return true;
             }
             if (auto end_load = dyn_cast<LoadInst>(end_base)) {
-              auto end_load_base = getBaseObject(end_load->getOperand(0), /*offsetAllowed*/ false);
+              auto end_load_base = getBaseObject(end_load->getOperand(0), /*offsetAllowed*/ true);
               // We don't need to consider the symmetric case since the other iteration of the if will for us
               // Thus here we only consider the case where both are loads of allocs
               if (isAllocationCall(end_load_base, TLI) || isa<AllocaInst>(end_load_base)) {

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -2904,8 +2904,8 @@ bool overwritesToMemoryReadBy(const TypeResults *TR, llvm::AAResults &AA,
   }
 
   if (loadPtr && storePtr)
-    if (auto alias =
-            arePointersGuaranteedNoAlias(TLI, AA, LI, loadPtr, storePtr, true))
+    if (auto alias = arePointersGuaranteedNoAlias(TLI, AA, DT, LI, loadPtr,
+                                                  storePtr, true))
       if (*alias)
         return false;
 
@@ -4544,8 +4544,10 @@ bool isNVLoad(const llvm::Value *V) {
 }
 
 bool notCapturedBefore(llvm::Value *V, Instruction *inst,
-                       size_t checkLoadCaptures) {
-  Instruction *VI = dyn_cast<Instruction>(V);
+                       size_t checkLoadCaptures, Instruction *startinst) {
+  Instruction *VI = startinst;
+  if (!VI)
+    VI = dyn_cast<Instruction>(V);
   if (!VI)
     VI = &*inst->getParent()->getParent()->getEntryBlock().begin();
   else
@@ -4659,8 +4661,9 @@ std::optional<bool>
 llvm::Optional<bool>
 #endif
 arePointersGuaranteedNoAlias(TargetLibraryInfo &TLI, llvm::AAResults &AA,
-                             llvm::LoopInfo &LI, llvm::Value *op0,
-                             llvm::Value *op1, bool offsetAllowed) {
+                             llvm::DominatorTree &DT, llvm::LoopInfo &LI,
+                             llvm::Value *op0, llvm::Value *op1,
+                             bool offsetAllowed) {
   auto lhs = getBaseObject(op0, offsetAllowed);
   auto rhs = getBaseObject(op1, offsetAllowed);
 
@@ -4687,57 +4690,90 @@ arePointersGuaranteedNoAlias(TargetLibraryInfo &TLI, llvm::AAResults &AA,
   bool noalias[2] = {noalias_lhs, noalias_rhs};
 
   for (int i = 0; i < 2; i++) {
+    int start_i = i;
     Value *start = (i == 0) ? lhs : rhs;
+    int end_i = 1 - i;
     Value *end = (i == 0) ? rhs : lhs;
-    if (noalias[i]) {
-      if (noalias[1 - i]) {
+
+    if (noalias[start_i]) {
+      if (noalias[end_i]) {
         return true;
       }
       if (isa<Argument>(end)) {
         return true;
       }
+
+      if (auto starti = dyn_cast<Instruction>(start)) {
+        // If end dominates start, then since start is noalias at its creation,
+        // it is definitionally not aliasing end
+        if (DT.dominates(end, starti)) {
+          return true;
+        }
+      }
+
       if (auto endi = dyn_cast<Instruction>(end)) {
         if (notCapturedBefore(start, endi, 0)) {
           return true;
         }
       }
     }
-    if (auto ld = dyn_cast<LoadInst>(start)) {
-      auto base = getBaseObject(ld->getOperand(0), /*offsetAllowed*/ false);
-      if (isAllocationCall(base, TLI)) {
-        // The memory read by `ld` holds either undef or a fresh pointer
-        // installed by the allocator itself, unless something wrote to it
-        // after the allocation. Only in the former case is the loaded
-        // pointer guaranteed to differ from any previously existing
-        // pointer: if a store into the allocation happened before the
-        // load, the loaded value may be any captured pointer, including
-        // `end` (e.g. a value stored into a Core.Box and loaded back).
-        // Therefore scan for clobbers between the allocation and the
-        // load, not between the load and the compare.
-        bool overwritten = false;
-        if (auto basei = dyn_cast<Instruction>(base)) {
-          allInstructionsBetween(LI, basei, ld, [&](Instruction *I) -> bool {
-            if (!I->mayWriteToMemory())
-              return /*earlyBreak*/ false;
 
-            if (writesToMemoryReadBy(nullptr, AA, TLI,
-                                     /*maybeReader*/ ld,
-                                     /*maybeWriter*/ I)) {
-              overwritten = true;
-              return /*earlyBreak*/ true;
-            }
-            return /*earlyBreak*/ false;
-          });
-        } else {
-          overwritten = true;
+    if (auto ld = dyn_cast<LoadInst>(start)) {
+      auto base = getBaseObject(ld->getOperand(0), /*offsetAllowed*/ true);
+      if (isAllocationCall(base, TLI) || isa<AllocaInst>(base)) {
+        auto alloc_call = cast<Instruction>(base);
+
+        if (noalias[end_i] || DT.dominates(end, alloc_call)) {
+
+          // Even if the alloc was written into:
+          // if either:
+          //    a) end preceeded the allocation
+          //    OR
+          //    b) end didn't alias any other value at time of construction
+          // AND
+          //    end was not captured prior to the load,
+          //  it cannot possibly alias.
+          //
+          //  In the (a) case, end was created prior, not captured into the
+          //  allocation prior to store. So there is no way the allocation can
+          //  contain the bits of end In the (b) case, end is a fresh (aka non
+          //  aliasing) pointer, which means no other pointers in scope could
+          //  point to, none of which were captured
+          if (notCapturedBefore(end, ld, 0, alloc_call)) {
+            return true;
+          }
+
+          bool alloc_written = false;
+          allInstructionsBetween(
+              LI, alloc_call, ld, [&](Instruction *I) -> bool {
+                if (!I->mayWriteToMemory())
+                  return /*earlyBreak*/ false;
+
+                if (writesToMemoryReadBy(nullptr, AA, TLI,
+                                         /*maybeReader*/ ld,
+                                         /*maybeWriter*/ I)) {
+                  alloc_written = true;
+                  return /*earlyBreak*/ true;
+                }
+                return /*earlyBreak*/ false;
+              });
+
+          // If there was no store into the allocation prior to the load, the
+          // load cannot possibly alias with a value which defined prior to the
+          // the allocation. Additionally, if there is any value which is
+          // noalias upon construction, that value also cannot alias the load.
+          if (!alloc_written) {
+            return true;
+          }
         }
 
-        if (!overwritten) {
-          if (isa<Argument>(end))
+        // Look through all loads out of alloc_call, and check if any of them
+        // are captured before endi. If there are none, we can say there is no
+        // alias between endi and ld = load alloc_call.
+        if (auto endi = dyn_cast<Instruction>(end)) {
+          if (notCapturedBefore(alloc_call, endi, 1)) {
             return true;
-          if (auto endi = dyn_cast<Instruction>(end))
-            if (isNoAlias(end) || (notCapturedBefore(start, endi, 1)))
-              return true;
+          }
         }
       }
     }

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -4721,53 +4721,85 @@ arePointersGuaranteedNoAlias(TargetLibraryInfo &TLI, llvm::AAResults &AA,
     }
 
     if (auto ld = dyn_cast<LoadInst>(start)) {
-      auto base = getBaseObject(ld->getOperand(0), /*offsetAllowed*/ true);
+      auto base = getBaseObject(ld->getOperand(0), /*offsetAllowed*/ false);
+      auto end_base = getBaseObject(end, /*offsetAllowed*/ false);
       if (isAllocationCall(base, TLI) || isa<AllocaInst>(base)) {
         auto alloc_call = cast<Instruction>(base);
-
-        if (noalias[end_i] || DT.dominates(end, alloc_call)) {
-
-          // Even if the alloc was written into:
-          // if either:
-          //    a) end preceeded the allocation
-          //    OR
-          //    b) end didn't alias any other value at time of construction
-          // AND
-          //    end was not captured prior to the load,
-          //  it cannot possibly alias.
-          //
-          //  In the (a) case, end was created prior, not captured into the
-          //  allocation prior to store. So there is no way the allocation can
-          //  contain the bits of end In the (b) case, end is a fresh (aka non
-          //  aliasing) pointer, which means no other pointers in scope could
-          //  point to, none of which were captured
-          if (notCapturedBefore(end, ld, 0, alloc_call)) {
-            return true;
-          }
-
-          bool alloc_written = false;
-          allInstructionsBetween(
-              LI, alloc_call, ld, [&](Instruction *I) -> bool {
-                if (!I->mayWriteToMemory())
-                  return /*earlyBreak*/ false;
-
-                if (writesToMemoryReadBy(nullptr, AA, TLI,
-                                         /*maybeReader*/ ld,
-                                         /*maybeWriter*/ I)) {
-                  alloc_written = true;
-                  return /*earlyBreak*/ true;
-                }
-                return /*earlyBreak*/ false;
-              });
-
-          // If there was no store into the allocation prior to the load, the
-          // load cannot possibly alias with a value which defined prior to the
-          // the allocation. Additionally, if there is any value which is
-          // noalias upon construction, that value also cannot alias the load.
-          if (!alloc_written) {
-            return true;
-          }
+        // Even if the alloc was written into:
+        // if either:
+        //    end didn't alias any other value at time of construction
+        // AND
+        //    end was not captured prior to the load,
+        //  it cannot possibly alias.
+        //
+        //  In this case, end is a fresh (aka non
+        //  aliasing) pointer, which means no other pointers in scope could
+        //  point to, none of which were captured.
+        //
+        //  It is not sufficient here to merely prove end dominates alloc_call and
+        //  is not captured, since there could be an aliasing pointer to end which
+        //  is captured.
+        if (noalias[end_i] && notCapturedBefore(end_base, ld, 0, alloc_call)) {
+          return true;
         }
+
+        // However if nothing was written to the alloc prior to the load, we know that 
+        // there is no way to dataflow end into start, so we now merely must prove there is no
+        // way to dataflow start into end.
+
+        bool alloc_written = false;
+        allInstructionsBetween(
+            LI, alloc_call, ld, [&](Instruction *I) -> bool {
+              if (!I->mayWriteToMemory())
+                return /*earlyBreak*/ false;
+
+              if (writesToMemoryReadBy(nullptr, AA, TLI,
+                                        /*maybeReader*/ ld,
+                                        /*maybeWriter*/ I)) {
+                alloc_written = true;
+                return /*earlyBreak*/ true;
+              }
+              return /*earlyBreak*/ false;
+            });
+
+          if (!alloc_written) {
+            // If end is marked noalias at the time of construction it definitionally
+            // cannot alias another potential load out of alloc.
+            // If the base of end occurs prior to alloc_call, there is no way for
+            // alloc_call to dataflow into end.
+            if (noalias[end_i] || DT.dominates(end_base, alloc_call)) {
+              return true;
+            }
+            if (auto end_load = dyn_cast<LoadInst>(end_base)) {
+              auto end_load_base = getBaseObject(end_load->getOperand(0), /*offsetAllowed*/ false);
+              if (isAllocationCall(end_load_base, TLI) || isa<AllocaInst>(end_load_base)) {
+                auto end_alloc_call = cast<Instruction>(end_load_base);
+                bool end_alloc_written = false;
+                allInstructionsBetween(
+                    LI, end_alloc_call, end_load, [&](Instruction *I) -> bool {
+                      if (!I->mayWriteToMemory())
+                        return /*earlyBreak*/ false;
+
+                      if (writesToMemoryReadBy(nullptr, AA, TLI,
+                                                /*maybeReader*/ end_load,
+                                                /*maybeWriter*/ I)) {
+                        end_alloc_written = true;
+                        return /*earlyBreak*/ true;
+                      }
+                      return /*earlyBreak*/ false;
+                    });
+                    // If neither base allocation was written to prior to load, if the two bases are different, we can assume the undef
+                    // (or internal allocations within) are different.
+                if (!end_alloc_written) {
+                  if (auto base_noalias = arePointersGuaranteedNoAlias(TLI, AA, DT, LI, alloc_call, end_alloc_call, /*offsetAllowed*/false)) {
+                    if (*base_noalias) {
+                      return true;
+                    }
+                  }
+                }
+              }
+            }
+          }
       }
     }
   }

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -4768,17 +4768,6 @@ arePointersGuaranteedNoAlias(TargetLibraryInfo &TLI, llvm::AAResults &AA,
             return true;
           }
         }
-
-        // Look through all loads out of alloc_call, and check if any of them
-        // are captured before endi. If there are none, we can say there is no
-        // alias between endi and ld = load alloc_call.
-        if (auto endi = dyn_cast<Instruction>(end)) {
-          if (DT.dominates(ld, endi)) {
-            if (notCapturedBefore(alloc_call, endi, 1)) {
-              return true;
-            }
-          }
-        }
       }
     }
   }

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -4743,79 +4743,81 @@ arePointersGuaranteedNoAlias(TargetLibraryInfo &TLI, llvm::AAResults &AA,
           return true;
         }
 
-        // However if nothing was written to the alloc prior to the load, we know that 
-        // there is no way to dataflow end into start, so we now merely must prove there is no
-        // way to dataflow start into end.
+        // However if nothing was written to the alloc prior to the load, we
+        // know that there is no way to dataflow end into start, so we now
+        // merely must prove there is no way to dataflow start into end.
 
         bool alloc_written = false;
-        allInstructionsBetween(
-            LI, alloc_call, ld, [&](Instruction *I) -> bool {
-              if (!I->mayWriteToMemory())
-                return /*earlyBreak*/ false;
+        allInstructionsBetween(LI, alloc_call, ld, [&](Instruction *I) -> bool {
+          if (!I->mayWriteToMemory())
+            return /*earlyBreak*/ false;
 
-              if (writesToMemoryReadBy(nullptr, AA, TLI,
-                                        /*maybeReader*/ ld,
-                                        /*maybeWriter*/ I)) {
-                alloc_written = true;
-                return /*earlyBreak*/ true;
+          if (writesToMemoryReadBy(nullptr, AA, TLI,
+                                   /*maybeReader*/ ld,
+                                   /*maybeWriter*/ I)) {
+            alloc_written = true;
+            return /*earlyBreak*/ true;
+          }
+          return /*earlyBreak*/ false;
+        });
+
+        if (!alloc_written) {
+          // If end is marked noalias at the time of construction it
+          // definitionally cannot alias another potential load out of alloc. If
+          // the base of end occurs prior to alloc_call (and is distinct from
+          // alloc_call), there is no way for alloc_call to dataflow into end.
+          if (noalias[end_i] ||
+              (end_base != alloc_call && DT.dominates(end_base, alloc_call))) {
+            return true;
+          }
+
+          // If the allocation was not written into prior to ld, any pointer
+          // value loaded from it must have been created by one of the loads
+          // reading from alloc_call. If every load out of alloc_call is
+          // distinct from end, and was neither captured before end nor created
+          // after end, alloc_call's loaded values cannot dataflow into end.
+          SmallVector<Value *, 8> worklist;
+          SmallPtrSet<Value *, 8> visited;
+          SmallVector<LoadInst *, 8> alloc_loads;
+
+          worklist.push_back(alloc_call);
+          visited.insert(alloc_call);
+
+          while (!worklist.empty()) {
+            Value *V = worklist.pop_back_val();
+            for (User *U : V->users()) {
+              if (!visited.insert(U).second)
+                continue;
+              if (isPointerArithmeticInst(U, /*includephi*/ true,
+                                          /*includebin*/ true)) {
+                worklist.push_back(U);
+              } else if (auto LI = dyn_cast<LoadInst>(U)) {
+                alloc_loads.push_back(LI);
               }
-              return /*earlyBreak*/ false;
-            });
-
-          if (!alloc_written) {
-            // If end is marked noalias at the time of construction it definitionally
-            // cannot alias another potential load out of alloc.
-            // If the base of end occurs prior to alloc_call (and is distinct from
-            // alloc_call), there is no way for alloc_call to dataflow into end.
-            if (noalias[end_i] || (end_base != alloc_call && DT.dominates(end_base, alloc_call))) {
-              return true;
-            }
-
-            // If the allocation was not written into prior to ld, any pointer value
-            // loaded from it must have been created by one of the loads reading from alloc_call.
-            // If every load out of alloc_call is distinct from end, and was neither captured
-            // before end nor created after end, alloc_call's loaded values cannot dataflow into end.
-            SmallVector<Value *, 8> worklist;
-            SmallPtrSet<Value *, 8> visited;
-            SmallVector<LoadInst *, 8> alloc_loads;
-
-            worklist.push_back(alloc_call);
-            visited.insert(alloc_call);
-
-            while (!worklist.empty()) {
-              Value *V = worklist.pop_back_val();
-              for (User *U : V->users()) {
-                if (!visited.insert(U).second)
-                  continue;
-                if (isPointerArithmeticInst(U, /*includephi*/ true, /*includebin*/ true)) {
-                  worklist.push_back(U);
-                } else if (auto LI = dyn_cast<LoadInst>(U)) {
-                  alloc_loads.push_back(LI);
-                }
-              }
-            }
-
-            bool all_loads_no_alias = true;
-            for (LoadInst *alloc_load : alloc_loads) {
-              if (alloc_load == end) {
-                all_loads_no_alias = false;
-                break;
-              }
-              if (auto end_inst = dyn_cast<Instruction>(end)) {
-                if (DT.dominates(end_inst, alloc_load)) {
-                  continue;
-                }
-              }
-              if (!notCapturedBefore(alloc_load, dyn_cast<Instruction>(end), 0)) {
-                all_loads_no_alias = false;
-                break;
-              }
-            }
-
-            if (all_loads_no_alias) {
-              return true;
             }
           }
+
+          bool all_loads_no_alias = true;
+          for (LoadInst *alloc_load : alloc_loads) {
+            if (alloc_load == end) {
+              all_loads_no_alias = false;
+              break;
+            }
+            if (auto end_inst = dyn_cast<Instruction>(end)) {
+              if (DT.dominates(end_inst, alloc_load)) {
+                continue;
+              }
+            }
+            if (!notCapturedBefore(alloc_load, dyn_cast<Instruction>(end), 0)) {
+              all_loads_no_alias = false;
+              break;
+            }
+          }
+
+          if (all_loads_no_alias) {
+            return true;
+          }
+        }
       }
     }
   }

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -4736,9 +4736,9 @@ arePointersGuaranteedNoAlias(TargetLibraryInfo &TLI, llvm::AAResults &AA,
         //  aliasing) pointer, which means no other pointers in scope could
         //  point to, none of which were captured.
         //
-        //  It is not sufficient here to merely prove end dominates alloc_call and
-        //  is not captured, since there could be an aliasing pointer to end which
-        //  is captured.
+        //  It is not sufficient here to merely prove end dominates alloc_call
+        //  and is not captured, since there could be an aliasing pointer to end
+        //  which is captured.
         if (noalias[end_i] && notCapturedBefore(end_base, ld, 0, alloc_call)) {
           return true;
         }

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -4770,36 +4770,50 @@ arePointersGuaranteedNoAlias(TargetLibraryInfo &TLI, llvm::AAResults &AA,
             if (noalias[end_i] || (end_base != alloc_call && DT.dominates(end_base, alloc_call))) {
               return true;
             }
-            if (auto end_load = dyn_cast<LoadInst>(end_base)) {
-              auto end_load_base = getBaseObject(end_load->getOperand(0), /*offsetAllowed*/ true);
-              // We don't need to consider the symmetric case since the other iteration of the if will for us
-              // Thus here we only consider the case where both are loads of allocs
-              if (isAllocationCall(end_load_base, TLI) || isa<AllocaInst>(end_load_base)) {
-                auto end_alloc_call = cast<Instruction>(end_load_base);
-                bool end_alloc_written = false;
-                allInstructionsBetween(
-                    LI, end_alloc_call, end_load, [&](Instruction *I) -> bool {
-                      if (!I->mayWriteToMemory())
-                        return /*earlyBreak*/ false;
 
-                      if (writesToMemoryReadBy(nullptr, AA, TLI,
-                                                /*maybeReader*/ end_load,
-                                                /*maybeWriter*/ I)) {
-                        end_alloc_written = true;
-                        return /*earlyBreak*/ true;
-                      }
-                      return /*earlyBreak*/ false;
-                    });
-                    // If neither base allocation was written to prior to load, if the two bases are different, we can assume the undef
-                    // (or internal allocations within) are different.
-                if (!end_alloc_written) {
-                  if (auto base_noalias = arePointersGuaranteedNoAlias(TLI, AA, DT, LI, alloc_call, end_alloc_call, /*offsetAllowed*/false)) {
-                    if (*base_noalias) {
-                      return true;
-                    }
-                  }
+            // If the allocation was not written into prior to ld, any pointer value
+            // loaded from it must have been created by one of the loads reading from alloc_call.
+            // If every load out of alloc_call is distinct from end, and was neither captured
+            // before end nor created after end, alloc_call's loaded values cannot dataflow into end.
+            SmallVector<Value *, 8> worklist;
+            SmallPtrSet<Value *, 8> visited;
+            SmallVector<LoadInst *, 8> alloc_loads;
+
+            worklist.push_back(alloc_call);
+            visited.insert(alloc_call);
+
+            while (!worklist.empty()) {
+              Value *V = worklist.pop_back_val();
+              for (User *U : V->users()) {
+                if (!visited.insert(U).second)
+                  continue;
+                if (isPointerArithmeticInst(U, /*includephi*/ true, /*includebin*/ true)) {
+                  worklist.push_back(U);
+                } else if (auto LI = dyn_cast<LoadInst>(U)) {
+                  alloc_loads.push_back(LI);
                 }
               }
+            }
+
+            bool all_loads_no_alias = true;
+            for (LoadInst *alloc_load : alloc_loads) {
+              if (alloc_load == end) {
+                all_loads_no_alias = false;
+                break;
+              }
+              if (auto end_inst = dyn_cast<Instruction>(end)) {
+                if (DT.dominates(end_inst, alloc_load)) {
+                  continue;
+                }
+              }
+              if (!notCapturedBefore(alloc_load, dyn_cast<Instruction>(end), 0)) {
+                all_loads_no_alias = false;
+                break;
+              }
+            }
+
+            if (all_loads_no_alias) {
+              return true;
             }
           }
       }

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -4569,7 +4569,9 @@ bool notCapturedBefore(llvm::Value *V, Instruction *inst,
   }
   SmallVector<std::tuple<Instruction *, size_t, Value *>, 1> todo;
   for (auto U : V->users()) {
-    todo.emplace_back(cast<Instruction>(U), checkLoadCaptures, V);
+    if (auto I = dyn_cast<Instruction>(U)) {
+      todo.emplace_back(cast<Instruction>(I), checkLoadCaptures, V);
+    }
   }
   std::set<std::tuple<Value *, size_t, Value *>> seen;
   while (todo.size()) {

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -4765,13 +4765,15 @@ arePointersGuaranteedNoAlias(TargetLibraryInfo &TLI, llvm::AAResults &AA,
           if (!alloc_written) {
             // If end is marked noalias at the time of construction it definitionally
             // cannot alias another potential load out of alloc.
-            // If the base of end occurs prior to alloc_call, there is no way for
-            // alloc_call to dataflow into end.
-            if (noalias[end_i] || DT.dominates(end_base, alloc_call)) {
+            // If the base of end occurs prior to alloc_call (and is distinct from
+            // alloc_call), there is no way for alloc_call to dataflow into end.
+            if (noalias[end_i] || (end_base != alloc_call && DT.dominates(end_base, alloc_call))) {
               return true;
             }
             if (auto end_load = dyn_cast<LoadInst>(end_base)) {
               auto end_load_base = getBaseObject(end_load->getOperand(0), /*offsetAllowed*/ false);
+              // We don't need to consider the symmetric case since the other iteration of the if will for us
+              // Thus here we only consider the case where both are loads of allocs
               if (isAllocationCall(end_load_base, TLI) || isa<AllocaInst>(end_load_base)) {
                 auto end_alloc_call = cast<Instruction>(end_load_base);
                 bool end_alloc_written = false;

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -4773,8 +4773,10 @@ arePointersGuaranteedNoAlias(TargetLibraryInfo &TLI, llvm::AAResults &AA,
         // are captured before endi. If there are none, we can say there is no
         // alias between endi and ld = load alloc_call.
         if (auto endi = dyn_cast<Instruction>(end)) {
-          if (notCapturedBefore(alloc_call, endi, 1)) {
-            return true;
+          if (DT.dominates(ld, endi)) {
+            if (notCapturedBefore(alloc_call, endi, 1)) {
+              return true;
+            }
           }
         }
       }

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -4705,37 +4705,40 @@ arePointersGuaranteedNoAlias(TargetLibraryInfo &TLI, llvm::AAResults &AA,
     if (auto ld = dyn_cast<LoadInst>(start)) {
       auto base = getBaseObject(ld->getOperand(0), /*offsetAllowed*/ false);
       if (isAllocationCall(base, TLI)) {
-        if (isa<Argument>(end))
-          return true;
-        if (auto endi = dyn_cast<Instruction>(end))
-          if (isNoAlias(end) || (notCapturedBefore(start, endi, 1))) {
-            Instruction *starti = dyn_cast<Instruction>(start);
-            if (!starti) {
-              if (!isa<Argument>(start))
-                continue;
-              starti =
-                  &cast<Argument>(start)->getParent()->getEntryBlock().front();
+        // The memory read by `ld` holds either undef or a fresh pointer
+        // installed by the allocator itself, unless something wrote to it
+        // after the allocation. Only in the former case is the loaded
+        // pointer guaranteed to differ from any previously existing
+        // pointer: if a store into the allocation happened before the
+        // load, the loaded value may be any captured pointer, including
+        // `end` (e.g. a value stored into a Core.Box and loaded back).
+        // Therefore scan for clobbers between the allocation and the
+        // load, not between the load and the compare.
+        bool overwritten = false;
+        if (auto basei = dyn_cast<Instruction>(base)) {
+          allInstructionsBetween(LI, basei, ld, [&](Instruction *I) -> bool {
+            if (!I->mayWriteToMemory())
+              return /*earlyBreak*/ false;
+
+            if (writesToMemoryReadBy(nullptr, AA, TLI,
+                                     /*maybeReader*/ ld,
+                                     /*maybeWriter*/ I)) {
+              overwritten = true;
+              return /*earlyBreak*/ true;
             }
+            return /*earlyBreak*/ false;
+          });
+        } else {
+          overwritten = true;
+        }
 
-            bool overwritten = false;
-            allInstructionsBetween(
-                LI, starti, endi, [&](Instruction *I) -> bool {
-                  if (!I->mayWriteToMemory())
-                    return /*earlyBreak*/ false;
-
-                  if (writesToMemoryReadBy(nullptr, AA, TLI,
-                                           /*maybeReader*/ ld,
-                                           /*maybeWriter*/ I)) {
-                    overwritten = true;
-                    return /*earlyBreak*/ true;
-                  }
-                  return /*earlyBreak*/ false;
-                });
-
-            if (!overwritten) {
+        if (!overwritten) {
+          if (isa<Argument>(end))
+            return true;
+          if (auto endi = dyn_cast<Instruction>(end))
+            if (isNoAlias(end) || (notCapturedBefore(start, endi, 1)))
               return true;
-            }
-          }
+        }
       }
     }
   }

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -1876,7 +1876,8 @@ static inline bool isNoAlias(const llvm::Value *val) {
   if (auto arg = llvm::dyn_cast<llvm::Argument>(val)) {
     arg->hasNoAliasAttr();
   }
-  if (isa<AllocaInst>(val)) return true;
+  if (llvm::isa<llvm::AllocaInst>(val))
+    return true;
   return false;
 }
 

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -2387,7 +2387,8 @@ bool isNVLoad(const llvm::Value *V);
 //! If checkLoadCaptured != 0, also consider catpures of any loads of the value
 //! as a capture (for the number of loads set).
 bool notCapturedBefore(llvm::Value *V, llvm::Instruction *inst,
-                       size_t checkLoadCaptured);
+                       size_t checkLoadCaptured,
+                       llvm::Instruction *startinst = nullptr);
 
 //! Check if value if b captured
 bool notCaptured(llvm::Value *V);
@@ -2401,8 +2402,9 @@ std::optional<bool>
 llvm::Optional<bool>
 #endif
 arePointersGuaranteedNoAlias(llvm::TargetLibraryInfo &TLI, llvm::AAResults &AA,
-                             llvm::LoopInfo &LI, llvm::Value *op0,
-                             llvm::Value *op1, bool offsetAllowed = false);
+                             llvm::DominatorTree &DT, llvm::LoopInfo &LI,
+                             llvm::Value *op0, llvm::Value *op1,
+                             bool offsetAllowed = false);
 
 static inline std::tuple<llvm::StringRef, llvm::StringRef, llvm::StringRef>
 tripleSplitDollar(llvm::StringRef caller) {

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -1876,6 +1876,7 @@ static inline bool isNoAlias(const llvm::Value *val) {
   if (auto arg = llvm::dyn_cast<llvm::Argument>(val)) {
     arg->hasNoAliasAttr();
   }
+  if (isa<AllocaInst>(val)) return true;
   return false;
 }
 

--- a/enzyme/test/Enzyme/JLSimplify/boxedroundtrip.ll
+++ b/enzyme/test/Enzyme/JLSimplify/boxedroundtrip.ll
@@ -50,9 +50,8 @@ top:
 ; CHECK:   %cmp = icmp eq ptr addrspace(10) %contents, %v
 ; CHECK-NEXT:   ret i1 %cmp
 
-; When load %contents dominates instruction %after_v, %after_v did not exist
-; at the time of %contents load, and box is not captured before %after_v,
-; so fold to false is legal.
+; When load %contents dominates instruction %after_v, %after_v loads from %other_slot which
+; could hold %v (which was stored in box), so comparison cannot be folded to false.
 define i1 @boxed_roundtrip_ld_dominates(ptr %task, ptr addrspace(10) %tag, ptr addrspace(10) %v, ptr addrspace(11) %other_slot) {
 top:
   %box = call noalias nonnull align 8 dereferenceable(8) ptr addrspace(10) @julia.gc_alloc_obj(ptr %task, i64 8, ptr addrspace(10) %tag)
@@ -65,7 +64,8 @@ top:
 }
 
 ; CHECK: define i1 @boxed_roundtrip_ld_dominates
-; CHECK:   ret i1 false
+; CHECK:   %cmp = icmp eq ptr addrspace(10) %contents, %after_v
+; CHECK-NEXT:   ret i1 %cmp
 
 ; Two loads from the exact same allocation load identical values; comparison must not be folded to false.
 define i1 @same_alloc_loads(ptr %task, ptr addrspace(10) %tag) {

--- a/enzyme/test/Enzyme/JLSimplify/boxedroundtrip.ll
+++ b/enzyme/test/Enzyme/JLSimplify/boxedroundtrip.ll
@@ -1,0 +1,34 @@
+; RUN: %opt < %s %newLoadEnzyme -passes="jl-inst-simplify" -S | FileCheck %s
+
+declare noalias nonnull align 8 dereferenceable(8) ptr addrspace(10) @julia.gc_alloc_obj(ptr, i64, ptr addrspace(10))
+
+; A pointer stored into a fresh allocation (e.g. a Core.Box for a captured
+; variable) and loaded back IS the stored pointer; the comparison against it
+; must not be folded away.
+define i1 @boxed_roundtrip(ptr %task, ptr addrspace(10) %tag, ptr addrspace(10) %v) {
+top:
+  %box = call noalias nonnull align 8 dereferenceable(8) ptr addrspace(10) @julia.gc_alloc_obj(ptr %task, i64 8, ptr addrspace(10) %tag)
+  %slot = addrspacecast ptr addrspace(10) %box to ptr addrspace(11)
+  store ptr addrspace(10) %v, ptr addrspace(11) %slot, align 8
+  %contents = load ptr addrspace(10), ptr addrspace(11) %slot, align 8
+  %cmp = icmp eq ptr addrspace(10) %contents, %v
+  ret i1 %cmp
+}
+
+; CHECK: define i1 @boxed_roundtrip
+; CHECK:   %cmp = icmp eq ptr addrspace(10) %contents, %v
+; CHECK-NEXT:   ret i1 %cmp
+
+; Without a store between the allocation and the load, the loaded value is
+; undef (or a fresh allocator-installed pointer), so the fold remains legal.
+define i1 @fresh_load(ptr %task, ptr addrspace(10) %tag, ptr addrspace(10) %v) {
+top:
+  %box = call noalias nonnull align 8 dereferenceable(8) ptr addrspace(10) @julia.gc_alloc_obj(ptr %task, i64 8, ptr addrspace(10) %tag)
+  %slot = addrspacecast ptr addrspace(10) %box to ptr addrspace(11)
+  %contents = load ptr addrspace(10), ptr addrspace(11) %slot, align 8
+  %cmp = icmp eq ptr addrspace(10) %contents, %v
+  ret i1 %cmp
+}
+
+; CHECK: define i1 @fresh_load
+; CHECK:   ret i1 false

--- a/enzyme/test/Enzyme/JLSimplify/boxedroundtrip.ll
+++ b/enzyme/test/Enzyme/JLSimplify/boxedroundtrip.ll
@@ -67,3 +67,19 @@ top:
 ; CHECK: define i1 @boxed_roundtrip_ld_dominates
 ; CHECK:   ret i1 false
 
+; Two loads from the exact same allocation load identical values; comparison must not be folded to false.
+define i1 @same_alloc_loads(ptr %task, ptr addrspace(10) %tag) {
+top:
+  %box = call noalias nonnull align 8 dereferenceable(8) ptr addrspace(10) @julia.gc_alloc_obj(ptr %task, i64 8, ptr addrspace(10) %tag)
+  %slot = addrspacecast ptr addrspace(10) %box to ptr addrspace(11)
+  %c1 = load ptr addrspace(10), ptr addrspace(11) %slot, align 8
+  %c2 = load ptr addrspace(10), ptr addrspace(11) %slot, align 8
+  %cmp = icmp eq ptr addrspace(10) %c1, %c2
+  ret i1 %cmp
+}
+
+; CHECK: define i1 @same_alloc_loads
+; CHECK:   %cmp = icmp eq ptr addrspace(10) %c1, %c2
+; CHECK-NEXT:   ret i1 %cmp
+
+

--- a/enzyme/test/Enzyme/JLSimplify/boxedroundtrip.ll
+++ b/enzyme/test/Enzyme/JLSimplify/boxedroundtrip.ll
@@ -32,3 +32,38 @@ top:
 
 ; CHECK: define i1 @fresh_load
 ; CHECK:   ret i1 false
+
+; When stored value %v is an instruction that dominates the load %contents,
+; the stored value could be in the box, so comparison must not be folded.
+define i1 @boxed_roundtrip_inst(ptr %task, ptr addrspace(10) %tag, ptr addrspace(11) %src) {
+top:
+  %v = load ptr addrspace(10), ptr addrspace(11) %src, align 8
+  %box = call noalias nonnull align 8 dereferenceable(8) ptr addrspace(10) @julia.gc_alloc_obj(ptr %task, i64 8, ptr addrspace(10) %tag)
+  %slot = addrspacecast ptr addrspace(10) %box to ptr addrspace(11)
+  store ptr addrspace(10) %v, ptr addrspace(11) %slot, align 8
+  %contents = load ptr addrspace(10), ptr addrspace(11) %slot, align 8
+  %cmp = icmp eq ptr addrspace(10) %contents, %v
+  ret i1 %cmp
+}
+
+; CHECK: define i1 @boxed_roundtrip_inst
+; CHECK:   %cmp = icmp eq ptr addrspace(10) %contents, %v
+; CHECK-NEXT:   ret i1 %cmp
+
+; When load %contents dominates instruction %after_v, %after_v did not exist
+; at the time of %contents load, and box is not captured before %after_v,
+; so fold to false is legal.
+define i1 @boxed_roundtrip_ld_dominates(ptr %task, ptr addrspace(10) %tag, ptr addrspace(10) %v, ptr addrspace(11) %other_slot) {
+top:
+  %box = call noalias nonnull align 8 dereferenceable(8) ptr addrspace(10) @julia.gc_alloc_obj(ptr %task, i64 8, ptr addrspace(10) %tag)
+  %slot = addrspacecast ptr addrspace(10) %box to ptr addrspace(11)
+  store ptr addrspace(10) %v, ptr addrspace(11) %slot, align 8
+  %contents = load ptr addrspace(10), ptr addrspace(11) %slot, align 8
+  %after_v = load ptr addrspace(10), ptr addrspace(11) %other_slot, align 8
+  %cmp = icmp eq ptr addrspace(10) %contents, %after_v
+  ret i1 %cmp
+}
+
+; CHECK: define i1 @boxed_roundtrip_ld_dominates
+; CHECK:   ret i1 false
+

--- a/enzyme/test/Enzyme/JLSimplify/boxedroundtrip.ll
+++ b/enzyme/test/Enzyme/JLSimplify/boxedroundtrip.ll
@@ -1,4 +1,4 @@
-; RUN: %opt < %s %newLoadEnzyme -passes="jl-inst-simplify" -S | FileCheck %s
+; RUN: %opt < %s %newLoadEnzyme -passes="jl-inst-simplify" -S -opaque-pointers | FileCheck %s
 
 declare noalias nonnull align 8 dereferenceable(8) ptr addrspace(10) @julia.gc_alloc_obj(ptr, i64, ptr addrspace(10))
 


### PR DESCRIPTION
## The bug

`arePointersGuaranteedNoAlias` (Utils.cpp) treats a pointer loaded from a fresh allocation as guaranteed-unequal to another pointer, scanning for clobbering writes only **between the load and the compare**. That interval is wrong: the loaded SSA value is fixed at load time, so the scan proves nothing. If a store into the allocation happens **before the load**, the loaded value is an arbitrary captured pointer — including the compared-against one. `jl-inst-simplify` then folds the `icmp` to a constant.

Minimal shape (folds to `false` before this patch, even though it is always `true`):

```llvm
%box = call noalias ptr addrspace(10) @julia.gc_alloc_obj(...)
%slot = addrspacecast ptr addrspace(10) %box to ptr addrspace(11)
store ptr addrspace(10) %v, ptr addrspace(11) %slot
%contents = load ptr addrspace(10), ptr addrspace(11) %slot
%cmp = icmp eq ptr addrspace(10) %contents, %v   ; always true, folded to false
```

Julia hits this whenever a value round-trips through a `Core.Box` (captured + reassigned local): `x !== nothing` folds to `true` for `x === nothing`.

## How it surfaced

Enzyme.jl's CUDA CI ("Reverse Kernel" testset) fails with

```
AssertionError: codegen_i=2 > length(codegen_types)=1 ... source_typ=CuDeviceVector{Float32, 1}
```

CUDACore's `augmented_primal` rule calls `Enzyme.tape_type` at runtime; `nested_codegen!` compiles the rule's whole call graph — including `Enzyme.Compiler.lower_convention` — into the differentiated module, where this fold rewrites `returnRoots = returnRoots !== nothing` into an unconditional `store jl_true` (`returnRoots` is a `Core.Box` there). `classify_arguments` then sees `has_returnroots=true` for a `Nothing`-returning kernel and asserts.

## The fix

Scan for clobbers **between the allocation and the load** instead. If nothing wrote to the loaded location in that interval, the loaded value is `undef` or an allocator-installed fresh pointer, and the fold remains legal; otherwise bail. The previously unguarded `isa<Argument>(end)` fast path had the same hole and now sits behind the same check.

## Testing

- New lit test `enzyme/test/Enzyme/JLSimplify/boxedroundtrip.ll`: the boxed roundtrip compare must survive; the no-store variant must still fold. Fails against the unpatched pass, passes with this patch.
- All existing JLSimplify tests produce bit-identical output with and without the patch (verified with LLVM 21 `opt`); in particular `loads.ll`'s intended fresh-array-data fold still fires.
- End-to-end with Enzyme.jl v0.13.173 on Julia 1.12.6 via `deps/build_local.jl`: a CPU-only reproducer (custom rule shape with a `Core.Box`ed `Union{Nothing,Type}` local) errors on the released jll and computes the correct gradient with this patch; the CUDA "Reverse Kernel" assertion above no longer triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)