### PR TITLE
chore(repeat): remove MPI from CI matrix/intel oneAPI installation

### DIFF
--- a/.github/workflows/fortran.yml
+++ b/.github/workflows/fortran.yml
@@ -46,7 +46,6 @@ jobs:
         os: [ubuntu-22.04]
         compiler: [flang]
         llvm: [21]
-        mpi: [2021.7.1]
     timeout-minutes: 60
     steps:
     - name: add llvm with clang and flang
@@ -76,7 +75,6 @@ jobs:
         build: [Release, Debug]
         os: [ubuntu-22.04]
         compiler: [ifx]
-        mpi: [2021.7.1]
         versions:
           - llvm: 15
             ifx: 2023.0.0
@@ -100,7 +98,7 @@ jobs:
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         sudo echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-        sudo apt-get update && sudo apt-get install -y intel-oneapi-compiler-fortran-${{ matrix.versions.ifx }} intel-oneapi-mpi-${{ matrix.mpi }} intel-oneapi-mpi-devel-${{ matrix.mpi }}
+        sudo apt-get update && sudo apt-get install -y intel-oneapi-compiler-fortran-${{ matrix.versions.ifx }}
         source /opt/intel/oneapi/setvars.sh
         printenv >> $GITHUB_ENV
     - uses: actions/checkout@v4


### PR DESCRIPTION
In the CI, MPI runtime library is installed even though no tests use it. This PR simply removes it again (it was removed in https://github.com/EnzymeAD/Enzyme/pull/2941 but a newer PR must've overwritten this change).

Perhaps adding more comprehensive MPI runtime tests would be useful in the future? I can open a separate issue to document that, please let me know. Currently, there are rule/transformation tests for MPI, but it doesn't look like there are integration tests that check MPI runtime with Enzyme:

```shell
[b383137@levante4 test]$ pwd
/work/bm1233/b383137/Enzyme/enzyme/test
[b383137@levante4 test]$ find . -name "*mpi*"
./Integration/ReverseMode/mpi_reduce.c
./Integration/ReverseMode/mpi_bcast.c
./Integration/ForwardMode/mpi
./Integration/ForwardMode/mpi/mpi_reduce.c
./Integration/ForwardMode/mpi/mpi_bcast.c
./Enzyme/ReverseMode/mpirep.ll
./Enzyme/ReverseMode/mpi2.ll
./Enzyme/ReverseMode/mpi_allgather.ll
./Enzyme/ReverseMode/mpi_allreduce.ll
./Enzyme/ReverseMode/ompinvoke.ll
./Enzyme/ReverseMode/mpi_gather.ll
./Enzyme/ReverseMode/mpi_irecv.ll
./Enzyme/ReverseMode/mpi_scatter.ll
./Enzyme/ReverseMode/mpi_bcast.ll
./Enzyme/ReverseMode/mpi.ll
./Enzyme/ForwardMode/mpi
./Enzyme/ForwardMode/mpi/mpi2.ll
./Enzyme/ForwardMode/mpi/mpi_allgather.ll
./Enzyme/ForwardMode/mpi/mpi_allreduce.ll
./Enzyme/ForwardMode/mpi/mpi_gather.ll
./Enzyme/ForwardMode/mpi/mpi_irecv.ll
./Enzyme/ForwardMode/mpi/mpi_scatter.ll
./Enzyme/ForwardMode/mpi/mpi_bcast.ll
./Enzyme/ForwardMode/mpi/mpi.ll
```