### PR TITLE
[TA] Don't recurse infinitely on self-referential constant globals

### DIFF
--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -670,6 +670,38 @@ FnTypeInfo::knownIntegralValues(llvm::Value *val, const DominatorTree &DT,
   return intseen[val];
 }
 
+/// Return whether the initializer of the constant global GV transitively
+/// refers back to GV itself, either directly or through the initializer of
+/// another constant global. Analyzing such an initializer would recurse
+/// forever, as the analysis of a global is only memoized once its initializer
+/// has been fully analyzed. This arises in practice for relative-pointer jump
+/// tables, whose entries look like `sub (i64 0, i64 ptrtoint (ptr @tab
+/// to i64))`.
+static bool isCyclicConstantGlobal(GlobalVariable *GV) {
+  SmallPtrSet<Constant *, 8> Seen;
+  SmallVector<Constant *, 8> Todo = {GV->getInitializer()};
+  while (!Todo.empty()) {
+    Constant *C = Todo.pop_back_val();
+    if (C == GV)
+      return true;
+    if (!Seen.insert(C).second)
+      continue;
+    if (auto SubGV = dyn_cast<GlobalVariable>(C)) {
+      // Mirror the recursion below, which only descends into the initializer
+      // of a fixed constant global.
+      if (SubGV->isConstant() && SubGV->hasInitializer())
+        Todo.push_back(SubGV->getInitializer());
+      continue;
+    }
+    if (isa<GlobalValue>(C))
+      continue;
+    for (auto &Op : C->operands())
+      if (auto COp = dyn_cast<Constant>(Op.get()))
+        Todo.push_back(COp);
+  }
+  return false;
+}
+
 /// Given a constant value, deduce any type information applicable
 void getConstantAnalysis(Constant *Val, TypeAnalyzer &TA,
                          std::map<llvm::Value *, TypeTree> &analysis) {
@@ -900,8 +932,12 @@ void getConstantAnalysis(Constant *Val, TypeAnalyzer &TA,
       analysis[Val] = T;
       return;
     }
-    // A fixed constant global is a pointer to its initializer
-    if (GV->isConstant() && GV->hasInitializer()) {
+    // A fixed constant global is a pointer to its initializer. A global whose
+    // initializer refers back to itself is instead handled below as an
+    // ordinary pointer of unknown pointee, as its initializer cannot be
+    // analyzed without recursing infinitely.
+    if (GV->isConstant() && GV->hasInitializer() &&
+        !isCyclicConstantGlobal(GV)) {
       getConstantAnalysis(GV->getInitializer(), TA, analysis);
       TypeTree constTT = analysis[GV->getInitializer()].Only(-1, nullptr);
       constTT.insert({-1}, ConcreteType(BaseType::Pointer));

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -670,38 +670,6 @@ FnTypeInfo::knownIntegralValues(llvm::Value *val, const DominatorTree &DT,
   return intseen[val];
 }
 
-/// Return whether the initializer of the constant global GV transitively
-/// refers back to GV itself, either directly or through the initializer of
-/// another constant global. Analyzing such an initializer would recurse
-/// forever, as the analysis of a global is only memoized once its initializer
-/// has been fully analyzed. This arises in practice for relative-pointer jump
-/// tables, whose entries look like `sub (i64 0, i64 ptrtoint (ptr @tab
-/// to i64))`.
-static bool isCyclicConstantGlobal(GlobalVariable *GV) {
-  SmallPtrSet<Constant *, 8> Seen;
-  SmallVector<Constant *, 8> Todo = {GV->getInitializer()};
-  while (!Todo.empty()) {
-    Constant *C = Todo.pop_back_val();
-    if (C == GV)
-      return true;
-    if (!Seen.insert(C).second)
-      continue;
-    if (auto SubGV = dyn_cast<GlobalVariable>(C)) {
-      // Mirror the recursion below, which only descends into the initializer
-      // of a fixed constant global.
-      if (SubGV->isConstant() && SubGV->hasInitializer())
-        Todo.push_back(SubGV->getInitializer());
-      continue;
-    }
-    if (isa<GlobalValue>(C))
-      continue;
-    for (auto &Op : C->operands())
-      if (auto COp = dyn_cast<Constant>(Op.get()))
-        Todo.push_back(COp);
-  }
-  return false;
-}
-
 /// Given a constant value, deduce any type information applicable
 void getConstantAnalysis(Constant *Val, TypeAnalyzer &TA,
                          std::map<llvm::Value *, TypeTree> &analysis) {
@@ -932,12 +900,19 @@ void getConstantAnalysis(Constant *Val, TypeAnalyzer &TA,
       analysis[Val] = T;
       return;
     }
-    // A fixed constant global is a pointer to its initializer. A global whose
-    // initializer refers back to itself is instead handled below as an
-    // ordinary pointer of unknown pointee, as its initializer cannot be
-    // analyzed without recursing infinitely.
-    if (GV->isConstant() && GV->hasInitializer() &&
-        !isCyclicConstantGlobal(GV)) {
+    // A fixed constant global is a pointer to its initializer
+    if (GV->isConstant() && GV->hasInitializer()) {
+      // Record that this global is a pointer before analyzing its initializer.
+      // An initializer which refers back to its own global (such as a relative
+      // pointer jump table) would otherwise recurse forever, as the type of a
+      // global is only recorded once its initializer has been fully analyzed.
+      // Seeding with the fact that a global is a pointer is always correct, so
+      // any type deduced from it remains sound, and the seed is refined into
+      // the full type below once the initializer has been analyzed.
+      TypeTree seed;
+      seed.insert({-1}, ConcreteType(BaseType::Pointer));
+      GV->setMetadata("enzyme_type", seed.toMD(GV->getContext()));
+
       getConstantAnalysis(GV->getInitializer(), TA, analysis);
       TypeTree constTT = analysis[GV->getInitializer()].Only(-1, nullptr);
       constTT.insert({-1}, ConcreteType(BaseType::Pointer));

--- a/enzyme/test/Enzyme/ReverseMode/recursiveglobal.ll
+++ b/enzyme/test/Enzyme/ReverseMode/recursiveglobal.ll
@@ -1,0 +1,26 @@
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme-preopt=false -enzyme -mem2reg -instsimplify -simplifycfg -S | FileCheck %s; fi
+; RUN: %opt < %s %newLoadEnzyme -enzyme-preopt=false -passes="enzyme,function(mem2reg,instsimplify,%simplifycfg)" -S | FileCheck %s
+
+; A constant global whose initializer refers back to itself, as emitted for a
+; relative-pointer jump table when lowering a switch over several constant
+; tables. Type analysis must not recurse infinitely analyzing the initializer.
+
+@tab = constant [1 x i64] [i64 sub (i64 0, i64 ptrtoint ([1 x i64]* @tab to i64))]
+
+define double @f(double %x) {
+  %v = load double, double* bitcast ([1 x i64]* @tab to double*), align 8
+  ret double %v
+}
+
+define double @d(double %x) {
+  %r = call double (...) @__enzyme_autodiff(double (double)* @f, double %x)
+  ret double %r
+}
+
+declare double @__enzyme_autodiff(...)
+
+; The pointer-typed shadow setup in between differs across LLVM versions, so
+; only the signature and the (zero) derivative are checked here.
+; CHECK: define internal { double } @diffef(double %x, double %differeturn)
+; CHECK-NEXT: invert:
+; CHECK: ret { double } zeroinitializer

--- a/enzyme/test/Enzyme/ReverseMode/recursiveglobal.ll
+++ b/enzyme/test/Enzyme/ReverseMode/recursiveglobal.ll
@@ -1,26 +1,60 @@
 ; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme-preopt=false -enzyme -mem2reg -instsimplify -simplifycfg -S | FileCheck %s; fi
 ; RUN: %opt < %s %newLoadEnzyme -enzyme-preopt=false -passes="enzyme,function(mem2reg,instsimplify,%simplifycfg)" -S | FileCheck %s
 
-; A constant global whose initializer refers back to itself, as emitted for a
-; relative-pointer jump table when lowering a switch over several constant
-; tables. Type analysis must not recurse infinitely analyzing the initializer.
+; Constant globals whose initializers refer back to themselves. Type analysis
+; must not recurse infinitely analyzing such an initializer.
 
+; A relative pointer jump table, as emitted when lowering a switch over several
+; constant tables. Nothing can be said about what it points at.
 @tab = constant [1 x i64] [i64 sub (i64 0, i64 ptrtoint ([1 x i64]* @tab to i64))]
+
+; A self referential struct which also holds a double. Breaking the cycle must
+; not discard the rest of the initializer: the pointer at offset 0 and the
+; double at offset 8 are both still deduced.
+@mixed = constant { i8*, double } { i8* bitcast ({ i8*, double }* @mixed to i8*), double 3.000000e+00 }
 
 define double @f(double %x) {
   %v = load double, double* bitcast ([1 x i64]* @tab to double*), align 8
   ret double %v
 }
 
+define double @g(double %x) {
+  %p = getelementptr inbounds { i8*, double }, { i8*, double }* @mixed, i64 0, i32 1
+  %v = load double, double* %p, align 8
+  %m = fmul double %v, %x
+  ret double %m
+}
+
 define double @d(double %x) {
   %r = call double (...) @__enzyme_autodiff(double (double)* @f, double %x)
-  ret double %r
+  %s = call double (...) @__enzyme_autodiff(double (double)* @g, double %x)
+  %t = fadd double %r, %s
+  ret double %t
 }
 
 declare double @__enzyme_autodiff(...)
 
-; The pointer-typed shadow setup in between differs across LLVM versions, so
-; only the signature and the (zero) derivative are checked here.
+; The textual pointer types differ across LLVM versions, so the globals are
+; matched loosely and the deduced types are checked via their metadata below.
+; CHECK: @tab = constant {{.*}}!enzyme_type ![[TAB:[0-9]+]]
+; CHECK: @mixed = constant {{.*}}!enzyme_type ![[MIXED:[0-9]+]]
+
+; @tab is only read, so the derivative is zero.
 ; CHECK: define internal { double } @diffef(double %x, double %differeturn)
 ; CHECK-NEXT: invert:
 ; CHECK: ret { double } zeroinitializer
+
+; CHECK: define internal { double } @diffeg(double %x, double %differeturn)
+; CHECK-NEXT: invert:
+; CHECK: %[[MUL:.+]] = fmul fast double %differeturn, 3.000000e+00
+; CHECK: insertvalue { double } undef, double %[[MUL]], 0
+
+; @tab is a pointer to an unknown pointee, as its initializer is entirely
+; self referential.
+; CHECK-DAG: ![[TAB]] = !{!"Unknown", i32 -1, ![[TABP:[0-9]+]]}
+; CHECK-DAG: ![[TABP]] = !{!"Pointer"}
+
+; @mixed keeps the types of both of its fields.
+; CHECK-DAG: ![[MIXED]] = !{!"Unknown", i32 -1, ![[MIXEDI:[0-9]+]]}
+; CHECK-DAG: ![[MIXEDI]] = !{!"Pointer", i32 0, !{{[0-9]+}}, i32 8, ![[MIXEDF:[0-9]+]]}
+; CHECK-DAG: ![[MIXEDF]] = !{!"Float@double"}


### PR DESCRIPTION
Fixes #3027.

### Root cause

`getConstantAnalysis` records the type of a constant global only *after* its initializer has been fully analyzed:

```cpp
if (GV->isConstant() && GV->hasInitializer()) {
  getConstantAnalysis(GV->getInitializer(), TA, analysis);  // nothing recorded for GV yet
  ...
  GV->setMetadata("enzyme_type", constTT.toMD(GV->getContext()));
}
```

So an initializer that refers back to its own global re-enters the analysis of that global with nothing recorded, and recurses until the stack overflows. For the reported input:

```llvm
@tab = constant [1 x i64] [i64 sub (i64 0, i64 ptrtoint (ptr @tab to i64))]
```

the cycle is `@tab` -> initializer array -> `sub` constexpr -> `visitBinaryOperator` -> `ptrtoint` constexpr -> `@tab`.

These relative pointer jump tables are emitted by LLVM when lowering a switch over three or more constant tables, so this is reachable from ordinary source -- hence the Rust reproducer in the issue, which builds cleanly with two tables and crashes with three.

### Fix

Record that the global is a pointer *before* analyzing its initializer, so a self referential initializer terminates on the existing `enzyme_type` early return. The seed is then overwritten with the full type once the initializer has been analyzed.

A global is a pointer no matter what its initializer says, so the seed is an unconditionally true fact rather than a guess, and everything deduced from it stays sound. It also preserves precision that bailing out on the cycle would lose: a self referential aggregate keeps the types of its remaining fields rather than decaying to an opaque pointer. The test covers this with

```llvm
@mixed = constant { i8*, double } { i8* bitcast ({ i8*, double }* @mixed to i8*), double 3.0 }
```

whose deduced type is `{0: Pointer, 8: Float@double}`.

Cycles routed through a second constant global (`@a`'s initializer naming `@b` and vice versa) terminate for the same reason.

### Testing

- New lit test `Enzyme/ReverseMode/recursiveglobal.ll`. It fails on current `main` (segfault) and passes with this change.
- Full suite on LLVM 15: 1037 passed / 1 failed, versus 1036 passed / 1 failed before the change. The one failure (`ReverseModeVector/partial_int_window.ll`) is pre-existing and unrelated.

The first commit implements this by detecting the cycle up front and bailing; the second replaces that with the seeding approach above, which is smaller and strictly more precise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
