### PR TITLE
Disable enzyme lit test ci for macos debug

### DIFF
--- a/.github/workflows/enzyme-ci.yml
+++ b/.github/workflows/enzyme-ci.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         llvm: ["15", "16"]
-        build: ["Release", "Debug"] # "RelWithDebInfo"
+        build: ["Release"] # "RelWithDebInfo"
   
     timeout-minutes: 30 
     steps:


### PR DESCRIPTION
we test in release and have limited macos jobs