### PR TITLE
mlir: pass to split ifs with multi-results into separate ops

### DIFF
--- a/enzyme/Enzyme/MLIR/Passes/CMakeLists.txt
+++ b/enzyme/Enzyme/MLIR/Passes/CMakeLists.txt
@@ -20,6 +20,7 @@ add_mlir_dialect_library(MLIREnzymeTransforms
     PrintAliasAnalysis.cpp
     EnzymeToMemRef.cpp
     SimplifyMath.cpp
+    SplitMultiResults.cpp
     AddToOpToIndexAndLoad.cpp
     AddToOpToSplit.cpp
     RaiseLLVMExtPass.cpp

--- a/enzyme/Enzyme/MLIR/Passes/Passes.td
+++ b/enzyme/Enzyme/MLIR/Passes/Passes.td
@@ -173,6 +173,13 @@ def DifferentiateWrapperPass : Pass<"enzyme-wrap"> {
   ];
 }
 
+def SplitMultiResultsPass : Pass<"split-multi-results"> {
+  let summary = "Split region ops that yield multiple results into separate ops";
+  let dependentDialects = [
+    "scf::SCFDialect"
+  ];
+}
+
 def PrintActivityAnalysisPass : Pass<"print-activity-analysis"> {
   let summary = "Print the results of activity analysis";
   let dependentDialects = [

--- a/enzyme/Enzyme/MLIR/Passes/SplitMultiResults.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/SplitMultiResults.cpp
@@ -1,0 +1,115 @@
+//===- SplitMultiResults.cpp - Split multi-result region ops --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a pass that splits region control flow that produces
+// multiple results into separate operations for each result.
+//===----------------------------------------------------------------------===//
+
+#include "Passes/Passes.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace enzyme {
+#define GEN_PASS_DEF_SPLITMULTIRESULTSPASS
+#include "Passes/Passes.h.inc"
+} // namespace enzyme
+} // namespace mlir
+
+using namespace mlir;
+namespace {
+
+// Given a block terminator, determine if the terminator's operands are solely
+// computed by pure operations within the block.
+static bool allComputedByPureOps(Operation *terminator) {
+  Block *parent = terminator->getBlock();
+  DenseSet<Value> visited;
+  visited.insert_range(terminator->getOperands());
+  SmallVector<Value> frontier(terminator->getOperands());
+  while (!frontier.empty()) {
+    Value curr = frontier.pop_back_val();
+    Operation *definingOp = curr.getDefiningOp();
+    if (!definingOp || definingOp->getBlock() != parent)
+      continue;
+
+    if (!mlir::isPure(definingOp))
+      return false;
+
+    for (Value operand : definingOp->getOperands()) {
+      if (!visited.contains(operand)) {
+        visited.insert(operand);
+        frontier.push_back(operand);
+      }
+    }
+  }
+
+  return true;
+}
+struct SplitMultiIf : public mlir::OpRewritePattern<scf::IfOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(scf::IfOp ifOp,
+                                PatternRewriter &rewriter) const override {
+    if (ifOp.getNumResults() < 2)
+      return failure();
+    if (llvm::all_of(ifOp.getResults(),
+                     [](OpResult res) { return res.use_empty(); })) {
+      return failure();
+    }
+    // ignore nested ifs
+    if (llvm::any_of(ifOp.getRegions(), [](Region *region) {
+          return llvm::any_of(region->getOps(), [](Operation &op) {
+            return op.getNumRegions() != 0;
+          });
+        })) {
+      return failure();
+    }
+    // all operands should be computed by pure operations.
+    if (!(allComputedByPureOps(ifOp.thenYield()) &&
+          allComputedByPureOps(ifOp.elseYield()))) {
+      return failure();
+    }
+
+    for (OpResult ifRes : ifOp.getResults()) {
+      auto newIf = scf::IfOp::create(rewriter, ifOp.getLoc(), ifRes.getType(),
+                                     ifOp.getCondition(),
+                                     /*withElseRegion=*/true);
+      IRMapping map;
+      OpBuilder::InsertionGuard guard(rewriter);
+      for (auto [oldReg, newReg] :
+           llvm::zip(ifOp.getRegions(), newIf.getRegions())) {
+        for (auto &&[oldBlk, newBlk] : llvm::zip(*oldReg, *newReg)) {
+          rewriter.setInsertionPointToStart(&newBlk);
+          for (auto &op : oldBlk.without_terminator()) {
+            if (mlir::isPure(&op))
+              rewriter.clone(op, map);
+          }
+          scf::YieldOp::create(
+              rewriter, ifOp.getLoc(),
+              map.lookupOrDefault(
+                  oldBlk.getTerminator()->getOperand(ifRes.getResultNumber())));
+        }
+      }
+      rewriter.replaceAllUsesWith(ifRes, newIf.getResult(0));
+    }
+    return success();
+  }
+};
+
+struct SplitMultiResultsPass
+    : public enzyme::impl::SplitMultiResultsPassBase<SplitMultiResultsPass> {
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    patterns.insert<SplitMultiIf>(&getContext());
+
+    GreedyRewriteConfig config;
+    (void)applyPatternsGreedily(getOperation(), std::move(patterns), config);
+  }
+};
+} // namespace

--- a/enzyme/test/MLIR/Passes/multi-if.mlir
+++ b/enzyme/test/MLIR/Passes/multi-if.mlir
@@ -1,0 +1,36 @@
+// RUN: %eopt %s --split-multi-results --split-input-file | FileCheck %s
+
+func.func @multi_if(%cond: i1, %x: f64) -> (f64, f64) {
+  %res:2 = scf.if %cond -> (f64, f64) {
+    %cos = math.cos %x : f64
+    %tanh = math.tanh %x : f64
+    scf.yield %cos, %tanh : f64, f64
+  } else {
+    %sin = math.sin %x : f64
+    scf.yield %x, %sin : f64, f64
+  }
+  %mul = arith.mulf %res#0, %res#0 : f64
+  %add = arith.addf %res#1, %res#1 : f64
+  return %mul, %add : f64, f64
+}
+
+// CHECK-LABEL:   func.func @multi_if(
+// CHECK-SAME:      %[[ARG0:.*]]: i1,
+// CHECK-SAME:      %[[ARG1:.*]]: f64) -> (f64, f64) {
+// CHECK:           %[[IF_0:.*]] = scf.if %[[ARG0]] -> (f64) {
+// CHECK:             %[[COS_0:.*]] = math.cos %[[ARG1]] : f64
+// CHECK:             scf.yield %[[COS_0]] : f64
+// CHECK:           } else {
+// CHECK:             scf.yield %[[ARG1]] : f64
+// CHECK:           }
+// CHECK:           %[[IF_1:.*]] = scf.if %[[ARG0]] -> (f64) {
+// CHECK:             %[[TANH_0:.*]] = math.tanh %[[ARG1]] : f64
+// CHECK:             scf.yield %[[TANH_0]] : f64
+// CHECK:           } else {
+// CHECK:             %[[SIN_0:.*]] = math.sin %[[ARG1]] : f64
+// CHECK:             scf.yield %[[SIN_0]] : f64
+// CHECK:           }
+// CHECK:           %[[MULF_0:.*]] = arith.mulf %[[IF_0]], %[[IF_0]] : f64
+// CHECK:           %[[ADDF_0:.*]] = arith.addf %[[IF_1]], %[[IF_1]] : f64
+// CHECK:           return %[[MULF_0]], %[[ADDF_0]] : f64, f64
+// CHECK:         }


### PR DESCRIPTION
This pass splits `scf.if` ops that produce multiple results into separate ops that each produce one result. Currently, mincut assumes that the results of region cf ops like `scf.if` must be cached, which produces suboptimal results for a number of GPU benchmarks. This pass makes it easier to get mincut to re-compute the results of these ops, though the longer term solution would be to get mincut to properly support partially re-computing region ops. cc: @Pangoraw @ftynse