### PR TITLE
Fix reverse of gc preserve regions closed by several ends

### DIFF
--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -33,6 +33,30 @@ void (*EnzymeShadowAllocRewrite)(LLVMValueRef, void *, LLVMValueRef, uint64_t,
                                  LLVMValueRef, uint8_t) = nullptr;
 }
 
+/// Return the unique llvm.julia.gc_preserve_end closing the preserve region
+/// opened by \p Begin, or nullptr if there is not exactly one.
+///
+/// The reverse pass turns a preserve region inside out: it is opened at the
+/// reverse of the gc_preserve_end and closed at the reverse of the
+/// gc_preserve_begin. That is only expressible if a single end exists. A region
+/// may well have several ends -- LICM readily creates those by hoisting the
+/// preserve of a loop-invariant value out of a loop while duplicating the end
+/// onto every loop exit -- and each of them is a separate entry of the reversed
+/// region, so the re-created gc_preserve_end would have to consume a phi of the
+/// tokens produced at each of those entries. Tokens cannot be phi'd.
+static CallInst *getUniqueGCPreserveEnd(CallInst *Begin) {
+  CallInst *End = nullptr;
+  for (auto U : Begin->users()) {
+    auto CI = dyn_cast<CallInst>(U);
+    if (!CI || getFuncNameFromCall(CI) != "llvm.julia.gc_preserve_end")
+      continue;
+    if (End)
+      return nullptr;
+    End = CI;
+  }
+  return End;
+}
+
 void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
                                  llvm::StringRef funcName) {
   using namespace llvm;
@@ -2364,6 +2388,12 @@ bool AdjointGenerator::handleKnownCallDerivatives(
 
         auto begin_call = cast<CallInst>(call.getOperand(0));
 
+        // A region closed by several ends cannot be reversed by opening it
+        // here, and is instead conservatively handled at the reverse of the
+        // corresponding gc_preserve_begin.
+        if (getUniqueGCPreserveEnd(begin_call) != &call)
+          return true;
+
         IRBuilder<> Builder2(&call);
         getReverseBuilder(Builder2);
         SmallVector<Value *, 1> args;
@@ -2438,11 +2468,52 @@ bool AdjointGenerator::handleKnownCallDerivatives(
         auto ifound = gutils->invertedPointers.find(&call);
         assert(ifound != gutils->invertedPointers.end());
         auto placeholder = cast<CallInst>(&*ifound->second);
-        Builder2.CreateCall(
-            called->getParent()->getOrInsertFunction(
-                "llvm.julia.gc_preserve_end",
-                FunctionType::get(Builder2.getVoidTy(), call.getType(), false)),
-            placeholder);
+
+        auto end_fn = called->getParent()->getOrInsertFunction(
+            "llvm.julia.gc_preserve_end",
+            FunctionType::get(Builder2.getVoidTy(), call.getType(), false));
+
+        if (getUniqueGCPreserveEnd(&call)) {
+          // The region is opened at the reverse of that single end, which is
+          // the sole entry of the reversed region and thus dominates here.
+          Builder2.CreateCall(end_fn, placeholder);
+          return true;
+        }
+
+        // Without a single reverse entry to open the region at (see
+        // getUniqueGCPreserveEnd) emit an empty preserve region of the
+        // preserved values here instead. This is the last point of the
+        // reversed region, so needing the values here keeps them live -- and
+        // therefore rooted -- across all of the reverse code they guarded.
+        SmallVector<Value *, 1> reverse_args;
+        for (auto &arg : call.args()) {
+          bool primalUsed = false;
+          bool shadowUsed = false;
+          gutils->getReturnDiffeType(arg, &primalUsed, &shadowUsed);
+
+          if (primalUsed)
+            reverse_args.push_back(
+                gutils->lookupM(gutils->getNewFromOriginal(arg), Builder2));
+
+          if (!gutils->isConstantValue(arg) && shadowUsed) {
+            Value *ptrshadow = gutils->lookupM(
+                gutils->invertPointerM(arg, BuilderZ), Builder2);
+            if (gutils->getWidth() == 1)
+              reverse_args.push_back(ptrshadow);
+            else
+              for (size_t i = 0; i < gutils->getWidth(); ++i)
+                reverse_args.push_back(
+                    gutils->extractMeta(Builder2, ptrshadow, i));
+          }
+        }
+
+        auto revp = Builder2.CreateCall(called, reverse_args);
+        Builder2.CreateCall(end_fn, revp);
+
+        // The placeholder is unused: nothing opens the region at the reverse
+        // of an end anymore.
+        gutils->invertedPointers.erase(ifound);
+        gutils->erase(placeholder);
       }
       return true;
     }

--- a/enzyme/test/Enzyme/ReverseMode/gcpres_multiend.ll
+++ b/enzyme/test/Enzyme/ReverseMode/gcpres_multiend.ll
@@ -1,0 +1,70 @@
+; RUN: if [ %llvmver -ge 17 ]; then %opt < %s %newLoadEnzyme -enzyme-preopt=false -passes="enzyme" -S | FileCheck %s; fi
+
+; A gc preserve region may be closed by more than one gc_preserve_end -- LICM
+; hoisting the preserve of a loop invariant value out of a loop while
+; duplicating the end onto every loop exit produces exactly that. Such a region
+; cannot be reversed by opening it at the reverse of an end: every end is a
+; separate entry of the reversed region, so the re-created gc_preserve_end would
+; have to consume a phi of the tokens, and tokens cannot be phi'd. Check that a
+; self contained preserve is emitted at the reverse of the begin instead of a
+; token which does not dominate its use.
+
+declare token @llvm.julia.gc_preserve_begin(...)
+
+declare void @llvm.julia.gc_preserve_end(token)
+
+define void @f(ptr addrspace(10) %z, i1 %c) {
+entry:
+  %tok = call token (...) @llvm.julia.gc_preserve_begin(ptr addrspace(10) %z)
+  br i1 %c, label %then, label %else
+
+then:
+  store double 3.140000e+00, ptr addrspace(10) %z, align 8
+  call void @llvm.julia.gc_preserve_end(token %tok)
+  br label %exit
+
+else:
+  store double 2.710000e+00, ptr addrspace(10) %z, align 8
+  call void @llvm.julia.gc_preserve_end(token %tok)
+  br label %exit
+
+exit:
+  ret void
+}
+
+; Function Attrs: nounwind
+declare ptr @__enzyme_virtualreverse(...)
+
+define ptr @test() {
+entry:
+  %0 = call ptr (...) @__enzyme_virtualreverse(ptr @f)
+  ret ptr %0
+}
+
+; CHECK: define internal ptr @augmented_f(ptr addrspace(10) %z, ptr addrspace(10) %"z'", i1 %c)
+; CHECK: entry:
+; CHECK:   %[[augtok:.+]] = call token (...) @llvm.julia.gc_preserve_begin(ptr addrspace(10) %z, ptr addrspace(10) %"z'")
+; CHECK:   br i1 %c, label %then, label %else
+
+; CHECK: then:
+; CHECK:   store double 3.140000e+00, ptr addrspace(10) %z, align 8
+; CHECK:   call void @llvm.julia.gc_preserve_end(token %[[augtok]])
+
+; CHECK: else:
+; CHECK:   store double 2.710000e+00, ptr addrspace(10) %z, align 8
+; CHECK:   call void @llvm.julia.gc_preserve_end(token %[[augtok]])
+
+; CHECK: define internal void @diffef(ptr addrspace(10) %z, ptr addrspace(10) %"z'", i1 %c, ptr %tapeArg)
+
+; The reverse of the begin is the single exit of the reversed region, so the
+; preserve is opened and closed there rather than spanning it.
+; CHECK: invertentry:
+; CHECK-NEXT:   %[[revtok:.+]] = call token (...) @llvm.julia.gc_preserve_begin(ptr addrspace(10) %z, ptr addrspace(10) %"z'")
+; CHECK-NEXT:   call void @llvm.julia.gc_preserve_end(token %[[revtok]])
+; CHECK-NEXT:   ret void
+
+; CHECK: invertthen:
+; CHECK-NEXT:   store double 0.000000e+00, ptr addrspace(10) %"z'"
+
+; CHECK: invertelse:
+; CHECK-NEXT:   store double 0.000000e+00, ptr addrspace(10) %"z'"


### PR DESCRIPTION
Fixes https://github.com/EnzymeAD/Enzyme.jl/issues/3404.

### The problem

A julia gc preserve region may be closed by more than one `gc_preserve_end`. LICM produces exactly that whenever the preserved value is loop invariant: the `gc_preserve_begin` is hoisted out of the loop while the end is duplicated onto every loop exit. In the reported case (a `TensorKit.planartrace!` gradient) `FusionTreeDict{F,T}()` inlines to `Dict{K,V}()`, whose zero length `Memory` codegen constant folds to a global, and the `fill!` on it wraps that global in a preserve -- one begin against eight ends, with no `GC.@preserve` anywhere in the source.

Reverse mode turns a preserve region inside out: it opens the region at the reverse of the `gc_preserve_end` and closes it at the reverse of the `gc_preserve_begin`. That is only expressible when a single end exists. With several, every end is a separate *entry* of the reversed region, so each of them re-created a begin over the same placeholder and the last one visited won -- leaving a token that does not dominate the re-created end:

```
Instruction does not dominate all uses!
  %706 = call token (...) @llvm.julia.gc_preserve_begin(...)
  call void @llvm.julia.gc_preserve_end(token %706)
LLVM error: function failed verification (4)
```

### The fix

Tokens cannot be phi'd, so there is no token a multi entry reversed region could be closed with. When the begin does not have exactly one end, emit a self contained preserve of the preserved values at the reverse of the begin instead. That point is the single *exit* of the reversed region, so needing the values there keeps them live -- and therefore rooted -- across all of the reverse code they guarded. Regions with a single end are unaffected.

### Testing

- New `test/Enzyme/ReverseMode/gcpres_multiend.ll`; without the patch this aborts with the error above.
- Differential run of the whole `test/Enzyme/ReverseMode` suite (569 tests, LLVM 18) before and after: exactly one test changes state, the new one, FAIL to PASS. No regressions.
- The Enzyme.jl reproducer from EnzymeAD/Enzyme.jl#3404 now compiles. Its `test_reverse` goes from 0 passed / 1 errored (crash on the first configuration) to 133 finite difference checks passed, with one remaining unrelated `EnzymeNoDerivativeError` in `gemm` caused by the fallback BLAS on my machine.
- A package free reduction (one `Base.@_gc_preserve_begin`, two `Base.@_gc_preserve_end`) now differentiates and matches the analytic gradient.
- Full Enzyme.jl test suite against this build: 217907 passed, 59 broken, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)