### PR TITLE
Utils: use target IntPtrType for CreateAllocation's malloc size arg

### DIFF
--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -622,7 +622,30 @@ Value *CreateAllocation(IRBuilder<> &Builder, llvm::Type *T, Value *Count,
   Value *res;
   auto &M = *Builder.GetInsertBlock()->getParent()->getParent();
   auto AlignI = M.getDataLayout().getTypeAllocSizeInBits(T) / 8;
-  auto Align = ConstantInt::get(Count->getType(), AlignI);
+
+  // On 32-bit targets (wasm32-wasi, 32-bit ARM/x86, etc.) the C ABI's
+  // malloc takes size_t = i32; if upstream tape-cache math widened
+  // Count to i64, feeding it straight into CreateMalloc emits
+  // `call i8* @malloc(i64 ...)` against wasi-libc's `malloc(i32)` and
+  // traps at load with signature_mismatch:malloc. Truncate Count to the
+  // target IntPtrType only when Count is WIDER than IntPtrTy -- narrower
+  // Counts are already handled correctly by LLVM's usual i64-widening
+  // before the malloc call on 64-bit hosts, and altering that path would
+  // rearrange the golden IR that existing FileCheck tests record.
+  //
+  // CustomAllocator is a user-supplied callback whose type contract we
+  // preserve unchanged.
+  Type *IntPtrTy = M.getDataLayout().getIntPtrType(M.getContext(), 0);
+  Value *AllocCount = Count;
+  Type *AllocSizeTy = Count->getType();
+  if (!CustomAllocator && AllocSizeTy->isIntegerTy() &&
+      IntPtrTy->isIntegerTy() &&
+      AllocSizeTy->getIntegerBitWidth() > IntPtrTy->getIntegerBitWidth()) {
+    AllocCount = Builder.CreateZExtOrTrunc(Count, IntPtrTy, Name + ".size");
+    AllocSizeTy = IntPtrTy;
+  }
+  auto Align = ConstantInt::get(AllocSizeTy, AlignI);
+
   CallInst *malloccall = nullptr;
   if (CustomAllocator) {
     LLVMValueRef wzeromem = nullptr;
@@ -647,15 +670,15 @@ Value *CreateAllocation(IRBuilder<> &Builder, llvm::Type *T, Value *Count,
   } else {
 #if LLVM_VERSION_MAJOR > 17
     res =
-        Builder.CreateMalloc(Count->getType(), T, Align, Count, nullptr, Name);
+        Builder.CreateMalloc(AllocSizeTy, T, Align, AllocCount, nullptr, Name);
 #else
     if (Builder.GetInsertPoint() == Builder.GetInsertBlock()->end()) {
-      res = CallInst::CreateMalloc(Builder.GetInsertBlock(), Count->getType(),
-                                   T, Align, Count, nullptr, Name);
+      res = CallInst::CreateMalloc(Builder.GetInsertBlock(), AllocSizeTy, T,
+                                   Align, AllocCount, nullptr, Name);
       Builder.SetInsertPoint(Builder.GetInsertBlock());
     } else {
-      res = CallInst::CreateMalloc(&*Builder.GetInsertPoint(), Count->getType(),
-                                   T, Align, Count, nullptr, Name);
+      res = CallInst::CreateMalloc(&*Builder.GetInsertPoint(), AllocSizeTy, T,
+                                   Align, AllocCount, nullptr, Name);
     }
     if (!cast<Instruction>(res)->getParent())
       Builder.Insert(cast<Instruction>(res));
@@ -666,11 +689,14 @@ Value *CreateAllocation(IRBuilder<> &Builder, llvm::Type *T, Value *Count,
       malloccall = cast<CallInst>(cast<Instruction>(res)->getOperand(0));
     }
 
-    // Assert computation of size of array doesn't wrap
+    // Assert computation of size of array doesn't wrap.  Match against the
+    // (possibly-cast) size operand `AllocCount` that CreateMalloc actually
+    // consumed -- on 64-bit hosts where no cast was needed this is still
+    // pointer-equal to `Count`, so the identity check still fires.
     if (auto BI = dyn_cast<BinaryOperator>(malloccall->getArgOperand(0))) {
       if (BI->getOpcode() == BinaryOperator::Mul) {
-        if ((BI->getOperand(0) == Align && BI->getOperand(1) == Count) ||
-            (BI->getOperand(1) == Align && BI->getOperand(0) == Count))
+        if ((BI->getOperand(0) == Align && BI->getOperand(1) == AllocCount) ||
+            (BI->getOperand(1) == Align && BI->getOperand(0) == AllocCount))
           BI->setHasNoSignedWrap(true);
         BI->setHasNoUnsignedWrap(true);
       }
@@ -727,9 +753,15 @@ Value *CreateAllocation(IRBuilder<> &Builder, llvm::Type *T, Value *Count,
       tozero = Builder.CreatePointerCast(
           tozero, PointerType::get(Type::getInt8Ty(PT->getContext()),
                                    PT->getAddressSpace()));
+    // Use AllocCount (the possibly-cast size operand feeding CreateMalloc),
+    // not the pre-cast Count. When we did cast (wasm32 case), Count is
+    // wider than IntPtrTy and mixing it with Align (IntPtrTy) here would
+    // emit invalid IR like `mul i32 8, i64 %n`. On 64-bit hosts where no
+    // cast was needed, AllocCount is pointer-equal to Count so behavior
+    // matches the pre-patch code.
     Value *args[] = {
         tozero, ConstantInt::get(Type::getInt8Ty(malloccall->getContext()), 0),
-        Builder.CreateMul(Align, Count, "", true, true),
+        Builder.CreateMul(Align, AllocCount, "", true, true),
         ConstantInt::getFalse(malloccall->getContext())};
     Type *tys[] = {args[0]->getType(), args[2]->getType()};
 

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -641,7 +641,7 @@ Value *CreateAllocation(IRBuilder<> &Builder, llvm::Type *T, Value *Count,
   if (!CustomAllocator && AllocSizeTy->isIntegerTy() &&
       IntPtrTy->isIntegerTy() &&
       AllocSizeTy->getIntegerBitWidth() > IntPtrTy->getIntegerBitWidth()) {
-    AllocCount = Builder.CreateZExtOrTrunc(Count, IntPtrTy, Name + ".size");
+    AllocCount = Builder.CreateTrunc(Count, IntPtrTy, Name + ".size");
     AllocSizeTy = IntPtrTy;
   }
   auto Align = ConstantInt::get(AllocSizeTy, AlignI);

--- a/enzyme/test/Enzyme/ReverseMode/wasm32_malloc_size.ll
+++ b/enzyme/test/Enzyme/ReverseMode/wasm32_malloc_size.ll
@@ -1,0 +1,84 @@
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -S | FileCheck %s; fi
+; RUN: %opt < %s %newLoadEnzyme -passes="enzyme" -enzyme-preopt=false -S | FileCheck %s
+
+; Regression for wasm32 tape-cache malloc sizing.
+;
+; On 32-bit targets the C ABI's malloc takes size_t = i32. wasi-libc on
+; wasm32-wasi declares `void *malloc(i32)`; if Enzyme's tape-cache math
+; widens the size operand to i64, we emit `call ptr @malloc(i64 ...)`
+; against the i32-parameter declaration and the module fails validation
+; ("signature_mismatch:malloc") at load. CreateAllocation truncates
+; Count to the target IntPtrTy whenever Count is wider, so this test
+; asserts that on wasm32 every Enzyme-emitted cache malloc receives an
+; i32 size operand.
+;
+; The primal is a two-level accumulation ((A*x - y) squared, summed over
+; rows) reduced from the mean-squared-error reproducer in the patch
+; description. The inner accumulator's LCSSA lift into the outer loop
+; body forces per-outer-iteration caching, which is what triggers the
+; problematic CreateAllocation path.
+
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
+target triple = "wasm32-unknown-wasi"
+
+define double @loss(double* nocapture readonly %A, double* nocapture readonly %x,
+                    double* nocapture readonly %y, i64 %n) {
+entry:
+  br label %outer.loop
+
+outer.loop:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %outer.exit ]
+  %sum = phi double [ 0.0, %entry ], [ %next.sum, %outer.exit ]
+  br label %inner.loop
+
+inner.loop:
+  %j = phi i64 [ 0, %outer.loop ], [ %j.next, %inner.loop ]
+  %acc = phi double [ 0.0, %outer.loop ], [ %next.acc, %inner.loop ]
+  %row = mul i64 %i, %n
+  %ij = add i64 %row, %j
+  %a.p = getelementptr inbounds double, double* %A, i64 %ij
+  %a.v = load double, double* %a.p, align 8
+  %x.p = getelementptr inbounds double, double* %x, i64 %j
+  %x.v = load double, double* %x.p, align 8
+  %ax = fmul double %a.v, %x.v
+  %next.acc = fadd double %acc, %ax
+  %j.next = add i64 %j, 1
+  %inner.done = icmp eq i64 %j.next, %n
+  br i1 %inner.done, label %outer.exit, label %inner.loop
+
+outer.exit:
+  %y.p = getelementptr inbounds double, double* %y, i64 %i
+  %y.v = load double, double* %y.p, align 8
+  %r = fsub double %next.acc, %y.v
+  %r2 = fmul double %r, %r
+  %next.sum = fadd double %sum, %r2
+  %i.next = add i64 %i, 1
+  %outer.done = icmp eq i64 %i.next, %n
+  br i1 %outer.done, label %ret, label %outer.loop
+
+ret:
+  ret double %next.sum
+}
+
+define double @dloss(double* %A, double* %dA, double* %x, double* %dx,
+                     double* %y, i64 %n) {
+entry:
+  %r = call double (i8*, ...) @__enzyme_autodiff(
+    i8* bitcast (double (double*, double*, double*, i64)* @loss to i8*),
+    metadata !"enzyme_dup", double* %A, double* %dA,
+    metadata !"enzyme_dup", double* %x, double* %dx,
+    metadata !"enzyme_const", double* %y,
+    metadata !"enzyme_const", i64 %n)
+  ret double %r
+}
+
+declare double @__enzyme_autodiff(i8*, ...)
+
+; The emitted cache malloc must use the target IntPtrTy (i32 on wasm32),
+; NOT the pre-cast i64 loop-bound-derived Count. Enzyme should insert
+; a `trunc i64 ... to i32` and feed the i32 size into @malloc.
+
+; CHECK: trunc i64 {{.*}} to i32
+; CHECK: @malloc(i32
+; CHECK-NOT: @malloc(i64
+; CHECK: declare {{.*}} @malloc(i32)


### PR DESCRIPTION
`CreateAllocation` fed `Count->getType()` as the size type into `CreateMalloc`. On 64-bit hosts this coincidentally matches `size_t`; on 32-bit targets it doesn't. On wasm32-wasi an i64 `Count` (typical when reverse-mode tape math widens the size) produces `call i8* @malloc(i64 %n)` against wasi-libc's `void *malloc(i32)` declaration — the wasm module loads and then traps at first invocation with `signature_mismatch:malloc`.

Fix: compute `IntPtrTy = DataLayout::getIntPtrType(ctx, 0)` and cast `Count` via `CreateZExtOrTrunc` on the default path before feeding `CreateMalloc`. 64-bit hosts unchanged (IntPtrTy == i64 == Count's type, no cast emitted). wasm32 gets `malloc(i32)` as wasi-libc expects. Also updates the size-wrap-flag hint to match against the cast operand.

The `CustomAllocator` branch is untouched — user-supplied callback contract preserved.

Reproducer (wasi-sdk-33 / LLVM 22 / Enzyme main, wasm32-wasip1 target): reverse-mode over `sum((A*x - y)^2)` MSE loss traps at load without this patch, compiles+runs cleanly with it. Verified in a downstream wasi-sdk overlay project (tegmentum/enzyme-wasm) under wasmtime 46.