### PR TITLE
mlir: Only delegate loop-carried caches to the loop remover

### DIFF
--- a/enzyme/Enzyme/MLIR/Passes/RemovalUtils.h
+++ b/enzyme/Enzyme/MLIR/Passes/RemovalUtils.h
@@ -304,6 +304,7 @@ public:
           toDelete.push_back(info);
           return;
         }
+
         cachesMap[pushedValue] = info;
 
         if (isa<OpName>(info.popOp->getParentOp())) {
@@ -329,6 +330,24 @@ public:
     // nothing to do
     if (updatedGradients.empty() && caches.empty())
       return success();
+
+    // What is left here is carried out of this loop, so removing it needs the
+    // loop the pops are in, and that is only found when a pop's parent is a
+    // loop of this same kind (see where otherForOp is set). Without one, every
+    // use of otherForOp below would be through a null op. Report it rather than
+    // leaving caches nothing further down can lower either. Checked before the
+    // gradient rewriting starts, so the loop is not left half-transformed.
+    if (!caches.empty() && !otherForOp) {
+      auto diag = forOp->emitError()
+                  << "cannot remove " << caches.size()
+                  << " cache(s) pushed in this loop: no " << forOp->getName()
+                  << " holding their pops to pair it with";
+      for (CacheInfo &info : caches)
+        diag.attachNote(info.popOp->getLoc())
+            << "pop is in " << info.popOp->getParentOp()->getName()
+            << ", pushed from " << info.pushOp->getParentOp()->getName();
+      return diag;
+    }
 
     DenseMap<Value, llvm::SmallVector<Operation *>> updatedGradientUsers;
 

--- a/enzyme/Enzyme/MLIR/Passes/RemoveUnusedEnzymeOps.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/RemoveUnusedEnzymeOps.cpp
@@ -344,12 +344,47 @@ static void annotateRegionOpsInLoops(Operation *op) {
   // When we have non-looping region branch ops (e.g. scf.if) inside of a loop,
   // we want the pushes/pops to be removed by the outer loop remover, not the
   // inner op remover. This helps mincut reduce the overall caching overhead.
+  //
+  // Only for caches the loop remover can take. One it can is initialized
+  // outside the loop, so that it outlives an iteration and its pushes can be
+  // paired with pops in the reverse loop. An init inside the loop belongs to
+  // that iteration alone; removal stops at the init's parent and never reaches
+  // the loop, so standing the region op down for it leaves nothing to remove it
+  // at all. Inlining a differentiated function into a loop body brings in
+  // exactly those, along with the ifs it cached across.
   op->walk([](LoopLikeOpInterface loop) {
-    loop->walk([](RegionBranchOpInterface regionBranch) {
-      if (!regionBranch.hasLoop()) {
-        regionBranch->setAttr(kPreserveCacheAttrName,
-                              UnitAttr::get(regionBranch.getContext()));
-      }
+    loop->walk([&](RegionBranchOpInterface regionBranch) {
+      if (regionBranch.hasLoop())
+        return;
+
+      // The attribute covers the whole region op, so one loop-local cache in it
+      // is enough to have to keep removing them here. Both ends count: the
+      // push and the pop of such a cache sit in different region ops, and
+      // standing either of them down strands it.
+      bool anyLoopLocal = false;
+      auto checkCache = [&](Value cache) {
+        Operation *init = cache.getDefiningOp();
+        if (!init || loop->isProperAncestor(init))
+          anyLoopLocal = true;
+      };
+      regionBranch->walk([&](Operation *nested) {
+        // A cache under a nested loop is that loop's to pair, and its own
+        // region ops are annotated when the walk above reaches it.
+        if (nested != regionBranch.getOperation() &&
+            isa<LoopLikeOpInterface>(nested))
+          return WalkResult::skip();
+
+        if (auto push = dyn_cast<enzyme::PushOp>(nested))
+          checkCache(push.getCache());
+        else if (auto pop = dyn_cast<enzyme::PopOp>(nested))
+          checkCache(pop.getCache());
+        return WalkResult::advance();
+      });
+      if (anyLoopLocal)
+        return;
+
+      regionBranch->setAttr(kPreserveCacheAttrName,
+                            UnitAttr::get(regionBranch.getContext()));
     });
   });
 }

--- a/enzyme/test/MLIR/Passes/loop_local_cache_in_if.mlir
+++ b/enzyme/test/MLIR/Passes/loop_local_cache_in_if.mlir
@@ -1,0 +1,108 @@
+// RUN: %eopt %s --remove-unnecessary-enzyme-ops --split-input-file | FileCheck %s
+
+// A cache whose init is inside the loop is that iteration's own: it is pushed
+// and popped within one iteration, never carried to a reverse loop. The scf.if
+// holding it must therefore keep removing it itself, rather than standing down
+// (`preserve_cache`) in favour of the enclosing loop's remover, which pairs a
+// forward loop with a reverse one and so has nothing to pair this with. The
+// shape comes up when a differentiated function is inlined into a loop body.
+
+module {
+  func.func @loop_local(%cond: i1, %val: f32, %n: index, %out: memref<?xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+
+    scf.parallel (%i) = (%c0) to (%n) step (%c1) {
+      %cache = "enzyme.init"() : () -> !enzyme.Cache<f32>
+      scf.if %cond {
+        "enzyme.push"(%cache, %val) : (!enzyme.Cache<f32>, f32) -> ()
+      }
+      scf.if %cond {
+        %p = "enzyme.pop"(%cache) : (!enzyme.Cache<f32>) -> f32
+        memref.store %p, %out[%i] : memref<?xf32>
+      }
+      scf.reduce
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @loop_local(
+// CHECK-NOT:     enzyme.init
+// CHECK-NOT:     enzyme.push
+// CHECK-NOT:     enzyme.pop
+// CHECK-NOT:     preserve_cache
+
+// -----
+
+// The same cache initialized outside the loop is carried across it, so the ifs
+// do stand down and leave it to the loop's remover.
+
+module {
+  func.func @loop_carried(%cond: i1, %val: f32, %n: index, %out: memref<?xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %cache = "enzyme.init"() : () -> !enzyme.Cache<f32>
+
+    scf.parallel (%i) = (%c0) to (%n) step (%c1) {
+      scf.if %cond {
+        "enzyme.push"(%cache, %val) : (!enzyme.Cache<f32>, f32) -> ()
+      }
+      scf.reduce
+    }
+    scf.parallel (%i) = (%c0) to (%n) step (%c1) {
+      scf.if %cond {
+        %p = "enzyme.pop"(%cache) : (!enzyme.Cache<f32>) -> f32
+        memref.store %p, %out[%i] : memref<?xf32>
+      }
+      scf.reduce
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @loop_carried(
+// CHECK:         scf.if %{{.*}} {
+// CHECK:         } {preserve_cache}
+
+// -----
+
+// A cache local to a *nested* loop is that loop's business: it must not count
+// against annotating the if that happens to contain the loop, whose own cache
+// (%outer) is carried across the parallel. Everything here is removable.
+
+module {
+  func.func @nested_loop(%cond: i1, %val: f32, %n: index, %out: memref<?xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %outer = "enzyme.init"() : () -> !enzyme.Cache<f32>
+
+    scf.parallel (%i) = (%c0) to (%n) step (%c1) {
+      scf.if %cond {
+        %inner = "enzyme.init"() : () -> !enzyme.Cache<f32>
+        scf.for %j = %c0 to %n step %c1 {
+          "enzyme.push"(%inner, %val) : (!enzyme.Cache<f32>, f32) -> ()
+        }
+        scf.for %j = %c0 to %n step %c1 {
+          %p = "enzyme.pop"(%inner) : (!enzyme.Cache<f32>) -> f32
+          memref.store %p, %out[%j] : memref<?xf32>
+        }
+        "enzyme.push"(%outer, %val) : (!enzyme.Cache<f32>, f32) -> ()
+      }
+      scf.reduce
+    }
+    scf.parallel (%i) = (%c0) to (%n) step (%c1) {
+      scf.if %cond {
+        %q = "enzyme.pop"(%outer) : (!enzyme.Cache<f32>) -> f32
+        memref.store %q, %out[%i] : memref<?xf32>
+      }
+      scf.reduce
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @nested_loop(
+// CHECK-NOT:     enzyme.init
+// CHECK-NOT:     enzyme.push
+// CHECK-NOT:     enzyme.pop


### PR DESCRIPTION
`annotateRegionOpsInLoops` marks every non-looping region branch op inside a loop with `preserve_cache`, standing its remover down so the enclosing loop's remover takes the caches — which is what lets mincut see them all together. That is only valid for caches the loop remover can pair: it matches pushes in a forward loop with pops in the reverse one, so the cache has to be initialized *outside* the loop to outlive an iteration.

A cache whose init is inside the loop belongs to that iteration alone. Removal stops at the init's parent and never reaches the loop, so standing the region op down leaves nothing to remove it: the pushes and pops survive to the loop remover, which finds no reverse loop holding the pops and dereferences a null op (the `assert(reverseIfOp && ...)`-style check is compiled out in a release build).

Inlining a differentiated function into a loop body produces exactly this shape, bringing the `scf.if`s the callee cached across into the caller's loop. On XSBench, adding an `inline` pass after `enzyme` turns 13 such caches into a segfault in `ParallelOpEnzymeOpsRemover`.

## Change

- Annotate only when no cache in the region op is loop-local. Both ends are checked — a push and its pop sit in different region ops, so standing either down strands the cache — and the walk stops at nested loops, whose caches are their own remover's business.
- `ForLikeEnzymeOpsRemover` now reports the unpairable case with a diagnostic naming each cache's push/pop parents, rather than running into the null.

## Testing

New `test/MLIR/Passes/loop_local_cache_in_if.mlir` covers three shapes: a loop-local init (removed, not annotated), an init outside the loop (delegated, `preserve_cache` present), and an `if` containing a nested loop whose cache is local to that loop (does not veto annotating the `if`).

`check-enzymemlir`: 154 pass. `MLIR/ReverseMode/linalg.mlir` fails both before and after this change ("Linalg op with tensor semantics not yet supported").

🤖 Generated with [Claude Code](https://claude.com/claude-code)