### PR TITLE
Retain unused pointer trait metadata

### DIFF
--- a/enzyme/Enzyme/MLIR/Passes/RemovalUtils.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/RemovalUtils.cpp
@@ -219,7 +219,7 @@ template <> struct llvm::PointerLikeTypeTraits<Node> {
   static inline Node getFromVoidPointer(void *p) {
     return Node::getFromOpaqueValue(p);
   }
-  static constexpr int NumLowBitsAvailable =
+  [[maybe_unused]] static constexpr int NumLowBitsAvailable =
       llvm::PointerLikeTypeTraits<Inner>::NumLowBitsAvailable;
 };
 


### PR DESCRIPTION
## Reproducer

Configure Enzyme MLIR against LLVM/Clang/MLIR 23.1.0-rc2 and build `MLIREnzymeTransforms`. Clang diagnoses `NumLowBitsAvailable` as unused, and Enzyme promotes that project warning to an error.

## Root cause

LLVM 23 does not instantiate this `PointerLikeTypeTraits` member on the affected build path, although the member remains part of the pointer-trait contract.

## Minimal fix

Mark the metadata member `[[maybe_unused]]`. This retains the trait contract and changes neither its value nor generated IR.

## Validation

- `MLIREnzymeTransforms` builds with `/usr/lib/llvm23/bin/clang++` 23.1.0-rc2.
- `enzymemlir-opt` builds with the same toolchain.
- Existing `MLIR/Passes/mem2reg.mlir` passes through `FileCheck`, providing a transformation smoke oracle.
- `git diff --check` passes.