### PR TITLE
Add execution-based numerical tests for MLIR lit tests

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
@@ -227,7 +227,10 @@ private:
     strides.push_back(b.getIndexAttr(1));
     for (int64_t i = 0, e = rowTy.getRank(); i < e; ++i) {
       offsets.push_back(b.getIndexAttr(0));
-      sizes.push_back(b.getIndexAttr(rowTy.getDimSize(i)));
+      if (rowTy.isDynamicDim(i))
+        sizes.push_back(memref::DimOp::create(b, loc, buf, i + 1).getResult());
+      else
+        sizes.push_back(b.getIndexAttr(rowTy.getDimSize(i)));
       strides.push_back(b.getIndexAttr(1));
     }
     auto resTy = memref::SubViewOp::inferRankReducedResultType(
@@ -254,7 +257,10 @@ private:
     if (auto mt = dyn_cast<MemRefType>(valTy)) {
       Value row = checkpointRow(b, loc, buf, slot, mt);
       SmallVector<Value> dynSizes;
-      Value fresh = memref::AllocOp::create(b, loc, mt);
+      for (int64_t i = 0, e = mt.getRank(); i < e; ++i)
+        if (mt.isDynamicDim(i))
+          dynSizes.push_back(memref::DimOp::create(b, loc, row, i));
+      Value fresh = memref::AllocOp::create(b, loc, mt, dynSizes);
       memref::CopyOp::create(b, loc, row, fresh);
       return fresh;
     }

--- a/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
@@ -1171,11 +1171,8 @@ public:
       Location loc = forOp.getInductionVar().getLoc();
       auto currentIV = arith::MulIOp::create(
           cacheBuilder, loc,
-          arith::AddIOp::create(
-              cacheBuilder, loc,
-              arith::MulIOp::create(cacheBuilder, loc,
-                                    outerFwd.getInductionVar(), nInnerCst),
-              innerFwd.getInductionVar()),
+          arith::AddIOp::create(cacheBuilder, loc, outerFwd.getInductionVar(),
+                                innerFwd.getInductionVar()),
           newForOp.getStep());
 
       for (auto [oldArg, newArg] :

--- a/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
@@ -193,6 +193,14 @@ private:
     return arith::DivUIOp::create(builder, loc, diff, step);
   }
 
+  static Value castToType(OpBuilder &builder, Location loc, Value v,
+                          Type targetType) {
+    if (v.getType() == targetType)
+      return v;
+    assert(targetType.isIndex());
+    return arith::IndexCastOp::create(builder, loc, targetType, v);
+  }
+
   static std::optional<int64_t> getCheckpointBudget(scf::ForOp forOp) {
     if (auto a = forOp->getAttrOfType<IntegerAttr>("enzyme.checkpoint_period"))
       return a.getInt();
@@ -204,7 +212,8 @@ private:
       SmallVector<int64_t> shape;
       shape.push_back(budget);
       shape.append(mt.getShape().begin(), mt.getShape().end());
-      return MemRefType::get(shape, mt.getElementType());
+      return MemRefType::get(shape, mt.getElementType(),
+                             MemRefLayoutAttrInterface{}, mt.getMemorySpace());
     }
     return MemRefType::get({budget}, t);
   }
@@ -218,7 +227,10 @@ private:
     strides.push_back(b.getIndexAttr(1));
     for (int64_t i = 0, e = rowTy.getRank(); i < e; ++i) {
       offsets.push_back(b.getIndexAttr(0));
-      sizes.push_back(b.getIndexAttr(rowTy.getDimSize(i)));
+      if (rowTy.isDynamicDim(i))
+        sizes.push_back(memref::DimOp::create(b, loc, buf, i + 1).getResult());
+      else
+        sizes.push_back(b.getIndexAttr(rowTy.getDimSize(i)));
       strides.push_back(b.getIndexAttr(1));
     }
     auto resTy = memref::SubViewOp::inferRankReducedResultType(
@@ -244,7 +256,11 @@ private:
                               Type valTy) {
     if (auto mt = dyn_cast<MemRefType>(valTy)) {
       Value row = checkpointRow(b, loc, buf, slot, mt);
-      Value fresh = memref::AllocOp::create(b, loc, mt);
+      SmallVector<Value> dynSizes;
+      for (int64_t i = 0, e = mt.getRank(); i < e; ++i)
+        if (mt.isDynamicDim(i))
+          dynSizes.push_back(memref::DimOp::create(b, loc, row, i));
+      Value fresh = memref::AllocOp::create(b, loc, mt, dynSizes);
       memref::CopyOp::create(b, loc, row, fresh);
       return fresh;
     }
@@ -280,6 +296,7 @@ private:
       startV = gutils->getNewFromOriginal(forOp.getLowerBound());
       stepV = gutils->getNewFromOriginal(forOp.getStep());
       numItersV = getNumIterationsValue(builder, loc, forOp, gutils);
+      numItersV = castToType(builder, loc, numItersV, idxTy);
     } else {
       int64_t numIters =
           ForOpEnzymeOpsRemover::getConstantNumberOfIterations(forOp).value();
@@ -302,7 +319,7 @@ private:
 
     SetVector<Value> outsideRefs;
     getUsedValuesDefinedAbove(forOp->getRegions(), outsideRefs);
-    SmallVector<Value> immutableRefs, mutableRefs;
+    SmallVector<Value> immutableRefs, mutableRefs, mutableRefsCaches;
     for (auto ref : outsideRefs) {
       if (isa<ClonableTypeInterface>(ref.getType()))
         mutableRefs.push_back(ref);
@@ -349,15 +366,26 @@ private:
     Value split = enzyme::BinomialProgressOp::create(builder, loc, idxTy,
                                                      numStepsRem, budgetRem);
 
+    for (auto ref : mutableRefs) {
+      auto iface = cast<ClonableTypeInterface>(ref.getType());
+      Value clone = iface.cloneValue(builder, mapping.lookupOrDefault(ref));
+      mutableRefsCaches.push_back(gutils->initAndPushCache(clone, builder));
+    }
+
     // Inner recompute loop: advance the primal `split` steps.
     auto innerFwd =
         scf::ForOp::create(builder, loc, c0, split, c1,
                            SmallVector<Value>(state.begin(), state.end()));
     preserveAttributesButCheckpointing(innerFwd, forOp);
 
+    // Remove scf.yield automatically added when there are no carried values
+    if (!innerFwd.getBody()->empty())
+      innerFwd.getBody()->front().erase();
+
     builder.setInsertionPointToStart(innerFwd.getBody());
     Value i = innerFwd.getInductionVar();
     Value globalStep = arith::AddIOp::create(builder, loc, stepCtr, i);
+    globalStep = castToType(builder, loc, globalStep, stepV.getType());
     Value iv = arith::AddIOp::create(
         builder, loc, startV,
         arith::MulIOp::create(builder, loc, stepV, globalStep));
@@ -390,11 +418,8 @@ private:
       caches.push_back(gutils->initAndPushCache(buf, builder));
     caches.push_back(gutils->initAndPushCache(idxBuf, builder));
 
-    for (auto ref : mutableRefs) {
-      auto iface = cast<ClonableTypeInterface>(ref.getType());
-      Value clone = iface.cloneValue(builder, mapping.lookupOrDefault(ref));
-      caches.push_back(gutils->initAndPushCache(clone, builder));
-    }
+    caches.append(mutableRefsCaches);
+
     for (auto ref : immutableRefs)
       caches.push_back(
           gutils->initAndPushCache(mapping.lookupOrDefault(ref), builder));
@@ -449,13 +474,8 @@ private:
       ckptBufs.push_back(gutils->popCache(caches[j], builder));
     Value idxBuf = gutils->popCache(caches[numIterArgs], builder);
 
-    size_t cacheIdx = numIterArgs + 1;
-    SmallVector<Value> cachedMutableRefs;
-    for (auto ref : mutableRefs) {
-      Value v = gutils->popCache(caches[cacheIdx++], builder);
-      cachedMutableRefs.push_back(v);
-      mapping.map(ref, v);
-    }
+    size_t cacheIdx = numIterArgs + mutableRefs.size() + 1;
+
     for (auto ref : immutableRefs)
       mapping.map(ref, gutils->popCache(caches[cacheIdx++], builder));
 
@@ -499,6 +519,14 @@ private:
 
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointToStart(revOuter.getBody());
+
+    SmallVector<Value> cachedMutableRefs;
+    cacheIdx = numIterArgs + 1;
+    for (auto ref : mutableRefs) {
+      Value v = gutils->popCache(caches[cacheIdx++], builder);
+      cachedMutableRefs.push_back(v);
+      mapping.map(ref, v);
+    }
 
     Value ivO = revOuter.getInductionVar();
     Value sp = revOuter.getBody()->getArgument(1);
@@ -571,6 +599,9 @@ private:
           scf::ForOp::create(builder, loc, pos, rematUB, c1,
                              SmallVector<Value>(astate.begin(), astate.end()));
       preserveAttributesButCheckpointing(innerRemat, forOp);
+      if (!innerRemat.getBody()->empty())
+        innerRemat.getBody()->front().erase();
+
       {
         OpBuilder::InsertionGuard g2(builder);
         builder.setInsertionPointToStart(innerRemat.getBody());
@@ -607,9 +638,10 @@ private:
 
     // Adjoint of a single body step at (currentRevStep - 1).
     Value stepAdj = arith::SubIOp::create(builder, loc, currentRevStep, c1);
+    Value stepAdjC = castToType(builder, loc, stepAdj, stepV.getType());
     Value ivAdj = arith::AddIOp::create(
         builder, loc, startV,
-        arith::MulIOp::create(builder, loc, stepV, stepAdj));
+        arith::MulIOp::create(builder, loc, stepV, stepAdjC));
 
     for (auto &&[oldArg, newArg] : llvm::zip_equal(
              forOp.getBody()->getArguments().drop_front(), reconState))
@@ -667,6 +699,10 @@ private:
       }
     }
 
+    for (auto ref : cachedMutableRefs)
+      if (auto iface = dyn_cast<ClonableTypeInterface>(ref.getType()))
+        iface.freeClonedValue(builder, ref);
+
     SmallVector<Value> outerYields;
     outerYields.push_back(newSp);
     outerYields.append(newAdjoints.begin(), newAdjoints.end());
@@ -688,9 +724,6 @@ private:
     for (auto buf : ckptBufs)
       memref::DeallocOp::create(builder, loc, buf);
     memref::DeallocOp::create(builder, loc, idxBuf);
-    for (auto ref : cachedMutableRefs)
-      if (auto iface = dyn_cast<ClonableTypeInterface>(ref.getType()))
-        iface.freeClonedValue(builder, ref);
 
     return success(valid);
   }

--- a/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
@@ -227,10 +227,7 @@ private:
     strides.push_back(b.getIndexAttr(1));
     for (int64_t i = 0, e = rowTy.getRank(); i < e; ++i) {
       offsets.push_back(b.getIndexAttr(0));
-      if (rowTy.isDynamicDim(i))
-        sizes.push_back(memref::DimOp::create(b, loc, buf, i + 1).getResult());
-      else
-        sizes.push_back(b.getIndexAttr(rowTy.getDimSize(i)));
+      sizes.push_back(b.getIndexAttr(rowTy.getDimSize(i)));
       strides.push_back(b.getIndexAttr(1));
     }
     auto resTy = memref::SubViewOp::inferRankReducedResultType(
@@ -257,10 +254,7 @@ private:
     if (auto mt = dyn_cast<MemRefType>(valTy)) {
       Value row = checkpointRow(b, loc, buf, slot, mt);
       SmallVector<Value> dynSizes;
-      for (int64_t i = 0, e = mt.getRank(); i < e; ++i)
-        if (mt.isDynamicDim(i))
-          dynSizes.push_back(memref::DimOp::create(b, loc, row, i));
-      Value fresh = memref::AllocOp::create(b, loc, mt, dynSizes);
+      Value fresh = memref::AllocOp::create(b, loc, mt);
       memref::CopyOp::create(b, loc, row, fresh);
       return fresh;
     }

--- a/enzyme/Enzyme/MLIR/Passes/EnzymeToMemRef.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/EnzymeToMemRef.cpp
@@ -338,6 +338,34 @@ struct SetOpConversion : public OpConversionPattern<enzyme::SetOp> {
   }
 };
 
+// `enzyme.load`/`enzyme.store` are `memref.load`/`memref.store` annotated
+// with the (possibly dynamic) dimension sizes of the memref, for use by
+// passes that need that information (e.g. mincut). The sizes are not needed
+// to actually perform the load/store, so lowering simply drops them.
+struct LoadOpConversion : public OpConversionPattern<enzyme::LoadOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(enzyme::LoadOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<memref::LoadOp>(op, adaptor.getMemref(),
+                                                adaptor.getIndices());
+    return success();
+  }
+};
+
+struct StoreOpConversion : public OpConversionPattern<enzyme::StoreOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(enzyme::StoreOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<memref::StoreOp>(
+        op, adaptor.getValue(), adaptor.getMemref(), adaptor.getIndices());
+    return success();
+  }
+};
+
 struct GetOpConversion : public OpConversionPattern<enzyme::GetOp> {
   using OpConversionPattern<enzyme::GetOp>::OpConversionPattern;
 
@@ -403,6 +431,8 @@ struct EnzymeToMemRefPass
     patterns.add<PopOpConversion>(typeConverter, context);
     patterns.add<SetOpConversion>(typeConverter, context);
     patterns.add<GetOpConversion>(typeConverter, context);
+    patterns.add<LoadOpConversion>(typeConverter, context);
+    patterns.add<StoreOpConversion>(typeConverter, context);
 
     ConversionTarget target(*context);
     target.addLegalDialect<memref::MemRefDialect>();

--- a/enzyme/Enzyme/MLIR/Passes/RemovalUtils.h
+++ b/enzyme/Enzyme/MLIR/Passes/RemovalUtils.h
@@ -98,6 +98,35 @@ static Value ensureIndexType(Value value, OpBuilder &builder) {
                                     builder.getIndexType(), value);
 }
 
+static Value traceToNonBlockArgSource(Value value) {
+  while (!isa<BlockArgument>(value)) {
+    if (auto svOp = value.getDefiningOp<memref::SubViewOp>())
+      value = svOp.getSource();
+    else if (auto castOp = value.getDefiningOp<memref::CastOp>())
+      value = castOp.getSource();
+    else if (auto rcOp = value.getDefiningOp<memref::ReinterpretCastOp>())
+      value = rcOp.getSource();
+    else
+      break;
+  }
+  return isa<BlockArgument>(value) ? nullptr : value;
+}
+
+static MultidimensionalAllocInterface
+getMultiDimCacheAllocOp(Value pushedValue, LoopCacheType cacheType,
+                        ShapedType shapeTy, Operation *forOp) {
+  if (cacheType != LoopCacheType::MEMREF)
+    return nullptr;
+  Value source = traceToNonBlockArgSource(pushedValue);
+  if (!source)
+    return nullptr;
+  auto allocOp =
+      dyn_cast_or_null<MultidimensionalAllocInterface>(source.getDefiningOp());
+  if (!allocOp || !allocOp.hoistable(forOp))
+    return nullptr;
+  return allocOp;
+}
+
 template <typename FinalClass, typename OpName>
 struct ForLikeEnzymeOpsRemover
     : public EnzymeOpsRemoverOpInterface::ExternalModel<FinalClass, OpName> {
@@ -429,24 +458,27 @@ public:
       Attribute memorySpace = nullptr;
       MultidimensionalAllocInterface allocOp;
       if (auto ST = dyn_cast<ShapedType>(ET)) {
-        allocOp = dyn_cast_or_null<MultidimensionalAllocInterface>(
-            pushedValue.getDefiningOp());
-        if (cacheType == LoopCacheType::MEMREF && allocOp &&
-            allocOp.hoistable(forOp)) {
-          multiDim = true;
+        allocOp = getMultiDimCacheAllocOp(pushedValue, cacheType, ST, forOp);
+        bool fullyStatic = llvm::all_of(ST.getShape(), [](int64_t dim) {
+          return dim != ShapedType::kDynamic;
+        });
+        multiDim =
+            allocOp || (fullyStatic && cacheType == LoopCacheType::TENSOR);
+        if (allocOp) {
           if (auto MT = dyn_cast<MemRefType>(pushedValue.getType()))
             memorySpace = MT.getMemorySpace();
           allocOp.appendDynamicDims(dynamicDims);
-        } else if (llvm::all_of(ST.getShape(), [](int64_t dim) {
-                     return dim != ShapedType::kDynamic;
-                   })) {
-          multiDim = true;
         }
 
         if (multiDim) {
           newShape.append(ST.getShape().begin(), ST.getShape().end());
           ET = ST.getElementType();
         }
+      }
+
+      if (!memorySpace) {
+        if (auto innerMT = dyn_cast<MemRefType>(ET))
+          memorySpace = innerMT.getMemorySpace();
       }
 
       auto newType = cacheType == LoopCacheType::TENSOR
@@ -551,16 +583,21 @@ public:
                 MT.getShape(), cast<MemRefType>(initValue.getType()), offsets,
                 sizes, strides);
 
-            rewriter.setInsertionPoint(memref.getDefiningOp());
-            rewriter.replaceOpWithNewOp<memref::SubViewOp>(
-                memref.getDefiningOp(), RT, initValue,
-                /*offsets*/ inductionVariable,
-                /*sizes*/ dynSizes,
-                /*strides*/ ValueRange(),
-                /*static_offsets*/ rewriter.getDenseI64ArrayAttr(offsets),
-                /*static_sizes*/ rewriter.getDenseI64ArrayAttr(sizes),
-                /*static_strides*/ rewriter.getDenseI64ArrayAttr(strides));
+            rewriter.setInsertionPointAfterValue(memref);
+            rewriter.replaceAllUsesWith(
+                memref,
+                memref::SubViewOp::create(
+                    rewriter, memref.getLoc(), RT, initValue,
+                    /*offsets*/ inductionVariable,
+                    /*sizes*/ dynSizes,
+                    /*strides*/ ValueRange(),
+                    /*static_offsets*/ rewriter.getDenseI64ArrayAttr(offsets),
+                    /*static_sizes*/ rewriter.getDenseI64ArrayAttr(sizes),
+                    /*static_strides*/ rewriter.getDenseI64ArrayAttr(strides))
+                    .getResult());
 
+            if (auto defOp = memref.getDefiningOp())
+              rewriter.eraseOp(defOp);
           } else {
             if (dynamicDims.empty()) {
               memref::StoreOp::create(rewriter, info.pushOp->getLoc(),
@@ -699,26 +736,23 @@ public:
       if (auto ST = dyn_cast<ShapedType>(ET)) {
         if (auto MT = dyn_cast<MemRefType>(ST))
           memorySpace = MT.getMemorySpace();
-
-        auto svOp = info.pushedValue().getDefiningOp<memref::SubViewOp>();
-        if (svOp) {
-          allocOp = dyn_cast_or_null<MultidimensionalAllocInterface>(
-              svOp.getSource().getDefiningOp());
-          if (cacheType == LoopCacheType::MEMREF)
-            multiDim = true;
-        } else {
-          allocOp = dyn_cast_or_null<MultidimensionalAllocInterface>(
-              info.pushedValue().getDefiningOp());
-          if (llvm::all_of(ST.getShape(), [](int64_t dim) {
-                return dim != ShapedType::kDynamic;
-              }))
-            multiDim = true;
-        }
+        allocOp =
+            getMultiDimCacheAllocOp(info.pushedValue(), cacheType, ST, forOp);
+        bool fullyStatic = llvm::all_of(ST.getShape(), [](int64_t dim) {
+          return dim != ShapedType::kDynamic;
+        });
+        multiDim =
+            allocOp || (fullyStatic && cacheType == LoopCacheType::TENSOR);
 
         if (multiDim) {
           newShape.append(ST.getShape().begin(), ST.getShape().end());
           ET = ST.getElementType();
         }
+      }
+
+      if (!memorySpace) {
+        if (auto innerMT = dyn_cast<MemRefType>(ET))
+          memorySpace = innerMT.getMemorySpace();
       }
 
       auto newType = cacheType == LoopCacheType::TENSOR

--- a/enzyme/test/MLIR/Integration/ReverseMode/BUILD
+++ b/enzyme/test/MLIR/Integration/ReverseMode/BUILD
@@ -1,0 +1,30 @@
+package(
+    default_applicable_licenses = [],
+    default_visibility = ["//visibility:public"],
+)
+
+# Execution-based numerical tests for scf.for reverse-mode checkpointing with
+# mutable memory: unlike the FileCheck-only IR-shape tests in
+# //test/MLIR/ReverseMode, these actually JIT-run the differentiated function
+# via mlir-runner and check the printed numerical result.
+
+load("@llvm-project//llvm:lit_test.bzl", "lit_test")
+
+[
+    lit_test(
+        name = "%s.test" % src,
+        srcs = [src],
+        data = [
+            "Inputs/exec_main_10xf64.mlir.inc",
+            "//:enzymemlir-opt",
+            "//test:lit.cfg.py",
+            "//test:lit.site.cfg.py",
+            "@llvm-project//llvm:FileCheck",
+            "@llvm-project//mlir:libmlir_c_runner_utils.so",
+            "@llvm-project//mlir:libmlir_runner_utils.so",
+            "@llvm-project//mlir:mlir-opt",
+            "@llvm-project//mlir:mlir-runner",
+        ],
+    )
+    for src in glob(["*.mlir"])
+]

--- a/enzyme/test/MLIR/Integration/ReverseMode/Inputs/exec_main_10xf64.mlir.inc
+++ b/enzyme/test/MLIR/Integration/ReverseMode/Inputs/exec_main_10xf64.mlir.inc
@@ -1,0 +1,16 @@
+memref.global "private" @__buf : memref<10xf64> = dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]>
+memref.global "private" @__dbuf : memref<10xf64> = dense<0.0>
+
+func.func @main() {
+  %buf = memref.get_global @__buf : memref<10xf64>
+  %dbuf = memref.get_global @__dbuf : memref<10xf64>
+  %seed = arith.constant 1.0 : f64
+  call @reduce_sum(%buf, %dbuf, %seed) : (memref<10xf64>, memref<10xf64>, f64) -> ()
+  %ubuf = memref.cast %buf : memref<10xf64> to memref<*xf64>
+  %udbuf = memref.cast %dbuf : memref<10xf64> to memref<*xf64>
+  call @printMemrefF64(%ubuf) : (memref<*xf64>) -> ()
+  call @printMemrefF64(%udbuf) : (memref<*xf64>) -> ()
+  return
+}
+
+func.func private @printMemrefF64(%ptr : memref<*xf64>)

--- a/enzyme/test/MLIR/Integration/ReverseMode/scf_for_checkpointing_binomial_mutable_memory_exec.mlir
+++ b/enzyme/test/MLIR/Integration/ReverseMode/scf_for_checkpointing_binomial_mutable_memory_exec.mlir
@@ -1,0 +1,30 @@
+// REQUIRES: mlir-runner
+//
+// Same numeric check as scf_for_checkpointing_mutable_memory_exec.mlir, but
+// for binomial (Revolve) checkpointing.
+//
+// RUN: (%eopt %s --enzyme-wrap="infn=reduce_sum outfn= argTys=enzyme_dup retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --enzyme-simplify-math --remove-unnecessary-enzyme-ops --canonicalize --lower-enzyme-binomial-progress --convert-enzyme-to-memref | tail -n +2 | head -n -2; cat %S/Inputs/exec_main_10xf64.mlir.inc) | %mlir-opt --convert-scf-to-cf --expand-strided-metadata --lower-affine --convert-arith-to-llvm --finalize-memref-to-llvm --convert-cf-to-llvm --convert-func-to-llvm --reconcile-unrealized-casts | %mlir-runner -e main -entry-point-result=void -shared-libs=%mlir_runner_utils,%mlir_c_runner_utils | FileCheck %s
+
+func.func @reduce_sum(%buf: memref<10xf64>) -> f64 {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  %init = arith.constant 0.0 : f64
+
+  %sum = scf.for %i = %c0 to %c10 step %c1 iter_args(%acc = %init) -> (f64) {
+    %val = memref.load %buf[%i] : memref<10xf64>
+    %new_acc = arith.addf %acc, %val : f64
+    memref.store %new_acc, %buf[%c0] : memref<10xf64>
+    scf.yield %new_acc : f64
+  } {enzyme.enable_checkpointing = true,
+     enzyme.binomial_checkpointing,
+     enzyme.checkpoint_period=4,
+     enzyme.disable_mincut=true}
+
+  return %sum : f64
+}
+
+// CHECK: Unranked Memref base@ = {{0x[0-9a-f]*}} rank = 1 offset = 0 sizes = [10] strides = [1] data =
+// CHECK-NEXT: [55, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+// CHECK: Unranked Memref base@ = {{0x[0-9a-f]*}} rank = 1 offset = 0 sizes = [10] strides = [1] data =
+// CHECK-NEXT: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]

--- a/enzyme/test/MLIR/Integration/ReverseMode/scf_for_checkpointing_mutable_memory_exec.mlir
+++ b/enzyme/test/MLIR/Integration/ReverseMode/scf_for_checkpointing_mutable_memory_exec.mlir
@@ -1,0 +1,35 @@
+// REQUIRES: mlir-runner
+//
+// Numeric regression test for the uniform (sqrt-chunked) checkpointing
+// forward-loop index bug: the forward chunk-caching loop's induction
+// variable was double-scaled by the chunk size (nInner), so for a
+// checkpoint_period that didn't evenly divide the 10-element buffer, the
+// recomputed primal accessed the buffer out of bounds. Compare against
+// scf_for_mutable_memory_exec.mlir (enable_checkpointing=false): both must
+// produce the exact same primal/gradient result, since checkpointing is
+// purely a memory/recompute strategy and must not change the numerics.
+//
+// RUN: (%eopt %s --enzyme-wrap="infn=reduce_sum outfn= argTys=enzyme_dup retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --enzyme-simplify-math --remove-unnecessary-enzyme-ops --convert-enzyme-to-memref | tail -n +2 | head -n -2; cat %S/Inputs/exec_main_10xf64.mlir.inc) | %mlir-opt --convert-scf-to-cf --expand-strided-metadata --lower-affine --convert-arith-to-llvm --finalize-memref-to-llvm --convert-cf-to-llvm --convert-func-to-llvm --reconcile-unrealized-casts | %mlir-runner -e main -entry-point-result=void -shared-libs=%mlir_runner_utils,%mlir_c_runner_utils | FileCheck %s
+
+func.func @reduce_sum(%buf: memref<10xf64>) -> f64 {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  %init = arith.constant 0.0 : f64
+
+  %sum = scf.for %i = %c0 to %c10 step %c1 iter_args(%acc = %init) -> (f64) {
+    %val = memref.load %buf[%i] : memref<10xf64>
+    %new_acc = arith.addf %acc, %val : f64
+    memref.store %new_acc, %buf[%c0] : memref<10xf64>
+    scf.yield %new_acc : f64
+  } {enzyme.enable_checkpointing = true,
+     enzyme.checkpoint_period=4,
+     enzyme.disable_mincut=true}
+
+  return %sum : f64
+}
+
+// CHECK: Unranked Memref base@ = {{0x[0-9a-f]*}} rank = 1 offset = 0 sizes = [10] strides = [1] data =
+// CHECK-NEXT: [55, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+// CHECK: Unranked Memref base@ = {{0x[0-9a-f]*}} rank = 1 offset = 0 sizes = [10] strides = [1] data =
+// CHECK-NEXT: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]

--- a/enzyme/test/MLIR/Integration/ReverseMode/scf_for_mutable_memory_exec.mlir
+++ b/enzyme/test/MLIR/Integration/ReverseMode/scf_for_mutable_memory_exec.mlir
@@ -1,0 +1,33 @@
+// REQUIRES: mlir-runner
+//
+// Executes the reverse-mode derivative of a scf.for loop whose body both
+// reads and writes the same memref (see ../../ReverseMode/scf_for_mutable_memory.mlir
+// for the FileCheck-only IR-shape test), then checks the actual numerical
+// result: the primal `buf` should end with the same final mutation trace as
+// running the loop directly, and the gradient of `sum` w.r.t. `buf` should be
+// all-ones (since the mutation of buf[0] is never re-read, `sum` is just a
+// sum of the original buf entries).
+//
+// RUN: (%eopt %s --enzyme-wrap="infn=reduce_sum outfn= argTys=enzyme_dup retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --enzyme-simplify-math --remove-unnecessary-enzyme-ops | tail -n +2 | head -n -2; cat %S/Inputs/exec_main_10xf64.mlir.inc) | %mlir-opt --convert-scf-to-cf --expand-strided-metadata --lower-affine --convert-arith-to-llvm --finalize-memref-to-llvm --convert-cf-to-llvm --convert-func-to-llvm --reconcile-unrealized-casts | %mlir-runner -e main -entry-point-result=void -shared-libs=%mlir_runner_utils,%mlir_c_runner_utils | FileCheck %s
+
+func.func @reduce_sum(%buf: memref<10xf64>) -> f64 {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  %init = arith.constant 0.0 : f64
+
+  %sum = scf.for %i = %c0 to %c10 step %c1 iter_args(%acc = %init) -> (f64) {
+    %val = memref.load %buf[%i] : memref<10xf64>
+    %new_acc = arith.addf %acc, %val : f64
+    memref.store %new_acc, %buf[%c0] : memref<10xf64>
+    scf.yield %new_acc : f64
+  } {enzyme.enable_checkpointing = false,
+     enzyme.checkpoint_period=4, enzyme.disable_mincut=true}
+
+  return %sum : f64
+}
+
+// CHECK: Unranked Memref base@ = {{0x[0-9a-f]*}} rank = 1 offset = 0 sizes = [10] strides = [1] data =
+// CHECK-NEXT: [55, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+// CHECK: Unranked Memref base@ = {{0x[0-9a-f]*}} rank = 1 offset = 0 sizes = [10] strides = [1] data =
+// CHECK-NEXT: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]

--- a/enzyme/test/MLIR/ReverseMode/scf_for_checkpointing_binomial_mutable_memory.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_for_checkpointing_binomial_mutable_memory.mlir
@@ -1,0 +1,106 @@
+// RUN: %eopt %s --enzyme-wrap="infn=reduce_sum outfn= argTys=enzyme_dup retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --enzyme-simplify-math --remove-unnecessary-enzyme-ops --canonicalize | FileCheck %s
+
+module {
+  func.func @reduce_sum(%buf: memref<10xf64>) -> f64 {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c10 = arith.constant 10 : index
+    %init = arith.constant 0.0 : f64
+
+    %sum = scf.for %i = %c0 to %c10 step %c1 iter_args(%acc = %init) -> (f64) {
+      %val = memref.load %buf[%i] : memref<10xf64>
+      %new_acc = arith.addf %acc, %val : f64
+      memref.store %new_acc, %buf[%c0] : memref<10xf64>
+      scf.yield %new_acc : f64
+    } {enzyme.enable_checkpointing = true,
+       enzyme.binomial_checkpointing,
+       enzyme.checkpoint_period=4,
+       enzyme.disable_mincut=true}
+
+    return %sum : f64
+  }
+}
+
+
+// CHECK:  func.func @reduce_sum(%arg0: memref<10xf64>, %arg1: memref<10xf64>, %arg2: f64) {
+// CHECK-NEXT:    %c9 = arith.constant 9 : index
+// CHECK-NEXT:    %c4 = arith.constant 4 : index
+// CHECK-NEXT:    %c10 = arith.constant 10 : index
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %c0 = arith.constant 0 : index
+// CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:    %alloc = memref.alloc() : memref<4xf64>
+// CHECK-NEXT:    %alloc_0 = memref.alloc() : memref<4xindex>
+// CHECK-NEXT:    %alloc_1 = memref.alloc() : memref<4x10xf64>
+// CHECK-NEXT:    %0:2 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %c0, %arg5 = %cst) -> (index, f64) {
+// CHECK-NEXT:      memref.store %arg5, %alloc[%arg3] : memref<4xf64>
+// CHECK-NEXT:      memref.store %arg4, %alloc_0[%arg3] : memref<4xindex>
+// CHECK-NEXT:      %3 = arith.subi %c10, %arg4 : index
+// CHECK-NEXT:      %4 = arith.subi %c4, %arg3 : index
+// CHECK-NEXT:      %5 = arith.minui %4, %3 : index
+// CHECK-NEXT:      %6 = enzyme.binomial_progress %3, %5 : index
+// CHECK-NEXT:      %subview = memref.subview %alloc_1[%arg3, 0] [1, 10] [1, 1] : memref<4x10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:      memref.copy %arg0, %subview : memref<10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:      %7 = scf.for %arg6 = %c0 to %6 step %c1 iter_args(%arg7 = %arg5) -> (f64) {
+// CHECK-NEXT:        %9 = arith.addi %arg4, %arg6 : index
+// CHECK-NEXT:        %10 = memref.load %arg0[%9] : memref<10xf64>
+// CHECK-NEXT:        %11 = arith.addf %arg7, %10 : f64
+// CHECK-NEXT:        memref.store %11, %arg0[%c0] : memref<10xf64>
+// CHECK-NEXT:        scf.yield %11 : f64
+// CHECK-NEXT:      } {enzyme.disable_mincut = true}
+// CHECK-NEXT:      %8 = arith.addi %arg4, %6 : index
+// CHECK-NEXT:      scf.yield %8, %7 : index, f64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %1 = arith.addf %arg2, %cst : f64
+// CHECK-NEXT:    %2:2 = scf.for %arg3 = %c0 to %c10 step %c1 iter_args(%arg4 = %c4, %arg5 = %1) -> (index, f64) {
+// CHECK-NEXT:      %3 = arith.subi %c9, %arg3 : index
+// CHECK-NEXT:      %subview = memref.subview %alloc_1[%3, 0] [1, 10] [1, 1] : memref<4x10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:      %4 = arith.subi %arg4, %c1 : index
+// CHECK-NEXT:      %5 = arith.subi %c10, %arg3 : index
+// CHECK-NEXT:      %6 = memref.load %alloc[%4] : memref<4xf64>
+// CHECK-NEXT:      %7 = memref.load %alloc_0[%4] : memref<4xindex>
+// CHECK-NEXT:      %8:3 = scf.while (%arg6 = %7, %arg7 = %4, %arg8 = %6) : (index, index, f64) -> (index, index, f64) {
+// CHECK-NEXT:        %19 = arith.addi %arg6, %c1 : index
+// CHECK-NEXT:        %20 = arith.cmpi slt, %19, %5 : index
+// CHECK-NEXT:        scf.condition(%20) %arg6, %arg7, %arg8 : index, index, f64
+// CHECK-NEXT:      } do {
+// CHECK-NEXT:      ^bb0(%arg6: index, %arg7: index, %arg8: f64):
+// CHECK-NEXT:        %19 = arith.subi %5, %arg6 : index
+// CHECK-NEXT:        %20 = arith.subi %c4, %arg7 : index
+// CHECK-NEXT:        %21 = arith.minui %20, %19 : index
+// CHECK-NEXT:        %22 = enzyme.binomial_progress %19, %21 : index
+// CHECK-NEXT:        memref.store %arg8, %alloc[%arg7] : memref<4xf64>
+// CHECK-NEXT:        memref.store %arg6, %alloc_0[%arg7] : memref<4xindex>
+// CHECK-NEXT:        %23 = arith.addi %arg6, %22 : index
+// CHECK-NEXT:        %24 = arith.cmpi eq, %23, %5 : index
+// CHECK-NEXT:        %25 = arith.subi %23, %c1 : index
+// CHECK-NEXT:        %26 = arith.select %24, %25, %23 : index
+// CHECK-NEXT:        %27 = scf.for %arg9 = %arg6 to %26 step %c1 iter_args(%arg10 = %arg8) -> (f64) {
+// CHECK-NEXT:          %29 = memref.load %subview[%arg9] : memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:          %30 = arith.addf %arg10, %29 : f64
+// CHECK-NEXT:          memref.store %30, %subview[%c0] : memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:          scf.yield %30 : f64
+// CHECK-NEXT:        } {enzyme.disable_mincut = true}
+// CHECK-NEXT:        %28 = arith.addi %arg7, %c1 : index
+// CHECK-NEXT:        scf.yield %23, %28, %27 : index, index, f64
+// CHECK-NEXT:      }
+// CHECK-NEXT:      %9 = arith.subi %c9, %arg3 : index
+// CHECK-NEXT:      %10 = memref.load %subview[%9] : memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:      %11 = arith.addf %8#2, %10 : f64
+// CHECK-NEXT:      memref.store %11, %subview[%c0] : memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:      %12 = arith.addf %arg5, %cst : f64
+// CHECK-NEXT:      %13 = memref.load %arg1[%c0] : memref<10xf64>
+// CHECK-NEXT:      %14 = arith.addf %12, %13 : f64
+// CHECK-NEXT:      memref.store %cst, %arg1[%c0] : memref<10xf64>
+// CHECK-NEXT:      %15 = arith.addf %14, %cst : f64
+// CHECK-NEXT:      %16 = arith.addf %14, %cst : f64
+// CHECK-NEXT:      %17 = memref.load %arg1[%9] : memref<10xf64>
+// CHECK-NEXT:      %18 = arith.addf %17, %16 : f64
+// CHECK-NEXT:      memref.store %18, %arg1[%9] : memref<10xf64>
+// CHECK-NEXT:      scf.yield %8#1, %15 : index, f64
+// CHECK-NEXT:    } {enzyme.disable_mincut = true}
+// CHECK-NEXT:    memref.dealloc %alloc_1 : memref<4x10xf64>
+// CHECK-NEXT:    memref.dealloc %alloc : memref<4xf64>
+// CHECK-NEXT:    memref.dealloc %alloc_0 : memref<4xindex>
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }

--- a/enzyme/test/MLIR/ReverseMode/scf_for_checkpointing_mutable_memory.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_for_checkpointing_mutable_memory.mlir
@@ -34,16 +34,15 @@ func.func @reduce_sum(%buf: memref<10xf64>) -> f64 {
 // CHECK-NEXT:      %5 = arith.select %4, %c1, %c3 : index
 // CHECK-NEXT:      %subview = memref.subview %alloc[%3, 0] [1, 10] [1, 1] : memref<4x10xf64> to memref<10xf64, strided<[1], offset: ?>>
 // CHECK-NEXT:      memref.copy %arg0, %subview : memref<10xf64> to memref<10xf64, strided<[1], offset: ?>>
-// CHECK-NEXT:      %6 = arith.muli %arg3, %c3 : index
-// CHECK-NEXT:      %7 = scf.for %arg5 = %c0 to %5 step %c1 iter_args(%arg6 = %arg4) -> (f64) {
-// CHECK-NEXT:        %8 = arith.addi %6, %arg5 : index
-// CHECK-NEXT:        %9 = memref.load %arg0[%8] : memref<10xf64>
-// CHECK-NEXT:        %10 = arith.addf %arg6, %9 : f64
-// CHECK-NEXT:        memref.store %10, %arg0[%c0] : memref<10xf64>
-// CHECK-NEXT:        scf.yield %10 : f64
+// CHECK-NEXT:      %6 = scf.for %arg5 = %c0 to %5 step %c1 iter_args(%arg6 = %arg4) -> (f64) {
+// CHECK-NEXT:        %7 = arith.addi %arg3, %arg5 : index
+// CHECK-NEXT:        %8 = memref.load %arg0[%7] : memref<10xf64>
+// CHECK-NEXT:        %9 = arith.addf %arg6, %8 : f64
+// CHECK-NEXT:        memref.store %9, %arg0[%c0] : memref<10xf64>
+// CHECK-NEXT:        scf.yield %9 : f64
 // CHECK-NEXT:      } {enzyme.disable_mincut = true}
 // CHECK-NEXT:      memref.store %arg4, %alloc_0[%3] : memref<4xf64>
-// CHECK-NEXT:      scf.yield %7 : f64
+// CHECK-NEXT:      scf.yield %6 : f64
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %1 = arith.addf %arg2, %cst : f64
 // CHECK-NEXT:    %2 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %1) -> (f64) {

--- a/enzyme/test/MLIR/ReverseMode/scf_for_checkpointing_mutable_memory.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_for_checkpointing_mutable_memory.mlir
@@ -1,0 +1,95 @@
+// RUN: %eopt %s --enzyme-wrap="infn=reduce_sum outfn= argTys=enzyme_dup retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --enzyme-simplify-math --remove-unnecessary-enzyme-ops | FileCheck %s
+
+func.func @reduce_sum(%buf: memref<10xf64>) -> f64 {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  %init = arith.constant 0.0 : f64
+
+  %sum = scf.for %i = %c0 to %c10 step %c1 iter_args(%acc = %init) -> (f64) {
+    %val = memref.load %buf[%i] : memref<10xf64>
+    %new_acc = arith.addf %acc, %val : f64
+    memref.store %new_acc, %buf[%c0] : memref<10xf64>
+    scf.yield %new_acc : f64
+  } {enzyme.enable_checkpointing = true,
+     enzyme.checkpoint_period=4,
+     enzyme.disable_mincut=true}
+
+  return %sum : f64
+}
+
+// CHECK:  func.func @reduce_sum(%arg0: memref<10xf64>, %arg1: memref<10xf64>, %arg2: f64) {
+// CHECK-NEXT:    %c4 = arith.constant 4 : index
+// CHECK-NEXT:    %c9 = arith.constant 9 : index
+// CHECK-NEXT:    %c12 = arith.constant 12 : index
+// CHECK-NEXT:    %c3 = arith.constant 3 : index
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %c0 = arith.constant 0 : index
+// CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:    %alloc = memref.alloc() : memref<4x10xf64>
+// CHECK-NEXT:    %alloc_0 = memref.alloc() : memref<4xf64>
+// CHECK-NEXT:    %0 = scf.for %arg3 = %c0 to %c12 step %c3 iter_args(%arg4 = %cst) -> (f64) {
+// CHECK-NEXT:      %3 = arith.divui %arg3, %c3 : index
+// CHECK-NEXT:      %4 = arith.cmpi eq, %arg3, %c9 : index
+// CHECK-NEXT:      %5 = arith.select %4, %c1, %c3 : index
+// CHECK-NEXT:      %subview = memref.subview %alloc[%3, 0] [1, 10] [1, 1] : memref<4x10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:      memref.copy %arg0, %subview : memref<10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:      %6 = arith.muli %arg3, %c3 : index
+// CHECK-NEXT:      %7 = scf.for %arg5 = %c0 to %5 step %c1 iter_args(%arg6 = %arg4) -> (f64) {
+// CHECK-NEXT:        %8 = arith.addi %6, %arg5 : index
+// CHECK-NEXT:        %9 = memref.load %arg0[%8] : memref<10xf64>
+// CHECK-NEXT:        %10 = arith.addf %arg6, %9 : f64
+// CHECK-NEXT:        memref.store %10, %arg0[%c0] : memref<10xf64>
+// CHECK-NEXT:        scf.yield %10 : f64
+// CHECK-NEXT:      } {enzyme.disable_mincut = true}
+// CHECK-NEXT:      memref.store %arg4, %alloc_0[%3] : memref<4xf64>
+// CHECK-NEXT:      scf.yield %7 : f64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %1 = arith.addf %arg2, %cst : f64
+// CHECK-NEXT:    %2 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %1) -> (f64) {
+// CHECK-NEXT:      %3 = arith.subi %c3, %arg3 : index
+// CHECK-NEXT:      %subview = memref.subview %alloc[%3, 0] [1, 10] [1, 1] : memref<4x10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:      %4 = arith.subi %c3, %arg3 : index
+// CHECK-NEXT:      %5 = memref.load %alloc_0[%3] : memref<4xf64>
+// CHECK-NEXT:      %6 = arith.cmpi eq, %arg3, %c0 : index
+// CHECK-NEXT:      %7 = arith.select %6, %c1, %c3 : index
+// CHECK-NEXT:      %8 = arith.muli %4, %c3 : index
+// CHECK-NEXT:      %alloc_1 = memref.alloc(%7) : memref<?xmemref<10xf64>>
+// CHECK-NEXT:      %alloc_2 = memref.alloc(%7) : memref<?xindex>
+// CHECK-NEXT:      %alloc_3 = memref.alloc(%7) : memref<?xindex>
+// CHECK-NEXT:      %9 = scf.for %arg5 = %c0 to %7 step %c1 iter_args(%arg6 = %5) -> (f64) {
+// CHECK-NEXT:        %11 = arith.addi %8, %arg5 : index
+// CHECK-NEXT:        enzyme.store %11, %alloc_2[%arg5] ([%7]) : memref<?xindex>
+// CHECK-NEXT:        %12 = memref.load %subview[%11] : memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:        %13 = arith.addf %arg6, %12 : f64
+// CHECK-NEXT:        enzyme.store %arg1, %alloc_1[%arg5] ([%7]) : memref<?xmemref<10xf64>>
+// CHECK-NEXT:        enzyme.store %c0, %alloc_3[%arg5] ([%7]) : memref<?xindex>
+// CHECK-NEXT:        memref.store %13, %subview[%c0] : memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:        scf.yield %13 : f64
+// CHECK-NEXT:      }
+// CHECK-NEXT:      %10 = scf.for %arg5 = %c0 to %7 step %c1 iter_args(%arg6 = %arg4) -> (f64) {
+// CHECK-NEXT:        %11 = arith.subi %7, %c1 : index
+// CHECK-NEXT:        %12 = arith.subi %11, %arg5 : index
+// CHECK-NEXT:        %13 = arith.addf %arg6, %cst : f64
+// CHECK-NEXT:        %14 = enzyme.load %alloc_1[%12] ([%7]) : memref<?xmemref<10xf64>>
+// CHECK-NEXT:        %15 = enzyme.load %alloc_3[%12] ([%7]) : memref<?xindex>
+// CHECK-NEXT:        %16 = memref.load %14[%15] : memref<10xf64>
+// CHECK-NEXT:        %17 = arith.addf %13, %16 : f64
+// CHECK-NEXT:        memref.store %cst, %14[%15] : memref<10xf64>
+// CHECK-NEXT:        %18 = arith.addf %17, %cst : f64
+// CHECK-NEXT:        %19 = arith.addf %17, %cst : f64
+// CHECK-NEXT:        %20 = enzyme.load %alloc_2[%12] ([%7]) : memref<?xindex>
+// CHECK-NEXT:        %21 = memref.load %14[%20] : memref<10xf64>
+// CHECK-NEXT:        %22 = arith.addf %21, %19 : f64
+// CHECK-NEXT:        memref.store %22, %14[%20] : memref<10xf64>
+// CHECK-NEXT:        scf.yield %18 : f64
+// CHECK-NEXT:      } {enzyme.disable_mincut = true}
+// CHECK-NEXT:      memref.dealloc %alloc_3 : memref<?xindex>
+// CHECK-NEXT:      memref.dealloc %alloc_2 : memref<?xindex>
+// CHECK-NEXT:      memref.dealloc %alloc_1 : memref<?xmemref<10xf64>>
+// CHECK-NEXT:      scf.yield %10 : f64
+// CHECK-NEXT:    } {enzyme.disable_mincut = true}
+// CHECK-NEXT:    memref.dealloc %alloc_0 : memref<4xf64>
+// CHECK-NEXT:    memref.dealloc %alloc : memref<4x10xf64>
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }

--- a/enzyme/test/MLIR/ReverseMode/scf_for_memref_binomial_checkpointing.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_for_memref_binomial_checkpointing.mlir
@@ -26,6 +26,7 @@ module {
 // CHECK-LABEL: func.func @main(
 // CHECK-DAG:     %[[STATE:.+]] = memref.alloc() : memref<3xf32>
 // CHECK-DAG:     %[[IDX:.+]] = memref.alloc() : memref<3xindex>
+// CHECK-NEXT:    %[[CLONE_ARG0:.+]] = memref.alloc() : memref<3xf32>
 
 // Forward checkpoint-placement loop (budget = 3).
 // CHECK:         scf.for {{.*}} = %c0 to %c3 step %c1
@@ -33,15 +34,16 @@ module {
 // CHECK:           memref.store {{.*}}, %[[IDX]]
 
 // The mutable outside reference is snapshotted (cloned) for the reverse pass.
-// CHECK:         %[[CLONE:.+]] = memref.alloc() : memref<f32>
-// CHECK:         memref.copy %arg0, %[[CLONE]]
+// CHECK:      %[[SUBVIEW:.+]] = memref.subview %[[CLONE_ARG0]][%{{.+}}] [1] [1] : memref<3xf32> to memref<f32, strided<[], offset: ?>>
+// CHECK-NEXT:      memref.copy %arg0, %[[SUBVIEW]] : memref<f32> to memref<f32, strided<[], offset: ?>>
 
 // Reverse loop over all 9 steps, with the remat scf.while.
 // CHECK:         scf.for {{.*}} = %c0 to %c9 step %c1
+// CHECK:           %[[SUBVIEWREV:.+]] = memref.subview %[[CLONE_ARG0]][%2] [1] [1] : memref<3xf32> to memref<f32, strided<[], offset: ?>>
 // CHECK:           scf.while
-
+// CHECK:             %[[VAL:.+]] = memref.load %[[SUBVIEWREV]][] : memref<f32, strided<[], offset: ?>>
 // All allocations are freed.
-// CHECK-DAG:     memref.dealloc %[[STATE]]
-// CHECK-DAG:     memref.dealloc %[[IDX]]
-// CHECK-DAG:     memref.dealloc %[[CLONE]]
+// CHECK-DAG:     memref.dealloc %[[STATE]] : memref<3xf32>
+// CHECK-DAG:     memref.dealloc %[[IDX]] : memref<3xindex>
+// CHECK-DAG:     memref.dealloc %[[CLONE_ARG0]] : memref<3xf32>
 // CHECK:         return

--- a/enzyme/test/MLIR/ReverseMode/scf_for_mutable_memory.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_for_mutable_memory.mlir
@@ -1,0 +1,71 @@
+// RUN: %eopt %s --enzyme-wrap="infn=reduce_sum outfn= argTys=enzyme_dup retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --enzyme-simplify-math --remove-unnecessary-enzyme-ops | FileCheck %s
+
+// Check that the accumulated gradients of a memref that is both read and
+// written to inside the loop (%buf[%i] is read, %buf[%c0] is written every
+// iteration) end up accumulated into the shadow memref (%arg1), the dup of
+// the original argument, rather than being lost or accumulated somewhere
+// else.
+
+func.func @reduce_sum(%buf: memref<10xf64>) -> f64 {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  %init = arith.constant 0.0 : f64
+
+  %sum = scf.for %i = %c0 to %c10 step %c1 iter_args(%acc = %init) -> (f64) {
+    %val = memref.load %buf[%i] : memref<10xf64>
+    %new_acc = arith.addf %acc, %val : f64
+    memref.store %new_acc, %buf[%c0] : memref<10xf64>
+    scf.yield %new_acc : f64
+  } {enzyme.enable_checkpointing = false,
+     enzyme.checkpoint_period=4, enzyme.disable_mincut=true}
+
+  return %sum : f64
+}
+
+// CHECK-LABEL:   func.func @reduce_sum(
+// CHECK-SAME:      %[[ARG0:.*]]: memref<10xf64>, %[[ARG1:.*]]: memref<10xf64>, %[[ARG2:.*]]: f64) {
+// CHECK:           %[[C9:.*]] = arith.constant 9 : index
+// CHECK:           %[[C10:.*]] = arith.constant 10 : index
+// CHECK:           %[[C1:.*]] = arith.constant 1 : index
+// CHECK:           %[[C0:.*]] = arith.constant 0 : index
+// CHECK:           %[[CST:.*]] = arith.constant 0.000000e+00 : f64
+// CHECK:           %[[ALLOC:.*]] = memref.alloc() : memref<10xmemref<10xf64>>
+// CHECK:           %[[ALLOC_0:.*]] = memref.alloc() : memref<10xindex>
+// CHECK:           %[[ALLOC_1:.*]] = memref.alloc() : memref<10xindex>
+// CHECK:           %[[FOR_0:.*]] = scf.for %[[IV:.*]] = %[[C0]] to %[[C10]] step %[[C1]] iter_args(%[[ACC:.*]] = %[[CST]]) -> (f64) {
+// CHECK:             memref.store %[[IV]], %[[ALLOC_0]]{{\[}}%[[IV]]] : memref<10xindex>
+// CHECK:             %[[LOAD_0:.*]] = memref.load %[[ARG0]]{{\[}}%[[IV]]] : memref<10xf64>
+// CHECK:             %[[ADDF_0:.*]] = arith.addf %[[ACC]], %[[LOAD_0]] : f64
+// Every iteration caches the shadow memref itself (%[[ARG1]]), not a fresh
+// per-iteration copy -- it is a mutable handle whose identity must be
+// preserved across iterations.
+// CHECK:             memref.store %[[ARG1]], %[[ALLOC]]{{\[}}%[[IV]]] : memref<10xmemref<10xf64>>
+// CHECK:             memref.store %[[C0]], %[[ALLOC_1]]{{\[}}%[[IV]]] : memref<10xindex>
+// CHECK:             memref.store %[[ADDF_0]], %[[ARG0]]{{\[}}%[[C0]]] : memref<10xf64>
+// CHECK:             scf.yield %[[ADDF_0]] : f64
+// CHECK:           }
+// CHECK:           %[[ADDF_1:.*]] = arith.addf %[[ARG2]], %[[CST]] : f64
+// CHECK:           %[[FOR_1:.*]] = scf.for %[[IV_REV:.*]] = %[[C0]] to %[[C10]] step %[[C1]] iter_args(%[[DACC:.*]] = %[[ADDF_1]]) -> (f64) {
+// CHECK:             %[[IDX:.*]] = arith.subi %[[C9]], %[[IV_REV]] : index
+// CHECK:             %[[ADDF_2:.*]] = arith.addf %[[DACC]], %[[CST]] : f64
+// CHECK:             %[[SHADOW:.*]] = memref.load %[[ALLOC]]{{\[}}%[[IDX]]] : memref<10xmemref<10xf64>>
+// CHECK:             %[[STOREIDX:.*]] = memref.load %[[ALLOC_1]]{{\[}}%[[IDX]]] : memref<10xindex>
+// CHECK:             %[[DVAL_0:.*]] = memref.load %[[SHADOW]]{{\[}}%[[STOREIDX]]] : memref<10xf64>
+// CHECK:             %[[ADDF_3:.*]] = arith.addf %[[ADDF_2]], %[[DVAL_0]] : f64
+// CHECK:             memref.store %[[CST]], %[[SHADOW]]{{\[}}%[[STOREIDX]]] : memref<10xf64>
+// CHECK:             %[[ADDF_4:.*]] = arith.addf %[[ADDF_3]], %[[CST]] : f64
+// CHECK:             %[[ADDF_5:.*]] = arith.addf %[[ADDF_3]], %[[CST]] : f64
+// CHECK:             %[[LOADIDX:.*]] = memref.load %[[ALLOC_0]]{{\[}}%[[IDX]]] : memref<10xindex>
+// CHECK:             %[[DVAL_1:.*]] = memref.load %[[SHADOW]]{{\[}}%[[LOADIDX]]] : memref<10xf64>
+// CHECK:             %[[ADDF_6:.*]] = arith.addf %[[DVAL_1]], %[[ADDF_5]] : f64
+// The gradient contribution from the load is accumulated back into the
+// shadow memref (%[[SHADOW]], i.e. %[[ARG1]]) in place.
+// CHECK:             memref.store %[[ADDF_6]], %[[SHADOW]]{{\[}}%[[LOADIDX]]] : memref<10xf64>
+// CHECK:             scf.yield %[[ADDF_4]] : f64
+// CHECK:           } {enzyme.disable_mincut = true}
+// CHECK:           memref.dealloc %[[ALLOC_1]] : memref<10xindex>
+// CHECK:           memref.dealloc %[[ALLOC_0]] : memref<10xindex>
+// CHECK:           memref.dealloc %[[ALLOC]] : memref<10xmemref<10xf64>>
+// CHECK:           return
+// CHECK:         }

--- a/enzyme/test/lit.site.cfg.py.in
+++ b/enzyme/test/lit.site.cfg.py.in
@@ -66,6 +66,33 @@ if len("@ENZYME_BINARY_DIR@") == 0:
   eclang += "-I " + os.path.dirname(os.path.abspath(__file__)) + "/Integration" 
 
 config.substitutions.append(('%eopt', emopt))
+
+# mlir-opt/mlir-runner and the runner support libs live alongside the LLVM
+# tools/libs when LLVM is built with MLIR enabled (the CMake case here, since
+# this project builds against a preexisting LLVM+MLIR install/build). Under
+# Bazel, @llvm-project//mlir data deps land as a sibling of this file's own
+# runfiles directory (runfiles_root/llvm-project/mlir/...), same as how
+# %eopt's fallback above locates //:enzymemlir-opt relative to __file__.
+mlir_tools_dir = config.llvm_tools_dir
+mlir_libs_dir = config.llvm_libs_dir
+if len("@ENZYME_BINARY_DIR@") == 0:
+  mlir_tools_dir = (os.path.dirname(os.path.abspath(__file__))
+                     + "/../../llvm-project/mlir")
+  mlir_libs_dir = mlir_tools_dir
+
+mlir_opt = mlir_tools_dir + "/mlir-opt"
+mlir_runner = mlir_tools_dir + "/mlir-runner"
+mlir_runner_utils = mlir_libs_dir + "/libmlir_runner_utils" + config.llvm_shlib_ext
+mlir_c_runner_utils = mlir_libs_dir + "/libmlir_c_runner_utils" + config.llvm_shlib_ext
+
+if os.path.exists(mlir_runner):
+  config.available_features.add('mlir-runner')
+
+config.substitutions.append(('%mlir-opt', mlir_opt))
+config.substitutions.append(('%mlir-runner', mlir_runner))
+config.substitutions.append(('%mlir_runner_utils', mlir_runner_utils))
+config.substitutions.append(('%mlir_c_runner_utils', mlir_c_runner_utils))
+
 config.substitutions.append(('%llvmver', config.llvm_ver))
 config.substitutions.append(('%FileCheck', config.llvm_tools_dir + "/FileCheck"))
 config.substitutions.append(('%clang', eclang))


### PR DESCRIPTION
> [!note]
> Experiment since this has been useful to find bugs in the checkpointing implementations.

## Summary
Stacked on #3009. The tests added there (`scf_for*mutable_memory*`) are FileCheck-only — they assert on the shape of the generated IR, not on actual numerical correctness. That's what let the forward-loop induction-variable double-scaling bug (fixed in `also fix inner iv rematerialization`) go unnoticed: the IR looked plausible but computed wrong indices for any checkpoint period that didn't evenly divide the loop trip count.

This PR adds real execution tests: they run the differentiated function through `mlir-runner` and check the printed primal/gradient values, for all three checkpointing strategies (off, uniform, binomial). All three now agree exactly, which they didn't before the fix.

- `test/MLIR/Integration/ReverseMode/{scf_for_mutable_memory,scf_for_checkpointing_mutable_memory,scf_for_checkpointing_binomial_mutable_memory}_exec.mlir`: new execution tests.
- `test/lit.site.cfg.py.in`: adds `%mlir-opt`/`%mlir-runner`/`%mlir_runner_utils`/`%mlir_c_runner_utils` substitutions, gated behind an available-only-if-present `mlir-runner` feature so these tests cleanly skip (not fail) wherever those tools aren't built (e.g. the plain CMake build against system LLVM, which doesn't build MLIR tools at all).
- `Enzyme/MLIR/Passes/EnzymeToMemRef.cpp`: adds lowering patterns for `enzyme.load`/`enzyme.store` (previously only `init`/`push`/`pop`/`get`/`set` were handled) — needed because the uniform checkpointing path emits these for its per-iteration caches, and they have to be gone before the IR can reach `mlir-opt`'s LLVM lowering pipeline.

## Test plan
- [x] `bazel test //test/MLIR/Integration/ReverseMode:all` — 3/3 new tests pass
- [x] `bazel test //test/MLIR/...` — 147/147 tests pass (no regressions from the `EnzymeToMemRef.cpp` additions)
- [ ] CMake build: these tests will report `UNSUPPORTED` (not built/tested) since the CMake config here doesn't build MLIR tools — confirm this is acceptable, or wire up MLIR tool builds in CMake CI as a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)