### PR TITLE
Respect the min-cut admission rule when pushing loopy PHI preheaders

### DIFF
--- a/enzyme/Enzyme/DifferentialUseAnalysis.cpp
+++ b/enzyme/Enzyme/DifferentialUseAnalysis.cpp
@@ -1287,7 +1287,8 @@ bool checkLoopyReductionPHI(const GradientUtils *gutils,
 
 void pushLoopyPHIPreheader(const GradientUtils *gutils, llvm::Value *V,
                            llvm::SetVector<llvm::Value *> &Intermediates,
-                           std::deque<llvm::Value *> &todo) {
+                           std::deque<llvm::Value *> &todo,
+                           llvm::function_ref<bool(llvm::Value *)> admissible) {
   using namespace llvm;
   if (auto P0 = dyn_cast<PHINode>(V)) {
     if (!gutils->OrigLI)
@@ -1347,6 +1348,16 @@ void pushLoopyPHIPreheader(const GradientUtils *gutils, llvm::Value *V,
       // thus need not be added to the recompute graph (which only contains
       // instructions).
       if (!isa<Instruction>(Pstart))
+        break;
+      // Only values the caller would itself admit may enter the recompute
+      // graph. Everything in Intermediates that the min-cut declines to cache
+      // is later assumed recomputable; adding a value that is not legal to
+      // recompute breaks that invariant and trips the assertion in
+      // computeMinCache. Such a value is instead handled by the ordinary
+      // caching path, exactly as the main worklist does when legalRecompute
+      // fails. Stop walking the chain: anything further up is only reachable
+      // through this value.
+      if (!admissible(Pstart))
         break;
       Intermediates.insert(Pstart);
       todo.push_back(Pstart);

--- a/enzyme/Enzyme/DifferentialUseAnalysis.h
+++ b/enzyme/Enzyme/DifferentialUseAnalysis.h
@@ -84,9 +84,20 @@ bool checkLoopyReductionPHI(const GradientUtils *gutils,
                             const llvm::PHINode *P0,
                             const llvm::Value *incomingVal);
 
+/// Add the preheader start value of a loopy reduction PHI to the min-cut
+/// recompute graph.
+///
+/// \p admissible must return whether a value may legally be added to
+/// \p Intermediates, i.e. that it is either already a known recompute or is
+/// legal to recompute given what is available in the reverse pass. Callers
+/// must supply the same admission rule that governs their own worklist:
+/// everything in \p Intermediates is later assumed to be recomputable unless
+/// the min-cut selected it for caching, and violating that fires an assertion
+/// in GradientUtils::computeMinCache.
 void pushLoopyPHIPreheader(const GradientUtils *gutils, llvm::Value *V,
                            llvm::SetVector<llvm::Value *> &Intermediates,
-                           std::deque<llvm::Value *> &todo);
+                           std::deque<llvm::Value *> &todo,
+                           llvm::function_ref<bool(llvm::Value *)> admissible);
 
 template <QueryType VT, bool OneLevel = false>
 inline bool is_value_needed_in_reverse(

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -8740,10 +8740,33 @@ void GradientUtils::computeMinCache() {
                                     Required, MinReq, this, TLI);
     SmallPtrSet<Value *, 5> NeedGraph;
 
+    // Same admission rule the worklist above applies before inserting into
+    // Intermediates: a value may join the recompute graph only if it is
+    // already a known recompute, or is legal to recompute from what the
+    // reverse pass has available. Keeping these two in agreement is what makes
+    // the `legalRecompute` assertion below hold.
+    auto admissibleIntermediate = [&](Value *V) {
+      if (Recomputes.count(V))
+        return true;
+      auto I = dyn_cast<Instruction>(V);
+      if (!I)
+        return false;
+      ValueToValueMapTy Available2;
+      for (auto a : Available)
+        Available2[a.first] = a.second;
+      for (Loop *L = OrigLI->getLoopFor(I->getParent()); L != nullptr;
+           L = L->getParentLoop()) {
+        for (auto v : LoopAvail[L]) {
+          Available2[v] = v;
+        }
+      }
+      return legalRecompute(V, Available2, nullptr);
+    };
+
     for (Value *V : MinReq) {
       NeedGraph.insert(V);
-      DifferentialUseAnalysis::pushLoopyPHIPreheader(this, V, Intermediates,
-                                                     todo);
+      DifferentialUseAnalysis::pushLoopyPHIPreheader(
+          this, V, Intermediates, todo, admissibleIntermediate);
     }
     for (Value *V : Required) {
       todo.push_back(V);
@@ -8754,8 +8777,8 @@ void GradientUtils::computeMinCache() {
       if (NeedGraph.count(V))
         continue;
       NeedGraph.insert(V);
-      DifferentialUseAnalysis::pushLoopyPHIPreheader(this, V, Intermediates,
-                                                     todo);
+      DifferentialUseAnalysis::pushLoopyPHIPreheader(
+          this, V, Intermediates, todo, admissibleIntermediate);
       auto I = dyn_cast<Instruction>(V);
       if (!I)
         continue;

--- a/enzyme/test/Enzyme/ReverseMode/mincut-loopy-phi-preheader-legality.ll
+++ b/enzyme/test/Enzyme/ReverseMode/mincut-loopy-phi-preheader-legality.ll
@@ -1,0 +1,59 @@
+; RUN: %opt < %s %newLoadEnzyme -passes="enzyme" -enzyme-preopt=false -S | FileCheck %s
+
+; A loopy reduction PHI whose preheader incoming value is an instruction (here a
+; load from an active argument) rather than a constant.
+;
+; pushLoopyPHIPreheader must not add such a value to the min-cut recompute graph
+; unless it is legal to recompute, since computeMinCache later assumes exactly
+; that of every Intermediate the min-cut declined to cache. Adding it
+; unconditionally aborted with
+;   GradientUtils.cpp: void GradientUtils::computeMinCache():
+;     Assertion `legalRecompute(V, Available2, nullptr)' failed.
+
+declare double @__enzyme_autodiff(...)
+
+@enzyme_dup = external global i32
+@enzyme_const = external global i32
+
+define double @wrap(ptr nocapture readonly %diag, ptr nocapture writeonly %out) {
+start:
+  %seed = load double, ptr %diag, align 8
+  br label %loop
+
+loop:
+  %i = phi i64 [ 0, %start ], [ %i.next, %loop ]
+  %gu = phi double [ %seed, %start ], [ %gu.next, %loop ]
+  %i.next = add nuw nsw i64 %i, 1
+  %p = getelementptr inbounds double, ptr %diag, i64 %i
+  %v = load double, ptr %p, align 8
+  %cmp = fcmp ogt double %gu, %v
+  %vplus = fadd double %v, 0.000000e+00
+  %gu.next = select i1 %cmp, double %gu, double %vplus
+  %done = icmp eq i64 %i.next, 8
+  br i1 %done, label %exit, label %loop
+
+exit:
+  %gu.final = phi double [ %gu.next, %loop ]
+  %isneg = fcmp ogt double %gu.final, 0.000000e+00
+  %sigma = select i1 %isneg, double 0.000000e+00, double %gu.final
+  %slot = getelementptr inbounds i8, ptr %out, i64 56
+  store double %sigma, ptr %slot, align 8
+  ret double 0.000000e+00
+}
+
+define double @caller(ptr %diag, ptr %ddiag, ptr %out) {
+entry:
+  %r = call double (...) @__enzyme_autodiff(ptr @wrap, ptr @enzyme_dup, ptr %diag, ptr %ddiag, ptr @enzyme_const, ptr %out)
+  ret double %r
+}
+
+; CHECK: define internal void @diffewrap(
+
+; The adjoint of the preheader seed load must be accumulated into the shadow of
+; the active argument.
+; CHECK: invertstart:
+; CHECK:   %[[seedde:.+]] = load double, {{.+}} %"seed'de"
+; CHECK:   store double 0.000000e+00, {{.+}} %"seed'de"
+; CHECK:   %[[prev:.+]] = load double, {{.+}} %"diag'"
+; CHECK:   %[[acc:.+]] = fadd fast double %[[prev]], %[[seedde]]
+; CHECK:   store double %[[acc]], {{.+}} %"diag'"


### PR DESCRIPTION
Fixes #3040 

@wsmoses Not sure if it's the right approach and probably too wordy, so feel free to close. After bisecting it to the causing PR I gave it to the LLM you also used for your last fixes, and at least it works.