### PR TITLE
Remove deprecated use of make_scope_exit

### DIFF
--- a/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogicReverse.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogicReverse.cpp
@@ -174,12 +174,6 @@ LogicalResult MEnzymeLogic::differentiate(
     llvm::function_ref<buildReturnFunction> buildFuncReturnOp,
     std::function<std::pair<Value, Value>(Type)> cacheCreator) {
   gutils->registerCacheCreatorHook(cacheCreator);
-#if LLVM_VERSION_MAJOR >= 23
-  auto scope = llvm::scope_exit(
-#else
-  auto scope = llvm::make_scope_exit(
-#endif
-      [&]() { gutils->deregisterCacheCreatorHook(cacheCreator); });
 
   gutils->createReverseModeBlocks(oldRegion, newRegion);
 
@@ -191,6 +185,8 @@ LogicalResult MEnzymeLogic::differentiate(
     valid &= visitChildren(&oBB, reverseBB, gutils).succeeded();
     handlePredecessors(&oBB, newBB, reverseBB, gutils, buildFuncReturnOp);
   }
+
+  gutils->deregisterCacheCreatorHook(cacheCreator);
   return success(valid);
 }
 

--- a/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogicReverse.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogicReverse.cpp
@@ -174,7 +174,11 @@ LogicalResult MEnzymeLogic::differentiate(
     llvm::function_ref<buildReturnFunction> buildFuncReturnOp,
     std::function<std::pair<Value, Value>(Type)> cacheCreator) {
   gutils->registerCacheCreatorHook(cacheCreator);
+#if LLVM_VERSION_MAJOR >= 23
+  auto scope = llvm::scope_exit(
+#else
   auto scope = llvm::make_scope_exit(
+#endif
       [&]() { gutils->deregisterCacheCreatorHook(cacheCreator); });
 
   gutils->createReverseModeBlocks(oldRegion, newRegion);


### PR DESCRIPTION
Wrap it in an ifdef. This was removed in upstream LLVM recently (289a4568f7d18d1d42687f3a2fc2c72bcbadaa28).