### PR TITLE
Make the min cut graph's adjacency iteration deterministic

### DIFF
--- a/enzyme/Enzyme/MLIR/Passes/RemovalUtils.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/RemovalUtils.cpp
@@ -253,8 +253,16 @@ void dump(const Node &n) {
                  << "]\n";
 }
 
-struct Graph : public llvm::MapVector<Node, SmallPtrSet<Node, 2>> {
-  const SmallPtrSet<Node, 2> &at(const Node &n) {
+// The adjacency sets are insertion-ordered rather than hashed. A Node wraps a
+// Value or Operation pointer, so iterating a SmallPtrSet of them visits
+// neighbours in address order, which varies run to run under ASLR. The max
+// flow below then explores augmenting paths in a different order and, whenever
+// several minimum cuts have the same capacity, settles on a different one --
+// producing correct but different caching decisions on every run.
+using NodeSet = llvm::SmallSetVector<Node, 2>;
+
+struct Graph : public llvm::MapVector<Node, NodeSet> {
+  const NodeSet &at(const Node &n) {
     auto found = find(n);
     assert(found != end());
     return found->second;
@@ -625,7 +633,7 @@ static SetVector<Value> minCutValues(const Graph &Orig,
       assert(parent.count(v));
       Node u = parent.find(v)->second;
       assert(!u.isNull());
-      G[u].erase(v);
+      G[u].remove(v);
       G[v].insert(u);
       if (u.isValue() && !u.outgoing() && roots.contains(u.getValue()))
         break;
@@ -843,7 +851,7 @@ void mlir::enzyme::minCutCache(Block *forward, Block *reverse,
       continue;
     }
 
-    auto &&[_, inserted] = G[Node(owner)].insert(Node(todo));
+    bool inserted = G[Node(owner)].insert(Node(todo));
     if (inserted) {
       for (Value operand : owner->getOperands()) {
         G[Node(operand)].insert(Node(owner));
@@ -908,7 +916,7 @@ void mlir::enzyme::minCutCache(Block *forward, Block *reverse,
 
       for (auto user : todo.getUsers()) {
         Node N(user);
-        auto &&[_, inserted] = G[Node(todo)].insert(N);
+        bool inserted = G[Node(todo)].insert(N);
         if (inserted) {
           for (Value res : user->getResults()) {
             G[N].insert(Node(res));


### PR DESCRIPTION
`Node` wraps a `Value` or `Operation` pointer, so iterating a `SmallPtrSet<Node>` visits neighbours in **address order**. Under ASLR that order changes from run to run, so the max flow explores augmenting paths differently and — whenever several minimum cuts have the same capacity — settles on a different one.

Every choice is correct, and they all cache the same *number* of values. But *which* values get cached varies, and the generated IR varies with it.

### Reproduction

Easiest to see through Enzyme-JAX. Differentiating a checkpointed loop whose cached values depend on the induction variable (`test/lit_tests/diffrules/stablehlo/while_checkpointing_iv_dependent.mlir`), same binary, same input:

```
$ for i in $(seq 1 12); do enzymexlamlir-opt $F --enzyme --canonicalize \
    --remove-unnecessary-enzyme-ops --enzyme-simplify-math --arith-raise --canonicalize \
    | md5sum; done | sort -u | wc -l
9        # nine distinct outputs

$ setarch -R ...   # ASLR disabled
1        # deterministic
```

The `setarch -R` result pins it to address ordering rather than threading (`--mlir-disable-threading` made no difference) or anything input-dependent.

The observable difference is which cached value lands in which loop carry:

```mlir
-  %4 = stablehlo.reshape %iterArg_11 : (tensor<f64>) -> tensor<1xf64>
+  %4 = stablehlo.reshape %iterArg_12 : (tensor<f64>) -> tensor<1xf64>
```

### Fix

Make the adjacency sets insertion-ordered (`SmallSetVector`) so BFS enqueues neighbours in a stable order. With that, the same 12 runs produce **1** distinct output.

The remaining `SmallPtrSet<Node>` uses are membership-only `done` sets that are never iterated, so they are left as they are.

### Testing

Enzyme-JAX lit suite built against this Enzyme: 1094/1095, the single failure being a pre-existing unrelated one (`mem2reg_transfers.mlir`). Notably `while_checkpointing_iv_dependent.mlir` now passes *reliably* against its existing checked-in golden — before this change it matched only some of the time, which is what led to the investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)