### PR TITLE
Fix vectorized MLIR derivative constants

### DIFF
--- a/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
+++ b/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
@@ -618,7 +618,12 @@ bool handle(const Twine &curIndent, const Twine &argPattern, raw_ostream &os,
         std::string ord;
         bool shadowType = false;
         if (resultRoot->getNumArgs() == 0) {
-          ord = "op->getResult(0)";
+          ord = "gutils->getShadowType(op->getResult(0)";
+          // This constant participates in a tangent expression.  In vector
+          // forward mode, the tangent has a leading width dimension even when
+          // the primal result does not.  Use the shadow type so a constant
+          // such as `1 - tanh(x)^2` composes with width-vectorized operands.
+          shadowType = true;
         } else {
           if (resultRoot->getArgName(0)) {
             auto name = resultRoot->getArgName(0)->getAsUnquotedString();


### PR DESCRIPTION
Fixes zero-operand `ConstantFP` expressions emitted by the MLIR derivative TableGen backend.

In width>1 forward mode these constants previously used the primal result type, while surrounding derivative values use the shadow type with a leading width axis. This caused invalid HLO operations such as `tensor<batchxf32> - tensor<widthxbatchxf32>` when an `enzyme.batch` broadcast was differentiated under vector forward mode.

A companion Enzyme-JAX regression exercises `enzyme.batch` composed with width-2 forward AD. Local focused validation is still building.