### PR TITLE
Bind IRBuilder calls that share an argument list to locals

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,4 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Check for order-dependent IR emission
-      run: python3 enzyme/scripts/check_emission_order.py --github enzyme/Enzyme
+      run: |
+        python3 enzyme/scripts/check_emission_order.py --github \
+          --include-llvm-builder enzyme/Enzyme

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -1573,12 +1573,13 @@ public:
                         dyn_cast<VectorType>(SI.getOperand(0)->getType())) {
                   inc = Builder2.CreateVectorSplat(VTy->getElementCount(), inc);
                 }
-                Value *dif = CreateSelect(
-                    Builder2,
-                    Builder2.CreateICmpEQ(gutils->lookupM(index, EB), inc),
-                    diffe(&SI, Builder2),
-                    Constant::getNullValue(
-                        gutils->getShadowType(op1->getType())));
+                Value *difSI = diffe(&SI, Builder2);
+                Value *isSelected =
+                    Builder2.CreateICmpEQ(gutils->lookupM(index, EB), inc);
+                Value *dif =
+                    CreateSelect(Builder2, isSelected, difSI,
+                                 Constant::getNullValue(
+                                     gutils->getShadowType(op1->getType())));
                 addToDiffe(SI.getOperand(2 - i), dif, Builder2, addingType);
               }
             }
@@ -2636,10 +2637,10 @@ public:
                 prev = Builder2.CreateAdd(
                     prev, ConstantInt::get(prev->getType(), num, false), "",
                     /*NUW*/ true, /*NSW*/ true);
+                auto prevFP = Builder2.CreateBitCast(prev, FT);
+                auto idiffFP = Builder2.CreateBitCast(idiff, FT);
                 prev = Builder2.CreateBitCast(
-                    checkedMul(gutils->strongZero, Builder2,
-                               Builder2.CreateBitCast(idiff, FT),
-                               Builder2.CreateBitCast(prev, FT)),
+                    checkedMul(gutils->strongZero, Builder2, idiffFP, prevFP),
                     prev->getType());
                 return prev;
               };
@@ -2864,10 +2865,10 @@ public:
                 prev = Builder2.CreateAdd(
                     prev, ConstantInt::get(prev->getType(), num, false), "",
                     /*NUW*/ true, /*NSW*/ true);
+                auto prevFP = Builder2.CreateBitCast(prev, FT);
+                auto difiFP = Builder2.CreateBitCast(difi, FT);
                 prev = Builder2.CreateBitCast(
-                    checkedMul(gutils->strongZero, Builder2,
-                               Builder2.CreateBitCast(difi, FT),
-                               Builder2.CreateBitCast(prev, FT)),
+                    checkedMul(gutils->strongZero, Builder2, difiFP, prevFP),
                     prev->getType());
 
                 return prev;

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -2298,9 +2298,9 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
           res = bb.CreateInsertValue(res, bb.CreateExtractValue(cal, {0}), {0});
           for (unsigned i = 1; i <= 2; i++) {
             auto AI = bb.CreateAlloca(todiff->getReturnType());
-            bb.CreateStore(
-                bb.CreateExtractValue(cal, {i}),
-                bb.CreatePointerCast(AI, getUnqual(ST->getTypeAtIndex(i))));
+            auto AIcast =
+                bb.CreatePointerCast(AI, getUnqual(ST->getTypeAtIndex(i)));
+            bb.CreateStore(bb.CreateExtractValue(cal, {i}), AIcast);
             auto ty = todiff->getReturnType();
             if (i == 2)
               ty = GradientUtils::getShadowType(ty, width);
@@ -2378,9 +2378,9 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
           res = bb.CreateInsertValue(res, bb.CreateExtractValue(cal, {0}), {0});
           for (unsigned i = 1; i <= 1; i++) {
             auto AI = bb.CreateAlloca(todiff->getReturnType());
-            bb.CreateStore(
-                bb.CreateExtractValue(cal, {i}),
-                bb.CreatePointerCast(AI, getUnqual(ST->getTypeAtIndex(i))));
+            auto AIcast =
+                bb.CreatePointerCast(AI, getUnqual(ST->getTypeAtIndex(i)));
+            bb.CreateStore(bb.CreateExtractValue(cal, {i}), AIcast);
             Value *vres = bb.CreateLoad(todiff->getReturnType(), AI);
             res = bb.CreateInsertValue(res, vres, {i});
           }

--- a/enzyme/Enzyme/FunctionUtils.cpp
+++ b/enzyme/Enzyme/FunctionUtils.cpp
@@ -1698,11 +1698,11 @@ void SplitPHIs(llvm::Function &F) {
         todo.insert(nPhi);
       } else {
         auto cur3 = cast<SelectInst>(cur);
-        auto rep = B.CreateSelect(
-            cur3->getCondition(),
-            GradientUtils::extractMeta(B, cur3->getTrueValue(), i),
-            GradientUtils::extractMeta(B, cur3->getFalseValue(), i),
-            cur->getName() + ".extract." + std::to_string(i));
+        auto falseV = GradientUtils::extractMeta(B, cur3->getFalseValue(), i);
+        auto trueV = GradientUtils::extractMeta(B, cur3->getTrueValue(), i);
+        auto rep =
+            B.CreateSelect(cur3->getCondition(), trueV, falseV,
+                           cur->getName() + ".extract." + std::to_string(i));
         replacements.push_back(rep);
         if (auto sel = dyn_cast<SelectInst>(rep))
           todo.insert(sel);
@@ -4774,9 +4774,11 @@ std::optional<std::string> fixSparse_inner(Instruction *cur, llvm::Function &F,
                 SmallVector<Value *, 1> slice;
                 for (size_t i = 1; i < allOps.size(); i++)
                   slice.push_back(allOps[i]);
-                auto ane = pushcse(B.CreateFCmp(
-                    eq_predicate, pushcse(B.CreateFNeg(allOps[0])),
-                    pushcse(B.CreateCall(getFunctionFromCall(S), slice))));
+                auto sliceCall =
+                    pushcse(B.CreateCall(getFunctionFromCall(S), slice));
+                auto negOp = pushcse(B.CreateFNeg(allOps[0]));
+                auto ane =
+                    pushcse(B.CreateFCmp(eq_predicate, negOp, sliceCall));
                 auto ori = pushcse(B.CreateOr(op_checks, ane));
                 if (predicate == FCmpInst::FCMP_UNE ||
                     predicate == FCmpInst::FCMP_ONE) {
@@ -4998,12 +5000,12 @@ std::optional<std::string> fixSparse_inner(Instruction *cur, llvm::Function &F,
               return "UFCmpToICmp";
             }
             if (auto SI = dyn_cast<SelectInst>(fcmp->getOperand(1 - i))) {
+              auto falseCmp = pushcse(
+                  B.CreateCmp(fcmp->getPredicate(), C, SI->getFalseValue()));
+              auto trueCmp = pushcse(
+                  B.CreateCmp(fcmp->getPredicate(), C, SI->getTrueValue()));
               auto res = pushcse(
-                  B.CreateSelect(SI->getCondition(),
-                                 pushcse(B.CreateCmp(fcmp->getPredicate(), C,
-                                                     SI->getTrueValue())),
-                                 pushcse(B.CreateCmp(fcmp->getPredicate(), C,
-                                                     SI->getFalseValue()))));
+                  B.CreateSelect(SI->getCondition(), trueCmp, falseCmp));
               replaceAndErase(cur, res);
               return "FCmpSelect";
             }
@@ -5036,17 +5038,20 @@ std::optional<std::string> fixSparse_inner(Instruction *cur, llvm::Function &F,
         auto a = fcmp->getOperand(0);
         auto b = fcmp->getOperand(1);
         if (fcmp->getPredicate() == CmpInst::ICMP_EQ) {
-          auto res = pushcse(
-              B.CreateOr(pushcse(B.CreateAnd(a, b)),
-                         pushcse(B.CreateAnd(pushcse(B.CreateNot(a)),
-                                             pushcse(B.CreateNot(b))))));
+          auto notB = pushcse(B.CreateNot(b));
+          auto notA = pushcse(B.CreateNot(a));
+          auto neitherAB = pushcse(B.CreateAnd(notA, notB));
+          auto bothAB = pushcse(B.CreateAnd(a, b));
+          auto res = pushcse(B.CreateOr(bothAB, neitherAB));
           replaceAndErase(cur, res);
           return "CmpI1EQ";
         }
         if (fcmp->getPredicate() == CmpInst::ICMP_NE) {
-          auto res = pushcse(
-              B.CreateOr(pushcse(B.CreateAnd(pushcse(B.CreateNot(a)), b)),
-                         pushcse(B.CreateAnd(a, pushcse(B.CreateNot(b))))));
+          auto notB = pushcse(B.CreateNot(b));
+          auto aNotB = pushcse(B.CreateAnd(a, notB));
+          auto notA = pushcse(B.CreateNot(a));
+          auto notAB = pushcse(B.CreateAnd(notA, b));
+          auto res = pushcse(B.CreateOr(notAB, aNotB));
           replaceAndErase(cur, res);
           return "CmpI1NE";
         }
@@ -8452,9 +8457,9 @@ void fixSparseIndices(llvm::Function &F, llvm::FunctionAnalysisManager &FAM,
     if (forSparsification.count(L) == 0) {
       {
         IRBuilder<> PB(preheader->getTerminator());
-        forSparsification[L].first =
-            std::make_pair(PB.CreatePHI(idx->getType(), 0, "ph.idx"),
-                           PB.CreatePHI(idx->getType(), 0, "loop.idx"));
+        auto loopIdxPhi = PB.CreatePHI(idx->getType(), 0, "loop.idx");
+        auto phIdxPhi = PB.CreatePHI(idx->getType(), 0, "ph.idx");
+        forSparsification[L].first = std::make_pair(phIdxPhi, loopIdxPhi);
       }
 
       Value *LoopCount = nullptr;
@@ -8471,9 +8476,10 @@ void fixSparseIndices(llvm::Function &F, llvm::FunctionAnalysisManager &FAM,
             ConstantInt::get(idx->getType(), 1),
             Exp.expandCodeFor(LoopCountS, idx->getType(), &blk->front()));
       }
-      Value *inbounds = B.CreateAnd(
-          B.CreateICmpSLT(idx, LoopCount),
-          B.CreateICmpSGE(idx, ConstantInt::get(idx->getType(), 0)));
+      Value *nonNegative =
+          B.CreateICmpSGE(idx, ConstantInt::get(idx->getType(), 0));
+      Value *belowCount = B.CreateICmpSLT(idx, LoopCount);
+      Value *inbounds = B.CreateAnd(belowCount, nonNegative);
       Value *args[] = {inbounds, forSparsification[L].first.second};
       B.CreateCall(F.getParent()->getOrInsertFunction(
                        "enzyme.sparse.inbounds", B.getVoidTy(),

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -6521,7 +6521,9 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
             return li;
           },
           invertPointerM(II->getArgOperand(0), bb));
-    case Intrinsic::masked_load:
+    case Intrinsic::masked_load: {
+      auto invDefault = invertPointerM(II->getArgOperand(3), bb, TT);
+      auto invPtr = invertPointerM(II->getArgOperand(0), bb);
       return applyChainRule(
           II->getType(), bb,
           [&](Value *ptr, Value *defaultV) {
@@ -6535,8 +6537,8 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
             li->setDebugLoc(getNewFromOriginal(II->getDebugLoc()));
             return li;
           },
-          invertPointerM(II->getArgOperand(0), bb),
-          invertPointerM(II->getArgOperand(3), bb, TT));
+          invPtr, invDefault);
+    }
     }
     }
   } else if (auto phi = dyn_cast<PHINode>(oval)) {
@@ -6569,7 +6571,9 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
             }
             ++cnt;
          }
-         auto result = BuilderM.CreateSelect(which, invertPointerM(vals[1], BuilderM, TT), invertPointerM(vals[0], BuilderM, TT));
+         auto inv0 = invertPointerM(vals[0], BuilderM, TT);
+         auto inv1 = invertPointerM(vals[1], BuilderM, TT);
+         auto result = BuilderM.CreateSelect(which, inv1, inv0);
          return result;
      }
 #endif

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -48,6 +48,7 @@
 #include "llvm/IR/Value.h"
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -3177,7 +3178,7 @@ BasicBlock *GradientUtils::prepRematerializedLoopEntry(LoopContext &lc) {
   SmallPtrSet<Instruction *, 1> loopRematerializations;
   SmallPtrSet<Instruction *, 1> loopReallocations;
   SmallPtrSet<Instruction *, 1> loopShadowReallocations;
-  SmallPtrSet<Instruction *, 1> loopShadowZeroInits;
+  SmallSetVector<Instruction *, 1> loopShadowZeroInits;
   SmallPtrSet<Instruction *, 1> loopShadowRematerializations;
   Loop *origLI = nullptr;
   for (auto pair : rematerializableAllocations) {

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -518,10 +518,11 @@ Function *getOrInsertExponentialAllocator(Module &M, Function *newFunc,
 
   Value *gVal;
 
-  Value *prevSize =
-      B.CreateSelect(B.CreateICmpEQ(size, ConstantInt::get(size->getType(), 1)),
-                     ConstantInt::get(next->getType(), 0),
-                     B.CreateLShr(next, ConstantInt::get(next->getType(), 1)));
+  Value *halfNext = B.CreateLShr(next, ConstantInt::get(next->getType(), 1));
+  Value *isFirstSize =
+      B.CreateICmpEQ(size, ConstantInt::get(size->getType(), 1));
+  Value *prevSize = B.CreateSelect(
+      isFirstSize, ConstantInt::get(next->getType(), 0), halfNext);
 
   auto Arch = llvm::Triple(M.getTargetTriple()).getArch();
   bool forceMalloc = Arch == Triple::nvptx || Arch == Triple::nvptx64;
@@ -1365,27 +1366,39 @@ void copy_lower_to_upper(llvm::IRBuilder<> &B, llvm::Type *fpType,
   auto i_plus_one = LB.CreateAdd(i, one, "", true, true);
   i->addIncoming(i_plus_one, loop);
 
-  Value *copyArgs[] = {
-      to_blas_callconv(LB, LB.CreateSub(N_minus_1, i), byRef, cublas, nullptr,
-                       EB),
-      lookup_with_layout(LB, fpType, layoutarg, Aarg, ldaarg,
-                         CreateSelect(LB, islowerarg, i_plus_one, i),
-                         CreateSelect(LB, islowerarg, i, i_plus_one)),
-      to_blas_callconv(
-          LB,
-          lookup_with_layout(LB, fpType, layoutarg, nullptr, ldaarg,
-                             CreateSelect(LB, islowerarg, one, zero),
-                             CreateSelect(LB, islowerarg, zero, one)),
-          byRef, cublas, nullptr, EB),
-      lookup_with_layout(LB, fpType, layoutarg, Aarg, ldaarg,
-                         CreateSelect(LB, islowerarg, i, i_plus_one),
-                         CreateSelect(LB, islowerarg, i_plus_one, i)),
-      to_blas_callconv(
-          LB,
-          lookup_with_layout(LB, fpType, layoutarg, nullptr, ldaarg,
-                             CreateSelect(LB, islowerarg, zero, one),
-                             CreateSelect(LB, islowerarg, one, zero)),
-          byRef, cublas, nullptr, EB)};
+  // Each lookup_with_layout's two selects are bound in the order they are
+  // emitted; the array elements themselves stay in place, since a braced
+  // initializer is evaluated left to right.
+  Value *countArg = to_blas_callconv(LB, LB.CreateSub(N_minus_1, i), byRef,
+                                     cublas, nullptr, EB);
+
+  Value *aCol = CreateSelect(LB, islowerarg, i, i_plus_one);
+  Value *aRow = CreateSelect(LB, islowerarg, i_plus_one, i);
+  Value *aArg =
+      lookup_with_layout(LB, fpType, layoutarg, Aarg, ldaarg, aRow, aCol);
+
+  Value *incACol = CreateSelect(LB, islowerarg, zero, one);
+  Value *incARow = CreateSelect(LB, islowerarg, one, zero);
+  Value *incAArg =
+      to_blas_callconv(LB,
+                       lookup_with_layout(LB, fpType, layoutarg, nullptr,
+                                          ldaarg, incARow, incACol),
+                       byRef, cublas, nullptr, EB);
+
+  Value *bCol = CreateSelect(LB, islowerarg, i_plus_one, i);
+  Value *bRow = CreateSelect(LB, islowerarg, i, i_plus_one);
+  Value *bArg =
+      lookup_with_layout(LB, fpType, layoutarg, Aarg, ldaarg, bRow, bCol);
+
+  Value *incBCol = CreateSelect(LB, islowerarg, one, zero);
+  Value *incBRow = CreateSelect(LB, islowerarg, zero, one);
+  Value *incBArg =
+      to_blas_callconv(LB,
+                       lookup_with_layout(LB, fpType, layoutarg, nullptr,
+                                          ldaarg, incBRow, incBCol),
+                       byRef, cublas, nullptr, EB);
+
+  Value *copyArgs[] = {countArg, aArg, incAArg, bArg, incBArg};
 
   Type *copyTys[] = {copyArgs[0]->getType(), copyArgs[1]->getType(),
                      copyArgs[2]->getType(), copyArgs[3]->getType(),

--- a/enzyme/scripts/check_emission_order.py
+++ b/enzyme/scripts/check_emission_order.py
@@ -54,8 +54,17 @@ import sys
 # A call that inserts an op into the IR.
 MLIR_EMITTER = r"\b\w+::create\s*(?=\()|\bcreate\s*<|\breplaceOpWithNewOp\s*<"
 # LLVM's IRBuilder has the same hazard; opt in with --include-llvm-builder.
-LLVM_EMITTER = r"\bCreate[A-Z]\w*\s*(?=\()"
+# `Create*` only counts when the receiver is a builder declared in this file
+# (see builder_names) or when it is one of LLVM's static Instruction::Create
+# factories, which insert into a block themselves.
+LLVM_STATIC_EMITTER = r"\b[A-Z]\w*(?:Inst|Block|Node)::Create\s*(?=\()"
+BUILDER_DECL_RE = re.compile(
+    r"\b(?:IRBuilder|IRBuilderBase|OpBuilder|PatternRewriter|IRRewriter|"
+    r"RewriterBase|ImplicitLocOpBuilder)\s*(?:<[^;{}()]*>)?\s*"
+    r"(?:const\s*)?[&*]?\s*(\w+)\s*[(,;=)]"
+)
 EMITTER_RE = re.compile(MLIR_EMITTER)
+INCLUDE_LLVM = False
 
 # Statements/expressions that are not calls we should look into.
 KEYWORDS = {
@@ -194,8 +203,31 @@ def split_args(src, lo, hi):
     return args
 
 
-def collect_helpers(src):
+def builder_names(src):
+    """Names bound to an IR builder / rewriter in `src`."""
+    return set(BUILDER_DECL_RE.findall(src))
+
+
+def emitter_for(src):
+    """The emitter pattern for one file.
+
+    With --include-llvm-builder, `Create*` counts only on a receiver this file
+    declares as a builder, so an unrelated `CreateFoo()` helper is not mistaken
+    for IR emission.
+    """
+    if not INCLUDE_LLVM:
+        return EMITTER_RE
+    alts = [MLIR_EMITTER, LLVM_STATIC_EMITTER]
+    names = builder_names(src)
+    if names:
+        joined = "|".join(sorted(map(re.escape, names)))
+        alts.append(rf"\b(?:{joined})\s*(?:\.|->)\s*Create[A-Z]\w*\s*(?=\()")
+    return re.compile("|".join(alts))
+
+
+def collect_helpers(src, emitter_re=None):
     """Names of functions and lambdas in `src` whose body inserts ops."""
+    EMITTER_RE = emitter_re or emitter_for(src)
     names = set()
     for m in LAMBDA_ASSIGN_RE.finditer(src):
         open_idx = src.index("{", m.end() - 1)
@@ -236,6 +268,7 @@ def iter_sources(roots):
 def check_file(path, helper_re):
     raw = open(path, encoding="utf-8", errors="replace").read()
     src = strip_noise(raw)
+    EMITTER_RE = emitter_for(src)
 
     def emits(text):
         if LAMBDA_ARG_RE.match(text):
@@ -345,6 +378,7 @@ def check_container_iteration(path, helper_re):
     """Loops over an unordered container that turn its order into output."""
     raw = open(path, encoding="utf-8", errors="replace").read()
     src = strip_noise(raw)
+    EMITTER_RE = emitter_for(src)
     decls = unordered_decls(src)
     if not decls:
         return []
@@ -379,9 +413,33 @@ def check_container_iteration(path, helper_re):
             if close < 0:
                 continue
         body = src[m.end() : close]
-        emits = bool(EMITTER_RE.search(body)) or bool(
-            helper_re and helper_re.search(body)
-        )
+        # Iteration order only becomes instruction order when the insertion
+        # point is shared across iterations. A builder constructed inside the
+        # body anchors each op to its own item, and a static Foo::Create
+        # factory may not be inserted at all until something else places it --
+        # both are reported, but as warnings.
+        local_builders = builder_names(body)
+        strong = False
+        for em in EMITTER_RE.finditer(body):
+            text = em.group()
+            recv = re.match(r"(\w+)\s*(?:\.|->)", text)
+            if recv and recv.group(1) in local_builders:
+                continue
+            if re.match(r"[A-Z]\w*(?:Inst|Block|Node)::Create", text):
+                continue
+            if "::create" in text:  # MLIR: builder is the first argument
+                after = body[em.end() :]
+                paren = after.find("(")
+                first = (
+                    re.match(r"\s*\(?\s*(\w+)", after[paren:]) if paren >= 0 else None
+                )
+                if first and first.group(1) in local_builders:
+                    continue
+            strong = True
+            break
+        by_helper = bool(helper_re and helper_re.search(body))
+        emits = bool(EMITTER_RE.search(body)) or by_helper
+        strong = strong or by_helper
         if not (emits or ORDER_SENSITIVE_RE.search(body)):
             continue
         if SUPPRESS_RE.search(raw[m.start() : close + 1]):
@@ -397,7 +455,7 @@ def check_container_iteration(path, helper_re):
                 end_line,
                 hit,
                 " ".join(raw[m.start() : m.end()].split()),
-                "error" if emits else "warning",
+                "error" if (emits and strong) else "warning",
             )
         )
     return findings
@@ -422,8 +480,8 @@ def main():
     args = parser.parse_args()
 
     if args.include_llvm_builder:
-        global EMITTER_RE
-        EMITTER_RE = re.compile(MLIR_EMITTER + "|" + LLVM_EMITTER)
+        global INCLUDE_LLVM
+        INCLUDE_LLVM = True
 
     files = list(iter_sources(args.roots))
     helpers = set()

--- a/enzyme/scripts/check_emission_order.py
+++ b/enzyme/scripts/check_emission_order.py
@@ -28,6 +28,20 @@ a function or lambda in this tree whose own body does one of those (helpers
 such as `makeI64Constant`). Lambda *literals* passed as arguments do not
 count -- their body runs inside the callee, after argument evaluation.
 
+The second check is the same problem from a different source: iterating a
+container that orders by pointer or hash value rather than by insertion.
+
+    DenseMap<LLVMFuncOp, SmallVector<CallOpInterface>> kernelLaunches;
+    ...
+    for (auto &launch : kernelLaunches)   // order depends on pointer values
+      ... create ops ...
+
+This one is worse than the argument-order case: DenseMap/DenseSet order can
+differ between two runs of the same binary, not just between toolchains. The
+fix is a MapVector/SetVector, or sorting before the loop. Creating ops in the
+body is an error; merely collecting elements into a vector is reported as a
+warning, since whether that order reaches the output takes a human to judge.
+
 Suppress a false positive with `// NOLINT(emission-order)` on any line of the
 flagged expression.
 """
@@ -81,6 +95,20 @@ SUPPRESS_RE = re.compile(r"NOLINT\(\s*emission-order\s*\)")
 
 SOURCE_SUFFIXES = (".cpp", ".cc", ".h", ".hpp")
 SKIP_DIRS = {".git", "build", "third_party", "external"}
+
+# Containers whose iteration order is a function of pointer or hash values
+# rather than of insertion order.
+UNORDERED_TYPE_RE = re.compile(
+    r"(?<![\w:])(?:llvm::|std::)?"
+    r"(?:SmallPtrSet|SmallPtrSetImpl|SmallDenseMap|SmallDenseSet|DenseMap|"
+    r"DenseMapBase|DenseSet|StringMap|StringSet|unordered_map|unordered_set|"
+    r"unordered_multimap|unordered_multiset)\s*<"
+)
+RANGE_FOR_RE = re.compile(r"\bfor\s*\(\s*[^;{}]*?\s:\s*([^)]*)\)")
+# Anything in a loop body that turns iteration order into program output.
+ORDER_SENSITIVE_RE = re.compile(
+    r"\b(?:push_back|emplace_back|append|emitError|emitWarning|emitRemark)\s*\("
+)
 
 
 def strip_noise(src):
@@ -249,6 +277,132 @@ def check_file(path, helper_re):
     return findings
 
 
+def match_angle(src, open_idx):
+    depth = 0
+    for i in range(open_idx, len(src)):
+        if src[i] == "<":
+            depth += 1
+        elif src[i] == ">":
+            depth -= 1
+            if depth == 0:
+                return i
+        elif src[i] in ";{}":
+            return -1
+    return -1
+
+
+def brace_spans(src):
+    """(start, end) of every brace pair, innermost last for a given point."""
+    stack, spans = [], []
+    for i, c in enumerate(src):
+        if c == "{":
+            stack.append(i)
+        elif c == "}" and stack:
+            spans.append((stack.pop(), i))
+    return spans
+
+
+def unordered_decls(src):
+    """(name, pos, scope_start, scope_end) per unordered-container declaration.
+
+    Names are scoped to the innermost enclosing braces so that a parameter such
+    as `SmallPtrSetImpl<Block *> &block` in one function does not make every
+    other `block` in the file look like a hash container.
+    """
+    spans = brace_spans(src)
+    decls = []
+    for m in UNORDERED_TYPE_RE.finditer(src):
+        close = match_angle(src, m.end() - 1)
+        if close < 0:
+            continue
+        decl = re.match(r"\s*(?:const\s*)?[&*]?\s*(\w+)", src[close + 1 :])
+        if not decl:
+            continue
+        pos = m.start()
+        scope = min(
+            (s for s in spans if s[0] < close < s[1]),
+            key=lambda s: s[1] - s[0],
+            default=(0, len(src)),
+        )
+        decls.append((decl.group(1), pos, scope[0], scope[1]))
+    return decls
+
+
+def iterated_name(expr):
+    """The identifier a range-for actually iterates over, if any.
+
+    `xs`, `*xs`, `xs.keys()`, `llvm::reverse(xs)` -> "xs".
+    """
+    expr = expr.strip()
+    call = re.fullmatch(r"[\w:]+\s*\(\s*([^()]*?)\s*\)", expr)
+    if call:
+        expr = call.group(1).strip()
+    m = re.match(r"[*&]?\s*(\w+)\s*(?:\.\w+\s*\(\s*\)\s*)?$", expr)
+    return m.group(1) if m else None
+
+
+def check_container_iteration(path, helper_re):
+    """Loops over an unordered container that turn its order into output."""
+    raw = open(path, encoding="utf-8", errors="replace").read()
+    src = strip_noise(raw)
+    decls = unordered_decls(src)
+    if not decls:
+        return []
+
+    findings = []
+    for m in RANGE_FOR_RE.finditer(src):
+        name = iterated_name(m.group(1))
+        if name is None:
+            continue
+        at = m.start()
+        hit = next(
+            (
+                n
+                for n, pos, lo, hi in decls
+                if n == name and pos < at and lo <= at <= hi
+            ),
+            None,
+        )
+        if hit is None:
+            continue
+        # A braced body runs to its matching brace; a brace-less one is the
+        # single statement that follows.
+        rest = src[m.end() :]
+        lead = len(rest) - len(rest.lstrip())
+        if rest[lead : lead + 1] == "{":
+            open_idx = m.end() + lead
+            close = match_brace(src, open_idx)
+            if close < 0:
+                continue
+        else:
+            close = src.find(";", m.end())
+            if close < 0:
+                continue
+        body = src[m.end() : close]
+        emits = bool(EMITTER_RE.search(body)) or bool(
+            helper_re and helper_re.search(body)
+        )
+        if not (emits or ORDER_SENSITIVE_RE.search(body)):
+            continue
+        if SUPPRESS_RE.search(raw[m.start() : close + 1]):
+            continue
+        line = src.count("\n", 0, m.start()) + 1
+        end_line = src.count("\n", 0, close) + 1
+        # Creating ops in the body puts the order straight into the IR. Merely
+        # collecting into a vector may or may not reach the output, so it is
+        # reported but does not fail the run.
+        findings.append(
+            (
+                line,
+                end_line,
+                hit,
+                " ".join(raw[m.start() : m.end()].split()),
+                "error" if emits else "warning",
+            )
+        )
+    return findings
+
+
 def main():
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
@@ -288,28 +442,63 @@ def main():
         else None
     )
 
-    total = 0
+    errors, warnings = 0, 0
+
+    def report(path, line, end_line, msg, snippet, severity="error"):
+        nonlocal errors, warnings
+        if severity == "error":
+            errors += 1
+        else:
+            warnings += 1
+        print(f"{path}:{line}: {severity}: {msg}\n    {snippet}")
+        if args.github:
+            print(
+                f"::{severity} file={path},line={line},endLine={end_line},"
+                f"title=Nondeterministic IR emission order::{msg}"
+            )
+
     for path in files:
         for line, end_line, callee, snippet in check_file(path, helper_re):
-            total += 1
-            msg = (
+            report(
+                path,
+                line,
+                end_line,
                 f"{callee}(...) builds two or more ops in one argument list; "
                 f"evaluation order is unspecified, so the emitted IR order "
-                f"is compiler-dependent. Bind each to a local first."
+                f"is compiler-dependent. Bind each to a local first.",
+                snippet,
             )
-            print(f"{path}:{line}: {msg}\n    {snippet}")
-            if args.github:
-                print(
-                    f"::error file={path},line={line},endLine={end_line},"
-                    f"title=Nondeterministic IR emission order::{msg}"
-                )
+        for line, end_line, name, snippet, severity in check_container_iteration(
+            path, helper_re
+        ):
+            what = (
+                "creates ops while iterating"
+                if severity == "error"
+                else "collects the elements of"
+            )
+            report(
+                path,
+                line,
+                end_line,
+                f"loop {what} `{name}`, but that container orders by pointer "
+                f"or hash value rather than by insertion, so its order can "
+                f"differ between runs. Use MapVector/SetVector, or sort first.",
+                snippet,
+                severity,
+            )
 
-    if total:
+    if warnings:
         print(
-            f"\n{total} nondeterministic emission site(s). "
-            f"Bind each op to a local before the enclosing call, or add "
-            f"`// NOLINT(emission-order)` if the order provably cannot be "
-            f"observed.",
+            f"\n{warnings} loop(s) over an unordered container feed something "
+            f"order-sensitive but do not create ops directly; review whether "
+            f"the order reaches the output.",
+            file=sys.stderr,
+        )
+    if errors:
+        print(
+            f"\n{errors} nondeterministic emission site(s). See the guidance in "
+            f"each message, or add `// NOLINT(emission-order)` if the order "
+            f"provably cannot be observed.",
             file=sys.stderr,
         )
         return 1


### PR DESCRIPTION
Follow-up to #3044/#3045, one layer down: the same hazard in LLVM `IRBuilder` code.

```cpp
Value *inbounds = B.CreateAnd(
    B.CreateICmpSLT(idx, LoopCount),                              // which of these
    B.CreateICmpSGE(idx, ConstantInt::get(idx->getType(), 0)));   // is inserted first?
```

C++ does not sequence argument evaluation, so which instruction lands in the block first is the compiler's choice. It matters more here than on the MLIR side, since most FileCheck tests in this repo pin generated LLVM IR.

## Changes

20 sites, each bound to a local first — in the order the instructions were *previously* emitted, so the generated IR is unchanged and no test expectation moves:

| File | Sites |
|---|---|
| `FunctionUtils.cpp` | 8 (`CreateSelect`, `CreateFCmp`, the two `CreateOr`/`CreateAnd` i1 identities, the sparsification PHIs, the inbounds check) |
| `Utils.cpp` | 5 (`prevSize` select, the four `lookup_with_layout` calls) |
| `AdjointGenerator.h` | 3 (select over the index compare, two `checkedMul` bitcast pairs) |
| `GradientUtils.cpp` | 3 (`masked_load` chain rule, the phi select) |
| `EnzymeLogic.cpp` | 2 (`CreateStore` of an extract into a pointer cast) |

In `Utils.cpp` the four `lookup_with_layout` arguments were inside a braced initializer. Braced init *is* sequenced left to right, so the array elements keep their relative order — I lifted each element into its own statement rather than hoisting all the selects to the front, which would have reordered them across elements.

`enzyme/scripts/check_emission_order.py` picks up the container-iteration check from the Enzyme-JAX copy so the two stay in sync.

## Testing

Verified locally against the LLVM 15 lit suite (`llvms/llvm15/buildD`, after building `opt` there):

| | Passed | Expectedly failed | Failed |
|---|---|---|---|
| unmodified `main` | 1033 | 10 | 5 |
| this branch | 1033 | 10 | 5 |

Same five tests either way (`preprint.ll`, `allocator.ll`, `previdxout.ll`, `partial_int_window.ll`, `nodoublefree.ll`) — they fail on unmodified main against LLVM 15, so they are unrelated to this change. That is the intended result: these edits are meant to be IR-identical, so an unchanged suite is the assertion.

Two things worth recording about local builds, since they cost me a while:
- `llvm-project/build` (LLVM 22) and `llvms/llvm-project/buildD` (LLVM 20) both abort in `enzyme-tblgen` with a TableGen `cast<>` assertion, so current main does not build against them.
- `llvms/llvm15/buildD` works but was missing its generated headers (`llvm/IR/Attributes.inc` and friends), and both `llvm-tblgen` and `enzyme-tblgen` abort on a missing `libzstd.1.dylib` — SIP strips `DYLD_LIBRARY_PATH` when ninja spawns through `/bin/sh`, so exporting it does not help. It has no `opt`, so the lit suite cannot run there without building one.

## Container iteration, and gating the check

Later commits tighten the checker and turn `--include-llvm-builder` on in CI.

`Create*` used to be matched by name alone, which would count an unrelated `CreateFoo()` helper as emission while *missing* LLVM's static `CallInst::Create` / `BasicBlock::Create` factories (no uppercase letter after `Create`). Both now key off the receiver: a name the file declares as a builder, or one of those static factories.

That distinction matters for the container check, because iteration order only becomes instruction order when the insertion point is **shared across iterations**. Of the four loops that first appeared:

| Loop | Verdict |
|---|---|
| `GradientUtils.cpp:3244` `loopShadowZeroInits` | Real — `IRBuilder<> NB(newB)` lives outside the loop, so every iteration appends to the same block. Fixed here (`SmallSetVector`). |
| `FunctionUtils.cpp:2931` `Preds` | Real but weaker — appends a `tmpblk` block per predecessor. Warning. |
| `CacheUtility.cpp:652` `PotentialMins` | Partly — builder anchors per item, but `goto endOMP` means *which* SCEV wins depends on pointer order. Warning. |
| `FunctionUtils.cpp:641` `MTIReplacements` | Not observable — `IRBuilder<> B(MTI)` anchors each call at its own memtransfer. Warning. |

`loopShadowZeroInits` is populated only by a commented-out insert, so that change cannot alter behaviour today; it is correct for whenever the code returns, and it clears the last error. The job now runs `--include-llvm-builder`, leaving 13 collect-only loops as warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
