### PR TITLE
Add batch mode test

### DIFF
--- a/enzyme/Fortran/README.md
+++ b/enzyme/Fortran/README.md
@@ -36,7 +36,7 @@ $ flang -flto program-enzyme.bc -o program
 Both routes are exercised by the tests in `enzyme/test/Fortran`. The plugin route is
 flang-only; with ifx use the `opt` pipeline above.
 
-## Function hooks
+## Function hooks for differentiation
 
 We provide bindings for the `__enzyme_fwddiff` and `__enzyme_autodiff` function
 hooks using implicit interfaces. Some Fortran compilers disallow procedure names
@@ -105,3 +105,22 @@ then you can make use of activity descriptors like so:
   call enzyme_autodiff(my_subroutine, enzyme_const, n, &
                        enzyme_dup, x, dx, enzyme_dup, y, dy
 ```
+
+## Function hook for batching
+
+We do not currently provide bindings for the `__enzyme_batch` function hook
+because it requires `enzyme_width` to be passed-by-value as an integer and this
+is not supported by the implicit interfacing approach used for the other
+function hooks. As such, you will need to write your own explicit `interface`
+block to handle the batching. See the Fortran
+[batching test ](../test/Fortran/BatchMode/square_with_explicit_interface.f90)
+for an example.
+
+> [!NOTE]
+> In C, the batched output is provided using a simple `struct`. The required
+> syntax is different in Fortran - you should instead provide each entry of the
+> output batch individually.
+
+> [!NOTE]
+> You will likely find that batching works more straightforwardly with
+> subroutines than with Fortran functions.

--- a/enzyme/test/Fortran/BatchMode/CMakeLists.txt
+++ b/enzyme/test/Fortran/BatchMode/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Run regression and unit tests
+add_lit_testsuite(check-enzyme-fortran-batch "Running enzyme batch mode fortran integration tests"
+    ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${ENZYME_TEST_DEPS} LLVMEnzyme-${LLVM_VERSION_MAJOR}
+    ARGS -v
+)
+
+set_target_properties(check-enzyme-fortran-batch PROPERTIES FOLDER "Tests")

--- a/enzyme/test/Fortran/BatchMode/square_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/BatchMode/square_with_explicit_interface.f90
@@ -30,7 +30,8 @@ module squareBatch
     end subroutine square__enzyme_batch
   end interface
 contains
-  ! TODO: Get __enzyme_batch working with functions in Fortran
+  ! NOTE: __enzyme_batch works more straightforwardly with subroutines than with
+  !      Fortran functions
   subroutine square(x, y)
     real, intent(in)  :: x
     real, intent(out) :: y

--- a/enzyme/test/Fortran/BatchMode/square_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/BatchMode/square_with_explicit_interface.f90
@@ -1,0 +1,59 @@
+! REQUIRES: fortran
+! RUN: %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
+
+module squareBatch
+  interface
+    subroutine square__enzyme_batch(sr, width_desc, width, &
+                                    vec_desc, x1, x2, x3, x4, y1, y2, y3, y4)
+      interface
+        subroutine sr_decal(xx, yy)
+          real, intent(in)  :: xx
+          real, intent(out) :: yy
+        end subroutine sr_decal
+      end interface
+      procedure(sr_decal)        :: sr
+      integer, value, intent(in) :: width_desc
+      integer, value, intent(in) :: width
+      integer, value, intent(in) :: vec_desc
+      real, intent(in)           :: x1, x2, x3, x4
+      real, intent(out)          :: y1, y2, y3, y4
+    end subroutine square__enzyme_batch
+  end interface
+contains
+  ! TODO: Get __enzyme_batch working with functions in Fortran
+  subroutine square(x, y)
+    real, intent(in)  :: x
+    real, intent(out) :: y
+    y = x ** 2
+  end subroutine
+end module
+
+program main
+  use enzyme, only: enzyme_vector, enzyme_width
+  use squareBatch, only: square, square__enzyme_batch
+  implicit none
+  real :: x1, x2, x3, x4
+  real :: y1, y2, y3, y4
+
+  x1 = 23.1
+  x2 = 10.0
+  x3 = 100.0
+  x4 = 3.14
+
+  call square__enzyme_batch(square, enzyme_width, 4, &
+                            enzyme_vector, x1, x2, x3, x4, &
+                            y1, y2, y3, y4)
+
+  write(*,"(f0.4)") y1
+  write(*,"(f0.4)") y2
+  write(*,"(f0.4)") y3
+  write(*,"(f0.4)") y4
+end program
+
+! CHECK: 533.6100
+! CHECK-NEXT: 100.0000
+! CHECK-NEXT: 10000.0000
+! CHECK-NEXT: 9.8596

--- a/enzyme/test/Fortran/BatchMode/square_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/BatchMode/square_with_explicit_interface.f90
@@ -1,8 +1,15 @@
 ! REQUIRES: fortran
+! UNSUPPORTED: ifx
 ! RUN: %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s
 ! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
 ! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
 ! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
+! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
+
+! NOTE: This test is only configured to run with the flang compiler.
+!       For it to work with the ifx compiler we will need to figure out how to
+!       handle the different signature for __enzyme_batch used by ifx.
 
 module squareBatch
   interface


### PR DESCRIPTION
Closes #3052
Merges into #3020 

Here is a Fortran version of the batch mode tutorial here: https://github.com/EnzymeAD/Enzyme-Tutorial/blob/main/8_batch/batch.c.

I'm not 100% sure it's actually using `__enzyme_batch`, though. In earlier iterations, I was making use of a derived type
```fortran
  type vector                                                                                                                                                                                                                         
    real :: x1, x2, x3, x4                                                                                                                                                                                                            
  end type vector
```
(the equivalent of the struct used in the C example), but the error messages I got about the numbers of arguments led me towards the version presented in this PR. Using `type(vector) :: y` for output instead of `real :: y1, y2, y3, y4` I get
```
error: <unknown>:0:0: in function _QQmain void (): Enzyme: __enzyme_batch missing vector argument at index 9, need argument of type ptr at call   call void @square__enzyme_batch_(ptr nonnull @_QMmath_modPsquare, i32 %12, i32 4, i32 %13, ptr nonnull %4, ptr nonnull %3, ptr nonnull %2, ptr nonnull %1, ptr nonnull %5)
```

Worth noting that I couldn't get this to work with `square` defined as a function (as in the other similar tests).