### PR TITLE
Preserve attributes on loops built while differentiating

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
@@ -27,6 +27,22 @@ using namespace mlir::enzyme;
 using namespace mlir::affine;
 
 namespace {
+
+// A loop created while differentiating `oldOp` is still doing that loop's work,
+// so it inherits what was set on it. The checkpointing directives are left
+// behind, since the rewrite has already acted on them. Mirrors the helper of
+// the same name in the SCF implementation.
+static void preserveAttributesButCheckpointing(Operation *newOp,
+                                               Operation *oldOp) {
+  for (auto attr : oldOp->getDiscardableAttrs()) {
+    auto name = attr.getName();
+    if (name != "enzyme.enable_checkpointing" &&
+        name != "enzyme.binomial_checkpointing" &&
+        name != "enzyme.checkpoint_period")
+      newOp->setAttr(name, attr.getValue());
+  }
+}
+
 affine::AffineForOp
 createAffineForWithShadows(Operation *op, OpBuilder &builder,
                            MGradientUtils *gutils, Operation *original,
@@ -109,6 +125,7 @@ struct AffineForOpInterfaceReverse
     auto revFor = affine::AffineForOp::create(
         builder, op->getLoc(), revLBOperands, lb.getMap(), revUBOperands,
         ub.getMap(), forOp.getStepAsInt(), incomingGradients);
+    preserveAttributesButCheckpointing(revFor, op);
 
     bool valid = true;
     for (auto &&[oldReg, newReg] :
@@ -403,6 +420,9 @@ struct AffineParallelOpEnzymeOpsRemover
         otherParOp.getLowerBoundsMap(), otherParOp.getLowerBoundsGroups(),
         otherParOp.getUpperBoundsMap(), otherParOp.getUpperBoundsGroups(),
         otherParOp.getSteps(), otherParOp.getMapOperands());
+
+    newOtherParOp->setDiscardableAttrs(
+        otherParOp->getDiscardableAttrDictionary());
 
     newOtherParOp.getRegion().takeBody(otherParOp.getRegion());
     rewriter.replaceOp(otherParOp, newOtherParOp->getResults().slice(
@@ -829,6 +849,10 @@ public:
         rewriter, otherForOp->getLoc(), otherForOp.getLowerBoundOperands(),
         otherForOp.getLowerBoundMap(), otherForOp.getUpperBoundOperands(),
         otherForOp.getUpperBoundMap(), otherForOp.getStepAsInt(), operands);
+
+    // Same loop, more iteration arguments: it keeps what was set on it.
+    newOtherForOp->setDiscardableAttrs(
+        otherForOp->getDiscardableAttrDictionary());
 
     newOtherForOp.getRegion().takeBody(otherForOp.getRegion());
     rewriter.replaceOp(otherForOp, newOtherForOp->getResults().slice(

--- a/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
@@ -125,6 +125,13 @@ public:
         rewriter, otherForOp->getLoc(), otherForOp.getLowerBound(),
         otherForOp.getUpperBound(), otherForOp.getStep(), operands);
 
+    // The rebuilt loop is the same loop with extra iteration arguments, so it
+    // keeps everything that was set on it. Without this, anything the caller
+    // put there -- enzyme.disable_mincut in particular -- is dropped the moment
+    // the removal pass needs to widen the loop.
+    newOtherForOp->setDiscardableAttrs(
+        otherForOp->getDiscardableAttrDictionary());
+
     newOtherForOp.getRegion().takeBody(otherForOp.getRegion());
     rewriter.replaceOp(otherForOp, newOtherForOp->getResults().slice(
                                        0, otherForOp->getNumResults()));
@@ -1743,6 +1750,9 @@ struct ParallelOpEnzymeOpsRemover
     auto newOtherParOp = scf::ParallelOp::create(
         rewriter, otherParallelOp.getLoc(), otherParallelOp.getLowerBound(),
         otherParallelOp.getUpperBound(), otherParallelOp.getStep(), operands);
+
+    newOtherParOp->setDiscardableAttrs(
+        otherParallelOp->getDiscardableAttrDictionary());
 
     newOtherParOp.getRegion().takeBody(otherParallelOp.getRegion());
     rewriter.replaceOp(

--- a/enzyme/test/MLIR/ReverseMode/affine_for_preserve_attributes.mlir
+++ b/enzyme/test/MLIR/ReverseMode/affine_for_preserve_attributes.mlir
@@ -1,0 +1,24 @@
+// RUN: %eopt %s --enzyme-wrap="infn=reduce outfn= argTys=enzyme_active retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops --enzyme-simplify-math | FileCheck %s
+
+// Same for affine.for: widening the loop to carry the cache index must not
+// discard what was set on it.
+
+module {
+  func.func @reduce(%x: f32) -> (f32) {
+    %sum_0 = arith.constant 1.0 : f32
+
+    %sum = affine.for %iv = 0 to 128
+        iter_args(%sum_iter = %sum_0) -> (f32) {
+      %sum_next = arith.mulf %sum_iter, %x : f32
+      affine.yield %sum_next : f32
+    } {enzyme.marker}
+
+    return %sum : f32
+  }
+}
+
+// CHECK-LABEL: func.func @reduce
+// CHECK: affine.for
+// CHECK: } {enzyme.marker}
+// CHECK: affine.for
+// CHECK: } {enzyme.marker}

--- a/enzyme/test/MLIR/ReverseMode/scf_for_preserve_attributes.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_for_preserve_attributes.mlir
@@ -1,0 +1,27 @@
+// RUN: %eopt %s --enzyme-wrap="infn=reduce outfn= argTys=enzyme_active,enzyme_const retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops --enzyme-simplify-math | FileCheck %s
+
+// The removal pass widens both loops to carry the cache index by building a new
+// loop and taking the old one's region. That is the same loop with extra
+// iteration arguments, so whatever was set on it has to survive. enzyme.marker
+// stands in for any attribute that is not re-derived from somewhere else --
+// enzyme.disable_mincut happens to be backstopped by hasMinCut walking parent
+// ops, which is why dropping it went unnoticed.
+
+func.func @reduce(%x: f32, %ub: index) -> (f32) {
+  %lb = arith.constant 0 : index
+  %step = arith.constant 1 : index
+  %sum_0 = arith.constant 1.0 : f32
+  %sum = scf.for %iv = %lb to %ub step %step
+      iter_args(%sum_iter = %sum_0) -> (f32) {
+    %sum_next = arith.mulf %sum_iter, %x : f32
+    scf.yield %sum_next : f32
+  } {enzyme.cache_use_tensor, enzyme.disable_mincut, enzyme.marker}
+  return %sum : f32
+}
+
+// Both the widened forward loop and the widened reverse loop keep them.
+// CHECK-LABEL: func.func @reduce
+// CHECK: scf.for
+// CHECK: } {enzyme.cache_use_tensor, enzyme.disable_mincut, enzyme.marker}
+// CHECK: scf.for
+// CHECK: } {enzyme.cache_use_tensor, enzyme.disable_mincut, enzyme.marker}


### PR DESCRIPTION
Two places dropped attributes from loops built while differentiating.

**`replaceWithNewOperands`** widens a loop with the cache index by constructing a new loop, taking the old one's region and replacing it:

```cpp
auto newOtherForOp = scf::ForOp::create(rewriter, otherForOp->getLoc(), ...operands);
newOtherForOp.getRegion().takeBody(otherForOp.getRegion());
rewriter.replaceOp(otherForOp, ...);
return newOtherForOp;                       // attributes gone
```

It is the *same* loop with extra iteration arguments, but it is built with no attributes at all, so everything set on it is lost the moment `removeEnzymeOps` needs to widen it (`RemovalUtils.h:699`, `:785`). Fixed for all four variants: `scf.for`, `scf.parallel`, `affine.for`, `affine.parallel`.

**The affine implementation** also had no propagation onto the reverse loop, where SCF has `preserveAttributesButCheckpointing` and calls it at ten of its twelve loop-creation sites. This mirrors the helper and calls it on `revFor`.

### Why it was not noticed

Three things hid it:

1. `enzyme.disable_mincut` — the attribute this matters most for — is backstopped by `hasMinCut` walking parent ops, so the setting is still found when the loop's own copy is gone.
2. No existing golden checks these attributes at all.
3. FileCheck matches by substring, so an existing `CHECK-NEXT: }` matches `} {enzyme.disable_mincut = true}` whether or not the attribute survived.

### Testing

Two new tests, `scf_for_preserve_attributes.mlir` and `affine_for_preserve_attributes.mlir`. They use `enzyme.marker`, an attribute with no backstop, so the check is direct.

Without the fix, the output loops carry **no attributes at all**:

```mlir
// before
%0 = affine.for %arg2 = 0 to 128 iter_args(%arg3 = %cst) -> (f32) {
  ...
}                                    // enzyme.marker gone
```

With it, both the widened forward loop and the reverse loop carry what the input loop had. Verified by building at the pin with and without the change: `enzyme.marker` occurrences in the output go 0 → 2 for both the scf and affine cases.

Enzyme's MLIR tests through Enzyme-JAX's `enzymexlamlir-opt`: 93/95, including the two new ones. The two failures are pre-existing tool artifacts that fail identically without this change — `result_attrs.mlir` trips a Shardy check that only exists in that binary, and `trunc.mlir` uses a CHECK prefix my harness did not pass. Neither contains a loop.

### Related

Found while tracking down nondeterministic caching decisions, fixed separately in #3058.
