### PR TITLE
Fix vectorized MLIR derivative constants

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/MathDerivatives.td
+++ b/enzyme/Enzyme/MLIR/Implementations/MathDerivatives.td
@@ -22,7 +22,7 @@ def : MLIRDerivative<"math", "SqrtOp", (Op $x),
                   >;
 def : MLIRDerivative<"math", "AtanOp", (Op $x),
                     [
-                      (CheckedMulF (DiffeRet), (DivF (ConstantFP<"1.0","arith","ConstantOp"> $x):$one, (AddF (MulF $x, $x), $one)))
+                      (CheckedMulF (DiffeRet), (DivF (ConstantFP<"1.0","arith","ConstantOp">):$one, (AddF (MulF $x, $x), $one)))
                     ]
                   >;
 def : MLIRDerivative<"math", "AbsFOp", (Op $x),

--- a/enzyme/test/MLIR/ForwardMode/batched_derivative_constant.mlir
+++ b/enzyme/test/MLIR/ForwardMode/batched_derivative_constant.mlir
@@ -1,0 +1,20 @@
+// RUN: %eopt --enzyme %s | FileCheck %s
+
+// Regression for a width-forward derivative with an operand-less floating
+// constant. The constant participates in the tangent expression and must use
+// the width-stacked shadow type.
+module {
+  func.func @atan(%x: tensor<4xf32>) -> tensor<4xf32> {
+    %0 = math.atan %x : tensor<4xf32>
+    return %0 : tensor<4xf32>
+  }
+
+  func.func @main(%x: tensor<4xf32>, %dx: tensor<2x4xf32>) -> tensor<2x4xf32> {
+    %0 = enzyme.fwddiff @atan(%x, %dx) {activity = [#enzyme<activity enzyme_dup>], ret_activity = [#enzyme<activity enzyme_dupnoneed>], width = 2 : i64} : (tensor<4xf32>, tensor<2x4xf32>) -> tensor<2x4xf32>
+    return %0 : tensor<2x4xf32>
+  }
+}
+
+// CHECK-LABEL: func.func private @fwddiffe2atan
+// CHECK: arith.constant dense<1.000000e+00> : tensor<2x4xf32>
+// CHECK: arith.divf

--- a/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
+++ b/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
@@ -608,6 +608,7 @@ bool handle(const Twine &curIndent, const Twine &argPattern, raw_ostream &os,
         PrintFatalError(pattern->getLoc(), Twine("'value' not defined in ") +
                                                resultTree->getAsString());
 
+      bool vectorizedConstant = false;
       if (intrinsic == MLIRDerivatives) {
         if (resultRoot->getNumArgs() > 1)
           PrintFatalError(pattern->getLoc(),
@@ -621,8 +622,8 @@ bool handle(const Twine &curIndent, const Twine &argPattern, raw_ostream &os,
           ord = "gutils->getShadowType(op->getResult(0)";
           // This constant participates in a tangent expression.  In vector
           // forward mode, the tangent has a leading width dimension even when
-          // the primal result does not.  Use the shadow type so a constant
-          // such as `1 - tanh(x)^2` composes with width-vectorized operands.
+          // the primal result does not.  Use the shadow type to preserve the
+          // tangent shape.
           shadowType = true;
         } else {
           if (resultRoot->getArgName(0)) {
@@ -670,6 +671,7 @@ bool handle(const Twine &curIndent, const Twine &argPattern, raw_ostream &os,
           os << ")";
         os << ", ";
         os << "\"" << value->getValue() << "\"))";
+        vectorizedConstant = shadowType;
       } else {
         if (resultRoot->getNumArgs() != 1)
           PrintFatalError(pattern->getLoc(),
@@ -700,7 +702,7 @@ bool handle(const Twine &curIndent, const Twine &argPattern, raw_ostream &os,
                               resultTree->getAsString());
         os << ", \"" << value->getValue() << "\")";
       }
-      return false;
+      return vectorizedConstant;
     } else if (opName == "Zero" || Def->isSubClassOf("Zero")) {
       if (resultRoot->getNumArgs() != 1)
         PrintFatalError(pattern->getLoc(), "only single op Zero supported");

--- a/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
+++ b/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
@@ -618,7 +618,12 @@ bool handle(const Twine &curIndent, const Twine &argPattern, raw_ostream &os,
         std::string ord;
         bool shadowType = false;
         if (resultRoot->getNumArgs() == 0) {
-          ord = "op->getResult(0)";
+          ord = "gutils->getShadowType(op->getResult(0)";
+          // This constant participates in a tangent expression.  In vector
+          // forward mode, the tangent has a leading width dimension even when
+          // the primal result does not.  Use the shadow type so a constant
+          // such as `1 - tanh(x)^2` composes with width-vectorized operands.
+          shadowType = true;
         } else {
           if (resultRoot->getArgName(0)) {
             auto name = resultRoot->getArgName(0)->getAsUnquotedString();


### PR DESCRIPTION
Fixes #2961.

## Change

Zero-operand floating constants emitted into derivative expressions now use the derivative shadow type. The generator also propagates that the produced value is already vectorized, preventing the generic vectorization path from broadcasting it a second time.

An equivalent native derivative rule now uses the operand-less representation, so the core MLIR test suite directly exercises this code path.

## Regression

`test/MLIR/ForwardMode/batched_derivative_constant.mlir` fails against this PR's parent while constructing `arith.addf(tensor<2x4xf32>, tensor<4xf32>)`. With this change, it verifies that the generated `1` has type `tensor<2x4xf32>`.

## Invariant

A generated zero-operand derivative constant must have the same shadow type and vectorization state as the tangent expression it participates in.

This replaces the closed [#2955](https://github.com/EnzymeAD/Enzyme/pull/2955).