### PR TITLE
Make IR emission order independent of C++ argument evaluation order

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
@@ -1194,12 +1194,12 @@ public:
       auto ivTy = forOp.getLowerBound().getType();
       Value outerUB = makeIntConstant(forOp.getLowerBound().getLoc(), builder,
                                       nOuter + hasTrailing, ivTy);
-      auto revOuter = scf::ForOp::create(
-          builder, op->getLoc(),
-          makeIntConstant(forOp.getLowerBound().getLoc(), builder, 0, ivTy),
-          outerUB,
-          makeIntConstant(forOp.getLowerBound().getLoc(), builder, 1, ivTy),
-          incomingGradients);
+      Value outerStep =
+          makeIntConstant(forOp.getLowerBound().getLoc(), builder, 1, ivTy);
+      Value outerLB =
+          makeIntConstant(forOp.getLowerBound().getLoc(), builder, 0, ivTy);
+      auto revOuter = scf::ForOp::create(builder, op->getLoc(), outerLB,
+                                         outerUB, outerStep, incomingGradients);
       preserveAttributesButCheckpointing(revOuter, forOp);
 
       OpBuilder::InsertionGuard guard(builder);
@@ -1233,11 +1233,12 @@ public:
       if (trailingIters > 0) {
         // this is the first reverse iteration
         Location loc = forOp.getUpperBound().getLoc();
-        nInnerUB = arith::SelectOp::create(
-            builder, loc,
+        Value trailingCst = makeIntConstant(loc, builder, trailingIters, ivTy);
+        Value isFirstRevIter =
             arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::eq,
-                                  revOuter.getInductionVar(), zero),
-            makeIntConstant(loc, builder, trailingIters, ivTy), nInnerCst);
+                                  revOuter.getInductionVar(), zero);
+        nInnerUB = arith::SelectOp::create(builder, loc, isFirstRevIter,
+                                           trailingCst, nInnerCst);
       }
 
       auto revInner = scf::ForOp::create(builder, forOp.getLoc(), zero,
@@ -1258,19 +1259,17 @@ public:
 
       builder.setInsertionPointToEnd(revInner.getBody());
 
-      Value currentIV = arith::AddIOp::create(
+      Value startCst = arith::ConstantOp::create(
+          builder, loc, IntegerAttr::get(ivTy, startI));
+      Value stepCst = arith::ConstantOp::create(builder, loc,
+                                                IntegerAttr::get(ivTy, stepI));
+      Value flatIV = arith::AddIOp::create(
           builder, loc,
-          arith::MulIOp::create(
-              builder, loc,
-              arith::AddIOp::create(builder, loc,
-                                    arith::MulIOp::create(builder, loc,
-                                                          currentOuterStep,
-                                                          nInnerCst),
-                                    revInner.getInductionVar()),
-              arith::ConstantOp::create(builder, loc,
-                                        IntegerAttr::get(ivTy, stepI))),
-          arith::ConstantOp::create(builder, loc,
-                                    IntegerAttr::get(ivTy, startI)));
+          arith::MulIOp::create(builder, loc, currentOuterStep, nInnerCst),
+          revInner.getInductionVar());
+      Value currentIV = arith::AddIOp::create(
+          builder, loc, arith::MulIOp::create(builder, loc, flatIV, stepCst),
+          startCst);
 
       // Re-materialize this segment's primal for the reverse visitor (below,
       // in revLoop), and hand it that clone as forOp's body. The terminator is
@@ -1515,13 +1514,16 @@ public:
       scf::ForOp newForOp = cast<scf::ForOp>(gutils->getNewFromOriginal(op));
 
       Type ty = forOp.getLowerBound().getType();
-      auto outerFwd = scf::ForOp::create(
-          cacheBuilder, op->getLoc(),
-          makeIntConstant(forOp.getLowerBound().getLoc(), cacheBuilder, 0, ty),
+      Value outerFwdStep =
+          makeIntConstant(forOp.getStep().getLoc(), cacheBuilder, nInner, ty);
+      Value outerFwdUB =
           makeIntConstant(forOp.getUpperBound().getLoc(), cacheBuilder,
-                          nInner * (nOuter + hasTrailing), ty),
-          makeIntConstant(forOp.getStep().getLoc(), cacheBuilder, nInner, ty),
-          newForOp.getInitArgs());
+                          nInner * (nOuter + hasTrailing), ty);
+      Value outerFwdLB =
+          makeIntConstant(forOp.getLowerBound().getLoc(), cacheBuilder, 0, ty);
+      auto outerFwd =
+          scf::ForOp::create(cacheBuilder, op->getLoc(), outerFwdLB, outerFwdUB,
+                             outerFwdStep, newForOp.getInitArgs());
       preserveAttributesButCheckpointing(outerFwd, forOp);
 
       cacheBuilder.setInsertionPointToStart(outerFwd.getBody());
@@ -1533,13 +1535,15 @@ public:
         // if this is the last iteration, then the inner
         // loop will only make trailingIters iterations
         Location loc = forOp.getUpperBound().getLoc();
-        nInnerUB = arith::SelectOp::create(
-            cacheBuilder, loc,
-            arith::CmpIOp::create(
-                cacheBuilder, loc, arith::CmpIPredicate::eq,
-                outerFwd.getInductionVar(),
-                makeIntConstant(loc, cacheBuilder, nInner * nOuter, ty)),
-            makeIntConstant(loc, cacheBuilder, trailingIters, ty), nInnerCst);
+        Value trailingCst =
+            makeIntConstant(loc, cacheBuilder, trailingIters, ty);
+        Value lastOuterIter =
+            makeIntConstant(loc, cacheBuilder, nInner * nOuter, ty);
+        Value isLastFwdIter =
+            arith::CmpIOp::create(cacheBuilder, loc, arith::CmpIPredicate::eq,
+                                  outerFwd.getInductionVar(), lastOuterIter);
+        nInnerUB = arith::SelectOp::create(cacheBuilder, loc, isLastFwdIter,
+                                           trailingCst, nInnerCst);
       }
 
       IRMapping &mapping = gutils->originalToNewFn;
@@ -1553,11 +1557,12 @@ public:
             gutils->initAndPushCache(clone, cacheBuilder));
       }
 
+      Value innerFwdStep =
+          makeIntConstant(forOp.getStep().getLoc(), cacheBuilder, 1, ty);
+      Value innerFwdLB =
+          makeIntConstant(forOp.getLowerBound().getLoc(), cacheBuilder, 0, ty);
       auto innerFwd = scf::ForOp::create(
-          cacheBuilder, op->getLoc(),
-          makeIntConstant(forOp.getLowerBound().getLoc(), cacheBuilder, 0, ty),
-          nInnerUB,
-          makeIntConstant(forOp.getStep().getLoc(), cacheBuilder, 1, ty),
+          cacheBuilder, op->getLoc(), innerFwdLB, nInnerUB, innerFwdStep,
           outerFwd.getBody()->getArguments().drop_front());
       preserveAttributesButCheckpointing(innerFwd, forOp);
 


### PR DESCRIPTION
`SCFAutoDiffOpInterfaceImpl` builds several ops directly in the argument list of another op-creating call:

```cpp
auto revOuter = scf::ForOp::create(
    builder, op->getLoc(),
    makeIntConstant(forOp.getLowerBound().getLoc(), builder, 0, ivTy),
    outerUB,
    makeIntConstant(forOp.getLowerBound().getLoc(), builder, 1, ivTy),
    incomingGradients);
```

C++ leaves the evaluation order of function arguments unspecified, so *which constant is inserted into the block first* is the compiler's choice. The `for`'s operands are fixed, but the textual order of the ops it builds is not — the same source emits them one way on macOS and the other on Linux. Anything that pins emitted order (a `CHECK-NEXT` chain, a diff of dumped IR) is then build-dependent.

Enzyme-JAX hit this concretely: a `CHECK-NEXT` written against macOS output failed on Linux CI because two compares came out swapped (EnzymeAD/Enzyme-JAX#2721). The same hazard exists here.

## Changes

Each op that shares an argument list with another op-creating call is bound to a local first, so the source fixes the insertion order. No semantic change: the same ops with the same operands are created, only the order is now pinned.

7 sites in `MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp` — the reverse and cache `scf::ForOp` bounds, the two `arith::SelectOp` trailing-iteration guards, and the checkpointed induction-variable arithmetic.

Found by brace/paren-matching every call expression and flagging argument lists with two or more sibling op emitters, where an emitter is `X::create(...)` / `builder.create<...>(...)` / `rewriter.replaceOpWithNewOp<...>(...)` plus any local lambda or function whose body creates ops (`makeIntConstant`, ...). These 7 were the only real hits in `enzyme/Enzyme`; the scan is clean afterwards. (`MLIR/Passes/RemovalUtils.h:415` flags but is fine — the lambda body runs inside `map_to_vector`, after argument evaluation.)

## Testing

None locally — I have no build of this tree, so CI is the verification here. Existing tests should be unaffected: they pass on both macOS and Linux today, so no CHECK line can currently depend on an order that already differs between those two platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)