### PR TITLE
Add more Fortran tests

### DIFF
--- a/.github/workflows/fortran.yml
+++ b/.github/workflows/fortran.yml
@@ -80,8 +80,6 @@ jobs:
         versions:
           - llvm: 15
             ifx: 2023.0.0
-          - llvm: 16
-            ifx: 2023.1.0
           - llvm: 17
             ifx: 2023.2.4
     timeout-minutes: 60

--- a/enzyme/Fortran/README.md
+++ b/enzyme/Fortran/README.md
@@ -6,7 +6,7 @@ detailed in the following.
 ## Note on compilers
 
 Before providing details on the Fortran bindings, it is worth noting that Enzyme
-only supports the `2023.0.0`, `2023.1.0`, and `2023.2.4` versions of the Intel
+only supports the `2023.0.0` and `2023.2.4` versions of the Intel
 IFX Fortran compiler. We strongly recommend using the
 [Flang](https://flang.llvm.org) compiler, which is available as part of the
 [LLVM project](https://github.com/llvm/llvm-project).

--- a/enzyme/test/Fortran/ForwardMode/allocatableArraySimple_with_bindings.f90
+++ b/enzyme/test/Fortran/ForwardMode/allocatableArraySimple_with_bindings.f90
@@ -10,30 +10,30 @@
 !       For it to work with the ifx compiler we will need to figure out how to
 !       handle the indirection involved in the enzyme_fwddiff binding
 
-program app
-    use enzyme, only: enzyme_const, enzyme_dup, enzyme_fwddiff
-    implicit none
-    integer :: n
-    real, allocatable :: x(:), dx(:)
-    real :: y, dy
+program main
+  use enzyme, only: enzyme_const, enzyme_dup, enzyme_fwddiff
+  implicit none
+  integer :: n
+  real, allocatable :: x(:), dx(:)
+  real :: y, dy
 
-    n = 3
-    allocate(x(n))
-    allocate(dx(n))
+  n = 3
+  allocate(x(n))
+  allocate(dx(n))
 
-    x = [2,3,4]
-    dx = [1,0,0]
-    y = 0
-    dy = 0
+  x = [2,3,4]
+  dx = [1,0,0]
+  y = 0
+  dy = 0
 
-    call enzyme_fwddiff(selectFirst, enzyme_const, n, &
-                        enzyme_dup, x, dx, enzyme_dup, y, dy)
+  call enzyme_fwddiff(selectFirst, enzyme_const, n, &
+                      enzyme_dup, x, dx, enzyme_dup, y, dy)
 
-    print *, int(y)
-    print *, int(dx(1))
-    print *, int(dx(2))
-    print *, int(dx(3))
-    print *, int(dy)
+  print *, int(y)
+  print *, int(dx(1))
+  print *, int(dx(2))
+  print *, int(dx(3))
+  print *, int(dy)
 
 contains
 
@@ -45,10 +45,9 @@ contains
         real, intent(in) :: x(n)
         real, intent(inout) :: y
         y = x(1)
-    end subroutine
+    end subroutine selectFirst
 
-end program
-
+end program main
 
 ! CHECK: 2
 ! CHECK-NEXT: 1

--- a/enzyme/test/Fortran/ForwardMode/allocatableArraySimple_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ForwardMode/allocatableArraySimple_with_explicit_interface.f90
@@ -13,8 +13,10 @@ module selectFirstForward
   implicit none
   interface
     subroutine selectFirst__enzyme_fwddiff(fnc, x, dx, y, dy)
+      implicit none
       interface
         subroutine fnc_decal(a, z)
+          implicit none
           real, allocatable, intent(in) :: a(:)
           real, intent(inout) :: z
         end subroutine fnc_decal

--- a/enzyme/test/Fortran/ForwardMode/allocatableArraySimple_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ForwardMode/allocatableArraySimple_with_explicit_interface.f90
@@ -10,55 +10,54 @@
 !       https://github.com/EnzymeAD/Enzyme/issues/2820
 
 module selectFirstForward
-    implicit none
-    interface
-        subroutine selectFirst__enzyme_fwddiff(fnc, x, dx, y, dy)
-           interface
-               subroutine fnc_decal(a, z)
-                   real, allocatable, intent(in) :: a(:)
-                   real, intent(inout) :: z
-               end subroutine
-           end interface
-           procedure(fnc_decal) :: fnc
-           real, allocatable, intent(in) :: x(:)
-           real, allocatable, intent(inout) :: dx(:)
-           real, intent(inout) :: y
-           real, intent(inout) :: dy
-        end subroutine
-    end interface
+  implicit none
+  interface
+    subroutine selectFirst__enzyme_fwddiff(fnc, x, dx, y, dy)
+      interface
+        subroutine fnc_decal(a, z)
+          real, allocatable, intent(in) :: a(:)
+          real, intent(inout) :: z
+        end subroutine fnc_decal
+      end interface
+      procedure(fnc_decal) :: fnc
+      real, allocatable, intent(in) :: x(:)
+      real, allocatable, intent(inout) :: dx(:)
+      real, intent(inout) :: y
+      real, intent(inout) :: dy
+    end subroutine selectFirst__enzyme_fwddiff
+  end interface
 
-    contains
+contains
 
-    subroutine selectFirst(x, y)
-        real, allocatable, intent(in) :: x(:)
-        real, intent(inout) :: y
-        y = x(1)
-    end subroutine
-end module
+  subroutine selectFirst(x, y)
+    real, allocatable, intent(in) :: x(:)
+    real, intent(inout) :: y
+    y = x(1)
+  end subroutine selectFirst
+end module selectFirstForward
 
-program app
-    use selectFirstForward, only: selectFirst, selectFirst__enzyme_fwddiff
-    implicit none
-    real, allocatable :: x(:), dx(:)
-    real :: y, dy
+program main
+  use selectFirstForward, only: selectFirst, selectFirst__enzyme_fwddiff
+  implicit none
+  real, allocatable :: x(:), dx(:)
+  real :: y, dy
 
-    allocate(x(3))
-    allocate(dx(3))
+  allocate(x(3))
+  allocate(dx(3))
 
-    x = [2,3,4]
-    dx = [1,0,0]
-    y = 0
-    dy = 0
+  x = [2,3,4]
+  dx = [1,0,0]
+  y = 0
+  dy = 0
 
-    call selectFirst__enzyme_fwddiff(selectFirst, x, dx, y, dy)
+  call selectFirst__enzyme_fwddiff(selectFirst, x, dx, y, dy)
 
-    print *, int(y)
-    print *, int(dx(1))
-    print *, int(dx(2))
-    print *, int(dx(3))
-    print *, int(dy)
-end program
-
+  print *, int(y)
+  print *, int(dx(1))
+  print *, int(dx(2))
+  print *, int(dx(3))
+  print *, int(dy)
+end program main
 
 ! CHECK: 2
 ! CHECK-NEXT: 1

--- a/enzyme/test/Fortran/ForwardMode/allocatableArraySimple_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ForwardMode/allocatableArraySimple_with_explicit_interface.f90
@@ -11,6 +11,7 @@
 
 module selectFirstForward
   implicit none
+  public
   interface
     subroutine selectFirst__enzyme_fwddiff(fnc, x, dx, y, dy)
       implicit none

--- a/enzyme/test/Fortran/ReverseMode/allocatableArraySimple_with_bindings.f90
+++ b/enzyme/test/Fortran/ReverseMode/allocatableArraySimple_with_bindings.f90
@@ -10,44 +10,44 @@
 !       For it to work with the ifx compiler we will need to figure out how to
 !       handle the indirection involved in the enzyme_autodiff binding
 
-program app
-    use enzyme, only: enzyme_const, enzyme_dup, enzyme_autodiff
-    implicit none
-    integer :: n
-    real, allocatable :: x(:), dx(:)
-    real :: y, dy
+program main
+  use enzyme, only: enzyme_const, enzyme_dup, enzyme_autodiff
+  implicit none
+  integer :: n
+  real, allocatable :: x(:), dx(:)
+  real :: y, dy
 
-    n = 3
-    allocate(x(n))
-    allocate(dx(n))
+  n = 3
+  allocate(x(n))
+  allocate(dx(n))
 
-    x = [2,3,4]
-    dx = [0,0,0]
-    y = 0
-    dy = 1
+  x = [2,3,4]
+  dx = [0,0,0]
+  y = 0
+  dy = 1
 
-    call enzyme_autodiff(selectFirst, enzyme_const, n, &
-                         enzyme_dup, x, dx, enzyme_dup, y, dy)
+  call enzyme_autodiff(selectFirst, enzyme_const, n, &
+                       enzyme_dup, x, dx, enzyme_dup, y, dy)
 
-    print *, int(y)
-    print *, int(dx(1))
-    print *, int(dx(2))
-    print *, int(dx(3))
-    print *, int(dy)
+  print *, int(y)
+  print *, int(dx(1))
+  print *, int(dx(2))
+  print *, int(dx(3))
+  print *, int(dy)
 
 contains
 
-    ! TODO: Switch to assumed shape implementation once
-    !       https://github.com/EnzymeAD/Enzyme/issues/2820
-    !       has been addressed
-    subroutine selectFirst(n, x, y)
-        integer, intent(in) :: n
-        real, intent(in) :: x(n)
-        real, intent(inout) :: y
-        y = x(1)
-    end subroutine
+  ! TODO: Switch to assumed shape implementation once
+  !       https://github.com/EnzymeAD/Enzyme/issues/2820
+  !       has been addressed
+  subroutine selectFirst(n, x, y)
+    integer, intent(in) :: n
+    real, intent(in) :: x(n)
+    real, intent(inout) :: y
+    y = x(1)
+  end subroutine selectFirst
 
-end program
+end program main
 
 
 ! CHECK: 2

--- a/enzyme/test/Fortran/ReverseMode/allocatableArraySimple_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ReverseMode/allocatableArraySimple_with_explicit_interface.f90
@@ -10,54 +10,54 @@
 !       https://github.com/EnzymeAD/Enzyme/issues/2820
 
 module selectFirstReverse
-    implicit none
-    interface
-        subroutine selectFirst__enzyme_autodiff(fnc, x, dx, y, dy)
-           interface
-               subroutine fnc_decal(a, z)
-                   real, allocatable, intent(in) :: a(:)
-                   real, intent(inout) :: z
-               end subroutine
-           end interface
-           procedure(fnc_decal) :: fnc
-           real, allocatable, intent(in) :: x(:)
-           real, allocatable, intent(inout) :: dx(:)
-           real, intent(inout) :: y
-           real, intent(inout) :: dy
-        end subroutine
-    end interface
+  implicit none
+  interface
+    subroutine selectFirst__enzyme_autodiff(fnc, x, dx, y, dy)
+      interface
+        subroutine fnc_decal(a, z)
+          real, allocatable, intent(in) :: a(:)
+          real, intent(inout) :: z
+        end subroutine fnc_decal
+      end interface
+      procedure(fnc_decal) :: fnc
+      real, allocatable, intent(in) :: x(:)
+      real, allocatable, intent(inout) :: dx(:)
+      real, intent(inout) :: y
+      real, intent(inout) :: dy
+    end subroutine selectFirst__enzyme_autodiff
+  end interface
 
-    contains
+  contains
 
-    subroutine selectFirst(x, y)
-        real, allocatable, intent(in) :: x(:)
-        real, intent(inout) :: y
-        y = x(1)
-    end subroutine
-end module
+  subroutine selectFirst(x, y)
+    real, allocatable, intent(in) :: x(:)
+    real, intent(inout) :: y
+    y = x(1)
+  end subroutine selectFirst
+end module selectFirstReverse
 
-program app
-    use selectFirstReverse, only: selectFirst, selectFirst__enzyme_autodiff
-    implicit none
-    real, allocatable :: x(:), dx(:)
-    real :: y, dy
+program main
+  use selectFirstReverse, only: selectFirst, selectFirst__enzyme_autodiff
+  implicit none
+  real, allocatable :: x(:), dx(:)
+  real :: y, dy
 
-    allocate(x(3))
-    allocate(dx(3))
+  allocate(x(3))
+  allocate(dx(3))
 
-    x = [2,3,4]
-    dx = [0,0,0]
-    y = 0
-    dy = 1
+  x = [2,3,4]
+  dx = [0,0,0]
+  y = 0
+  dy = 1
 
-    call selectFirst__enzyme_autodiff(selectFirst, x, dx, y, dy)
+  call selectFirst__enzyme_autodiff(selectFirst, x, dx, y, dy)
 
-    print *, int(y)
-    print *, int(dx(1))
-    print *, int(dx(2))
-    print *, int(dx(3))
-    print *, int(dy)
-end program
+  print *, int(y)
+  print *, int(dx(1))
+  print *, int(dx(2))
+  print *, int(dx(3))
+  print *, int(dy)
+end program main
 
 
 ! CHECK: 2

--- a/enzyme/test/Fortran/ReverseMode/allocatableArraySimple_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ReverseMode/allocatableArraySimple_with_explicit_interface.f90
@@ -11,6 +11,7 @@
 
 module selectFirstReverse
   implicit none
+  public
   interface
     subroutine selectFirst__enzyme_autodiff(fnc, x, dx, y, dy)
       implicit none

--- a/enzyme/test/Fortran/ReverseMode/allocatableArraySimple_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ReverseMode/allocatableArraySimple_with_explicit_interface.f90
@@ -13,8 +13,10 @@ module selectFirstReverse
   implicit none
   interface
     subroutine selectFirst__enzyme_autodiff(fnc, x, dx, y, dy)
+      implicit none
       interface
         subroutine fnc_decal(a, z)
+          implicit none
           real, allocatable, intent(in) :: a(:)
           real, intent(inout) :: z
         end subroutine fnc_decal

--- a/enzyme/test/Fortran/ReverseMode/dot_with_bindings.f90
+++ b/enzyme/test/Fortran/ReverseMode/dot_with_bindings.f90
@@ -1,0 +1,62 @@
+! REQUIRES: fortran
+! RUN: if [[ %fc != ifx ]]; then %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s; fi
+! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
+
+! NOTE: This test is only configured to run with the flang compiler at -O0
+!       For it to work with the ifx compiler we will need to figure out how to
+!       handle the indirection involved in the enzyme_autodiff binding
+
+program dot
+  use enzyme, only: enzyme_const, enzyme_dup, enzyme_autodiff
+  implicit none
+
+  integer, parameter :: n = 20000000
+  integer, parameter :: s = 20
+  real :: x(n), y(n), z = 1 / s
+  real :: dx(n), dy(n), dz
+  integer :: i
+
+  ! Specify input
+  do i = 1, n
+    x(i) = s / i
+    y(i) = s + i - 1 ! NOTE: Minus one to account for 1-indexing
+  end do
+
+  ! Time gradient computation with respect to all variables (A, B, and C)
+  dx(:) = 0.0
+  dy(:) = 0.0
+  dz = 0.0
+  call enzyme_autodiff(dot, enzyme_const, n, &
+                       enzyme_dup, x, dx, &
+                       enzyme_dup, y, dy, &
+                       enzyme_dup, z, dz)
+  write(*, "(f4.1)") dx(1)
+  write(*, "(f4.1)") dy(1)
+  write(*, "(f4.1)") dz
+
+contains
+
+  ! Function for computing the dot product of two vectors and adding a scalar
+  real function dot(n, a, b, c)
+    integer, intent(in) :: n
+    real, dimension(n), intent(in) :: a
+    real, dimension(n), intent(in) :: b
+    real, intent(in) :: c
+    integer :: i
+    ! TODO: Use the `dot_product` intrinsic.
+    !       Requires accounting for `_FortranADotProductReal4` for this to work
+    !       at -O0
+    ! dot = dot_product(a, b) + c
+    dot = c
+    do i = 1, n
+      dot = dot + a(i) * b(i)
+    end do
+  end function dot
+
+end program dot
+
+! CHECK: 20.0
+! CHECK-NEXT: 20.0
+! CHECK-NEXT: 1.0

--- a/enzyme/test/Fortran/ReverseMode/dot_with_bindings.f90
+++ b/enzyme/test/Fortran/ReverseMode/dot_with_bindings.f90
@@ -8,7 +8,7 @@
 !       For it to work with the ifx compiler we will need to figure out how to
 !       handle the indirection involved in the enzyme_autodiff binding
 
-program dot
+program main
   use enzyme, only: enzyme_const, enzyme_dup, enzyme_autodiff
   implicit none
 
@@ -79,7 +79,7 @@ contains
     end do
   end function dot
 
-end program dot
+end program main
 
 ! CHECK: 20.0
 ! CHECK-NEXT: 20.0

--- a/enzyme/test/Fortran/ReverseMode/dot_with_bindings.f90
+++ b/enzyme/test/Fortran/ReverseMode/dot_with_bindings.f90
@@ -3,6 +3,8 @@
 ! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
 ! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
 ! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
+! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
 
 ! NOTE: This test is only configured to run with the flang compiler at -O0
 !       For it to work with the ifx compiler we will need to figure out how to

--- a/enzyme/test/Fortran/ReverseMode/dot_with_bindings.f90
+++ b/enzyme/test/Fortran/ReverseMode/dot_with_bindings.f90
@@ -24,13 +24,37 @@ program dot
     y(i) = s + i - 1 ! NOTE: Minus one to account for 1-indexing
   end do
 
-  ! Time gradient computation with respect to all variables (A, B, and C)
+  ! Compute gradient computation with respect to all variables (x, y, and z)
   dx(:) = 0.0
   dy(:) = 0.0
   dz = 0.0
   call enzyme_autodiff(dot, enzyme_const, n, &
                        enzyme_dup, x, dx, &
                        enzyme_dup, y, dy, &
+                       enzyme_dup, z, dz)
+  write(*, "(f4.1)") dx(1)
+  write(*, "(f4.1)") dy(1)
+  write(*, "(f4.1)") dz
+
+  ! Compute gradient computation with respect to just y and z
+  dx(:) = 0.0
+  dy(:) = 0.0
+  dz = 0.0
+  call enzyme_autodiff(dot, enzyme_const, n, &
+                       enzyme_const, x, &
+                       enzyme_dup, y, dy, &
+                       enzyme_dup, z, dz)
+  write(*, "(f4.1)") dx(1)
+  write(*, "(f4.1)") dy(1)
+  write(*, "(f4.1)") dz
+
+  ! Compute gradient computation with respect to just z
+  dx(:) = 0.0
+  dy(:) = 0.0
+  dz = 0.0
+  call enzyme_autodiff(dot, enzyme_const, n, &
+                       enzyme_const, x, &
+                       enzyme_const, y, &
                        enzyme_dup, z, dz)
   write(*, "(f4.1)") dx(1)
   write(*, "(f4.1)") dy(1)
@@ -59,4 +83,10 @@ end program dot
 
 ! CHECK: 20.0
 ! CHECK-NEXT: 20.0
+! CHECK-NEXT: 1.0
+! CHECK-NEXT: 0.0
+! CHECK-NEXT: 20.0
+! CHECK-NEXT: 1.0
+! CHECK-NEXT: 0.0
+! CHECK-NEXT: 0.0
 ! CHECK-NEXT: 1.0

--- a/enzyme/test/Fortran/ReverseMode/norm_with_bindings.f90
+++ b/enzyme/test/Fortran/ReverseMode/norm_with_bindings.f90
@@ -7,32 +7,8 @@
 !       For it to work with the ifx compiler we will need to figure out how to
 !       handle the indirection involved in the enzyme_autodiff binding
 
-module math
-contains
-  subroutine norm(n, x, y)
-    integer, intent(in) :: n
-    real, dimension(n), intent(in) :: x
-    real, dimension(n), intent(out) :: y
-    real :: s
-    integer :: i
-    ! TODO: Use the `sum` intrinsic. Requires accounting for `_FortranASumReal4`
-    !       for this to work at -O0
-    ! TODO: Use an array assignment. Requires accounting for `_FortranAAssign`
-    !       for this to work at -O0
-    ! y(:) = x / sum(x)
-    s = 0.0
-    do i = 1, n
-      s = s + x(i)
-    end do
-    do i = 1, n
-      y(i) = x(i) / s
-    end do
-  end subroutine norm
-end module math
-
-program app
+program main
   use enzyme, only: enzyme_const, enzyme_dup, enzyme_autodiff
-  use math, only: norm
   implicit none
   integer, parameter :: n = 1000000
   integer, parameter :: initial_value = 20
@@ -52,7 +28,30 @@ program app
   call enzyme_autodiff(norm, enzyme_const, n, &
                        enzyme_dup, x, dx, enzyme_dup, y, dy)
   write(*,"(f6.4)") dy(n)
-end program app
+
+contains
+
+  subroutine norm(n, x, y)
+    integer, intent(in) :: n
+    real, dimension(n), intent(in) :: x
+    real, dimension(n), intent(out) :: y
+    real :: s
+    integer :: i
+    ! TODO: Use the `sum` intrinsic. Requires accounting for `_FortranASumReal4`
+    !       for this to work at -O0
+    ! TODO: Use an array assignment. Requires accounting for `_FortranAAssign`
+    !       for this to work at -O0
+    ! y(:) = x / sum(x)
+    s = 0.0
+    do i = 1, n
+      s = s + x(i)
+    end do
+    do i = 1, n
+      y(i) = x(i) / s
+    end do
+  end subroutine norm
+
+end program main
 
 ! CHECK: 1.0000
 ! CHECK-NEXT: 0.0000

--- a/enzyme/test/Fortran/ReverseMode/norm_with_bindings.f90
+++ b/enzyme/test/Fortran/ReverseMode/norm_with_bindings.f90
@@ -2,6 +2,8 @@
 ! RUN: if [[ %llvmver -ge 13 && %fc != ifx ]]; then %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O1 -S -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s; fi
 ! RUN: if [[ %llvmver -ge 13 && %fc != ifx ]]; then %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O2 -S -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s; fi
 ! RUN: if [[ %llvmver -ge 13 && %fc != ifx ]]; then %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O3 -S -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s; fi
+! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
+! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
 
 ! NOTE: This test is only configured to run with the flang compiler
 !       For it to work with the ifx compiler we will need to figure out how to

--- a/enzyme/test/Fortran/ReverseMode/norm_with_bindings.f90
+++ b/enzyme/test/Fortran/ReverseMode/norm_with_bindings.f90
@@ -1,0 +1,58 @@
+! RUN: if [[ %llvmver -ge 13 && %fc != ifx ]]; then %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O0 -S -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s; fi
+! RUN: if [[ %llvmver -ge 13 && %fc != ifx ]]; then %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O1 -S -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s; fi
+! RUN: if [[ %llvmver -ge 13 && %fc != ifx ]]; then %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O2 -S -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s; fi
+! RUN: if [[ %llvmver -ge 13 && %fc != ifx ]]; then %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O3 -S -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s; fi
+
+! NOTE: This test is only configured to run with the flang compiler
+!       For it to work with the ifx compiler we will need to figure out how to
+!       handle the indirection involved in the enzyme_autodiff binding
+
+module math
+contains
+  subroutine norm(n, x, y)
+    integer, intent(in) :: n
+    real, dimension(n), intent(in) :: x
+    real, dimension(n), intent(out) :: y
+    real :: s
+    integer :: i
+    ! TODO: Use the `sum` intrinsic. Requires accounting for `_FortranASumReal4`
+    !       for this to work at -O0
+    ! TODO: Use an array assignment. Requires accounting for `_FortranAAssign`
+    !       for this to work at -O0
+    ! y(:) = x / sum(x)
+    s = 0.0
+    do i = 1, n
+      s = s + x(i)
+    end do
+    do i = 1, n
+      y(i) = x(i) / s
+    end do
+  end subroutine norm
+end module math
+
+program app
+  use enzyme, only: enzyme_const, enzyme_dup, enzyme_autodiff
+  use math, only: norm
+  implicit none
+  integer, parameter :: n = 1000000
+  integer, parameter :: initial_value = 20
+  real :: x(n), dx(n)
+  real :: y(n), dy(n), yp
+
+  x(:) = initial_value
+  dy(:) = 1.0
+
+  call norm(n, x, y)
+
+  ! Rescale the output to avoid compiler-specific output formatting
+  yp = y(n) * 1.0e+06
+  write(*,"(f6.4)") yp
+
+  dx(:) = 0.0
+  call enzyme_autodiff(norm, enzyme_const, n, &
+                       enzyme_dup, x, dx, enzyme_dup, y, dy)
+  write(*,"(f6.4)") dy(n)
+end program app
+
+! CHECK: 1.0000
+! CHECK-NEXT: 0.0000

--- a/enzyme/test/Fortran/ReverseMode/norm_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ReverseMode/norm_with_explicit_interface.f90
@@ -10,6 +10,7 @@
 
 module normReverse
   implicit none
+  public
   interface
     subroutine norm__enzyme_autodiff(sr, x_desc, x, dx, y_desc, y, dy)
       implicit none

--- a/enzyme/test/Fortran/ReverseMode/norm_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ReverseMode/norm_with_explicit_interface.f90
@@ -1,0 +1,61 @@
+! RUN: if [[ %llvmver -ge 13 && %fc == ifx ]]; then %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O0 -S -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s; fi
+! RUN: if [[ %llvmver -ge 13 && %fc == ifx ]]; then %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O1 -S -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s; fi
+! RUN: if [[ %llvmver -ge 13 && %fc == ifx ]]; then %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O2 -S -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s; fi
+! RUN: if [[ %llvmver -ge 13 && %fc == ifx ]]; then %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O3 -S -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s; fi
+
+! NOTE: This test is only configured to run with the ifx compiler
+!       For it to work with the flang compiler we will need to address
+!       https://github.com/EnzymeAD/Enzyme/issues/2820
+!       https://github.com/EnzymeAD/Enzyme/issues/2822
+
+module math
+  interface
+    subroutine norm__enzyme_autodiff(sr, x_desc, x, dx, y_desc, y, dy)
+      interface
+        subroutine sr_decal(a, b)
+          real, dimension(:), intent(in) :: a
+          real, dimension(:), intent(out) :: b
+        end subroutine
+      end interface
+      procedure(sr_decal) :: sr
+      integer, intent(in) :: x_desc
+      real, dimension(:), intent(in) :: x
+      real, dimension(:), intent(in) :: dx
+      integer, intent(in) :: y_desc
+      real, dimension(:), intent(inout) :: y
+      real, dimension(:), intent(inout) :: dy
+    end subroutine
+  end interface
+contains
+  subroutine norm(x, y)
+    real, dimension(:), intent(in) :: x
+    real, dimension(:), intent(out) :: y
+    y(:) = x / sum(x)
+  end subroutine norm
+end module math
+
+program app
+  use math, only: norm, norm__enzyme_autodiff
+  use enzyme, only: enzyme_dup
+  implicit none
+  integer, parameter :: n = 1000000
+  integer, parameter :: initial_value = 20
+  real :: x(n), dx(n)
+  real :: y(n), dy(n), yp
+
+  x(:) = initial_value
+  dy(:) = 1.0
+
+  call norm(x, y)
+
+  ! Rescale the output to avoid compiler-specific output formatting
+  yp = y(n) * 1.0e+06
+  write(*,"(f6.4)") yp
+
+  dx(:) = 0.0
+  call norm__enzyme_autodiff(norm, enzyme_dup, x, dx, enzyme_dup, y, dy)
+  write(*,"(f6.4)") dy(n)
+end program app
+
+! CHECK: 1.0000
+! CHECK-NEXT: 0.0000

--- a/enzyme/test/Fortran/ReverseMode/norm_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ReverseMode/norm_with_explicit_interface.f90
@@ -8,14 +8,14 @@
 !       https://github.com/EnzymeAD/Enzyme/issues/2820
 !       https://github.com/EnzymeAD/Enzyme/issues/2822
 
-module math
+module normReverse
   interface
     subroutine norm__enzyme_autodiff(sr, x_desc, x, dx, y_desc, y, dy)
       interface
         subroutine sr_decal(a, b)
           real, dimension(:), intent(in) :: a
           real, dimension(:), intent(out) :: b
-        end subroutine
+        end subroutine sr_decal
       end interface
       procedure(sr_decal) :: sr
       integer, intent(in) :: x_desc
@@ -24,7 +24,7 @@ module math
       integer, intent(in) :: y_desc
       real, dimension(:), intent(inout) :: y
       real, dimension(:), intent(inout) :: dy
-    end subroutine
+    end subroutine norm__enzyme_autodiff
   end interface
 contains
   subroutine norm(x, y)
@@ -32,10 +32,10 @@ contains
     real, dimension(:), intent(out) :: y
     y(:) = x / sum(x)
   end subroutine norm
-end module math
+end module normReverse
 
-program app
-  use math, only: norm, norm__enzyme_autodiff
+program main
+  use normReverse, only: norm, norm__enzyme_autodiff
   use enzyme, only: enzyme_dup
   implicit none
   integer, parameter :: n = 1000000
@@ -55,7 +55,7 @@ program app
   dx(:) = 0.0
   call norm__enzyme_autodiff(norm, enzyme_dup, x, dx, enzyme_dup, y, dy)
   write(*,"(f6.4)") dy(n)
-end program app
+end program main
 
 ! CHECK: 1.0000
 ! CHECK-NEXT: 0.0000

--- a/enzyme/test/Fortran/ReverseMode/norm_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ReverseMode/norm_with_explicit_interface.f90
@@ -9,10 +9,13 @@
 !       https://github.com/EnzymeAD/Enzyme/issues/2822
 
 module normReverse
+  implicit none
   interface
     subroutine norm__enzyme_autodiff(sr, x_desc, x, dx, y_desc, y, dy)
+      implicit none
       interface
         subroutine sr_decal(a, b)
+          implicit none
           real, dimension(:), intent(in) :: a
           real, dimension(:), intent(out) :: b
         end subroutine sr_decal

--- a/enzyme/test/Fortran/ReverseMode/square_with_bindings.f90
+++ b/enzyme/test/Fortran/ReverseMode/square_with_bindings.f90
@@ -10,33 +10,33 @@
 !       For it to work with the ifx compiler we will need to figure out how to
 !       handle the indirection involved in the enzyme_autodiff binding
 
-program app
-    use enzyme, only: enzyme_dup, enzyme_autodiff
-    implicit none
-    real :: x, dx
+program main
+  use enzyme, only: enzyme_dup, enzyme_autodiff
+  implicit none
+  real :: x, dx
 
-    ! Test without an activity descriptor
-    x = 3
-    print *, square(x)
-    dx = 0
-    call enzyme_autodiff(square, x, dx)
-    print *, dx
+  ! Test without an activity descriptor
+  x = 3
+  print *, square(x)
+  dx = 0
+  call enzyme_autodiff(square, x, dx)
+  print *, dx
 
-    ! Test with an activity descriptor
-    x = 4
-    print *, square(x)
-    dx = 0
-    call enzyme_autodiff(square, enzyme_dup, x, dx)
-    print *, dx
+  ! Test with an activity descriptor
+  x = 4
+  print *, square(x)
+  dx = 0
+  call enzyme_autodiff(square, enzyme_dup, x, dx)
+  print *, dx
 
 contains
 
-    real function square( x )
-        real, intent(in) :: x
-        square = x**2
-    end function
+  real function square(x)
+    real, intent(in) :: x
+    square = x**2
+  end function square
 
-end program app
+end program main
 
 ! CHECK: 9
 ! CHECK-NEXT: 6

--- a/enzyme/test/Fortran/ReverseMode/square_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ReverseMode/square_with_explicit_interface.f90
@@ -6,39 +6,39 @@
 ! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
 ! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
 
-module squareForward
+module squareReverse
+  interface
+    subroutine square__enzyme_autodiff(fn, x, dx)
     interface
-        subroutine square__enzyme_autodiff(fn, x, dx)
-        interface
-            real function fn_decal(a)
-                real, intent(in) :: a
-            end function
-        end interface
-        procedure(fn_decal) :: fn
-        real, intent(in) :: x
-        real, intent(inout) :: dx
-        end subroutine
+      real function fn_decal(a)
+        real, intent(in) :: a
+      end function fn_decal
     end interface
+    procedure(fn_decal) :: fn
+    real, intent(in) :: x
+    real, intent(inout) :: dx
+    end subroutine square__enzyme_autodiff
+  end interface
 contains
-    real function square( x )
-        real, intent(in) :: x
-        square = x**2
-    end function
-end module
+  real function square(x)
+    real, intent(in) :: x
+    square = x**2
+  end function square
+end module squareReverse
 
-program app
-    use squareForward, only: square, square__enzyme_autodiff
-    implicit none
-    real :: x, dx
+program main
+  use squareReverse, only: square, square__enzyme_autodiff
+  implicit none
+  real :: x, dx
 
-    x = 3
-    print *, square(x)
+  x = 3
+  print *, square(x)
 
-    dx = 0
-    call square__enzyme_autodiff(square, x, dx)
+  dx = 0
+  call square__enzyme_autodiff(square, x, dx)
 
-    print *, dx
-end program app
+  print *, dx
+end program main
 
 ! CHECK: 9
 ! CHECK-NEXT: 6

--- a/enzyme/test/Fortran/ReverseMode/square_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ReverseMode/square_with_explicit_interface.f90
@@ -7,16 +7,19 @@
 ! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
 
 module squareReverse
+  implicit none
   interface
     subroutine square__enzyme_autodiff(fn, x, dx)
-    interface
-      real function fn_decal(a)
-        real, intent(in) :: a
-      end function fn_decal
-    end interface
-    procedure(fn_decal) :: fn
-    real, intent(in) :: x
-    real, intent(inout) :: dx
+      implicit none
+      interface
+        real function fn_decal(a)
+          implicit none
+          real, intent(in) :: a
+        end function fn_decal
+      end interface
+      procedure(fn_decal) :: fn
+      real, intent(in) :: x
+      real, intent(inout) :: dx
     end subroutine square__enzyme_autodiff
   end interface
 contains

--- a/enzyme/test/Fortran/ReverseMode/square_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ReverseMode/square_with_explicit_interface.f90
@@ -8,6 +8,7 @@
 
 module squareReverse
   implicit none
+  public
   interface
     subroutine square__enzyme_autodiff(fn, x, dx)
       implicit none


### PR DESCRIPTION
Closes #3018 

Add some more Fortran tests based on those found in https://github.com/EnzymeAD/Enzyme-Tutorial.

I also took the liberty of making the naming scheme for the programs, modules, and procedures consistent across the tests and also the formatting.

It's worth noting that differentiation through intrinsics does work, just not at `-O0`. As soon as you apply optimisation, they don't appear in the LLVM IR.