### PR TITLE
mlir: Simplify enzyme ops before each remover, not only once per function

### DIFF
--- a/enzyme/Enzyme/MLIR/Passes/RemoveUnusedEnzymeOps.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/RemoveUnusedEnzymeOps.cpp
@@ -340,6 +340,35 @@ static void applyPatterns(Operation *op) {
   (void)applyPatternsGreedily(op, std::move(patterns), config);
 }
 
+// Same patterns, for an op that is not IsolatedFromAbove: the greedy driver
+// only takes those, so the enzyme ops inside are handed to it individually.
+static void applyPatternsToEnzymeOps(Operation *op,
+                                     RewriterBase::Listener *listener) {
+  SmallVector<Operation *> ops;
+  op->walk([&](Operation *nested) {
+    if (isa<enzyme::InitOp, enzyme::PushOp, enzyme::PopOp, enzyme::GetOp,
+            enzyme::SetOp>(nested))
+      ops.push_back(nested);
+  });
+  if (ops.empty())
+    return;
+
+  RewritePatternSet patterns(op->getContext());
+  patterns.insert<PopSimplify, GetSimplify, PushSimplify, SetSimplify,
+                  InitSimplify>(op->getContext());
+
+  GreedyRewriteConfig config;
+  config.enableFolding();
+  if (listener)
+    config.setListener(listener);
+  (void)applyOpPatternsGreedily(ops, std::move(patterns), config);
+}
+
+static bool hasInitInRegions(Operation *op) {
+  return op->walk([](enzyme::InitOp) { return WalkResult::interrupt(); })
+      .wasInterrupted();
+}
+
 static void annotateRegionOpsInLoops(Operation *op) {
   // When we have non-looping region branch ops (e.g. scf.if) inside of a loop,
   // we want the pushes/pops to be removed by the outer loop remover, not the
@@ -545,6 +574,10 @@ LogicalResult PostOrderWalkDriver::processWorklist() {
     auto op = worklist.pop();
     auto iface = cast<EnzymeOpsRemoverOpInterface>(op);
     current = op;
+
+    if (hasInitInRegions(op))
+      applyPatternsToEnzymeOps(op, this);
+
     rewriter.setInsertionPoint(current);
     result &= iface.removeEnzymeOps(rewriter).succeeded();
     current = nullptr;


### PR DESCRIPTION
`RemoveUnusedEnzymeOpsPass` runs the pattern-based simplifications (`PopSimplify` and friends) once over the whole operation before any remover. That is sufficient when AD ran at function scope — by then, a push and pop that merely hand a value from one point of a block to another are already gone.

When the differentiated code sits inside a region instead (an `enzyme.init` nested in a kernel body rather than at function scope), it is not. The removers run in post order and each hands its caches outwards, so pairs that are plainly forwardable appear in an enclosing op *after* that one simplification. The enclosing remover then treats them as caches needing a matching loop or branch to pair with, which for those pairs does not exist — on XSBench with an `inline` pass added after `enzyme`, that path ends in a segfault inside `GPUWrapperOpEnzymeOpsRemover` (Enzyme-JaX), which has no such pairing to fall back on.

## Change

`applyPatternsToEnzymeOps` runs the same patterns over the enzyme ops inside an op, immediately before removing from it, for ops with an init nested in them. It uses `applyOpPatternsGreedily`, since `applyPatternsGreedily` asserts an `IsolatedFromAbove` target and these are loops and branches. The walk driver is passed as a listener so its worklist does not keep ops the patterns erase.

## Testing

`check-enzymemlir`: 154 pass. `MLIR/ReverseMode/linalg.mlir` fails both before and after ("Linalg op with tensor semantics not yet supported").

No new lit test here, deliberately: the shapes reachable with the dialects this repo can load are all still simplified by the up-front `applyPatterns`, because `ForLikeEnzymeOpsRemover` handles same-block pairs itself. The op that does not, and where this shows up, is `enzymexla.gpu_wrapper`, which lives outside this repo. A regression test belongs on the Enzyme-JaX side, built from the reduced XSBench module that reproduces the crash; it goes from segfault to clean with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
