### PR TITLE
Return log-densities + divergent transition info from `impulse.infer`

### DIFF
--- a/enzyme/Enzyme/MLIR/Dialect/Impulse/ImpulseOps.td
+++ b/enzyme/Enzyme/MLIR/Dialect/Impulse/ImpulseOps.td
@@ -228,7 +228,7 @@ def InferOp : Impulse_Op<"infer", [DeclareOpInterfaceMethods<SymbolUserOpInterfa
     Returns: (trace, diagnostics, log_densities, rng, final_position, final_gradient,
               final_potential_energy, final_step_size, final_inverse_mass_matrix)
     - trace: tensor<num_samples x position_size x f64>
-    - diagnostics: tensor<num_samples x i1> - placeholder for future expansion
+    - diagnostics: tensor<num_samples x 2 x i1> - placeholder for future expansion
     - log_densities: tensor<num_samples x f64> - log densities of samples
     - rng: updated RNG state
     - final_position: tensor<1 x position_size x f64> - position after last sample

--- a/enzyme/Enzyme/MLIR/Dialect/Impulse/ImpulseOps.td
+++ b/enzyme/Enzyme/MLIR/Dialect/Impulse/ImpulseOps.td
@@ -273,19 +273,13 @@ def InferOp : Impulse_Op<"infer", [DeclareOpInterfaceMethods<SymbolUserOpInterfa
     DefaultValuedStrAttr<StrAttr, "">:$name
   );
 
-  let results = (outs
-    AnyRankedTensor:$trace,
-    AnyRankedTensor:$diagnostics,
-    AnyRankedTensor:$log_densities,
-    AnyType:$output_rng_state,
-    AnyRankedTensor:$final_position,
-    AnyRankedTensor:$final_gradient,
-    AnyRankedTensor:$final_potential_energy,
-    AnyRankedTensor:$final_step_size,
-    AnyRankedTensor:$final_inverse_mass_matrix,
+  let results = (outs AnyRankedTensor:$trace, AnyRankedTensor:$diagnostics,
+      AnyRankedTensor:$log_densities, AnyType:$output_rng_state,
+      AnyRankedTensor:$final_position, AnyRankedTensor:$final_gradient,
+      AnyRankedTensor:$final_potential_energy, AnyRankedTensor:$final_step_size,
+      AnyRankedTensor:$final_inverse_mass_matrix,
 
-    Variadic<AnyRankedTensor>:$adaptation_state_out
-  );
+      Variadic<AnyRankedTensor>:$adaptation_state_out);
 
   let assemblyFormat = [{
     ($fn^)?

--- a/enzyme/Enzyme/MLIR/Dialect/Impulse/ImpulseOps.td
+++ b/enzyme/Enzyme/MLIR/Dialect/Impulse/ImpulseOps.td
@@ -225,10 +225,11 @@ def InferOp : Impulse_Op<"infer", [DeclareOpInterfaceMethods<SymbolUserOpInterfa
     The `selection` attribute determines which addresses to sample via HMC/NUTS.
     All sample addresses are included in the trace tensor for consistency.
 
-    Returns: (trace, diagnostics, rng, final_position, final_gradient,
+    Returns: (trace, diagnostics, log_densities, rng, final_position, final_gradient,
               final_potential_energy, final_step_size, final_inverse_mass_matrix)
     - trace: tensor<num_samples x position_size x f64>
     - diagnostics: tensor<num_samples x i1> - placeholder for future expansion
+    - log_densities: tensor<num_samples x f64> - log densities of samples
     - rng: updated RNG state
     - final_position: tensor<1 x position_size x f64> - position after last sample
     - final_gradient: tensor<1 x position_size x f64> - gradient at final position
@@ -275,6 +276,7 @@ def InferOp : Impulse_Op<"infer", [DeclareOpInterfaceMethods<SymbolUserOpInterfa
   let results = (outs
     AnyRankedTensor:$trace,
     AnyRankedTensor:$diagnostics,
+    AnyRankedTensor:$log_densities,
     AnyType:$output_rng_state,
     AnyRankedTensor:$final_position,
     AnyRankedTensor:$final_gradient,

--- a/enzyme/Enzyme/MLIR/Interfaces/HMCUtils.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/HMCUtils.cpp
@@ -984,6 +984,11 @@ MCMCKernelResult impulse::SampleHMC(OpBuilder &builder, Location loc, Value q,
   auto acceptedTensor = arith::CmpFOp::create(
       builder, loc, arith::CmpFPredicate::OLT, randUniform, accProb);
 
+  // HMC doesn't collect divergence information so set to false
+  auto falseConst = arith::ConstantOp::create(
+      builder, loc, i1TensorType,
+      DenseElementsAttr::get(i1TensorType, builder.getBoolAttr(false)));
+
   // 8. Select between original and proposal
   auto qFinal = impulse::SelectOp::create(builder, loc, positionType,
                                           acceptedTensor, qProposal, q);
@@ -992,7 +997,7 @@ MCMCKernelResult impulse::SampleHMC(OpBuilder &builder, Location loc, Value q,
   auto UFinal = impulse::SelectOp::create(builder, loc, scalarType,
                                           acceptedTensor, UProposal, U);
 
-  return {qFinal, gradFinal, UFinal, acceptedTensor, accProb, rngNext};
+  return {qFinal, gradFinal, UFinal, acceptedTensor, falseConst, accProb, rngNext};
 }
 
 MCMCKernelResult impulse::SampleNUTS(OpBuilder &builder, Location loc, Value q,
@@ -1081,7 +1086,7 @@ MCMCKernelResult impulse::SampleNUTS(OpBuilder &builder, Location loc, Value q,
       builder, loc, finalTree.sum_accept_probs, numProposalsFloat);
 
   return {finalTree.q_proposal, finalTree.grad_proposal,
-          finalTree.U_proposal, trueConst,
+          finalTree.U_proposal, trueConst, finalTree.diverging,
           meanAcceptProb,       rngNext};
 }
 

--- a/enzyme/Enzyme/MLIR/Interfaces/HMCUtils.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/HMCUtils.cpp
@@ -997,7 +997,8 @@ MCMCKernelResult impulse::SampleHMC(OpBuilder &builder, Location loc, Value q,
   auto UFinal = impulse::SelectOp::create(builder, loc, scalarType,
                                           acceptedTensor, UProposal, U);
 
-  return {qFinal, gradFinal, UFinal, acceptedTensor, falseConst, accProb, rngNext};
+  return {qFinal,     gradFinal, UFinal, acceptedTensor,
+          falseConst, accProb,   rngNext};
 }
 
 MCMCKernelResult impulse::SampleNUTS(OpBuilder &builder, Location loc, Value q,
@@ -1085,9 +1086,13 @@ MCMCKernelResult impulse::SampleNUTS(OpBuilder &builder, Location loc, Value q,
   auto meanAcceptProb = arith::DivFOp::create(
       builder, loc, finalTree.sum_accept_probs, numProposalsFloat);
 
-  return {finalTree.q_proposal, finalTree.grad_proposal,
-          finalTree.U_proposal, trueConst, finalTree.diverging,
-          meanAcceptProb,       rngNext};
+  return {finalTree.q_proposal,
+          finalTree.grad_proposal,
+          finalTree.U_proposal,
+          trueConst,
+          finalTree.diverging,
+          meanAcceptProb,
+          rngNext};
 }
 
 NUTSTreeState impulse::buildBaseTree(OpBuilder &builder, Location loc,

--- a/enzyme/Enzyme/MLIR/Interfaces/HMCUtils.h
+++ b/enzyme/Enzyme/MLIR/Interfaces/HMCUtils.h
@@ -64,6 +64,7 @@ struct MCMCKernelResult {
   Value grad;        // Gradient at new position
   Value U;           // Potential energy at new position
   Value accepted;    // Whether proposal was accepted
+  Value divergent;   // Whether step was divergent (NUTS only; currently always false for HMC) 
   Value accept_prob; // Mean acceptance probability
   Value rng;         // Updated RNG state
 };

--- a/enzyme/Enzyme/MLIR/Interfaces/HMCUtils.h
+++ b/enzyme/Enzyme/MLIR/Interfaces/HMCUtils.h
@@ -64,7 +64,8 @@ struct MCMCKernelResult {
   Value grad;        // Gradient at new position
   Value U;           // Potential energy at new position
   Value accepted;    // Whether proposal was accepted
-  Value divergent;   // Whether step was divergent (NUTS only; currently always false for HMC) 
+  Value divergent;   // Whether step was divergent (NUTS only; currently always
+                     // false for HMC)
   Value accept_prob; // Mean acceptance probability
   Value rng;         // Updated RNG state
 };

--- a/enzyme/Enzyme/MLIR/Passes/ExpandImpulsePass.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/ExpandImpulsePass.cpp
@@ -1285,6 +1285,8 @@ struct ExpandImpulsePass
           RankedTensorType::get({collectionSize, positionSize}, elemType);
       auto acceptedBufferType =
           RankedTensorType::get({collectionSize}, rewriter.getI1Type());
+      auto logDensityBufferType =
+          RankedTensorType::get({collectionSize}, elemType);
 
       auto samplesBuffer = arith::ConstantOp::create(
           rewriter, loc, samplesBufferType,
@@ -1294,6 +1296,10 @@ struct ExpandImpulsePass
           rewriter, loc, acceptedBufferType,
           DenseElementsAttr::get(acceptedBufferType,
                                  rewriter.getBoolAttr(isNUTS)));
+      auto logDensityBuffer = arith::ConstantOp::create(
+          rewriter, loc, logDensityBufferType,
+          DenseElementsAttr::get(logDensityBufferType,
+                                 rewriter.getFloatAttr(elemType, 0.0)));
 
       auto c0 = arith::ConstantOp::create(
           rewriter, loc, i64TensorType,
@@ -1315,7 +1321,7 @@ struct ExpandImpulsePass
                                  rewriter.getI64IntegerAttr(thinning)));
 
       Value finalQ, finalGrad, finalU, finalRng, finalSamplesBuffer,
-          finalAcceptedBuffer;
+          finalAcceptedBuffer, finalLogDensityBuffer;
       if (collectionSize == 0) {
         finalQ = currentQ;
         finalGrad = currentGrad;
@@ -1323,15 +1329,18 @@ struct ExpandImpulsePass
         finalRng = currentRng;
         finalSamplesBuffer = samplesBuffer;
         finalAcceptedBuffer = acceptedBuffer;
+        finalLogDensityBuffer = logDensityBuffer;
       } else {
-        // Loop carries: [q, grad, U, rng, samplesBuffer, acceptedBuffer]
+        // Loop carries: [q, grad, U, rng, samplesBuffer, acceptedBuffer, logDensityBuffer]
         SmallVector<Type> loopResultTypes = {
             positionType,         positionType,      scalarType,
-            currentRng.getType(), samplesBufferType, acceptedBufferType};
+            currentRng.getType(), samplesBufferType, acceptedBufferType,
+            logDensityBufferType
+        };
         auto forLoopOp = impulse::ForOp::create(
             rewriter, loc, loopResultTypes, c0, numSamplesConst, c1,
             ValueRange{currentQ, currentGrad, currentU, currentRng,
-                       samplesBuffer, acceptedBuffer});
+                       samplesBuffer, acceptedBuffer, logDensityBuffer});
 
         Block *loopBody = rewriter.createBlock(&forLoopOp.getRegion());
         loopBody->addArgument(i64TensorType, loc);        // i (iteration index)
@@ -1341,6 +1350,7 @@ struct ExpandImpulsePass
         loopBody->addArgument(currentRng.getType(), loc); // rng
         loopBody->addArgument(samplesBufferType, loc);    // samplesBuffer
         loopBody->addArgument(acceptedBufferType, loc);   // acceptedBuffer
+        loopBody->addArgument(logDensityBufferType, loc); // logDensityBuffer
 
         rewriter.setInsertionPointToStart(loopBody);
         Value iterIdx = loopBody->getArgument(0);
@@ -1350,6 +1360,7 @@ struct ExpandImpulsePass
         Value rngLoop = loopBody->getArgument(4);
         Value samplesBufferLoop = loopBody->getArgument(5);
         Value acceptedBufferLoop = loopBody->getArgument(6);
+        Value logDensityBufferLoop = loopBody->getArgument(7);
 
         auto sample = runSampleStepWithStepSize(
             rewriter, loc, qLoop, gradLoop, ULoop, rngLoop, adaptedStepSize);
@@ -1394,10 +1405,21 @@ struct ExpandImpulsePass
             rewriter, loc, acceptedBufferType, shouldStore,
             updatedAcceptedBuffer, acceptedBufferLoop);
 
+        auto negU = arith::NegFOp::create(rewriter, loc, sample.U);
+        auto logDensity1D = impulse::ReshapeOp::create(
+            rewriter, loc, RankedTensorType::get({1}, elemType),
+            negU);
+        auto updatedLogDensityBuffer = impulse::DynamicUpdateSliceOp::create(
+            rewriter, loc, logDensityBufferType, logDensityBufferLoop, logDensity1D,
+            ValueRange{storageIdx});
+        auto selectedLogDensityBuffer = impulse::SelectOp::create(
+            rewriter, loc, logDensityBufferType, shouldStore,
+            updatedLogDensityBuffer, logDensityBufferLoop);
+
         impulse::YieldOp::create(rewriter, loc,
                                  ValueRange{sample.q, sample.grad, sample.U,
                                             sample.rng, selectedSamplesBuffer,
-                                            selectedAcceptedBuffer});
+                                            selectedAcceptedBuffer, selectedLogDensityBuffer});
 
         rewriter.setInsertionPointAfter(forLoopOp);
         finalQ = forLoopOp.getResult(0);
@@ -1406,6 +1428,7 @@ struct ExpandImpulsePass
         finalRng = forLoopOp.getResult(3);
         finalSamplesBuffer = forLoopOp.getResult(4);
         finalAcceptedBuffer = forLoopOp.getResult(5);
+        finalLogDensityBuffer = forLoopOp.getResult(6);
       }
 
       finalSamplesBuffer =
@@ -1413,7 +1436,7 @@ struct ExpandImpulsePass
                           "MCMC: collected samples", debugDump);
 
       SmallVector<Value> replacements = {
-          finalSamplesBuffer, finalAcceptedBuffer,
+          finalSamplesBuffer, finalAcceptedBuffer, finalLogDensityBuffer,
           finalRng,           finalQ,
           finalGrad,          finalU,
           adaptedStepSize,    adaptedInvMass};

--- a/enzyme/Enzyme/MLIR/Passes/ExpandImpulsePass.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/ExpandImpulsePass.cpp
@@ -1283,8 +1283,9 @@ struct ExpandImpulsePass
 
       auto samplesBufferType =
           RankedTensorType::get({collectionSize, positionSize}, elemType);
-      auto acceptedBufferType =
-          RankedTensorType::get({collectionSize}, rewriter.getI1Type());
+      auto diagnosticsBufferType =
+          // Diagnostics buffer has two columns: [is_accepted, is_divergent]
+          RankedTensorType::get({collectionSize, 2}, rewriter.getI1Type());
       auto logDensityBufferType =
           RankedTensorType::get({collectionSize}, elemType);
 
@@ -1292,9 +1293,9 @@ struct ExpandImpulsePass
           rewriter, loc, samplesBufferType,
           DenseElementsAttr::get(samplesBufferType,
                                  rewriter.getFloatAttr(elemType, 0.0)));
-      auto acceptedBuffer = arith::ConstantOp::create(
-          rewriter, loc, acceptedBufferType,
-          DenseElementsAttr::get(acceptedBufferType,
+      auto diagnosticsBuffer = arith::ConstantOp::create(
+          rewriter, loc, diagnosticsBufferType,
+          DenseElementsAttr::get(diagnosticsBufferType,
                                  rewriter.getBoolAttr(isNUTS)));
       auto logDensityBuffer = arith::ConstantOp::create(
           rewriter, loc, logDensityBufferType,
@@ -1321,26 +1322,26 @@ struct ExpandImpulsePass
                                  rewriter.getI64IntegerAttr(thinning)));
 
       Value finalQ, finalGrad, finalU, finalRng, finalSamplesBuffer,
-          finalAcceptedBuffer, finalLogDensityBuffer;
+          finalDiagnosticsBuffer, finalLogDensityBuffer;
       if (collectionSize == 0) {
         finalQ = currentQ;
         finalGrad = currentGrad;
         finalU = currentU;
         finalRng = currentRng;
         finalSamplesBuffer = samplesBuffer;
-        finalAcceptedBuffer = acceptedBuffer;
+        finalDiagnosticsBuffer = diagnosticsBuffer;
         finalLogDensityBuffer = logDensityBuffer;
       } else {
-        // Loop carries: [q, grad, U, rng, samplesBuffer, acceptedBuffer, logDensityBuffer]
+        // Loop carries: [q, grad, U, rng, samplesBuffer, diagnosticsBuffer,
+        // logDensityBuffer]
         SmallVector<Type> loopResultTypes = {
             positionType,         positionType,      scalarType,
-            currentRng.getType(), samplesBufferType, acceptedBufferType,
-            logDensityBufferType
-        };
+            currentRng.getType(), samplesBufferType, diagnosticsBufferType,
+            logDensityBufferType};
         auto forLoopOp = impulse::ForOp::create(
             rewriter, loc, loopResultTypes, c0, numSamplesConst, c1,
             ValueRange{currentQ, currentGrad, currentU, currentRng,
-                       samplesBuffer, acceptedBuffer, logDensityBuffer});
+                       samplesBuffer, diagnosticsBuffer, logDensityBuffer});
 
         Block *loopBody = rewriter.createBlock(&forLoopOp.getRegion());
         loopBody->addArgument(i64TensorType, loc);        // i (iteration index)
@@ -1349,8 +1350,8 @@ struct ExpandImpulsePass
         loopBody->addArgument(scalarType, loc);           // U
         loopBody->addArgument(currentRng.getType(), loc); // rng
         loopBody->addArgument(samplesBufferType, loc);    // samplesBuffer
-        loopBody->addArgument(acceptedBufferType, loc);   // acceptedBuffer
-        loopBody->addArgument(logDensityBufferType, loc); // logDensityBuffer
+        loopBody->addArgument(diagnosticsBufferType, loc); // diagnosticsBuffer
+        loopBody->addArgument(logDensityBufferType, loc);  // logDensityBuffer
 
         rewriter.setInsertionPointToStart(loopBody);
         Value iterIdx = loopBody->getArgument(0);
@@ -1359,7 +1360,7 @@ struct ExpandImpulsePass
         Value ULoop = loopBody->getArgument(3);
         Value rngLoop = loopBody->getArgument(4);
         Value samplesBufferLoop = loopBody->getArgument(5);
-        Value acceptedBufferLoop = loopBody->getArgument(6);
+        Value diagnosticsBufferLoop = loopBody->getArgument(6);
         Value logDensityBufferLoop = loopBody->getArgument(7);
 
         auto sample = runSampleStepWithStepSize(
@@ -1395,23 +1396,32 @@ struct ExpandImpulsePass
             rewriter, loc, samplesBufferType, shouldStore, updatedSamplesBuffer,
             samplesBufferLoop);
 
-        auto accepted1D = impulse::ReshapeOp::create(
-            rewriter, loc, RankedTensorType::get({1}, rewriter.getI1Type()),
+        auto oneCol = arith::ConstantOp::create(
+            rewriter, loc, i64TensorType,
+            DenseElementsAttr::get(i64TensorType,
+                                   rewriter.getI64IntegerAttr(1)));
+        auto accepted1x1 = impulse::ReshapeOp::create(
+            rewriter, loc, RankedTensorType::get({1, 1}, rewriter.getI1Type()),
             sample.accepted);
-        auto updatedAcceptedBuffer = impulse::DynamicUpdateSliceOp::create(
-            rewriter, loc, acceptedBufferType, acceptedBufferLoop, accepted1D,
-            ValueRange{storageIdx});
-        auto selectedAcceptedBuffer = impulse::SelectOp::create(
-            rewriter, loc, acceptedBufferType, shouldStore,
-            updatedAcceptedBuffer, acceptedBufferLoop);
+        auto divergent1x1 = impulse::ReshapeOp::create(
+            rewriter, loc, RankedTensorType::get({1, 1}, rewriter.getI1Type()),
+            sample.divergent);
+        auto updatedDiagnosticsBuffer = impulse::DynamicUpdateSliceOp::create(
+            rewriter, loc, diagnosticsBufferType, diagnosticsBufferLoop,
+            accepted1x1, ValueRange{storageIdx, zeroCol});
+        updatedDiagnosticsBuffer = impulse::DynamicUpdateSliceOp::create(
+            rewriter, loc, diagnosticsBufferType, updatedDiagnosticsBuffer,
+            divergent1x1, ValueRange{storageIdx, oneCol});
+        auto selectedDiagnosticsBuffer = impulse::SelectOp::create(
+            rewriter, loc, diagnosticsBufferType, shouldStore,
+            updatedDiagnosticsBuffer, diagnosticsBufferLoop);
 
         auto negU = arith::NegFOp::create(rewriter, loc, sample.U);
         auto logDensity1D = impulse::ReshapeOp::create(
-            rewriter, loc, RankedTensorType::get({1}, elemType),
-            negU);
+            rewriter, loc, RankedTensorType::get({1}, elemType), negU);
         auto updatedLogDensityBuffer = impulse::DynamicUpdateSliceOp::create(
-            rewriter, loc, logDensityBufferType, logDensityBufferLoop, logDensity1D,
-            ValueRange{storageIdx});
+            rewriter, loc, logDensityBufferType, logDensityBufferLoop,
+            logDensity1D, ValueRange{storageIdx});
         auto selectedLogDensityBuffer = impulse::SelectOp::create(
             rewriter, loc, logDensityBufferType, shouldStore,
             updatedLogDensityBuffer, logDensityBufferLoop);
@@ -1419,7 +1429,8 @@ struct ExpandImpulsePass
         impulse::YieldOp::create(rewriter, loc,
                                  ValueRange{sample.q, sample.grad, sample.U,
                                             sample.rng, selectedSamplesBuffer,
-                                            selectedAcceptedBuffer, selectedLogDensityBuffer});
+                                            selectedDiagnosticsBuffer,
+                                            selectedLogDensityBuffer});
 
         rewriter.setInsertionPointAfter(forLoopOp);
         finalQ = forLoopOp.getResult(0);
@@ -1427,7 +1438,7 @@ struct ExpandImpulsePass
         finalU = forLoopOp.getResult(2);
         finalRng = forLoopOp.getResult(3);
         finalSamplesBuffer = forLoopOp.getResult(4);
-        finalAcceptedBuffer = forLoopOp.getResult(5);
+        finalDiagnosticsBuffer = forLoopOp.getResult(5);
         finalLogDensityBuffer = forLoopOp.getResult(6);
       }
 
@@ -1435,11 +1446,15 @@ struct ExpandImpulsePass
           conditionalDump(rewriter, loc, finalSamplesBuffer,
                           "MCMC: collected samples", debugDump);
 
-      SmallVector<Value> replacements = {
-          finalSamplesBuffer, finalAcceptedBuffer, finalLogDensityBuffer,
-          finalRng,           finalQ,
-          finalGrad,          finalU,
-          adaptedStepSize,    adaptedInvMass};
+      SmallVector<Value> replacements = {finalSamplesBuffer,
+                                         finalDiagnosticsBuffer,
+                                         finalLogDensityBuffer,
+                                         finalRng,
+                                         finalQ,
+                                         finalGrad,
+                                         finalU,
+                                         adaptedStepSize,
+                                         adaptedInvMass};
       if (exposeAdaptation)
         replacements.append(finalAdaptationState.begin(),
                             finalAdaptationState.end());

--- a/enzyme/test/MLIR/Impulse/exp_transform.mlir
+++ b/enzyme/test/MLIR/Impulse/exp_transform.mlir
@@ -11,18 +11,18 @@ module {
   }
 
   // CHECK-LABEL: func.func @hmc
-  func.func @hmc(%rng : tensor<2xui64>, %rate : tensor<f64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>) {
+  func.func @hmc(%rng : tensor<2xui64>, %rate : tensor<f64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>) {
     %init_trace = arith.constant dense<[[1.0, 1.0]]> : tensor<1x2xf64>
 
     %inverse_mass_matrix = arith.constant dense<[[1.0, 0.0], [0.0, 1.0]]> : tensor<2x2xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
 
-    %res:8 = impulse.infer @test(%rng, %rate) given %init_trace
+    %res:9 = impulse.infer @test(%rng, %rate) given %init_trace
       inverse_mass_matrix = %inverse_mass_matrix
       step_size = %step_size
       { hmc_config = #impulse.hmc_config<trajectory_length = 1.000000e+00 : f64>, name = "hmc", selection = [[#impulse.symbol<1>], [#impulse.symbol<2>]], all_addresses = [[#impulse.symbol<1>], [#impulse.symbol<2>]], num_warmup = 0, num_samples = 1 }
-      : (tensor<2xui64>, tensor<f64>, tensor<1x2xf64>, tensor<2x2xf64>, tensor<f64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
-    return %res#0, %res#1, %res#2 : tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>
+      : (tensor<2xui64>, tensor<f64>, tensor<1x2xf64>, tensor<2x2xf64>, tensor<f64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
   }
 }
 

--- a/enzyme/test/MLIR/Impulse/hmc_diag_mass.mlir
+++ b/enzyme/test/MLIR/Impulse/hmc_diag_mass.mlir
@@ -10,35 +10,35 @@ module {
     return %t#0, %s#1, %t#1 : tensor<2xui64>, tensor<f64>, tensor<f64>
   }
 
-  func.func @hmc_diag_mass(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>) {
+  func.func @hmc_diag_mass(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>) {
     %init_trace = arith.constant dense<[[0.0, 0.0]]> : tensor<1x2xf64>
     %inv_mass = arith.constant dense<[2.0, 3.0]> : tensor<2xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
+    %res:9 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
       inverse_mass_matrix = %inv_mass
       step_size = %step_size
       { hmc_config = #impulse.hmc_config<trajectory_length = 1.0>,
         name = "hmc_diag", selection = [[#impulse.symbol<1>], [#impulse.symbol<2>]], all_addresses = [[#impulse.symbol<1>], [#impulse.symbol<2>]], num_warmup = 0, num_samples = 1 }
-      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>, tensor<2xf64>, tensor<f64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
-    return %res#0, %res#1, %res#2 : tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>
+      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>, tensor<2xf64>, tensor<f64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
   }
 
-  func.func @nuts_diag_mass(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>) {
+  func.func @nuts_diag_mass(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>) {
     %init_trace = arith.constant dense<[[0.0, 0.0]]> : tensor<1x2xf64>
     %inv_mass = arith.constant dense<[2.0, 3.0]> : tensor<2xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
+    %res:9 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
       inverse_mass_matrix = %inv_mass
       step_size = %step_size
       { nuts_config = #impulse.nuts_config<max_tree_depth = 3, max_delta_energy = 1000.0, adapt_step_size = false, adapt_mass_matrix = false>,
         name = "nuts_diag", selection = [[#impulse.symbol<1>], [#impulse.symbol<2>]], all_addresses = [[#impulse.symbol<1>], [#impulse.symbol<2>]], num_warmup = 0, num_samples = 1 }
-      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>, tensor<2xf64>, tensor<f64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
-    return %res#0, %res#1, %res#2 : tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>
+      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>, tensor<2xf64>, tensor<f64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
   }
 }
 
 // CHECK-LABEL: func.func @hmc_diag_mass
-// CHECK-SAME: (%[[RNG:.+]]: tensor<2xui64>, %[[MEAN:.+]]: tensor<f64>, %[[STDDEV:.+]]: tensor<f64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>)
+// CHECK-SAME: (%[[RNG:.+]]: tensor<2xui64>, %[[MEAN:.+]]: tensor<f64>, %[[STDDEV:.+]]: tensor<f64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>)
 // CHECK-DAG: %[[INV_MASS:.+]] = arith.constant dense<[2.000000e+00, 3.000000e+00]> : tensor<2xf64>
 // CHECK-DAG: %[[MASS_SQRT:.+]] = arith.constant dense<[0.70710678118654746, 0.57735026918962584]> : tensor<2xf64>
 // CHECK-DAG: %[[HALF:.+]] = arith.constant dense<5.000000e-01> : tensor<f64>
@@ -88,7 +88,7 @@ module {
 // CHECK-NEXT: impulse.select {{.*}} : (tensor<i1>, tensor<f64>, tensor<f64>)
 
 // CHECK-LABEL: func.func @nuts_diag_mass
-// CHECK-SAME: (%{{.+}}: tensor<2xui64>, %{{.+}}: tensor<f64>, %{{.+}}: tensor<f64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>)
+// CHECK-SAME: (%{{.+}}: tensor<2xui64>, %{{.+}}: tensor<f64>, %{{.+}}: tensor<f64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>)
 // CHECK-DAG: %[[N_INV_MASS:.+]] = arith.constant dense<[2.000000e+00, 3.000000e+00]> : tensor<2xf64>
 // CHECK-DAG: %[[N_MASS_SQRT:.+]] = arith.constant dense<[0.70710678118654746, 0.57735026918962584]> : tensor<2xf64>
 // CHECK: impulse.for

--- a/enzyme/test/MLIR/Impulse/hmc_kernel.mlir
+++ b/enzyme/test/MLIR/Impulse/hmc_kernel.mlir
@@ -9,20 +9,21 @@ module {
     return %s#0, %s#1 : tensor<2xui64>, tensor<f64>
   }
 
-  func.func @hmc(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<10x1xf64>, tensor<10xi1>, tensor<2xui64>) {
+  func.func @hmc(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>, tensor<2xui64>) {
     %init_trace = arith.constant dense<[[0.0]]> : tensor<1x1xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
+    %res:9 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
       step_size = %step_size
       { hmc_config = #impulse.hmc_config<trajectory_length = 1.0>,
         name = "hmc", selection = [[#impulse.symbol<1>]], all_addresses = [[#impulse.symbol<1>]], num_warmup = 0, num_samples = 10 }
-      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<10x1xf64>, tensor<10xi1>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
-    return %res#0, %res#1, %res#2 : tensor<10x1xf64>, tensor<10xi1>, tensor<2xui64>
+      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>, tensor<2xui64>
   }
 }
 
 // CHECK-LABEL: func.func @hmc
-// CHECK-SAME: (%[[RNG:.+]]: tensor<2xui64>, %[[MEAN:.+]]: tensor<f64>, %[[STDDEV:.+]]: tensor<f64>) -> (tensor<10x1xf64>, tensor<10xi1>, tensor<2xui64>)
+// CHECK-SAME: (%[[RNG:.+]]: tensor<2xui64>, %[[MEAN:.+]]: tensor<f64>, %[[STDDEV:.+]]: tensor<f64>) -> (tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>, tensor<2xui64>)
+// CHECK-DAG: %[[FALSE:.+]] = arith.constant dense<false> : tensor<i1>
 // CHECK-DAG: %[[NEG_EPS:.+]] = arith.constant dense<-1.000000e-01> : tensor<f64>
 // CHECK-DAG: %[[TRUE:.+]] = arith.constant dense<true> : tensor<i1>
 // CHECK-DAG: %[[HALF:.+]] = arith.constant dense<5.000000e-01> : tensor<f64>
@@ -30,7 +31,8 @@ module {
 // CHECK-DAG: %[[EPS:.+]] = arith.constant dense<1.000000e-01> : tensor<f64>
 // CHECK-DAG: %[[C10:.+]] = arith.constant dense<10> : tensor<i64>
 // CHECK-DAG: %[[C1:.+]] = arith.constant dense<1> : tensor<i64>
-// CHECK-DAG: %[[ACC_INIT:.+]] = arith.constant dense<false> : tensor<10xi1>
+// CHECK-DAG: %[[LD_INIT:.+]] = arith.constant dense<0.000000e+00> : tensor<10xf64>
+// CHECK-DAG: %[[DIAG_INIT:.+]] = arith.constant dense<false> : tensor<10x2xi1>
 // CHECK-DAG: %[[SAMPLES_INIT:.+]] = arith.constant dense<0.000000e+00> : tensor<10x1xf64>
 // CHECK-DAG: %[[ONE:.+]] = arith.constant dense<1.000000e+00> : tensor<f64>
 // CHECK-DAG: %[[C0:.+]] = arith.constant dense<0> : tensor<i64>
@@ -61,8 +63,8 @@ module {
 // CHECK-NEXT: } attributes {activity = [#enzyme<activity enzyme_active>], ret_activity = [#enzyme<activity enzyme_active>, #enzyme<activity enzyme_const>]}
 //
 // --- Main sampling loop ---
-// CHECK: %[[LOOP:.+]]:6 = impulse.for(%[[C0]] : tensor<i64>) to(%[[C10]] : tensor<i64>) step(%[[C1]] : tensor<i64>) iter_args(%[[Q0]], %[[AD_INIT]]#2, %[[U0]], %[[SPLIT2]]#0, %[[SAMPLES_INIT]], %[[ACC_INIT]] : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<10x1xf64>, tensor<10xi1>) -> tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<10x1xf64>, tensor<10xi1> {
-// CHECK-NEXT: ^bb0(%[[ITER:.+]]: tensor<i64>, %[[Q:.+]]: tensor<1x1xf64>, %[[GRAD:.+]]: tensor<1x1xf64>, %[[U:.+]]: tensor<f64>, %[[RNG_I:.+]]: tensor<2xui64>, %[[SAMP_BUF:.+]]: tensor<10x1xf64>, %[[ACC_BUF:.+]]: tensor<10xi1>):
+// CHECK: %[[LOOP:.+]]:7 = impulse.for(%[[C0]] : tensor<i64>) to(%[[C10]] : tensor<i64>) step(%[[C1]] : tensor<i64>) iter_args(%[[Q0]], %[[AD_INIT]]#2, %[[U0]], %[[SPLIT2]]#0, %[[SAMPLES_INIT]], %[[DIAG_INIT]], %[[LD_INIT]] : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>) -> tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64> {
+// CHECK-NEXT: ^bb0(%[[ITER:.+]]: tensor<i64>, %[[Q:.+]]: tensor<1x1xf64>, %[[GRAD:.+]]: tensor<1x1xf64>, %[[U:.+]]: tensor<f64>, %[[RNG_I:.+]]: tensor<2xui64>, %[[SAMP_BUF:.+]]: tensor<10x1xf64>, %[[DIAG_BUF:.+]]: tensor<10x2xi1>, %[[LD_BUF:.+]]: tensor<10xf64>):
 //
 // --- Sample momentum p ~ N(0, I) ---
 // CHECK-NEXT: %[[RNG_S:.+]]:3 = impulse.randomSplit %[[RNG_I]] : (tensor<2xui64>) -> (tensor<2xui64>, tensor<2xui64>, tensor<2xui64>)
@@ -145,14 +147,24 @@ module {
 // CHECK-NEXT: %[[STORE_COND:.+]] = arith.cmpi sge, %[[ITER]], %[[C0]] : tensor<i64>
 // CHECK-NEXT: %[[SAMP_UPD:.+]] = impulse.dynamic_update_slice %[[SAMP_BUF]], %[[Q_SEL]], %[[ITER]], %[[C0]] : (tensor<10x1xf64>, tensor<1x1xf64>, tensor<i64>, tensor<i64>) -> tensor<10x1xf64>
 // CHECK-NEXT: %[[SAMP_SEL:.+]] = impulse.select %[[STORE_COND]], %[[SAMP_UPD]], %[[SAMP_BUF]] : (tensor<i1>, tensor<10x1xf64>, tensor<10x1xf64>) -> tensor<10x1xf64>
-// CHECK-NEXT: %[[ACC_1D:.+]] = impulse.reshape %[[ACCEPTED]] : (tensor<i1>) -> tensor<1xi1>
-// CHECK-NEXT: %[[ACC_UPD:.+]] = impulse.dynamic_update_slice %[[ACC_BUF]], %[[ACC_1D]], %[[ITER]] : (tensor<10xi1>, tensor<1xi1>, tensor<i64>) -> tensor<10xi1>
-// CHECK-NEXT: %[[ACC_SEL:.+]] = impulse.select %[[STORE_COND]], %[[ACC_UPD]], %[[ACC_BUF]] : (tensor<i1>, tensor<10xi1>, tensor<10xi1>) -> tensor<10xi1>
+//
+// --- Store diagnostics: [accepted, divergent] ---
+// CHECK-NEXT: %[[ACC_1x1:.+]] = impulse.reshape %[[ACCEPTED]] : (tensor<i1>) -> tensor<1x1xi1>
+// CHECK-NEXT: %[[DIV_1x1:.+]] = impulse.reshape %[[FALSE]] : (tensor<i1>) -> tensor<1x1xi1>
+// CHECK-NEXT: %[[DIAG_UPD1:.+]] = impulse.dynamic_update_slice %[[DIAG_BUF]], %[[ACC_1x1]], %[[ITER]], %[[C0]] : (tensor<10x2xi1>, tensor<1x1xi1>, tensor<i64>, tensor<i64>) -> tensor<10x2xi1>
+// CHECK-NEXT: %[[DIAG_UPD2:.+]] = impulse.dynamic_update_slice %[[DIAG_UPD1]], %[[DIV_1x1]], %[[ITER]], %[[C1]] : (tensor<10x2xi1>, tensor<1x1xi1>, tensor<i64>, tensor<i64>) -> tensor<10x2xi1>
+// CHECK-NEXT: %[[DIAG_SEL:.+]] = impulse.select %[[STORE_COND]], %[[DIAG_UPD2]], %[[DIAG_BUF]] : (tensor<i1>, tensor<10x2xi1>, tensor<10x2xi1>) -> tensor<10x2xi1>
+//
+// --- Store log-density: -U ---
+// CHECK-NEXT: %[[NEG_U:.+]] = arith.negf %[[U_SEL]] : tensor<f64>
+// CHECK-NEXT: %[[LD_1D:.+]] = impulse.reshape %[[NEG_U]] : (tensor<f64>) -> tensor<1xf64>
+// CHECK-NEXT: %[[LD_UPD:.+]] = impulse.dynamic_update_slice %[[LD_BUF]], %[[LD_1D]], %[[ITER]] : (tensor<10xf64>, tensor<1xf64>, tensor<i64>) -> tensor<10xf64>
+// CHECK-NEXT: %[[LD_SEL:.+]] = impulse.select %[[STORE_COND]], %[[LD_UPD]], %[[LD_BUF]] : (tensor<i1>, tensor<10xf64>, tensor<10xf64>) -> tensor<10xf64>
 //
 // --- Yield from sampling loop ---
-// CHECK-NEXT: impulse.yield %[[Q_SEL]], %[[GRAD_SEL]], %[[U_SEL]], %[[RNG_S]]#0, %[[SAMP_SEL]], %[[ACC_SEL]] : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<10x1xf64>, tensor<10xi1>
+// CHECK-NEXT: impulse.yield %[[Q_SEL]], %[[GRAD_SEL]], %[[U_SEL]], %[[RNG_S]]#0, %[[SAMP_SEL]], %[[DIAG_SEL]], %[[LD_SEL]] : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>
 // CHECK-NEXT: }
-// CHECK-NEXT: return %[[LOOP]]#4, %[[LOOP]]#5, %[[LOOP]]#3 : tensor<10x1xf64>, tensor<10xi1>, tensor<2xui64>
+// CHECK-NEXT: return %[[LOOP]]#4, %[[LOOP]]#5, %[[LOOP]]#6, %[[LOOP]]#3 : tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>, tensor<2xui64>
 // CHECK-NEXT: }
 //
 // --- Generated function: test.generate ---

--- a/enzyme/test/MLIR/Impulse/mcmc_custom_logpdf.mlir
+++ b/enzyme/test/MLIR/Impulse/mcmc_custom_logpdf.mlir
@@ -20,10 +20,10 @@ module {
   // CHECK: func.call @logpdf
   // CHECK-NEXT: %{{.+}} = arith.negf
   // CHECK-NEXT: enzyme.yield
-  func.func @nuts_logpdf(%rng : tensor<2xui64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>) {
+  func.func @nuts_logpdf(%rng : tensor<2xui64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>) {
     %init_pos = arith.constant dense<[[1.0, -1.0]]> : tensor<1x2xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = "impulse.infer"(%rng, %step_size, %init_pos) {
+    %res:9 = "impulse.infer"(%rng, %step_size, %init_pos) {
       logpdf_fn = @logpdf,
       nuts_config = #impulse.nuts_config<max_tree_depth = 3, max_delta_energy = 1000.0, adapt_step_size = false, adapt_mass_matrix = false>,
       name = "nuts_logpdf",
@@ -32,9 +32,9 @@ module {
       num_warmup = 0,
       num_samples = 1,
       operand_segment_sizes = array<i32: 1, 0, 0, 0, 1, 1, 0, 0, 0>
-    } : (tensor<2xui64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
+    } : (tensor<2xui64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
 
-    return %res#0, %res#1, %res#2 : tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>
+    return %res#0, %res#1, %res#2, %res#3 : tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
   }
 
   // CHECK-LABEL: func.func @hmc_logpdf
@@ -49,10 +49,10 @@ module {
   // CHECK: func.call @logpdf
   // CHECK-NEXT: %{{.+}} = arith.negf
   // CHECK-NEXT: enzyme.yield
-  func.func @hmc_logpdf(%rng : tensor<2xui64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>) {
+  func.func @hmc_logpdf(%rng : tensor<2xui64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>) {
     %init_pos = arith.constant dense<[[0.5, -0.5]]> : tensor<1x2xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = "impulse.infer"(%rng, %step_size, %init_pos) {
+    %res:9 = "impulse.infer"(%rng, %step_size, %init_pos) {
       logpdf_fn = @logpdf,
       hmc_config = #impulse.hmc_config<trajectory_length = 1.000000e+00 : f64, adapt_step_size = false, adapt_mass_matrix = false>,
       name = "hmc_logpdf",
@@ -61,8 +61,8 @@ module {
       num_warmup = 0,
       num_samples = 1,
       operand_segment_sizes = array<i32: 1, 0, 0, 0, 1, 1, 0, 0, 0>
-    } : (tensor<2xui64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
-    return %res#0, %res#1, %res#2 : tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>
+    } : (tensor<2xui64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
   }
 
   func.func @shifted_logpdf(%x : tensor<2xf64>, %mu : tensor<2xf64>) -> tensor<f64> {
@@ -85,10 +85,10 @@ module {
   // CHECK: func.call @shifted_logpdf
   // CHECK-NEXT: %{{.+}} = arith.negf
   // CHECK-NEXT: enzyme.yield
-  func.func @nuts_shifted_logpdf(%rng : tensor<2xui64>, %mu : tensor<2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>) {
+  func.func @nuts_shifted_logpdf(%rng : tensor<2xui64>, %mu : tensor<2xf64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>) {
     %init_pos = arith.constant dense<[[0.5, -0.5]]> : tensor<1x2xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = "impulse.infer"(%rng, %mu, %step_size, %init_pos) {
+    %res:9 = "impulse.infer"(%rng, %mu, %step_size, %init_pos) {
       logpdf_fn = @shifted_logpdf,
       nuts_config = #impulse.nuts_config<max_tree_depth = 3, max_delta_energy = 1000.0, adapt_step_size = false, adapt_mass_matrix = false>,
       name = "nuts_shifted_logpdf",
@@ -97,8 +97,8 @@ module {
       num_warmup = 0,
       num_samples = 1,
       operand_segment_sizes = array<i32: 2, 0, 0, 0, 1, 1, 0, 0, 0>
-    } : (tensor<2xui64>, tensor<2xf64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
-    return %res#0, %res#1, %res#2 : tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>
+    } : (tensor<2xui64>, tensor<2xf64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
   }
 
   // CHECK-LABEL: func.func @hmc_shifted_logpdf
@@ -113,10 +113,10 @@ module {
   // CHECK: func.call @shifted_logpdf
   // CHECK-NEXT: %{{.+}} = arith.negf
   // CHECK-NEXT: enzyme.yield
-  func.func @hmc_shifted_logpdf(%rng : tensor<2xui64>, %mu : tensor<2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>) {
+  func.func @hmc_shifted_logpdf(%rng : tensor<2xui64>, %mu : tensor<2xf64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>) {
     %init_pos = arith.constant dense<[[0.5, -0.5]]> : tensor<1x2xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = "impulse.infer"(%rng, %mu, %step_size, %init_pos) {
+    %res:9 = "impulse.infer"(%rng, %mu, %step_size, %init_pos) {
       logpdf_fn = @shifted_logpdf,
       hmc_config = #impulse.hmc_config<trajectory_length = 1.000000e+00 : f64, adapt_step_size = false, adapt_mass_matrix = false>,
       name = "hmc_shifted_logpdf",
@@ -125,8 +125,8 @@ module {
       num_warmup = 0,
       num_samples = 1,
       operand_segment_sizes = array<i32: 2, 0, 0, 0, 1, 1, 0, 0, 0>
-    } : (tensor<2xui64>, tensor<2xf64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
-    return %res#0, %res#1, %res#2 : tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>
+    } : (tensor<2xui64>, tensor<2xf64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
   }
 
   func.func @anisotropic_logpdf(%x : tensor<2xf64>, %mu : tensor<2xf64>, %precision : tensor<2xf64>) -> tensor<f64> {
@@ -152,10 +152,10 @@ module {
   // CHECK: func.call @anisotropic_logpdf
   // CHECK-NEXT: %{{.+}} = arith.negf
   // CHECK-NEXT: enzyme.yield
-  func.func @nuts_anisotropic_logpdf(%rng : tensor<2xui64>, %mu : tensor<2xf64>, %precision : tensor<2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>) {
+  func.func @nuts_anisotropic_logpdf(%rng : tensor<2xui64>, %mu : tensor<2xf64>, %precision : tensor<2xf64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>) {
     %init_pos = arith.constant dense<[[0.5, -0.5]]> : tensor<1x2xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = "impulse.infer"(%rng, %mu, %precision, %step_size, %init_pos) {
+    %res:9 = "impulse.infer"(%rng, %mu, %precision, %step_size, %init_pos) {
       logpdf_fn = @anisotropic_logpdf,
       nuts_config = #impulse.nuts_config<max_tree_depth = 3, max_delta_energy = 1000.0, adapt_step_size = false, adapt_mass_matrix = false>,
       name = "nuts_anisotropic_logpdf",
@@ -164,8 +164,8 @@ module {
       num_warmup = 0,
       num_samples = 1,
       operand_segment_sizes = array<i32: 3, 0, 0, 0, 1, 1, 0, 0, 0>
-    } : (tensor<2xui64>, tensor<2xf64>, tensor<2xf64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
-    return %res#0, %res#1, %res#2 : tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>
+    } : (tensor<2xui64>, tensor<2xf64>, tensor<2xf64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
   }
 
   // CHECK-LABEL: func.func @hmc_anisotropic_logpdf
@@ -180,10 +180,10 @@ module {
   // CHECK: func.call @anisotropic_logpdf
   // CHECK-NEXT: %{{.+}} = arith.negf
   // CHECK-NEXT: enzyme.yield
-  func.func @hmc_anisotropic_logpdf(%rng : tensor<2xui64>, %mu : tensor<2xf64>, %precision : tensor<2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>) {
+  func.func @hmc_anisotropic_logpdf(%rng : tensor<2xui64>, %mu : tensor<2xf64>, %precision : tensor<2xf64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>) {
     %init_pos = arith.constant dense<[[0.5, -0.5]]> : tensor<1x2xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = "impulse.infer"(%rng, %mu, %precision, %step_size, %init_pos) {
+    %res:9 = "impulse.infer"(%rng, %mu, %precision, %step_size, %init_pos) {
       logpdf_fn = @anisotropic_logpdf,
       hmc_config = #impulse.hmc_config<trajectory_length = 1.000000e+00 : f64, adapt_step_size = false, adapt_mass_matrix = false>,
       name = "hmc_anisotropic_logpdf",
@@ -192,7 +192,7 @@ module {
       num_warmup = 0,
       num_samples = 1,
       operand_segment_sizes = array<i32: 3, 0, 0, 0, 1, 1, 0, 0, 0>
-    } : (tensor<2xui64>, tensor<2xf64>, tensor<2xf64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
-    return %res#0, %res#1, %res#2 : tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>
+    } : (tensor<2xui64>, tensor<2xf64>, tensor<2xf64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
   }
 }

--- a/enzyme/test/MLIR/Impulse/mcmc_sampling.mlir
+++ b/enzyme/test/MLIR/Impulse/mcmc_sampling.mlir
@@ -9,37 +9,37 @@ module {
     return %s#0, %s#1 : tensor<2xui64>, tensor<f64>
   }
 
-  func.func @sampling_basic(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<10x1xf64>, tensor<10xi1>, tensor<2xui64>) {
+  func.func @sampling_basic(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>, tensor<2xui64>) {
     %init_trace = arith.constant dense<[[0.0]]> : tensor<1x1xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
+    %res:9 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
       step_size = %step_size
       { nuts_config = #impulse.nuts_config<max_tree_depth = 5, max_delta_energy = 1000.0, adapt_step_size = false, adapt_mass_matrix = false>,
         name = "sampling_basic", selection = [[#impulse.symbol<1>]], all_addresses = [[#impulse.symbol<1>]], num_warmup = 0, num_samples = 10 }
-      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<10x1xf64>, tensor<10xi1>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
-    return %res#0, %res#1, %res#2 : tensor<10x1xf64>, tensor<10xi1>, tensor<2xui64>
+      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>, tensor<2xui64>
   }
 
-  func.func @sampling_thinning(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<5x1xf64>, tensor<5xi1>, tensor<2xui64>) {
+  func.func @sampling_thinning(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<5x1xf64>, tensor<5x2xi1>, tensor<5xf64>, tensor<2xui64>) {
     %init_trace = arith.constant dense<[[0.0]]> : tensor<1x1xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
+    %res:9 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
       step_size = %step_size
       { nuts_config = #impulse.nuts_config<max_tree_depth = 5, max_delta_energy = 1000.0, adapt_step_size = false, adapt_mass_matrix = false>,
         name = "sampling_thinning", selection = [[#impulse.symbol<1>]], all_addresses = [[#impulse.symbol<1>]], num_warmup = 0, num_samples = 10, thinning = 2 }
-      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<5x1xf64>, tensor<5xi1>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
-    return %res#0, %res#1, %res#2 : tensor<5x1xf64>, tensor<5xi1>, tensor<2xui64>
+      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<5x1xf64>, tensor<5x2xi1>, tensor<5xf64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<5x1xf64>, tensor<5x2xi1>, tensor<5xf64>, tensor<2xui64>
   }
 
-  func.func @sampling_with_warmup(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<10x1xf64>, tensor<10xi1>, tensor<2xui64>) {
+  func.func @sampling_with_warmup(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>, tensor<2xui64>) {
     %init_trace = arith.constant dense<[[0.0]]> : tensor<1x1xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
+    %res:9 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
       step_size = %step_size
       { nuts_config = #impulse.nuts_config<max_tree_depth = 5>,
         name = "sampling_with_warmup", selection = [[#impulse.symbol<1>]], all_addresses = [[#impulse.symbol<1>]], num_warmup = 5, num_samples = 10 }
-      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<10x1xf64>, tensor<10xi1>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
-    return %res#0, %res#1, %res#2 : tensor<10x1xf64>, tensor<10xi1>, tensor<2xui64>
+      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>, tensor<2xui64>
   }
 }
 
@@ -47,9 +47,10 @@ module {
 // sampling_basic: 10 samples, no thinning, no warmup
 // ============================================================
 // CHECK-LABEL: func.func @sampling_basic
-// CHECK-SAME: (%[[RNG:.+]]: tensor<2xui64>, %[[MEAN:.+]]: tensor<f64>, %[[STDDEV:.+]]: tensor<f64>) -> (tensor<10x1xf64>, tensor<10xi1>, tensor<2xui64>)
+// CHECK-SAME: (%[[RNG:.+]]: tensor<2xui64>, %[[MEAN:.+]]: tensor<f64>, %[[STDDEV:.+]]: tensor<f64>) -> (tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>, tensor<2xui64>)
 // CHECK-DAG: %[[C10:.+]] = arith.constant dense<10> : tensor<i64>
-// CHECK-DAG: %[[ACC_INIT:.+]] = arith.constant dense<true> : tensor<10xi1>
+// CHECK-DAG: %[[LOGDENS_INIT:.+]] = arith.constant dense<0.000000e+00> : tensor<10xf64>
+// CHECK-DAG: %[[ACC_INIT:.+]] = arith.constant dense<true> : tensor<10x2xi1>
 // CHECK-DAG: %[[SAMP_INIT:.+]] = arith.constant dense<0.000000e+00> : tensor<10x1xf64>
 // CHECK-DAG: %[[C0:.+]] = arith.constant dense<0> : tensor<i64>
 // CHECK-DAG: %[[INIT_TRACE:.+]] = arith.constant dense<0.000000e+00> : tensor<1x1xf64>
@@ -67,10 +68,10 @@ module {
 // CHECK: } attributes {activity = [#enzyme<activity enzyme_active>], ret_activity = [#enzyme<activity enzyme_active>, #enzyme<activity enzyme_const>]}
 //
 // --- Sampling loop: for i in 0..10 ---
-// CHECK: %[[SLOOP:.+]]:6 = impulse.for(%[[C0]] : tensor<i64>) to(%[[C10]] : tensor<i64>)
-// CHECK-SAME: iter_args(%{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %[[SAMP_INIT]], %[[ACC_INIT]] : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<10x1xf64>, tensor<10xi1>)
-// CHECK-SAME: -> tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<10x1xf64>, tensor<10xi1>
-// CHECK: ^bb0(%[[S_ITER:.+]]: tensor<i64>, %{{.+}}: tensor<1x1xf64>, %{{.+}}: tensor<1x1xf64>, %{{.+}}: tensor<f64>, %{{.+}}: tensor<2xui64>, %{{.+}}: tensor<10x1xf64>, %{{.+}}: tensor<10xi1>):
+// CHECK: %[[SLOOP:.+]]:7 = impulse.for(%[[C0]] : tensor<i64>) to(%[[C10]] : tensor<i64>)
+// CHECK-SAME: iter_args(%{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %[[SAMP_INIT]], %[[ACC_INIT]], %[[LOGDENS_INIT]] : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>)
+// CHECK-SAME: -> tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>
+// CHECK: ^bb0(%[[S_ITER:.+]]: tensor<i64>, %{{.+}}: tensor<1x1xf64>, %{{.+}}: tensor<1x1xf64>, %{{.+}}: tensor<f64>, %{{.+}}: tensor<2xui64>, %{{.+}}: tensor<10x1xf64>, %{{.+}}: tensor<10x2xi1>, %{{.+}}: tensor<10xf64>):
 //
 // --- Momentum sampling ---
 // CHECK: impulse.random {{.*}} {rng_distribution = #impulse<rng_distribution NORMAL>} : (tensor<2xui64>, tensor<f64>, tensor<f64>) -> (tensor<2xui64>, tensor<1x1xf64>)
@@ -83,21 +84,21 @@ module {
 //
 // --- Sample storage: update samples buffer ---
 // CHECK: impulse.dynamic_update_slice %{{.+}}, %{{.+}}, %[[S_ITER]], %{{.+}} : (tensor<10x1xf64>, tensor<1x1xf64>, tensor<i64>, tensor<i64>) -> tensor<10x1xf64>
-// CHECK: impulse.yield %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}} : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<10x1xf64>, tensor<10xi1>
+// CHECK: impulse.yield %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}} : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>
 // CHECK: }
-// CHECK: return %[[SLOOP]]#4, %[[SLOOP]]#5, %[[SLOOP]]#3 : tensor<10x1xf64>, tensor<10xi1>, tensor<2xui64>
+// CHECK: return %[[SLOOP]]#4, %[[SLOOP]]#5, %[[SLOOP]]#6, %[[SLOOP]]#3 : tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>, tensor<2xui64>
 // CHECK: }
 
 // ============================================================
 // sampling_thinning: 10 total iterations, thinning=2, output 5 samples
 // ============================================================
 // CHECK-LABEL: func.func @sampling_thinning
-// CHECK-SAME: -> (tensor<5x1xf64>, tensor<5xi1>, tensor<2xui64>)
+// CHECK-SAME: -> (tensor<5x1xf64>, tensor<5x2xi1>, tensor<5xf64>, tensor<2xui64>)
 //
 // --- Thinning loop ---
 // CHECK: impulse.for
-// CHECK-SAME: iter_args(%{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}} : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<5x1xf64>, tensor<5xi1>)
-// CHECK-SAME: -> tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<5x1xf64>, tensor<5xi1>
+// CHECK-SAME: iter_args(%{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}} : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<5x1xf64>, tensor<5x2xi1>, tensor<5xf64>)
+// CHECK-SAME: -> tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<5x1xf64>, tensor<5x2xi1>, tensor<5xf64>
 //
 // --- Thinning logic ---
 // CHECK: arith.divsi
@@ -108,14 +109,14 @@ module {
 //
 // --- Sample storage ---
 // CHECK: impulse.dynamic_update_slice %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}} : (tensor<5x1xf64>, tensor<1x1xf64>, tensor<i64>, tensor<i64>) -> tensor<5x1xf64>
-// CHECK: return {{.*}} : tensor<5x1xf64>, tensor<5xi1>, tensor<2xui64>
+// CHECK: return {{.*}} : tensor<5x1xf64>, tensor<5x2xi1>, tensor<5xf64>, tensor<2xui64>
 // CHECK: }
 
 // ============================================================
 // sampling_with_warmup: 5 warmup + 10 sampling iterations
 // ============================================================
 // CHECK-LABEL: func.func @sampling_with_warmup
-// CHECK-SAME: -> (tensor<10x1xf64>, tensor<10xi1>, tensor<2xui64>)
+// CHECK-SAME: -> (tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>, tensor<2xui64>)
 //
 // --- Warmup loop ---
 // CHECK: %[[WARMUP:.+]]:16 = impulse.for
@@ -152,5 +153,5 @@ module {
 // CHECK: impulse.dot {{.*}} : (tensor<1x1xf64>, tensor<1x1xf64>) -> tensor<1x1xf64>
 // CHECK: impulse.dot {{.*}} lhs_contracting_dimensions = array<i64: 0, 1>
 //
-// CHECK: return {{.*}} : tensor<10x1xf64>, tensor<10xi1>, tensor<2xui64>
+// CHECK: return {{.*}} : tensor<10x1xf64>, tensor<10x2xi1>, tensor<10xf64>, tensor<2xui64>
 // CHECK: }

--- a/enzyme/test/MLIR/Impulse/mcmc_strong_zero.mlir
+++ b/enzyme/test/MLIR/Impulse/mcmc_strong_zero.mlir
@@ -14,10 +14,10 @@ module {
   // CHECK: impulse.for
   // CHECK: enzyme.autodiff_region
   // CHECK: strong_zero = true
-  func.func @nuts_strong_zero(%rng : tensor<2xui64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>) {
+  func.func @nuts_strong_zero(%rng : tensor<2xui64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>) {
     %init_pos = arith.constant dense<[[1.0, -1.0]]> : tensor<1x2xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = "impulse.infer"(%rng, %step_size, %init_pos) {
+    %res:9 = "impulse.infer"(%rng, %step_size, %init_pos) {
       logpdf_fn = @logpdf,
       nuts_config = #impulse.nuts_config<max_tree_depth = 3, max_delta_energy = 1000.0, adapt_step_size = false, adapt_mass_matrix = false>,
       autodiff_attrs = {strong_zero = true},
@@ -27,8 +27,8 @@ module {
       num_warmup = 0,
       num_samples = 1,
       operand_segment_sizes = array<i32: 1, 0, 0, 0, 1, 1, 0, 0, 0>
-    } : (tensor<2xui64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
-    return %res#0, %res#1, %res#2 : tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>
+    } : (tensor<2xui64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
   }
 
   // CHECK-LABEL: func.func @nuts_default
@@ -38,10 +38,10 @@ module {
   // CHECK: enzyme.autodiff_region
   // CHECK-NOT: strong_zero
   // CHECK: enzyme.yield
-  func.func @nuts_default(%rng : tensor<2xui64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>) {
+  func.func @nuts_default(%rng : tensor<2xui64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>) {
     %init_pos = arith.constant dense<[[1.0, -1.0]]> : tensor<1x2xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = "impulse.infer"(%rng, %step_size, %init_pos) {
+    %res:9 = "impulse.infer"(%rng, %step_size, %init_pos) {
       logpdf_fn = @logpdf,
       nuts_config = #impulse.nuts_config<max_tree_depth = 3, max_delta_energy = 1000.0, adapt_step_size = false, adapt_mass_matrix = false>,
       name = "nuts_default",
@@ -50,8 +50,8 @@ module {
       num_warmup = 0,
       num_samples = 1,
       operand_segment_sizes = array<i32: 1, 0, 0, 0, 1, 1, 0, 0, 0>
-    } : (tensor<2xui64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
-    return %res#0, %res#1, %res#2 : tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>
+    } : (tensor<2xui64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
   }
 
   // CHECK-LABEL: func.func @hmc_strong_zero
@@ -60,10 +60,10 @@ module {
   // CHECK: impulse.for
   // CHECK: enzyme.autodiff_region
   // CHECK: strong_zero = true
-  func.func @hmc_strong_zero(%rng : tensor<2xui64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>) {
+  func.func @hmc_strong_zero(%rng : tensor<2xui64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>) {
     %init_pos = arith.constant dense<[[0.5, -0.5]]> : tensor<1x2xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = "impulse.infer"(%rng, %step_size, %init_pos) {
+    %res:9 = "impulse.infer"(%rng, %step_size, %init_pos) {
       logpdf_fn = @logpdf,
       hmc_config = #impulse.hmc_config<trajectory_length = 1.000000e+00 : f64, adapt_step_size = false, adapt_mass_matrix = false>,
       autodiff_attrs = {strong_zero = true},
@@ -73,7 +73,7 @@ module {
       num_warmup = 0,
       num_samples = 1,
       operand_segment_sizes = array<i32: 1, 0, 0, 0, 1, 1, 0, 0, 0>
-    } : (tensor<2xui64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
-    return %res#0, %res#1, %res#2 : tensor<1x2xf64>, tensor<1xi1>, tensor<2xui64>
+    } : (tensor<2xui64>, tensor<f64>, tensor<1x2xf64>) -> (tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x2xf64>, tensor<1x2xf64>, tensor<f64>, tensor<f64>, tensor<1x2xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<1x2xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
   }
 }

--- a/enzyme/test/MLIR/Impulse/mcmc_warmup.mlir
+++ b/enzyme/test/MLIR/Impulse/mcmc_warmup.mlir
@@ -10,51 +10,51 @@ module {
   }
 
   // adapt_step_size = true, adapt_mass_matrix = true
-  func.func @warmup_both(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>) {
+  func.func @warmup_both(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>) {
     %init_trace = arith.constant dense<[[0.0]]> : tensor<1x1xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
+    %res:9 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
       step_size = %step_size
       { nuts_config = #impulse.nuts_config<max_tree_depth = 5>,
         name = "warmup_both", selection = [[#impulse.symbol<1>]], all_addresses = [[#impulse.symbol<1>]], num_warmup = 10, num_samples = 1 }
-      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
-    return %res#0, %res#1, %res#2 : tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>
+      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
   }
 
   // adapt_step_size = true, adapt_mass_matrix = false
-  func.func @warmup_step_only(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>) {
+  func.func @warmup_step_only(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>) {
     %init_trace = arith.constant dense<[[0.0]]> : tensor<1x1xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
+    %res:9 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
       step_size = %step_size
       { nuts_config = #impulse.nuts_config<max_tree_depth = 5, max_delta_energy = 1000.0, adapt_step_size = true, adapt_mass_matrix = false>,
         name = "warmup_step_only", selection = [[#impulse.symbol<1>]], all_addresses = [[#impulse.symbol<1>]], num_warmup = 10, num_samples = 1 }
-      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
-    return %res#0, %res#1, %res#2 : tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>
+      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
   }
 
   // adapt_step_size = false, adapt_mass_matrix = true
-  func.func @warmup_mass_only(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>) {
+  func.func @warmup_mass_only(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>) {
     %init_trace = arith.constant dense<[[0.0]]> : tensor<1x1xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
+    %res:9 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
       step_size = %step_size
       { nuts_config = #impulse.nuts_config<max_tree_depth = 5, max_delta_energy = 1000.0, adapt_step_size = false, adapt_mass_matrix = true>,
         name = "warmup_mass_only", selection = [[#impulse.symbol<1>]], all_addresses = [[#impulse.symbol<1>]], num_warmup = 10, num_samples = 1 }
-      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
-    return %res#0, %res#1, %res#2 : tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>
+      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
   }
 
   // adapt_step_size = false, adapt_mass_matrix = false
-  func.func @warmup_none(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>) {
+  func.func @warmup_none(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>) {
     %init_trace = arith.constant dense<[[0.0]]> : tensor<1x1xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
+    %res:9 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
       step_size = %step_size
       { nuts_config = #impulse.nuts_config<max_tree_depth = 5, max_delta_energy = 1000.0, adapt_step_size = false, adapt_mass_matrix = false>,
         name = "warmup_none", selection = [[#impulse.symbol<1>]], all_addresses = [[#impulse.symbol<1>]], num_warmup = 10, num_samples = 1 }
-      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
-    return %res#0, %res#1, %res#2 : tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>
+      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
   }
 }
 
@@ -65,10 +65,10 @@ module {
 //   welfordMean, welfordM2, welfordN, windowIdx
 // ============================================================
 // CHECK-LABEL: func.func @warmup_both
-// CHECK-SAME: (%[[RNG:.+]]: tensor<2xui64>, %[[MEAN:.+]]: tensor<f64>, %[[STDDEV:.+]]: tensor<f64>) -> (tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>)
+// CHECK-SAME: (%[[RNG:.+]]: tensor<2xui64>, %[[MEAN:.+]]: tensor<f64>, %[[STDDEV:.+]]: tensor<f64>) -> (tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>)
 //
 // --- Constants ---
-// CHECK-DAG: %[[ACC_INIT:.+]] = arith.constant dense<true> : tensor<1xi1>
+// CHECK-DAG: %[[ACC_INIT:.+]] = arith.constant dense<true> : tensor<1x2xi1>
 // CHECK-DAG: %[[LOG10:.+]] = arith.constant dense<2.3025850929940459> : tensor<f64>
 // CHECK-DAG: %[[SHRINK:.+]] = arith.constant dense<5.000000e-03> : tensor<f64>
 // CHECK-DAG: %[[FMAX:.+]] = arith.constant dense<1.7976931348623157E+308> : tensor<f64>
@@ -229,9 +229,9 @@ module {
 // CHECK-NEXT: impulse.yield {{.*}} : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<f64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<i64>, tensor<f64>, tensor<1xf64>, tensor<1xf64>, tensor<i64>, tensor<i64>
 // CHECK-NEXT: }
 //
-// --- Post-warmup sampling loop: 6 iter_args with adapted params ---
-// CHECK-NEXT: %[[SLOOP:.+]]:6 = impulse.for(%[[C0]] : tensor<i64>) to(%[[C1]] : tensor<i64>) step(%[[C1]] : tensor<i64>) iter_args(%[[WARMUP]]#0, %[[WARMUP]]#1, %[[WARMUP]]#2, %[[WARMUP]]#3, %{{.+}}, %[[ACC_INIT]] : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1xi1>) -> tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1xi1> {
-// CHECK-NEXT: ^bb0(%[[SI:.+]]: tensor<i64>, %{{.+}}: tensor<1x1xf64>, %{{.+}}: tensor<1x1xf64>, %{{.+}}: tensor<f64>, %{{.+}}: tensor<2xui64>, %[[S_SAMP:.+]]: tensor<1x1xf64>, %[[S_ACC:.+]]: tensor<1xi1>):
+// --- Post-warmup sampling loop: 7 iter_args with adapted params ---
+// CHECK-NEXT: %[[SLOOP:.+]]:7 = impulse.for(%[[C0]] : tensor<i64>) to(%[[C1]] : tensor<i64>) step(%[[C1]] : tensor<i64>) iter_args(%[[WARMUP]]#0, %[[WARMUP]]#1, %[[WARMUP]]#2, %[[WARMUP]]#3, %{{.+}}, %[[ACC_INIT]], %[[ZERO_1D]] : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>) -> tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64> {
+// CHECK-NEXT: ^bb0(%[[SI:.+]]: tensor<i64>, %{{.+}}: tensor<1x1xf64>, %{{.+}}: tensor<1x1xf64>, %{{.+}}: tensor<f64>, %{{.+}}: tensor<2xui64>, %[[S_SAMP:.+]]: tensor<1x1xf64>, %[[S_ACC:.+]]: tensor<1x2xi1>, %[[S_LOGDENS:.+]]: tensor<1xf64>):
 //
 // --- Momentum with adapted mass matrix from warmup ---
 // CHECK-NEXT: %{{.+}} = impulse.randomSplit
@@ -250,14 +250,20 @@ module {
 // CHECK: %[[S_STORE:.+]] = arith.cmpi sge, %[[SI]], %[[C0]]
 // CHECK-NEXT: %{{.+}} = impulse.dynamic_update_slice %[[S_SAMP]], %[[S_TREE]]#6, %[[SI]], %[[C0]]
 // CHECK-NEXT: %{{.+}} = impulse.select %[[S_STORE]]
-// CHECK-NEXT: %{{.+}} = impulse.reshape %[[TRUE]] : (tensor<i1>) -> tensor<1xi1>
-// CHECK-NEXT: %{{.+}} = impulse.dynamic_update_slice %[[S_ACC]], %{{.+}}, %[[SI]]
+// CHECK-NEXT: %{{.+}} = impulse.reshape %[[TRUE]] : (tensor<i1>) -> tensor<1x1xi1>
+// CHECK-NEXT: %{{.+}} = impulse.reshape %[[S_TREE]]#13 : (tensor<i1>) -> tensor<1x1xi1>
+// CHECK-NEXT: %{{.+}} = impulse.dynamic_update_slice %[[S_ACC]], %{{.+}}, %[[SI]], %[[C0]]
+// CHECK-NEXT: %{{.+}} = impulse.dynamic_update_slice %{{.+}}, %{{.+}}, %[[SI]], %[[C1]]
+// CHECK-NEXT: %{{.+}} = impulse.select %[[S_STORE]]
+// CHECK-NEXT: %{{.+}} = arith.negf %[[S_TREE]]#8
+// CHECK-NEXT: %{{.+}} = impulse.reshape
+// CHECK-NEXT: %{{.+}} = impulse.dynamic_update_slice %[[S_LOGDENS]]
 // CHECK-NEXT: %{{.+}} = impulse.select %[[S_STORE]]
 //
 // --- Sampling yield ---
-// CHECK-NEXT: impulse.yield %[[S_TREE]]#6, %[[S_TREE]]#7, %[[S_TREE]]#8, %{{.+}}, %{{.+}}, %{{.+}} : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1xi1>
+// CHECK-NEXT: impulse.yield %[[S_TREE]]#6, %[[S_TREE]]#7, %[[S_TREE]]#8, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}} : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>
 // CHECK-NEXT: }
-// CHECK-NEXT: return %[[SLOOP]]#4, %[[SLOOP]]#5, %[[SLOOP]]#3 : tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>
+// CHECK-NEXT: return %[[SLOOP]]#4, %[[SLOOP]]#5, %[[SLOOP]]#6, %[[SLOOP]]#3 : tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
 // CHECK-NEXT: }
 
 // ============================================================
@@ -265,7 +271,7 @@ module {
 // 13 iter_args: no welford_mean, welford_m2, welford_n
 // ============================================================
 // CHECK-LABEL: func.func @warmup_step_only
-// CHECK-SAME: (%{{.+}}: tensor<2xui64>, %{{.+}}: tensor<f64>, %{{.+}}: tensor<f64>) -> (tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>)
+// CHECK-SAME: (%{{.+}}: tensor<2xui64>, %{{.+}}: tensor<f64>, %{{.+}}: tensor<f64>) -> (tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>)
 //
 // CHECK-DAG: %[[S_LOG10:.+]] = arith.constant dense<2.3025850929940459> : tensor<f64>
 // CHECK-DAG: %[[S_FMAX:.+]] = arith.constant dense<1.7976931348623157E+308> : tensor<f64>
@@ -363,9 +369,9 @@ module {
 // CHECK-NEXT: }
 //
 // --- Post-warmup sampling loop ---
-// CHECK-NEXT: %[[S_SLOOP:.+]]:6 = impulse.for(%[[S_C0]] : tensor<i64>) to(%[[S_C1]] : tensor<i64>) step(%[[S_C1]] : tensor<i64>) iter_args(%[[S_WARMUP]]#0, %[[S_WARMUP]]#1, %[[S_WARMUP]]#2, %[[S_WARMUP]]#3, %{{.+}}, %{{.+}} : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1xi1>) -> tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1xi1> {
+// CHECK-NEXT: %[[S_SLOOP:.+]]:7 = impulse.for(%[[S_C0]] : tensor<i64>) to(%[[S_C1]] : tensor<i64>) step(%[[S_C1]] : tensor<i64>) iter_args(%[[S_WARMUP]]#0, %[[S_WARMUP]]#1, %[[S_WARMUP]]#2, %[[S_WARMUP]]#3, %{{.+}}, %{{.+}}, %{{.+}} : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>) -> tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64> {
 // CHECK: impulse.while
-// CHECK: return %[[S_SLOOP]]#4, %[[S_SLOOP]]#5, %[[S_SLOOP]]#3 : tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>
+// CHECK: return %[[S_SLOOP]]#4, %[[S_SLOOP]]#5, %[[S_SLOOP]]#6, %[[S_SLOOP]]#3 : tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
 // CHECK-NEXT: }
 
 // ============================================================
@@ -373,7 +379,7 @@ module {
 // 16 iter_args: same layout as warmup_both but step size unchanged
 // ============================================================
 // CHECK-LABEL: func.func @warmup_mass_only
-// CHECK-SAME: (%{{.+}}: tensor<2xui64>, %{{.+}}: tensor<f64>, %{{.+}}: tensor<f64>) -> (tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>)
+// CHECK-SAME: (%{{.+}}: tensor<2xui64>, %{{.+}}: tensor<f64>, %{{.+}}: tensor<f64>) -> (tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>)
 //
 // CHECK-DAG: %[[M_SHRINK:.+]] = arith.constant dense<5.000000e-03> : tensor<f64>
 // CHECK-DAG: %[[M_FMAX:.+]] = arith.constant dense<1.7976931348623157E+308> : tensor<f64>
@@ -459,11 +465,11 @@ module {
 // CHECK-NEXT: }
 //
 // --- Post-warmup sampling with adapted mass matrix ---
-// CHECK-NEXT: %[[M_SLOOP:.+]]:6 = impulse.for(%[[M_C0]] : tensor<i64>) to(%[[M_C1]] : tensor<i64>) step(%[[M_C1]] : tensor<i64>) iter_args(%[[M_WARMUP]]#0, %[[M_WARMUP]]#1, %[[M_WARMUP]]#2, %[[M_WARMUP]]#3, %{{.+}}, %{{.+}} : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1xi1>) -> tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1xi1> {
+// CHECK-NEXT: %[[M_SLOOP:.+]]:7 = impulse.for(%[[M_C0]] : tensor<i64>) to(%[[M_C1]] : tensor<i64>) step(%[[M_C1]] : tensor<i64>) iter_args(%[[M_WARMUP]]#0, %[[M_WARMUP]]#1, %[[M_WARMUP]]#2, %[[M_WARMUP]]#3, %{{.+}}, %{{.+}}, %{{.+}} : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>) -> tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64> {
 // CHECK: impulse.dot %{{.+}}, %[[M_WARMUP]]#6
 // CHECK-NEXT: %{{.+}} = impulse.dot %{{.+}}, %[[M_WARMUP]]#5
 // CHECK: impulse.while
-// CHECK: return %[[M_SLOOP]]#4, %[[M_SLOOP]]#5, %[[M_SLOOP]]#3 : tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>
+// CHECK: return %[[M_SLOOP]]#4, %[[M_SLOOP]]#5, %[[M_SLOOP]]#6, %[[M_SLOOP]]#3 : tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
 // CHECK-NEXT: }
 
 // ============================================================
@@ -471,7 +477,7 @@ module {
 // 13 iter_args, trivial impulse.if (both branches identical)
 // ============================================================
 // CHECK-LABEL: func.func @warmup_none
-// CHECK-SAME: (%{{.+}}: tensor<2xui64>, %{{.+}}: tensor<f64>, %{{.+}}: tensor<f64>) -> (tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>)
+// CHECK-SAME: (%{{.+}}: tensor<2xui64>, %{{.+}}: tensor<f64>, %{{.+}}: tensor<f64>) -> (tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>)
 //
 // CHECK-DAG: %[[N_FMAX:.+]] = arith.constant dense<1.7976931348623157E+308> : tensor<f64>
 // CHECK-DAG: %[[N_FMIN:.+]] = arith.constant dense<4.940660e-324> : tensor<f64>
@@ -534,7 +540,7 @@ module {
 // CHECK-NEXT: }
 //
 // --- Post-warmup sampling ---
-// CHECK-NEXT: %[[N_SLOOP:.+]]:6 = impulse.for(%[[N_C0]] : tensor<i64>) to(%[[N_C1]] : tensor<i64>) step(%[[N_C1]] : tensor<i64>) iter_args(%[[N_WARMUP]]#0, %[[N_WARMUP]]#1, %[[N_WARMUP]]#2, %[[N_WARMUP]]#3, %{{.+}}, %{{.+}} : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1xi1>) -> tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1xi1> {
+// CHECK-NEXT: %[[N_SLOOP:.+]]:7 = impulse.for(%[[N_C0]] : tensor<i64>) to(%[[N_C1]] : tensor<i64>) step(%[[N_C1]] : tensor<i64>) iter_args(%[[N_WARMUP]]#0, %[[N_WARMUP]]#1, %[[N_WARMUP]]#2, %[[N_WARMUP]]#3, %{{.+}}, %{{.+}}, %{{.+}} : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>) -> tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64> {
 // CHECK: impulse.while
-// CHECK: return %[[N_SLOOP]]#4, %[[N_SLOOP]]#5, %[[N_SLOOP]]#3 : tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>
+// CHECK: return %[[N_SLOOP]]#4, %[[N_SLOOP]]#5, %[[N_SLOOP]]#6, %[[N_SLOOP]]#3 : tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
 // CHECK-NEXT: }

--- a/enzyme/test/MLIR/Impulse/mcmc_warmup_resumable.mlir
+++ b/enzyme/test/MLIR/Impulse/mcmc_warmup_resumable.mlir
@@ -13,14 +13,14 @@ module {
       -> (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<i64>, tensor<f64>, tensor<1xf64>, tensor<1xf64>, tensor<i64>, tensor<i64>) {
     %init_trace = arith.constant dense<[[0.0]]> : tensor<1x1xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:17 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
+    %res:18 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
       step_size = %step_size
       { nuts_config = #impulse.nuts_config<max_tree_depth = 5>,
         name = "expose_both", selection = [[#impulse.symbol<1>]], all_addresses = [[#impulse.symbol<1>]], num_warmup = 4, num_samples = 1 }
       : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>)
-        -> (tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>,
+        -> (tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>,
             tensor<f64>, tensor<f64>, tensor<f64>, tensor<i64>, tensor<f64>, tensor<1xf64>, tensor<1xf64>, tensor<i64>, tensor<i64>)
-    return %res#2, %res#8, %res#9, %res#10, %res#11, %res#12, %res#13, %res#14, %res#15, %res#16
+    return %res#3, %res#9, %res#10, %res#11, %res#12, %res#13, %res#14, %res#15, %res#16, %res#17
       : tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<i64>, tensor<f64>, tensor<1xf64>, tensor<1xf64>, tensor<i64>, tensor<i64>
   }
 
@@ -31,7 +31,7 @@ module {
       -> (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<i64>, tensor<f64>, tensor<1xf64>, tensor<1xf64>, tensor<i64>, tensor<i64>) {
     %init_trace = arith.constant dense<[[0.0]]> : tensor<1x1xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:17 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
+    %res:18 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
       step_size = %step_size
       warmup_offset = %off
       adaptation_state_in = %da0, %da1, %da2, %da3, %da4, %wm, %wm2, %wn, %widx
@@ -41,16 +41,16 @@ module {
       : (tensor<2xui64>, tensor<f64>, tensor<f64>,
          tensor<f64>, tensor<f64>, tensor<f64>, tensor<i64>, tensor<f64>, tensor<1xf64>, tensor<1xf64>, tensor<i64>, tensor<i64>,
          tensor<1x1xf64>, tensor<f64>, tensor<i64>)
-        -> (tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>,
+        -> (tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>,
             tensor<f64>, tensor<f64>, tensor<f64>, tensor<i64>, tensor<f64>, tensor<1xf64>, tensor<1xf64>, tensor<i64>, tensor<i64>)
-    return %res#2, %res#8, %res#9, %res#10, %res#11, %res#12, %res#13, %res#14, %res#15, %res#16
+    return %res#3, %res#9, %res#10, %res#11, %res#12, %res#13, %res#14, %res#15, %res#16, %res#17
       : tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<i64>, tensor<f64>, tensor<1xf64>, tensor<1xf64>, tensor<i64>, tensor<i64>
   }
 }
 
 // CHECK-LABEL: func.func @expose_both
 // CHECK: %[[WU:.+]]:16 = impulse.for
-// CHECK: %[[SAMP:.+]]:6 = impulse.for(%{{.+}} : tensor<i64>) to(%{{.+}} : tensor<i64>) step(%{{.+}} : tensor<i64>) iter_args(%[[WU]]#0, %[[WU]]#1, %[[WU]]#2, %[[WU]]#3,
+// CHECK: %[[SAMP:.+]]:7 = impulse.for(%{{.+}} : tensor<i64>) to(%{{.+}} : tensor<i64>) step(%{{.+}} : tensor<i64>) iter_args(%[[WU]]#0, %[[WU]]#1, %[[WU]]#2, %[[WU]]#3,
 // CHECK: return %[[SAMP]]#3, %[[WU]]#7, %[[WU]]#8, %[[WU]]#9, %[[WU]]#10, %[[WU]]#11, %[[WU]]#12, %[[WU]]#13, %[[WU]]#14, %[[WU]]#15 : tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<i64>, tensor<f64>, tensor<1xf64>, tensor<1xf64>, tensor<i64>, tensor<i64>
 
 // CHECK-LABEL: func.func @resume_offset

--- a/enzyme/test/MLIR/Impulse/nuts_kernel.mlir
+++ b/enzyme/test/MLIR/Impulse/nuts_kernel.mlir
@@ -9,20 +9,20 @@ module {
     return %s#0, %s#1 : tensor<2xui64>, tensor<f64>
   }
 
-  func.func @nuts(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>) {
+  func.func @nuts(%rng : tensor<2xui64>, %mean : tensor<f64>, %stddev : tensor<f64>) -> (tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>) {
     %init_trace = arith.constant dense<[[0.0]]> : tensor<1x1xf64>
     %step_size = arith.constant dense<0.1> : tensor<f64>
-    %res:8 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
+    %res:9 = impulse.infer @test(%rng, %mean, %stddev) given %init_trace
       step_size = %step_size
       { nuts_config = #impulse.nuts_config<max_tree_depth = 3, max_delta_energy = 1000.0, adapt_step_size = false, adapt_mass_matrix = false>,
         name = "nuts", selection = [[#impulse.symbol<1>]], all_addresses = [[#impulse.symbol<1>]], num_warmup = 0, num_samples = 1 }
-      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
-    return %res#0, %res#1, %res#2 : tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>
+      : (tensor<2xui64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>, tensor<f64>) -> (tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<1x1xf64>)
+    return %res#0, %res#1, %res#2, %res#3 : tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
   }
 }
 
 // CHECK-LABEL: func.func @nuts
-// CHECK-SAME: (%[[RNG:.+]]: tensor<2xui64>, %[[MEAN:.+]]: tensor<f64>, %[[STDDEV:.+]]: tensor<f64>) -> (tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>)
+// CHECK-SAME: (%[[RNG:.+]]: tensor<2xui64>, %[[MEAN:.+]]: tensor<f64>, %[[STDDEV:.+]]: tensor<f64>) -> (tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>)
 // CHECK-DAG: %[[CKPT_INIT:.+]] = arith.constant dense<0.000000e+00> : tensor<3x1xf64>
 // CHECK-DAG: %[[C3:.+]] = arith.constant dense<3> : tensor<i64>
 // CHECK-DAG: %[[TRUE:.+]] = arith.constant dense<true> : tensor<i1>
@@ -30,6 +30,8 @@ module {
 // CHECK-DAG: %[[HALF:.+]] = arith.constant dense<5.000000e-01> : tensor<f64>
 // CHECK-DAG: %[[ZERO_F:.+]] = arith.constant dense<0.000000e+00> : tensor<f64>
 // CHECK-DAG: %[[C1:.+]] = arith.constant dense<1> : tensor<i64>
+// CHECK-DAG: %[[INIT_LOGDENS:.+]] = arith.constant dense<0.000000e+00> : tensor<1xf64>
+// CHECK-DAG: %[[INIT_DIAG:.+]] = arith.constant dense<true> : tensor<1x2xi1>
 // CHECK-DAG: %[[ONE:.+]] = arith.constant dense<1.000000e+00> : tensor<f64>
 // CHECK-DAG: %[[C0:.+]] = arith.constant dense<0> : tensor<i64>
 // CHECK-DAG: %[[INIT_TRACE:.+]] = arith.constant dense<0.000000e+00> : tensor<1x1xf64>
@@ -48,10 +50,10 @@ module {
 // CHECK: } attributes {activity = [#enzyme<activity enzyme_active>], ret_activity = [#enzyme<activity enzyme_active>, #enzyme<activity enzyme_const>]}
 //
 // --- Sampling loop ---
-// CHECK: %[[SLOOP:.+]]:6 = impulse.for(%[[C0]] : tensor<i64>) to(%[[C1]] : tensor<i64>)
-// CHECK-SAME: iter_args(%{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %[[INIT_TRACE]], %{{.+}} : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1xi1>)
-// CHECK-SAME: -> tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1xi1>
-// CHECK: ^bb0(%[[S_ITER:.+]]: tensor<i64>, %[[S_Q:.+]]: tensor<1x1xf64>, %[[S_GRAD:.+]]: tensor<1x1xf64>, %{{.+}}: tensor<f64>, %{{.+}}: tensor<2xui64>, %{{.+}}: tensor<1x1xf64>, %{{.+}}: tensor<1xi1>):
+// CHECK: %[[SLOOP:.+]]:7 = impulse.for(%[[C0]] : tensor<i64>) to(%[[C1]] : tensor<i64>)
+// CHECK-SAME: iter_args(%{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %[[INIT_TRACE]], %[[INIT_DIAG]], %[[INIT_LOGDENS]] : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>)
+// CHECK-SAME: -> tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>
+// CHECK: ^bb0(%[[S_ITER:.+]]: tensor<i64>, %[[S_Q:.+]]: tensor<1x1xf64>, %[[S_GRAD:.+]]: tensor<1x1xf64>, %{{.+}}: tensor<f64>, %{{.+}}: tensor<2xui64>, %{{.+}}: tensor<1x1xf64>, %{{.+}}: tensor<1x2xi1>, %{{.+}}: tensor<1xf64>):
 //
 // --- Momentum sampling ---
 // CHECK: impulse.random {{.*}} {rng_distribution = #impulse<rng_distribution NORMAL>} : (tensor<2xui64>, tensor<f64>, tensor<f64>) -> (tensor<2xui64>, tensor<1x1xf64>)
@@ -173,15 +175,24 @@ module {
 // CHECK: impulse.yield {{.*}} : tensor<1x1xf64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<f64>, tensor<i64>, tensor<f64>, tensor<i1>, tensor<i1>, tensor<f64>, tensor<i64>, tensor<1x1xf64>, tensor<2xui64>
 // CHECK: }
 //
-// --- Store sample ---
+// --- Store sample and diagnostics ---
 // CHECK: arith.cmpi sge, %[[S_ITER]], %[[C0]]
 // CHECK: impulse.dynamic_update_slice {{.*}} : (tensor<1x1xf64>, tensor<1x1xf64>, tensor<i64>, tensor<i64>) -> tensor<1x1xf64>
 // CHECK: impulse.select
+// CHECK: impulse.reshape {{.*}} : (tensor<i1>) -> tensor<1x1xi1>
+// CHECK: impulse.reshape {{.*}} : (tensor<i1>) -> tensor<1x1xi1>
+// CHECK: impulse.dynamic_update_slice {{.*}} : (tensor<1x2xi1>, tensor<1x1xi1>, tensor<i64>, tensor<i64>) -> tensor<1x2xi1>
+// CHECK: impulse.dynamic_update_slice {{.*}} : (tensor<1x2xi1>, tensor<1x1xi1>, tensor<i64>, tensor<i64>) -> tensor<1x2xi1>
+// CHECK: impulse.select {{.*}} : (tensor<i1>, tensor<1x2xi1>, tensor<1x2xi1>)
+// CHECK: arith.negf {{.*}} : tensor<f64>
+// CHECK: impulse.reshape {{.*}} : (tensor<f64>) -> tensor<1xf64>
+// CHECK: impulse.dynamic_update_slice {{.*}} : (tensor<1xf64>, tensor<1xf64>, tensor<i64>) -> tensor<1xf64>
+// CHECK: impulse.select {{.*}} : (tensor<i1>, tensor<1xf64>, tensor<1xf64>)
 //
 // --- Sampling loop yield ---
-// CHECK: impulse.yield %[[TREE]]#6, %[[TREE]]#7, %[[TREE]]#8, {{.*}} : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1xi1>
+// CHECK: impulse.yield %[[TREE]]#6, %[[TREE]]#7, %[[TREE]]#8, {{.*}} : tensor<1x1xf64>, tensor<1x1xf64>, tensor<f64>, tensor<2xui64>, tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>
 // CHECK: }
-// CHECK: return %[[SLOOP]]#4, %[[SLOOP]]#5, %[[SLOOP]]#3 : tensor<1x1xf64>, tensor<1xi1>, tensor<2xui64>
+// CHECK: return %[[SLOOP]]#4, %[[SLOOP]]#5, %[[SLOOP]]#6, %[[SLOOP]]#3 : tensor<1x1xf64>, tensor<1x2xi1>, tensor<1xf64>, tensor<2xui64>
 // CHECK: }
 //
 // --- Generated function: test.generate ---


### PR DESCRIPTION
Currently `infer` only returns a single diagnostic, a boolean which indicates whether or not the transition was accepted. Naturally, it's often useful to have more info :)
Right now (some of) this info is already calculated but is thrown away. This PR is a pretty mechanical way of surfacing that. The `diagnostics` tensor is expanded to include a second column which indicates whether the transition is divergent, plus a separate new tensor containing the logdensities is returned.
This is a bit ugly and not incredibly generalisable, but since it's quite closely tied to the sampling algorithm and `infer` only admits two algorithms, I think it's fine for now. My feeling is that properly generalising diagnostics only really makes sense in the context of broader programmable inference APIs.
This ofc needs changes in Reactant as well which I'll push separately. I have tested this locally end to end and it all works as intendeds