### PR TITLE
Prefer OptionalPassInfoMixin

### DIFF
--- a/enzyme/Enzyme/FixupJuliaCallingConvention.cpp
+++ b/enzyme/Enzyme/FixupJuliaCallingConvention.cpp
@@ -1617,7 +1617,7 @@ public:
 };
 
 class FixupBatchedJuliaCallingConventionNewPM
-#ifdef LLVM_VERSION_MAJOR >= 23
+#if LLVM_VERSION_MAJOR >= 23
     : public OptionalPassInfoMixin<FixupBatchedJuliaCallingConventionNewPM> {
 #else
     : public PassInfoMixin<FixupBatchedJuliaCallingConventionNewPM> {

--- a/enzyme/Enzyme/FixupJuliaCallingConvention.cpp
+++ b/enzyme/Enzyme/FixupJuliaCallingConvention.cpp
@@ -1589,7 +1589,11 @@ void EnzymeFixupBatchedJuliaCallingConvention(Function *F) {
 }
 
 class FixupJuliaCallingConventionNewPM
+#if LLVM_VERSION_MAJOR >= 23
     : public OptionalPassInfoMixin<FixupJuliaCallingConventionNewPM> {
+#else
+    : public PassInfoMixin<FixupJuliaCallingConventionNewPM> {
+#endif
   bool sret_jlvalue;
 
 public:
@@ -1613,7 +1617,11 @@ public:
 };
 
 class FixupBatchedJuliaCallingConventionNewPM
+#ifdef LLVM_VERSION_MAJOR >= 23
     : public OptionalPassInfoMixin<FixupBatchedJuliaCallingConventionNewPM> {
+#else
+    : public PassInfoMixin<FixupBatchedJuliaCallingConventionNewPM> {
+#endif
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM) {
     bool changed = false;

--- a/enzyme/Enzyme/FixupJuliaCallingConvention.cpp
+++ b/enzyme/Enzyme/FixupJuliaCallingConvention.cpp
@@ -1589,7 +1589,7 @@ void EnzymeFixupBatchedJuliaCallingConvention(Function *F) {
 }
 
 class FixupJuliaCallingConventionNewPM
-    : public PassInfoMixin<FixupJuliaCallingConventionNewPM> {
+    : public OptionalPassInfoMixin<FixupJuliaCallingConventionNewPM> {
   bool sret_jlvalue;
 
 public:
@@ -1613,7 +1613,7 @@ public:
 };
 
 class FixupBatchedJuliaCallingConventionNewPM
-    : public PassInfoMixin<FixupBatchedJuliaCallingConventionNewPM> {
+    : public OptionalPassInfoMixin<FixupBatchedJuliaCallingConventionNewPM> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM) {
     bool changed = false;


### PR DESCRIPTION
This became preferred in LLVM 23 and PassInfoMixin will be moving to a detail namespace in LLVM 24, which means compilation errors without this patch.