### PR TITLE
Add a lint job for order-dependent IR emission

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+  merge_group:
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  emission-order:
+    name: Deterministic IR emission order
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Check for order-dependent IR emission
+      run: python3 enzyme/scripts/check_emission_order.py --github enzyme/Enzyme

--- a/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
@@ -1194,12 +1194,12 @@ public:
       auto ivTy = forOp.getLowerBound().getType();
       Value outerUB = makeIntConstant(forOp.getLowerBound().getLoc(), builder,
                                       nOuter + hasTrailing, ivTy);
-      auto revOuter = scf::ForOp::create(
-          builder, op->getLoc(),
-          makeIntConstant(forOp.getLowerBound().getLoc(), builder, 0, ivTy),
-          outerUB,
-          makeIntConstant(forOp.getLowerBound().getLoc(), builder, 1, ivTy),
-          incomingGradients);
+      Value outerStep =
+          makeIntConstant(forOp.getLowerBound().getLoc(), builder, 1, ivTy);
+      Value outerLB =
+          makeIntConstant(forOp.getLowerBound().getLoc(), builder, 0, ivTy);
+      auto revOuter = scf::ForOp::create(builder, op->getLoc(), outerLB,
+                                         outerUB, outerStep, incomingGradients);
       preserveAttributesButCheckpointing(revOuter, forOp);
 
       OpBuilder::InsertionGuard guard(builder);
@@ -1233,11 +1233,12 @@ public:
       if (trailingIters > 0) {
         // this is the first reverse iteration
         Location loc = forOp.getUpperBound().getLoc();
-        nInnerUB = arith::SelectOp::create(
-            builder, loc,
+        Value trailingCst = makeIntConstant(loc, builder, trailingIters, ivTy);
+        Value isFirstRevIter =
             arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::eq,
-                                  revOuter.getInductionVar(), zero),
-            makeIntConstant(loc, builder, trailingIters, ivTy), nInnerCst);
+                                  revOuter.getInductionVar(), zero);
+        nInnerUB = arith::SelectOp::create(builder, loc, isFirstRevIter,
+                                           trailingCst, nInnerCst);
       }
 
       auto revInner = scf::ForOp::create(builder, forOp.getLoc(), zero,
@@ -1258,19 +1259,17 @@ public:
 
       builder.setInsertionPointToEnd(revInner.getBody());
 
-      Value currentIV = arith::AddIOp::create(
+      Value startCst = arith::ConstantOp::create(
+          builder, loc, IntegerAttr::get(ivTy, startI));
+      Value stepCst = arith::ConstantOp::create(builder, loc,
+                                                IntegerAttr::get(ivTy, stepI));
+      Value flatIV = arith::AddIOp::create(
           builder, loc,
-          arith::MulIOp::create(
-              builder, loc,
-              arith::AddIOp::create(builder, loc,
-                                    arith::MulIOp::create(builder, loc,
-                                                          currentOuterStep,
-                                                          nInnerCst),
-                                    revInner.getInductionVar()),
-              arith::ConstantOp::create(builder, loc,
-                                        IntegerAttr::get(ivTy, stepI))),
-          arith::ConstantOp::create(builder, loc,
-                                    IntegerAttr::get(ivTy, startI)));
+          arith::MulIOp::create(builder, loc, currentOuterStep, nInnerCst),
+          revInner.getInductionVar());
+      Value currentIV = arith::AddIOp::create(
+          builder, loc, arith::MulIOp::create(builder, loc, flatIV, stepCst),
+          startCst);
 
       // Re-materialize this segment's primal for the reverse visitor (below,
       // in revLoop), and hand it that clone as forOp's body. The terminator is
@@ -1515,13 +1514,16 @@ public:
       scf::ForOp newForOp = cast<scf::ForOp>(gutils->getNewFromOriginal(op));
 
       Type ty = forOp.getLowerBound().getType();
-      auto outerFwd = scf::ForOp::create(
-          cacheBuilder, op->getLoc(),
-          makeIntConstant(forOp.getLowerBound().getLoc(), cacheBuilder, 0, ty),
+      Value outerFwdStep =
+          makeIntConstant(forOp.getStep().getLoc(), cacheBuilder, nInner, ty);
+      Value outerFwdUB =
           makeIntConstant(forOp.getUpperBound().getLoc(), cacheBuilder,
-                          nInner * (nOuter + hasTrailing), ty),
-          makeIntConstant(forOp.getStep().getLoc(), cacheBuilder, nInner, ty),
-          newForOp.getInitArgs());
+                          nInner * (nOuter + hasTrailing), ty);
+      Value outerFwdLB =
+          makeIntConstant(forOp.getLowerBound().getLoc(), cacheBuilder, 0, ty);
+      auto outerFwd =
+          scf::ForOp::create(cacheBuilder, op->getLoc(), outerFwdLB, outerFwdUB,
+                             outerFwdStep, newForOp.getInitArgs());
       preserveAttributesButCheckpointing(outerFwd, forOp);
 
       cacheBuilder.setInsertionPointToStart(outerFwd.getBody());
@@ -1533,13 +1535,15 @@ public:
         // if this is the last iteration, then the inner
         // loop will only make trailingIters iterations
         Location loc = forOp.getUpperBound().getLoc();
-        nInnerUB = arith::SelectOp::create(
-            cacheBuilder, loc,
-            arith::CmpIOp::create(
-                cacheBuilder, loc, arith::CmpIPredicate::eq,
-                outerFwd.getInductionVar(),
-                makeIntConstant(loc, cacheBuilder, nInner * nOuter, ty)),
-            makeIntConstant(loc, cacheBuilder, trailingIters, ty), nInnerCst);
+        Value trailingCst =
+            makeIntConstant(loc, cacheBuilder, trailingIters, ty);
+        Value lastOuterIter =
+            makeIntConstant(loc, cacheBuilder, nInner * nOuter, ty);
+        Value isLastFwdIter =
+            arith::CmpIOp::create(cacheBuilder, loc, arith::CmpIPredicate::eq,
+                                  outerFwd.getInductionVar(), lastOuterIter);
+        nInnerUB = arith::SelectOp::create(cacheBuilder, loc, isLastFwdIter,
+                                           trailingCst, nInnerCst);
       }
 
       IRMapping &mapping = gutils->originalToNewFn;
@@ -1553,11 +1557,12 @@ public:
             gutils->initAndPushCache(clone, cacheBuilder));
       }
 
+      Value innerFwdStep =
+          makeIntConstant(forOp.getStep().getLoc(), cacheBuilder, 1, ty);
+      Value innerFwdLB =
+          makeIntConstant(forOp.getLowerBound().getLoc(), cacheBuilder, 0, ty);
       auto innerFwd = scf::ForOp::create(
-          cacheBuilder, op->getLoc(),
-          makeIntConstant(forOp.getLowerBound().getLoc(), cacheBuilder, 0, ty),
-          nInnerUB,
-          makeIntConstant(forOp.getStep().getLoc(), cacheBuilder, 1, ty),
+          cacheBuilder, op->getLoc(), innerFwdLB, nInnerUB, innerFwdStep,
           outerFwd.getBody()->getArguments().drop_front());
       preserveAttributesButCheckpointing(innerFwd, forOp);
 

--- a/enzyme/scripts/check_emission_order.py
+++ b/enzyme/scripts/check_emission_order.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Flag IR emission whose order depends on C++ argument evaluation order.
+
+Building an op directly inside the argument list of another op-creating call:
+
+    Value cond = stablehlo::OrOp::create(
+        rewriter, loc,
+        stablehlo::CompareOp::create(rewriter, loc, n, one, LE),
+        stablehlo::CompareOp::create(rewriter, loc, s, one, LE));
+
+is a hazard when *two or more* arguments do it. C++ leaves the evaluation
+order of function arguments unspecified, so which compare is inserted into the
+block first is the compiler's choice. The `or`'s operands are fixed, but the
+textual order of the two compares is not: the same source emits them one way
+on macOS and the other on Linux, which makes generated IR -- and any CHECK
+line pinning it -- build-dependent.
+
+The fix is always the same: bind each op to a local first, so the source
+fixes the order.
+
+    Value nSmall = stablehlo::CompareOp::create(rewriter, loc, n, one, LE);
+    Value sSmall = stablehlo::CompareOp::create(rewriter, loc, s, one, LE);
+    Value cond = stablehlo::OrOp::create(rewriter, loc, nSmall, sSmall);
+
+An "emitter" is a call that inserts an op: `X::create(...)`,
+`builder.create<X>(...)`, `rewriter.replaceOpWithNewOp<X>(...)`, or a call to
+a function or lambda in this tree whose own body does one of those (helpers
+such as `makeI64Constant`). Lambda *literals* passed as arguments do not
+count -- their body runs inside the callee, after argument evaluation.
+
+Suppress a false positive with `// NOLINT(emission-order)` on any line of the
+flagged expression.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+# A call that inserts an op into the IR.
+MLIR_EMITTER = r"\b\w+::create\s*(?=\()|\bcreate\s*<|\breplaceOpWithNewOp\s*<"
+# LLVM's IRBuilder has the same hazard; opt in with --include-llvm-builder.
+LLVM_EMITTER = r"\bCreate[A-Z]\w*\s*(?=\()"
+EMITTER_RE = re.compile(MLIR_EMITTER)
+
+# Statements/expressions that are not calls we should look into.
+KEYWORDS = {
+    "if",
+    "for",
+    "while",
+    "switch",
+    "catch",
+    "return",
+    "sizeof",
+    "do",
+    "else",
+    "and",
+    "or",
+    "not",
+    "decltype",
+    "static_assert",
+    "assert",
+    "new",
+    "delete",
+    "throw",
+    "case",
+    "template",
+    "operator",
+    "noexcept",
+    "constexpr",
+    "alignof",
+}
+
+LAMBDA_ASSIGN_RE = re.compile(
+    r"\b(?:auto|const\s+auto)\s*&?\s*(\w+)\s*=\s*\[[^\]]*\]\s*"
+    r"(?:\([^)]*\))?\s*(?:mutable\s*)?(?:->[^{;]*)?\{"
+)
+CALL_RE = re.compile(r"(?<![\w])(\w+(?:::\w+)*)\s*(?:<[^<>;{}]*>)?\s*\(")
+LAMBDA_ARG_RE = re.compile(r"^\s*\[[^\]]*\]\s*(?:\(|\{|mutable|->)")
+SUPPRESS_RE = re.compile(r"NOLINT\(\s*emission-order\s*\)")
+
+SOURCE_SUFFIXES = (".cpp", ".cc", ".h", ".hpp")
+SKIP_DIRS = {".git", "build", "third_party", "external"}
+
+
+def strip_noise(src):
+    """Blank out comments, strings and char literals, preserving offsets."""
+    out = list(src)
+    i, n = 0, len(src)
+    while i < n:
+        c = src[i]
+        if c == "/" and i + 1 < n and src[i + 1] == "/":
+            while i < n and src[i] != "\n":
+                out[i] = " "
+                i += 1
+        elif c == "/" and i + 1 < n and src[i + 1] == "*":
+            out[i] = out[i + 1] = " "
+            i += 2
+            while i + 1 < n and not (src[i] == "*" and src[i + 1] == "/"):
+                if src[i] != "\n":
+                    out[i] = " "
+                i += 1
+            if i + 1 < n:
+                out[i] = out[i + 1] = " "
+                i += 2
+        elif c in "\"'":
+            quote = c
+            out[i] = " "
+            i += 1
+            while i < n and src[i] != quote:
+                if src[i] == "\\":
+                    out[i] = " "
+                    i += 1
+                if i < n and src[i] != "\n":
+                    out[i] = " "
+                i += 1
+            if i < n:
+                out[i] = " "
+                i += 1
+        else:
+            i += 1
+    return "".join(out)
+
+
+def match_paren(src, open_idx):
+    depth = 0
+    for i in range(open_idx, len(src)):
+        if src[i] == "(":
+            depth += 1
+        elif src[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+    return -1
+
+
+def match_brace(src, open_idx):
+    depth = 0
+    for i in range(open_idx, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+    return -1
+
+
+def split_args(src, lo, hi):
+    """Split [lo, hi) on top-level commas, ignoring () [] {} and <> nesting."""
+    args, depth, angle, start = [], 0, 0, lo
+    for i in range(lo, hi):
+        c = src[i]
+        if c in "([{":
+            depth += 1
+        elif c in ")]}":
+            depth -= 1
+        elif c == "<" and depth == 0:
+            angle += 1
+        elif c == ">" and depth == 0 and angle > 0:
+            angle -= 1
+        elif c == "," and depth == 0 and angle == 0:
+            args.append((start, i))
+            start = i + 1
+    args.append((start, hi))
+    return args
+
+
+def collect_helpers(src):
+    """Names of functions and lambdas in `src` whose body inserts ops."""
+    names = set()
+    for m in LAMBDA_ASSIGN_RE.finditer(src):
+        open_idx = src.index("{", m.end() - 1)
+        close = match_brace(src, open_idx)
+        if close > 0 and EMITTER_RE.search(src[open_idx:close]):
+            names.add(m.group(1))
+    for m in re.finditer(r"(?<![\w.>])(\w+)\s*\(", src):
+        name = m.group(1)
+        if name in KEYWORDS or len(name) < 3:
+            continue
+        close = match_paren(src, m.end() - 1)
+        if close < 0:
+            continue
+        tail = src[close + 1 : close + 40]
+        if not re.match(r"\s*(?:const\s*)?(?:noexcept\s*)?\{", tail):
+            continue
+        open_idx = close + 1 + tail.index("{")
+        body_end = match_brace(src, open_idx)
+        if body_end > 0 and EMITTER_RE.search(src[open_idx:body_end]):
+            names.add(name)
+    return names
+
+
+def iter_sources(roots):
+    for root in roots:
+        if os.path.isfile(root):
+            yield root
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [
+                d for d in dirnames if d not in SKIP_DIRS and not d.startswith("bazel-")
+            ]
+            for name in sorted(filenames):
+                if name.endswith(SOURCE_SUFFIXES):
+                    yield os.path.join(dirpath, name)
+
+
+def check_file(path, helper_re):
+    raw = open(path, encoding="utf-8", errors="replace").read()
+    src = strip_noise(raw)
+
+    def emits(text):
+        if LAMBDA_ARG_RE.match(text):
+            return False  # lambda literal: its body runs inside the callee
+        return bool(EMITTER_RE.search(text)) or bool(
+            helper_re and helper_re.search(text)
+        )
+
+    findings, reported_lines = [], set()
+    for m in CALL_RE.finditer(src):
+        if m.group(1).split("::")[-1] in KEYWORDS:
+            continue
+        open_idx = src.index("(", m.end() - 1)
+        close = match_paren(src, open_idx)
+        if close < 0:
+            continue
+        args = split_args(src, open_idx + 1, close)
+        if len(args) < 2:
+            continue
+        emitting = [a for a in args if emits(src[a[0] : a[1]])]
+        if len(emitting) < 2:
+            continue
+        line = src.count("\n", 0, m.start()) + 1
+        end_line = src.count("\n", 0, close) + 1
+        if SUPPRESS_RE.search(raw[m.start() : close + 1]):
+            continue
+        # only report the outermost expression on a given line
+        if line in reported_lines:
+            continue
+        reported_lines.add(line)
+        findings.append(
+            (
+                line,
+                end_line,
+                m.group(1),
+                " ".join(raw[m.start() : close + 1].split())[:200],
+            )
+        )
+    return findings
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("roots", nargs="+", help="directories or files to check")
+    parser.add_argument(
+        "--github",
+        action="store_true",
+        help="also emit GitHub Actions error annotations",
+    )
+    parser.add_argument(
+        "--include-llvm-builder",
+        action="store_true",
+        help="also treat LLVM IRBuilder Create* calls as "
+        "emitters (same hazard, separate cleanup)",
+    )
+    args = parser.parse_args()
+
+    if args.include_llvm_builder:
+        global EMITTER_RE
+        EMITTER_RE = re.compile(MLIR_EMITTER + "|" + LLVM_EMITTER)
+
+    files = list(iter_sources(args.roots))
+    helpers = set()
+    stripped = {}
+    for path in files:
+        stripped[path] = strip_noise(
+            open(path, encoding="utf-8", errors="replace").read()
+        )
+        helpers |= collect_helpers(stripped[path])
+    helpers -= KEYWORDS
+    helper_re = (
+        re.compile(
+            r"(?<![\w.>])(?:" + "|".join(sorted(map(re.escape, helpers))) + r")\s*\("
+        )
+        if helpers
+        else None
+    )
+
+    total = 0
+    for path in files:
+        for line, end_line, callee, snippet in check_file(path, helper_re):
+            total += 1
+            msg = (
+                f"{callee}(...) builds two or more ops in one argument list; "
+                f"evaluation order is unspecified, so the emitted IR order "
+                f"is compiler-dependent. Bind each to a local first."
+            )
+            print(f"{path}:{line}: {msg}\n    {snippet}")
+            if args.github:
+                print(
+                    f"::error file={path},line={line},endLine={end_line},"
+                    f"title=Nondeterministic IR emission order::{msg}"
+                )
+
+    if total:
+        print(
+            f"\n{total} nondeterministic emission site(s). "
+            f"Bind each op to a local before the enclosing call, or add "
+            f"`// NOLINT(emission-order)` if the order provably cannot be "
+            f"observed.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"checked {len(files)} files: no nondeterministic emission sites")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Follow-up to #3044 (stacked on it — the base retargets to `main` once that merges), so this pattern cannot come back.

## The check

Building two or more ops directly in one argument list leaves their insertion order to the compiler, since C++ does not sequence argument evaluation:

```cpp
auto revOuter = scf::ForOp::create(
    builder, op->getLoc(),
    makeIntConstant(loc, builder, 0, ivTy),   // which of these constants
    outerUB,
    makeIntConstant(loc, builder, 1, ivTy),   // is inserted first?
    incomingGradients);
```

The emitted IR — and any CHECK line pinning it — then depends on the toolchain. EnzymeAD/Enzyme-JAX#2721 hit this concretely: a `CHECK-NEXT` chain written against macOS output failed on Linux CI because two compares came out swapped.

`enzyme/scripts/check_emission_order.py` brace-matches every call expression and reports argument lists with two or more sibling *emitters*: `X::create(...)`, `builder.create<X>(...)`, `rewriter.replaceOpWithNewOp<X>(...)`, and calls to any function or lambda in the tree whose own body does one of those (`makeIntConstant`, ...).

Deliberately *not* flagged: a lambda literal passed as an argument, since its body runs inside the callee, after argument evaluation — that is what keeps `llvm::map_to_vector(FinalClass::getCanonicalLoopIVs(rewriter, forOp), [&](Value iv){ ... })` in `RemovalUtils.h` clean. Anything else that trips it can be suppressed with `// NOLINT(emission-order)`.

Output is a plain diagnostic plus `::error` annotations under `--github`, so findings land on the diff.

## The job

A standalone `Lint` workflow — the scan is ~1s over `enzyme/Enzyme`, so it does not need to ride along with a build.

## LLVM IRBuilder

`IRBuilder`'s `Create*` calls have exactly the same hazard, and it matters as much here since most FileCheck tests in this repo pin generated LLVM IR. `--include-llvm-builder` turns that on; it reports 20 sites in `enzyme/Enzyme` today (`Utils.cpp:1385`, `AdjointGenerator.h`, ...), so the flag is opt-in rather than wired into CI. Happy to do that cleanup as a follow-up and flip the job over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)