### PR TITLE
[Flang] [MLIR] Compiler plugin for Enzyme

### DIFF
--- a/.github/workflows/enzyme-mlir-flang.yml
+++ b/.github/workflows/enzyme-mlir-flang.yml
@@ -92,6 +92,7 @@ jobs:
       run: |
         mkdir flang-build && cd flang-build && cmake ../llvm -GNinja -DLLVM_ENABLE_PROJECTS="llvm;clang;mlir;flang" -DCMAKE_BUILD_TYPE=${{ matrix.llbuild }} \
         -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_TARGETS_TO_BUILD=X86 \
+        -DFLANG_PLUGIN_SUPPORT=ON \
         -DLLVM_USE_LINKER=gold -DLLVM_PARALLEL_LINK_JOBS=2 \
         -DCLANG_ENABLE_STATIC_ANALYZER=OFF -DCLANG_ENABLE_ARCMT=OFF \
         -DLLVM_OPTIMIZED_TABLEGEN=ON && ninja || echo "already built"

--- a/.github/workflows/enzyme-mlir-flang.yml
+++ b/.github/workflows/enzyme-mlir-flang.yml
@@ -1,0 +1,118 @@
+name: MLIR Flang
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+  merge_group:
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  build-linux:
+    name: MLIR Flang ${{ matrix.build }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build: ["Release", "Debug"]
+        llbuild: ["Release"]
+        os: [linux-x86-n2-32]
+
+    timeout-minutes: 500
+
+    container:
+      image: ${{ (contains(matrix.os, 'linux') && 'ghcr.io/enzymead/reactant-docker-images@sha256:91e1edb7a7c869d5a70db06e417f22907be0e67ca86641d48adcea221fedc674' ) || '' }}
+
+    steps:
+    - name: Install dependencies
+      run: |
+          apt-get update
+          apt-get install -y binutils ninja-build cmake gcc g++ python3 python3-dev
+
+    - uses: actions/checkout@v4
+      with:
+        path: 'Enzyme'
+
+    # The FlangEnzymeMLIR plugin needs the HLFIR-to-FIR pass pipeline extension
+    # points, which are not in any released LLVM and currently only live on this
+    # branch. Swap back to llvm/llvm-project at a pinned commit, as the MLIR
+    # workflow does, once they are upstream.
+    - uses: actions/checkout@v4
+      with:
+        repository: 'vchuravy/llvm-project'
+        ref: 'flang-hlfir-pass-pipeline-ep'
+        path: 'llvm-project'
+
+    - name: Set BASE_DIR
+      # We have to use `${GITHUB_WORKSPACE}` instead of `github.workspace` because GitHub
+      # is terrible and the two don't match inside containers:
+      # https://github.com/actions/runner/issues/2058
+      run: |
+        BASE_DIR=${GITHUB_WORKSPACE}
+        # Make sure this directory exists, for good measure
+        ls -lhrt "${BASE_DIR}"/Enzyme
+        ls -lhrt "${BASE_DIR}"/llvm-project
+        echo "BASE_DIR=${BASE_DIR}" >> ${GITHUB_ENV}
+
+    - name: Report runner resources
+      # A cold llvm;clang;mlir;flang build is the heaviest thing this repo builds.
+      # Recorded in its own step so the numbers survive even if the build step's
+      # runner is killed and its log never gets uploaded.
+      run: |
+        nproc
+        free -g
+        df -h "${BASE_DIR}"
+
+    - name: Get MLIR/Flang commit hash
+      id: mlir-commit
+      working-directory: 'llvm-project'
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+    - name: Cache MLIR/Flang
+      id: cache-mlir
+      uses: wsmoses/gcp-cache@main
+      with:
+        path: ${{ env.BASE_DIR }}/llvm-project/flang-build
+        key: ${{ matrix.llbuild }}-${{ matrix.os }}-flang-${{ steps.mlir-commit.outputs.sha_short }}
+        gcp-bucket: enzyme-ci-transient
+        gcp-prefix: enzyme-mlir-flang/
+
+    - name: MLIR/Flang build
+      if: steps.cache-mlir.outputs.cache-hit != 'true'
+      working-directory: ${{ env.BASE_DIR }}/'llvm-project'
+      run: |
+        mkdir flang-build && cd flang-build && cmake ../llvm -GNinja -DLLVM_ENABLE_PROJECTS="llvm;clang;mlir;flang" -DCMAKE_BUILD_TYPE=${{ matrix.llbuild }} \
+        -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_TARGETS_TO_BUILD=X86 \
+        -DLLVM_USE_LINKER=gold -DLLVM_PARALLEL_LINK_JOBS=2 \
+        -DCLANG_ENABLE_STATIC_ANALYZER=OFF -DCLANG_ENABLE_ARCMT=OFF \
+        -DLLVM_OPTIMIZED_TABLEGEN=ON && ninja || echo "already built"
+
+    # Passing the build root as LLVM_DIR lets Enzyme pick up MLIR and llvm-lit
+    # out of the build tree, as the MLIR workflow does. Clang_DIR/Flang_DIR have
+    # to be spelled out: ENZYME_FLANG_MLIR find_package()s both by config.
+    - name: Enzyme build
+      working-directory: ${{ env.BASE_DIR }}/'Enzyme'
+      run: |
+          mkdir enzyme-build && cd enzyme-build
+          cmake ../enzyme -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
+            -DLLVM_DIR=${{ env.BASE_DIR }}/llvm-project/flang-build \
+            -DClang_DIR=${{ env.BASE_DIR }}/llvm-project/flang-build/lib/cmake/clang \
+            -DFlang_DIR=${{ env.BASE_DIR }}/llvm-project/flang-build/lib/cmake/flang \
+            -DENZYME_MLIR=ON -DENZYME_FLANG_MLIR=ON -DENZYME_FORTRAN=ON \
+            -DCMAKE_Fortran_COMPILER=${{ env.BASE_DIR }}/llvm-project/flang-build/bin/flang
+          ninja
+
+    # Only the FIR/HLFIR suite: the rest of check-enzymemlir has failures on LLVM
+    # trunk unrelated to the Fortran path this workflow covers.
+    - name: Check enzyme-mlir-flang
+      working-directory: 'Enzyme/enzyme-build'
+      run: ninja check-enzymemlir-fir

--- a/enzyme/CMakeLists.txt
+++ b/enzyme/CMakeLists.txt
@@ -236,6 +236,21 @@ else()
     set(MLIR_FOUND 0)
 endif()
 message("found MLIR ${MLIR_FOUND}")
+
+# Flang is discovered the same way as Clang: FlangConfig.cmake exports the
+# FIR/HLFIR dialect targets and sets FLANG_INCLUDE_DIRS, which the FIR/HLFIR
+# autodiff layer (ENZYME_FLANG_MLIR) needs. It references MLIR imported targets, so
+# it must come after the MLIR find_package above or Flang_FOUND ends up FALSE.
+if (DEFINED Flang_DIR)
+    find_package(Flang CONFIG PATHS ${Flang_DIR} NO_DEFAULT_PATH)
+if (${Flang_FOUND})
+    include_directories(${FLANG_INCLUDE_DIRS})
+    message("flang inc dir ${FLANG_INCLUDE_DIRS}")
+endif()
+else()
+    set(Flang_FOUND 0)
+endif()
+message("found Flang ${Flang_FOUND}")
 # include(AddClang)
 
 add_definitions(${LLVM_DEFINITIONS})

--- a/enzyme/Enzyme/MLIR/CMakeLists.txt
+++ b/enzyme/Enzyme/MLIR/CMakeLists.txt
@@ -1,5 +1,15 @@
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
+# Resolve Flang up front, so Implementations/ can define the flang-dependent
+# library conditionally. FlangConfig references clang targets, so import Clang
+# first (pass -DFlang_DIR=<llvm-build>/lib/cmake/flang and likewise -DClang_DIR).
+option(ENZYME_FLANG_MLIR "Build the Flang-dependent FIR/HLFIR autodiff layer (needs Flang)" OFF)
+if (ENZYME_FLANG_MLIR)
+  find_package(Clang REQUIRED CONFIG)
+  find_package(Flang REQUIRED CONFIG)
+endif()
+
 add_subdirectory(Analysis)
 add_subdirectory(Dialect)
 add_subdirectory(Interfaces)
@@ -21,7 +31,7 @@ set(LIBS
         MLIROptLib
 	MLIRFuncInlinerExtension
         )
-add_llvm_executable(enzymemlir-opt enzymemlir-opt.cpp)
+add_llvm_executable(enzymemlir-opt enzymemlir-opt.cpp PARTIAL_SOURCES_INTENDED)
 
 install(TARGETS enzymemlir-opt
     EXPORT EnzymeTargets
@@ -30,3 +40,58 @@ COMPONENT enzymemlir-opt)
 
 llvm_update_compile_flags(enzymemlir-opt)
 target_link_libraries(enzymemlir-opt PRIVATE ${LIBS})
+
+# FIREnzyme: Enzyme-MLIR as a dialect+pass plugin for any MlirOptMain-based tool,
+# notably Flang's fir-opt. See enzyme-fir-plugin.cpp. It bundles the
+# flang-dependent HLFIR layer, which only exists once ENZYME_FLANG_MLIR is on and
+# Flang was found.
+option(ENZYME_FIR_PLUGIN "Build the FIREnzyme fir-opt/MLIR plugin" ON)
+if (ENZYME_FIR_PLUGIN AND TARGET MLIREnzymeHLFIRImplementations)
+  add_llvm_library(FIREnzyme-${LLVM_VERSION_MAJOR}
+    MODULE
+    enzyme-fir-plugin.cpp
+    PARTIAL_SOURCES_INTENDED
+    DISABLE_LLVM_LINK_LLVM_DYLIB
+    )
+  llvm_update_compile_flags(FIREnzyme-${LLVM_VERSION_MAJOR})
+  add_dependencies(FIREnzyme-${LLVM_VERSION_MAJOR}
+    MLIREnzymeHLFIRImplementations
+    MLIREnzymeImplementations
+    MLIREnzymeTransforms
+    MLIREnzymeAnalysis
+    MLIRLLVMExt
+    MLIRImpulse
+    MLIREnzyme
+    MLIREnzymeAutoDiffInterface)
+  # Bundle only the Enzyme archives (plus the upstream dialects fir-opt does not
+  # carry, see below) and leave every other MLIR/FIR/LLVM symbol undefined, to be
+  # resolved from the host fir-opt at load. Bundling ${dialect_libs} instead drags
+  # in a second copy of the llvm::cl::opt globals and aborts with "registered more
+  # than once".
+  target_link_libraries(FIREnzyme-${LLVM_VERSION_MAJOR} PRIVATE
+    -Wl,--start-group
+    # The flang-dependent HLFIR layer; its FIR/HLFIR/flang symbols stay
+    # undefined and resolve from the host.
+    $<TARGET_FILE:MLIREnzymeHLFIRImplementations>
+    $<TARGET_FILE:MLIREnzymeImplementations>
+    $<TARGET_FILE:MLIREnzymeTransforms>
+    $<TARGET_FILE:MLIREnzymeAnalysis>
+    # Enzyme's own dialects (referenced by the models/passes above).
+    $<TARGET_FILE:MLIRLLVMExt>
+    $<TARGET_FILE:MLIRImpulse>
+    $<TARGET_FILE:MLIREnzyme>
+    $<TARGET_FILE:MLIREnzymeAutoDiffInterface>
+    # Two dialects fir-opt does not register: Tensor, needed by the tensor
+    # autodiff model, and Linalg, because Transforms/Utils.cpp builds
+    # linalg.generic ops whatever models are registered. Bundled by file, so
+    # their own MLIR deps resolve from the host. (fir-opt does provide affine.)
+    $<TARGET_FILE:MLIRTensorDialect>
+    $<TARGET_FILE:MLIRLinalgDialect>
+    $<TARGET_FILE:MLIRLinalgTransforms>
+    -Wl,--end-group)
+  target_link_options(FIREnzyme-${LLVM_VERSION_MAJOR} PRIVATE
+    -Wl,--allow-shlib-undefined)
+  install(TARGETS FIREnzyme-${LLVM_VERSION_MAJOR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT FIREnzyme)
+endif()

--- a/enzyme/Enzyme/MLIR/Implementations/CMakeLists.txt
+++ b/enzyme/Enzyme/MLIR/Implementations/CMakeLists.txt
@@ -68,6 +68,7 @@ add_mlir_library(MLIREnzymeImplementations
   MathAutoDiffOpInterfaceImpl.cpp
   GPUAutoDiffOpInterfaceImpl.cpp
   EnzymeAutoDiffOpInterfaceImpl.cpp
+  PARTIAL_SOURCES_INTENDED
 
   DEPENDS
   MLIRAutoDiffOpInterfaceIncGen
@@ -98,3 +99,74 @@ add_mlir_library(MLIREnzymeImplementations
   MLIRSCFDialect
   MLIRLinalgDialect
 )
+
+# The Flang-dependent Fortran plumbing: the shared Fortran autodiff registration
+# and the `enzyme-lower-fortran-calls` pass (f__enzyme_* hook calls -> enzyme.*
+# ops, see HLFIREnzymeCallLowering.cpp). Behind ENZYME_FLANG_MLIR so the core
+# Enzyme-MLIR build never gains a Flang dependency. Bundled into the FIREnzyme
+# and FlangEnzymeMLIR plugins.
+if (ENZYME_FLANG_MLIR)
+  add_mlir_library(MLIREnzymeHLFIRImplementations
+    HLFIREnzymeCallLowering.cpp
+    EnzymeFortranAutoDiffRegistration.cpp
+    PARTIAL_SOURCES_INTENDED
+
+    DEPENDS
+    MLIRAutoDiffOpInterfaceIncGen
+    MLIREnzymeEnumsIncGen
+
+    LINK_LIBS PUBLIC
+    MLIREnzymeImplementations
+    MLIREnzymeAutoDiffInterface
+    HLFIRDialect
+    FIRBuilder
+    MLIRIR
+  )
+  target_include_directories(MLIREnzymeHLFIRImplementations PRIVATE ${FLANG_INCLUDE_DIRS})
+
+  # FlangEnzymeMLIR: a -load'able plugin for `flang -fc1` whose static
+  # initializer registers the Enzyme HLFIR passes into flang's codegen pipeline
+  # via fir::registerPassPipelineConfigCallback. See
+  # HLFIRFlangPluginRegistration.cpp.
+  add_llvm_library(FlangEnzymeMLIR-${LLVM_VERSION_MAJOR}
+    MODULE
+    HLFIRFlangPluginRegistration.cpp
+    PARTIAL_SOURCES_INTENDED
+    DISABLE_LLVM_LINK_LLVM_DYLIB
+  )
+  add_dependencies(FlangEnzymeMLIR-${LLVM_VERSION_MAJOR}
+    MLIREnzymeHLFIRImplementations
+    MLIREnzymeTransforms
+    MLIREnzymeImplementations
+    MLIREnzymeAnalysis
+    MLIRLLVMExt
+    MLIREnzyme
+    MLIREnzymeAutoDiffInterface)
+  target_include_directories(FlangEnzymeMLIR-${LLVM_VERSION_MAJOR} PRIVATE
+    ${FLANG_INCLUDE_DIRS})
+  # Bundle only the Enzyme archives (by file); MLIR/FIR/HLFIR/flang symbols are
+  # left undefined and resolve from the host `flang -fc1` at load, so no second
+  # copy of LLVM is pulled in. They reference one another, hence the
+  # --start-group. The plugin registers autodiff models per dialect rather than
+  # via registerCoreDialectAutodiffInterfaces, so the Linalg/NVVM models -- whose
+  # dialect symbols flang does not export -- are never linked in.
+  target_link_libraries(FlangEnzymeMLIR-${LLVM_VERSION_MAJOR} PRIVATE
+    -Wl,--start-group
+    $<TARGET_FILE:MLIREnzymeHLFIRImplementations>
+    $<TARGET_FILE:MLIREnzymeTransforms>
+    $<TARGET_FILE:MLIREnzymeImplementations>
+    $<TARGET_FILE:MLIREnzymeAnalysis>
+    # Enzyme's own llvm_ext dialect (referenced by the LLVM autodiff model).
+    $<TARGET_FILE:MLIRLLVMExt>
+    $<TARGET_FILE:MLIREnzyme>
+    $<TARGET_FILE:MLIREnzymeAutoDiffInterface>
+    # Tensor is the one upstream dialect the plugin cannot count on the host for
+    # (whether `flang -fc1` carries it depends on how it was configured), and the
+    # tensor autodiff model needs its TypeID and op classes. Where the host does
+    # export them they preempt the bundled copy, so there is a single instance
+    # either way.
+    $<TARGET_FILE:MLIRTensorDialect>
+    -Wl,--end-group)
+  target_link_options(FlangEnzymeMLIR-${LLVM_VERSION_MAJOR} PRIVATE
+    -Wl,--allow-shlib-undefined)
+endif()

--- a/enzyme/Enzyme/MLIR/Implementations/EnzymeFortranAutoDiffRegistration.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/EnzymeFortranAutoDiffRegistration.cpp
@@ -1,0 +1,49 @@
+//===- EnzymeFortranAutoDiffRegistration.cpp - shared Fortran registration ===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Shared registration of the Enzyme dialect + the autodiff interface external
+// models the `enzyme` differentiation pass needs to differentiate Fortran, i.e.
+// HLFIR/FIR plus the upstream dialects flang lowers to (arith, math, complex,
+// cf, scf, tensor, func, LLVM). Both delivery vehicles reuse this one entry
+// point so they register exactly the same set:
+//
+//   * the fir-opt MLIR plugin  -- enzyme-fir-plugin.cpp
+//   * the flang -fc1 -load one -- HLFIRFlangPluginRegistration.cpp
+//
+// It is deliberately a *subset* of registerCoreDialectAutodiffInterfaces: the
+// Linalg, NVVM and Affine models are omitted because Fortran HLFIR never
+// produces those ops at this stage and -- crucially for the lean plugins --
+// neither `flang -fc1` nor `fir-opt` registers those dialects, so their symbols
+// are not exported for the plugin to resolve against. The MemRef model is
+// likewise omitted: Fortran lowers to !fir.ref, not memref, and MemRef's
+// zeroInPlace pulls in linalg.fill (a Linalg symbol the host does not export).
+//
+//===----------------------------------------------------------------------===//
+
+#include "Implementations/CoreDialectsAutoDiffImplementations.h"
+#include "Implementations/HLFIRAutoDiffOpInterfaceImpl.h"
+
+#include "Dialect/Dialect.h"
+
+#include "mlir/IR/DialectRegistry.h"
+
+using namespace mlir;
+
+void mlir::enzyme::registerEnzymeFortranInterfaces(DialectRegistry &registry) {
+  registry.insert<mlir::enzyme::EnzymeDialect>();
+  registerArithDialectAutoDiffInterface(registry);
+  registerBuiltinDialectAutoDiffInterface(registry);
+  registerComplexDialectAutoDiffInterface(registry);
+  registerLLVMDialectAutoDiffInterface(registry);
+  registerMathDialectAutoDiffInterface(registry);
+  registerSCFDialectAutoDiffInterface(registry);
+  registerCFDialectAutoDiffInterface(registry);
+  registerFuncDialectAutoDiffInterface(registry);
+  registerTensorDialectAutoDiffInterface(registry);
+  registerEnzymeDialectAutoDiffInterface(registry);
+}

--- a/enzyme/Enzyme/MLIR/Implementations/HLFIRAutoDiffOpInterfaceImpl.h
+++ b/enzyme/Enzyme/MLIR/Implementations/HLFIRAutoDiffOpInterfaceImpl.h
@@ -1,0 +1,49 @@
+//===- HLFIRAutoDiffOpInterfaceImpl.h - Flang registration -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Registration entry points for the Flang-dependent Enzyme plumbing. These live
+// in a separate, Flang-dependent library so the core Enzyme-MLIR build does not
+// gain a Flang dependency; it is bundled only into the Enzyme fir-opt/flang
+// plugins (FIREnzyme, FlangEnzymeMLIR), which resolve HLFIR from the host. This
+// foundational layer declares the shared Fortran registration and the call-
+// lowering pass; the FIR/HLFIR autodiff registration entry points are declared
+// alongside their implementations in the later autodiff layers. See
+// PLAN_flang_enzyme_mlir.md.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ENZYME_MLIR_IMPLEMENTATIONS_HLFIRAUTODIFFOPINTERFACEIMPL_H
+#define ENZYME_MLIR_IMPLEMENTATIONS_HLFIRAUTODIFFOPINTERFACEIMPL_H
+
+#include <memory>
+
+namespace mlir {
+class DialectRegistry;
+class Pass;
+namespace enzyme {
+// Registers the Enzyme dialect and the subset of autodiff interface external
+// models needed to differentiate Fortran (HLFIR/FIR) code, into `registry`.
+// Shared by both delivery vehicles -- the fir-opt MLIR plugin
+// (enzyme-fir-plugin.cpp) and the flang -fc1 -load plugin
+// (HLFIRFlangPluginRegistration.cpp) -- so they register exactly the same set.
+// A deliberate subset of registerCoreDialectAutodiffInterfaces (see
+// EnzymeFortranAutoDiffRegistration.cpp for why Linalg/NVVM/Affine are
+// omitted).
+void registerEnzymeFortranInterfaces(DialectRegistry &registry);
+
+// A pass that rewrites Fortran differentiation-hook calls
+// (fir.call @...f__enzyme_fwddiff / f__enzyme_autodiff) into enzyme.fwddiff /
+// enzyme.autodiff ops, parsing enzyme_{const,dup,dupnoneed,out} activity
+// markers. Mirrors HandleAutoDiff/getMetadataName in Enzyme.cpp (the LLVM
+// path).
+std::unique_ptr<Pass> createHLFIRLowerEnzymeCallsPass();
+void registerHLFIRLowerEnzymeCallsPass();
+} // namespace enzyme
+} // namespace mlir
+
+#endif // ENZYME_MLIR_IMPLEMENTATIONS_HLFIRAUTODIFFOPINTERFACEIMPL_H

--- a/enzyme/Enzyme/MLIR/Implementations/HLFIREnzymeCallLowering.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/HLFIREnzymeCallLowering.cpp
@@ -1,0 +1,196 @@
+//===- HLFIREnzymeCallLowering.cpp - Fortran hook calls -> enzyme ops -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Rewrites Fortran Enzyme differentiation-hook calls into first-class enzyme
+// ops, at the HLFIR stage (while hlfir.* intrinsics are still present):
+//
+//   %f  = fir.address_of(@_QPmm) : ...
+//   %bp = fir.emboxproc %f : ... -> !fir.boxproc<() -> ()>
+//   %r  = fir.call @_QPf__enzyme_fwddiff(%bp, enzyme_dup, %x, %dx, ...) : ...
+//     ==>
+//   %r  = enzyme.fwddiff @_QPmm(%x, %dx, ...)
+//           {activity = [#enzyme<activity enzyme_dup>, ...],
+//            ret_activity = [#enzyme<activity enzyme_dupnoneed>]} : (...) -> T
+//
+// The callee is recovered by tracing the boxproc operand back to its
+// fir.address_of. Activity markers (enzyme_const / enzyme_dup /
+// enzyme_dupnoneed / enzyme_out) are the C-bound globals from
+// enzyme/Fortran/enzyme.f90; an operand addressing one sets the activity of the
+// following argument, as HandleAutoDiff does for the LLVM __enzyme_* path.
+// enzyme_dup and enzyme_dupnoneed consume a (primal, shadow) pair.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Implementations/HLFIRAutoDiffOpInterfaceImpl.h"
+
+#include "Dialect/Dialect.h"
+#include "Dialect/Ops.h"
+
+#include "flang/Optimizer/Dialect/FIROps.h"
+#include "flang/Optimizer/HLFIR/HLFIROps.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+
+#include "llvm/ADT/StringRef.h"
+
+#include <optional>
+
+using namespace mlir;
+
+namespace {
+
+// Trace a value back to the global symbol it addresses, peeling the ops Flang
+// puts between the fir.address_of and the use.
+static llvm::StringRef traceSymbolName(Value v) {
+  while (v) {
+    Operation *def = v.getDefiningOp();
+    if (!def)
+      return {};
+    if (auto d = dyn_cast<hlfir::DeclareOp>(def)) {
+      v = d.getMemref();
+      continue;
+    }
+    if (auto e = dyn_cast<fir::EmboxProcOp>(def)) {
+      v = e.getFunc();
+      continue;
+    }
+    if (auto c = dyn_cast<fir::ConvertOp>(def)) {
+      v = c.getValue();
+      continue;
+    }
+    if (auto l = dyn_cast<fir::LoadOp>(def)) {
+      v = l.getMemref();
+      continue;
+    }
+    if (auto a = dyn_cast<fir::AddrOfOp>(def))
+      return a.getSymbolAttr().getLeafReference().getValue();
+    return {};
+  }
+  return {};
+}
+
+// If `name` is an activity marker global, return the activity it denotes.
+static std::optional<enzyme::Activity> markerActivity(llvm::StringRef name) {
+  if (name == "enzyme_const")
+    return enzyme::Activity::enzyme_const;
+  if (name == "enzyme_dup")
+    return enzyme::Activity::enzyme_dup;
+  if (name == "enzyme_dupnoneed")
+    return enzyme::Activity::enzyme_dupnoneed;
+  if (name == "enzyme_out")
+    return enzyme::Activity::enzyme_active;
+  return std::nullopt;
+}
+
+static bool activityHasShadow(enzyme::Activity a) {
+  return a == enzyme::Activity::enzyme_dup ||
+         a == enzyme::Activity::enzyme_dupnoneed;
+}
+
+// Rewrite one fir.call to a differentiation hook. Returns failure only for a
+// malformed call; a call that is not a hook is left alone.
+static LogicalResult lowerEnzymeCall(fir::CallOp call) {
+  auto callee = call.getCallee();
+  if (!callee)
+    return success(); // indirect call, not a hook
+  llvm::StringRef cn = callee->getLeafReference().getValue();
+  bool fwd = cn.contains("enzyme_fwddiff");
+  bool rev = cn.contains("enzyme_autodiff");
+  if (!fwd && !rev)
+    return success();
+
+  auto args = call.getArgs();
+  if (args.empty())
+    return call.emitError("enzyme differentiation hook call has no callee "
+                          "operand");
+
+  llvm::StringRef target = traceSymbolName(args[0]);
+  if (target.empty())
+    return call.emitError(
+        "could not resolve the function being differentiated (expected a "
+        "fir.emboxproc of a fir.address_of)");
+
+  MLIRContext *ctx = call.getContext();
+  OpBuilder b(call);
+
+  // Walk the arguments, honoring activity markers. The default is enzyme_dup,
+  // matching the LLVM path.
+  SmallVector<Value> inputs;
+  SmallVector<Attribute> activity;
+  for (size_t i = 1, n = args.size(); i < n;) {
+    enzyme::Activity ty = enzyme::Activity::enzyme_dup;
+    if (auto m = markerActivity(traceSymbolName(args[i]))) {
+      ty = *m;
+      if (++i >= n)
+        return call.emitError("activity marker is not followed by an argument");
+    }
+    inputs.push_back(args[i++]); // primal
+    if (activityHasShadow(ty)) {
+      if (i >= n)
+        return call.emitError("enzyme_dup argument is missing its shadow");
+      inputs.push_back(args[i++]); // shadow
+    }
+    activity.push_back(enzyme::ActivityAttr::get(ctx, ty));
+  }
+
+  // Forward returns the tangent (dupnoneed); reverse seeds an active result.
+  SmallVector<Attribute> retActivity;
+  for ([[maybe_unused]] Type rt : call.getResultTypes())
+    retActivity.push_back(
+        enzyme::ActivityAttr::get(ctx, fwd ? enzyme::Activity::enzyme_dupnoneed
+                                           : enzyme::Activity::enzyme_active));
+
+  Operation *newOp;
+  if (fwd)
+    newOp = enzyme::ForwardDiffOp::create(
+        b, call.getLoc(), call.getResultTypes(), target, inputs,
+        b.getArrayAttr(activity), b.getArrayAttr(retActivity));
+  else
+    newOp = enzyme::AutoDiffOp::create(b, call.getLoc(), call.getResultTypes(),
+                                       target, inputs, b.getArrayAttr(activity),
+                                       b.getArrayAttr(retActivity));
+
+  call.replaceAllUsesWith(newOp->getResults());
+  call.erase();
+  return success();
+}
+
+struct HLFIRLowerEnzymeCallsPass
+    : public PassWrapper<HLFIRLowerEnzymeCallsPass, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(HLFIRLowerEnzymeCallsPass)
+
+  StringRef getArgument() const final { return "enzyme-lower-fortran-calls"; }
+  StringRef getDescription() const final {
+    return "Rewrite Fortran f__enzyme_fwddiff/f__enzyme_autodiff calls into "
+           "enzyme.fwddiff/enzyme.autodiff ops";
+  }
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<enzyme::EnzymeDialect>();
+  }
+
+  void runOnOperation() override {
+    SmallVector<fir::CallOp> calls;
+    getOperation().walk([&](fir::CallOp call) { calls.push_back(call); });
+    for (fir::CallOp call : calls)
+      if (failed(lowerEnzymeCall(call)))
+        return signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::enzyme::createHLFIRLowerEnzymeCallsPass() {
+  return std::make_unique<HLFIRLowerEnzymeCallsPass>();
+}
+
+void mlir::enzyme::registerHLFIRLowerEnzymeCallsPass() {
+  PassRegistration<HLFIRLowerEnzymeCallsPass>();
+}

--- a/enzyme/Enzyme/MLIR/Implementations/HLFIRFlangPluginRegistration.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/HLFIRFlangPluginRegistration.cpp
@@ -1,0 +1,64 @@
+//===- HLFIRFlangPluginRegistration.cpp - flang -load bridge --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// When this object is loaded into `flang -fc1` via -load, the static
+// initializer below registers a callback with flang
+// (fir::registerPassPipelineConfigCallback) that uses the HLFIROptEarly
+// extension point to add two passes to flang's HLFIR-to-FIR pipeline, while the
+// hlfir.* intrinsics are still present:
+//
+//   1. enzyme-lower-fortran-calls: f__enzyme_fwddiff/autodiff -> enzyme.* ops.
+//   2. enzyme: differentiate those ops in place.
+//
+// Only the Enzyme code is carried here; MLIR/FIR/HLFIR and flang symbols
+// resolve from the host at load time.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Implementations/HLFIRAutoDiffOpInterfaceImpl.h"
+#include "Passes/Passes.h"
+
+#include "flang/Optimizer/Passes/Pipelines.h"
+#include "flang/Tools/CrossToolHelpers.h"
+
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Pass/PassManager.h"
+
+#include "llvm/Support/CommandLine.h"
+
+using namespace mlir;
+
+namespace {
+
+// Attach the Enzyme dialect and the Fortran autodiff models to the flang-owned
+// context. flang has already loaded FIR/HLFIR/func/... into it, so appending
+// the registry applies their extensions immediately and defers the rest.
+void appendEnzymeFortranInterfaces(MLIRContext &context) {
+  DialectRegistry registry;
+  mlir::enzyme::registerEnzymeFortranInterfaces(registry);
+  context.appendDialectRegistry(registry);
+  context.loadDialect<mlir::enzyme::EnzymeDialect>();
+}
+
+struct EnzymeFlangPipelineRegistration {
+  EnzymeFlangPipelineRegistration() {
+    fir::registerPassPipelineConfigCallback(
+        [](MLIRToLLVMPassPipelineConfig &config) {
+          config.registerHLFIROptEarlyEPCallbacks(
+              [](mlir::PassManager &pm, llvm::OptimizationLevel) {
+                appendEnzymeFortranInterfaces(*pm.getContext());
+                pm.addPass(mlir::enzyme::createHLFIRLowerEnzymeCallsPass());
+                pm.addPass(mlir::enzyme::createDifferentiatePass());
+              });
+        });
+  }
+};
+// Runs when `flang -fc1 -load` dlopens this object.
+static EnzymeFlangPipelineRegistration enzymeFlangPipelineRegistration;
+} // namespace

--- a/enzyme/Enzyme/MLIR/enzyme-fir-plugin.cpp
+++ b/enzyme/Enzyme/MLIR/enzyme-fir-plugin.cpp
@@ -1,0 +1,50 @@
+//===- enzyme-fir-plugin.cpp - Enzyme as an MLIR plugin for fir-opt -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Enzyme-MLIR as a dialect+pass plugin for any `MlirOptMain`-based tool, in
+// particular Flang's stock `fir-opt`, which needs no changes to load it:
+//
+//   flang -fc1 -emit-hlfir foo.f90 -o foo.hlfir
+//   fir-opt --load-dialect-plugin=FIREnzyme.so \
+//           --load-pass-plugin=FIREnzyme.so \
+//           --pass-pipeline='builtin.module(enzyme)' \
+//           foo.hlfir -o foo.diff.hlfir
+//
+// Both plugin entry points live in this one file, so a single FIREnzyme.so
+// serves --load-dialect-plugin and --load-pass-plugin. fir-opt registers the
+// FIR/HLFIR dialects itself, so it parses the module and the Enzyme pass
+// loaded here differentiates it.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/Tools/Plugins/DialectPlugin.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+
+#include "llvm/Config/llvm-config.h"
+
+#include "Implementations/HLFIRAutoDiffOpInterfaceImpl.h"
+#include "Passes/Passes.h"
+
+using namespace mlir;
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::mlir::DialectPluginLibraryInfo
+mlirGetDialectPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, "Enzyme", LLVM_VERSION_STRING,
+          [](DialectRegistry *registry) {
+            mlir::enzyme::registerEnzymeFortranInterfaces(*registry);
+          }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return {MLIR_PLUGIN_API_VERSION, "Enzyme", LLVM_VERSION_STRING, []() {
+            mlir::enzyme::registerenzymePasses();
+            mlir::enzyme::registerHLFIRLowerEnzymeCallsPass();
+          }};
+}

--- a/enzyme/test/MLIR/CMakeLists.txt
+++ b/enzyme/test/MLIR/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(OptimizeAD)
 add_subdirectory(Passes)
 add_subdirectory(Impulse)
 add_subdirectory(ReverseMode)
+add_subdirectory(FIR)
 
 # Run regression and unit tests
 add_lit_testsuite(check-enzymemlir "Running MLIR regression tests"

--- a/enzyme/test/MLIR/FIR/CMakeLists.txt
+++ b/enzyme/test/MLIR/FIR/CMakeLists.txt
@@ -1,0 +1,26 @@
+# These tests are driven by the plugins rather than by enzymemlir-opt, and lit
+# gates them on the fir_enzyme_plugin / flang_enzyme_mlir / enzyme_module
+# features, so they simply do not run unless the corresponding targets were
+# built. Depend on whichever exist in this configuration.
+set(ENZYME_FIR_TEST_DEPS)
+if (TARGET FIREnzyme-${LLVM_VERSION_MAJOR})
+    list(APPEND ENZYME_FIR_TEST_DEPS FIREnzyme-${LLVM_VERSION_MAJOR})
+endif()
+if (TARGET FlangEnzymeMLIR-${LLVM_VERSION_MAJOR})
+    list(APPEND ENZYME_FIR_TEST_DEPS FlangEnzymeMLIR-${LLVM_VERSION_MAJOR})
+endif()
+# EnzymeFortran (ENZYME_FORTRAN) compiles enzyme.mod, which the tests that
+# `use enzyme` include from the module directory.
+if (TARGET EnzymeFortran)
+    list(APPEND ENZYME_FIR_TEST_DEPS EnzymeFortran)
+endif()
+
+# A testsuite of its own so CI can run just the Fortran path without the rest of
+# check-enzymemlir.
+add_lit_testsuite(check-enzymemlir-fir "Running MLIR FIR/HLFIR tests"
+    ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${ENZYME_FIR_TEST_DEPS}
+    ARGS -v
+)
+
+set_target_properties(check-enzymemlir-fir PROPERTIES FOLDER "Tests")

--- a/enzyme/test/MLIR/FIR/flang_plugin_load.f90
+++ b/enzyme/test/MLIR/FIR/flang_plugin_load.f90
@@ -1,0 +1,18 @@
+! Loading FlangEnzymeMLIR into `flang -fc1` registers the Enzyme passes into
+! flang's own HLFIR-to-FIR pipeline. Code with no differentiation hook must come
+! through that pipeline unchanged, which is what exercises the registration
+! itself: the plugin loads, the extension point fires, and both added passes run
+! as no-ops.
+!
+! REQUIRES: flang_enzyme_mlir
+! RUN: %flang_enzyme -emit-fir %s -o - | FileCheck %s
+
+subroutine scale(x, r)
+  real, intent(in)  :: x
+  real, intent(out) :: r
+  r = x * 2.0
+end subroutine
+
+! CHECK-LABEL: func.func @_QPscale
+! CHECK: arith.mulf
+! CHECK-NOT: enzyme.

--- a/enzyme/test/MLIR/FIR/lower_fortran_calls.f90
+++ b/enzyme/test/MLIR/FIR/lower_fortran_calls.f90
@@ -1,0 +1,37 @@
+! The enzyme-lower-fortran-calls pass rewrites a Fortran hook call into an
+! enzyme.fwddiff op at the HLFIR stage: the callee is recovered from the
+! fir.emboxproc/fir.address_of, and the activity markers select per-argument
+! activity (enzyme_dup pairs the primal with its shadow, enzyme_const takes the
+! primal alone).
+!
+! Differentiating the resulting op needs the FIR autodiff models, so this stops
+! at the lowering; the end-to-end runs live with those models.
+!
+! REQUIRES: fir_enzyme_plugin
+! RUN: %flang_fc1 -emit-hlfir %s -o - | %fir_enzyme --pass-pipeline='builtin.module(enzyme-lower-fortran-calls)' | FileCheck %s
+
+module marks
+  integer, bind(C, name="enzyme_dup")   :: enzyme_dup
+  integer, bind(C, name="enzyme_const") :: enzyme_const
+end module
+
+real function square(x, y)
+  real, intent(in) :: x, y
+  square = x * x + y
+end function
+
+subroutine driver(x, dx, y, r)
+  use marks
+  real, intent(in)  :: x, dx, y
+  real, intent(out) :: r
+  real, external    :: square
+  real, external    :: f__enzyme_fwddiff
+  r = f__enzyme_fwddiff(square, enzyme_dup, x, dx, enzyme_const, y)
+end subroutine
+
+! CHECK-LABEL: func.func @_QPdriver
+! x active (dup, with shadow dx), y inactive (const); markers are dropped.
+! CHECK: enzyme.fwddiff @_QPsquare(
+! CHECK-SAME: activity = [#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_const>]
+! CHECK-SAME: ret_activity = [#enzyme<activity enzyme_dupnoneed>]
+! CHECK-NOT: fir.call @_QPf__enzyme_fwddiff

--- a/enzyme/test/lit.site.cfg.py.in
+++ b/enzyme/test/lit.site.cfg.py.in
@@ -66,6 +66,23 @@ if len("@ENZYME_BINARY_DIR@") == 0:
   eclang += "-I " + os.path.dirname(os.path.abspath(__file__)) + "/Integration" 
 
 config.substitutions.append(('%eopt', emopt))
+
+# %fir_enzyme runs Flang's stock fir-opt with the FIREnzyme plugin loaded in both
+# its dialect and pass roles.
+fir_opt = config.llvm_tools_dir + "/fir-opt"
+fir_enzyme_plugin = config.enzyme_obj_root + "/Enzyme/MLIR/FIREnzyme-" + config.llvm_ver + config.llvm_shlib_ext
+if len("@ENZYME_BINARY_DIR@") == 0:
+  fir_enzyme_plugin = os.path.dirname(os.path.abspath(__file__)) + "/../FIREnzyme-" + config.llvm_ver + config.llvm_shlib_ext
+config.substitutions.append(('%fir_enzyme',
+  fir_opt + " --load-dialect-plugin=" + fir_enzyme_plugin +
+  " --load-pass-plugin=" + fir_enzyme_plugin))
+if os.path.exists(fir_opt) and os.path.exists(fir_enzyme_plugin):
+  config.available_features.add('fir_enzyme_plugin')
+
+# flang -fc1, for compiling Fortran to HLFIR.
+flang = config.llvm_tools_dir + "/flang"
+config.substitutions.append(('%flang_fc1', flang + " -fc1"))
+
 config.substitutions.append(('%llvmver', config.llvm_ver))
 config.substitutions.append(('%FileCheck', config.llvm_tools_dir + "/FileCheck"))
 config.substitutions.append(('%clang', eclang))
@@ -133,6 +150,31 @@ config.substitutions.append(('%loadFlangEnzyme',
                              + config.llvm_ver + config.llvm_shlib_ext))
 if "@ENZYME_FLANG_ENABLED@" == "1" and os.path.basename(config.fc).startswith("flang"):
     config.available_features.add('flangenzyme')
+
+# The FlangEnzymeMLIR plugin registers the Enzyme HLFIR passes into flang's own
+# codegen pipeline when loaded. %flang_enzyme is the frontend form
+# (`flang -fc1 -load`), %flang_enzyme_driver the driver form, which compiles and
+# links a whole executable. The flang_enzyme_mlir feature needs a flang carrying
+# the HLFIR-to-FIR pipeline extension points, which are in no released LLVM
+# (24+ only).
+# NB: %flang_enzyme_driver must be registered first -- lit substitutes in order,
+# and the shorter name would otherwise leave a stray "_driver" behind.
+flang_enzyme_plugin = '@ENZYME_BINARY_DIR@/Enzyme/MLIR/Implementations/FlangEnzymeMLIR-' + config.llvm_ver + config.llvm_shlib_ext
+if len("@ENZYME_BINARY_DIR@") == 0:
+  flang_enzyme_plugin = os.path.dirname(os.path.abspath(__file__)) + "/../Enzyme/MLIR/Implementations/FlangEnzymeMLIR-" + config.llvm_ver + config.llvm_shlib_ext
+config.substitutions.append(('%flang_enzyme_driver',
+  flang + " -Xflang -load -Xflang " + flang_enzyme_plugin))
+config.substitutions.append(('%flang_enzyme',
+  flang + " -fc1 -load " + flang_enzyme_plugin))
+if (int(config.llvm_ver) >= 24 and os.path.exists(flang)
+        and os.path.exists(flang_enzyme_plugin)):
+    config.available_features.add('flang_enzyme_mlir')
+
+# The Fortran interface (Fortran/enzyme.f90) is compiled by ENZYME_FORTRAN into
+# the module directory %loadFortran points at; enzyme_module gates the tests that
+# `use enzyme`.
+if os.path.exists('@ENZYME_BINARY_DIR@/modules/enzyme.mod'):
+    config.available_features.add('enzyme_module')
 
 # Let the main config do the real work.
 cfgfile = "@ENZYME_SOURCE_DIR@/test/lit.cfg.py"


### PR DESCRIPTION
## Requires a companion llvm-project branch

This needs Flang built from **`flang-hlfir-pass-pipeline-ep`** on https://github.com/vchuravy/llvm-project

- [x] https://github.com/llvm/llvm-project/pull/212152
- [ ] https://github.com/llvm/llvm-project/pull/212194
- [ ] https://github.com/llvm/llvm-project/pull/212195
- [ ] https://github.com/llvm/llvm-project/pull/212196

## Goal

`flang -fc1 -load FlangEnzymeMLIR-<v>.so -emit-fir foo.f90` 
