### PR TITLE
Serialize TypeTree offsets as signed constants

### DIFF
--- a/enzyme/Enzyme/MustExitScalarEvolution.cpp
+++ b/enzyme/Enzyme/MustExitScalarEvolution.cpp
@@ -470,7 +470,8 @@ ScalarEvolution::ExitLimit MustExitScalarEvolution::computeExitLimitFromICmp(
         break;
       SmallVector<SCEVUse, 2> sv = {
           RHS,
-          getConstant(ConstantInt::get(cast<IntegerType>(RHS->getType()), -1))};
+          getConstant(ConstantInt::get(cast<IntegerType>(RHS->getType()), -1,
+                                       /*IsSigned*/ true))};
       // Since this is not an infinite loop by induction, RHS cannot be
       // int_min/uint_min Therefore subtracting 1 does not wrap.
       if (IsSigned)

--- a/enzyme/Enzyme/TypeAnalysis/TypeTree.h
+++ b/enzyme/Enzyme/TypeAnalysis/TypeTree.h
@@ -1484,8 +1484,10 @@ public:
     }
     subMD.push_back(llvm::MDString::get(ctx, base.str()));
     for (auto pair : todo) {
-      subMD.push_back(llvm::ConstantAsMetadata::get(
-          llvm::ConstantInt::get(llvm::IntegerType::get(ctx, 32), pair.first)));
+      // Offsets may be negative (e.g. -1 to denote any offset), so the
+      // constant must be created as a signed value.
+      subMD.push_back(llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(
+          llvm::IntegerType::get(ctx, 32), pair.first, /*IsSigned*/ true)));
       subMD.push_back(pair.second.toMD(ctx));
     }
     return llvm::MDNode::get(ctx, subMD);

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -2306,7 +2306,7 @@ Function *getOrInsertCheckedFree(Module &M, CallInst *call, Type *Ty,
 llvm::Value *nextPowerOfTwo(llvm::IRBuilder<> &B, llvm::Value *V) {
   assert(V->getType()->isIntegerTy());
   IntegerType *T = cast<IntegerType>(V->getType());
-  V = B.CreateAdd(V, ConstantInt::get(T, -1));
+  V = B.CreateAdd(V, ConstantInt::get(T, -1, /*IsSigned*/ true));
   for (size_t i = 1; i < T->getBitWidth(); i *= 2) {
     V = B.CreateOr(V, B.CreateLShr(V, ConstantInt::get(T, i)));
   }

--- a/enzyme/test/Enzyme/ForwardMode/globalconsttypemd.ll
+++ b/enzyme/test/Enzyme/ForwardMode/globalconsttypemd.ll
@@ -1,5 +1,4 @@
-; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -S | FileCheck %s; fi
-; RUN: %opt < %s %newLoadEnzyme -passes="enzyme" -enzyme-preopt=false -S | FileCheck %s
+; RUN: if [ %llvmver -ge 15 ]; then %opt < %s %OPnewLoadEnzyme -passes="enzyme" -enzyme-preopt=false -S | FileCheck %s; fi
 
 ; Constant globals have their type analysis result cached as !enzyme_type
 ; metadata. Offsets within a TypeTree may be negative (-1 denotes "any

--- a/enzyme/test/Enzyme/ForwardMode/globalconsttypemd.ll
+++ b/enzyme/test/Enzyme/ForwardMode/globalconsttypemd.ll
@@ -1,0 +1,37 @@
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -S | FileCheck %s; fi
+; RUN: %opt < %s %newLoadEnzyme -passes="enzyme" -enzyme-preopt=false -S | FileCheck %s
+
+; Constant globals have their type analysis result cached as !enzyme_type
+; metadata. Offsets within a TypeTree may be negative (-1 denotes "any
+; offset"), so the offsets must be serialized as signed constants.
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+
+@str = private unnamed_addr constant [12 x i8] c"src/main.rs\00", align 1
+@loc = private unnamed_addr constant <{ ptr, [16 x i8] }> <{ ptr @str, [16 x i8] c"\0B\00\00\00\00\00\00\00\08\00\00\00\05\00\00\00" }>, align 8
+
+define float @mul(ptr align 4 %a, ptr align 4 %b, ptr align 8 %loc) {
+  %la = load float, ptr %a, align 4
+  %lb = load float, ptr %b, align 4
+  %res = fmul float %la, %lb
+  ret float %res
+}
+
+define float @f(ptr align 4 %a, ptr align 4 %b) {
+  %res = call float @mul(ptr align 4 %a, ptr align 4 %b, ptr align 8 @loc)
+  ret float %res
+}
+
+define float @df(ptr %a, ptr %da, ptr %b, ptr %db) {
+  %res = call float (...) @__enzyme_fwddiff(ptr @f, ptr %a, ptr %da, ptr %b, ptr %db)
+  ret float %res
+}
+
+declare float @__enzyme_fwddiff(...)
+
+; CHECK: @str = private unnamed_addr constant [12 x i8] c"src/main.rs\00", align 1, !enzyme_type ![[STRTY:[0-9]+]]
+; CHECK: @loc = {{.*}}, !enzyme_type ![[LOCTY:[0-9]+]]
+
+; CHECK-DAG: ![[STRTY]] = !{!"Unknown", i32 -1, ![[ANYPTR:[0-9]+]]}
+; CHECK-DAG: ![[ANYPTR]] = !{!"Pointer", i32 -1, !{{[0-9]+}}}
+; CHECK-DAG: ![[LOCTY]] = !{!"Unknown", i32 -1, !{{[0-9]+}}}


### PR DESCRIPTION
Fixes #3060 — `Assertion \`llvm::isUIntN(BitWidth, val) && "Value is not an N-bit unsigned value"'` on LLVM 23.

## Root cause

`TypeTree::toMD` serializes offsets into `!enzyme_type` metadata:

```cpp
llvm::ConstantInt::get(llvm::IntegerType::get(ctx, 32), pair.first)
```

`pair.first` is an `int` offset, and TypeTree uses **`-1` to mean "any offset"**. That converts to `uint64_t` `0xFFFFFFFFFFFFFFFF`, which is not a 32-bit unsigned value.

LLVM changed the behavior under us:

| | `ConstantInt::get(IntegerType*, uint64_t V, bool IsSigned)` |
|---|---|
| LLVM ≤ 21 | `APInt(BitWidth, V, isSigned, /*implicitTrunc=*/true)` — silently truncates |
| LLVM ≥ 23 | `APInt(Ty->getBitWidth(), V, IsSigned, ImplicitTrunc=false)` — **asserts** |

## Why it started firing now

This is a latent bug that only became reachable on this path in e4afe548 ("Speed up large constant ta"), which caches constant-global type analysis:

```cpp
GV->setMetadata("enzyme_type", constTT.toMD(GV->getContext()));
```

Rust hits it on essentially every autodiff kernel, since its panic-location globals get a TypeTree containing `-1` offsets (`!{!"Unknown", i32 -1, ...}`).

Backtrace from a local LLVM 23 build:

```
llvm::APInt::APInt(unsigned, unsigned long, bool, bool)
llvm::ConstantInt::get(llvm::IntegerType*, unsigned long, bool, bool)
TypeTree::toMD(llvm::LLVMContext&)
getConstantAnalysis(...)
TypeAnalyzer::getAnalysis / getCallInfo / visitIPOCall ...
EnzymeBase::HandleAutoDiff
```

Note this is **not** LLVM-23-only — LLVM 24 asserts identically. The opt21 link in the issue passes only because of the implicit truncation.

## Fix

Pass `IsSigned=true`. This is bit-identical to the old truncating behavior (`-1` → `0xFFFFFFFF`) and matches the reader side, `insertFromMD`, which already uses `getSExtValue()`.

Two other `ConstantInt::get(Ty, -1)` sites found by audit are fixed the same way (`MustExitScalarEvolution.cpp`, `Utils.cpp:nextPowerOfTwo`). Both would assert identically on LLVM ≥ 23 for sub-64-bit types; I could not construct an input that reaches either, so they carry no dedicated test.

## Testing

New test `test/Enzyme/ForwardMode/globalconsttypemd.ll` is reduced from the issue reproducer and pins the emitted `!enzyme_type` offsets. Verified it **fails (asserts) without the fix** and passes with it, on LLVM 21, 23, and 24.

`check-enzyme` on LLVM 24, before vs. after:

| | Passed | Failed | `isUIntN` aborts |
|---|---|---|---|
| baseline | 287 | 752 | **30** |
| with fix | 290 | 749 | **0** |

The 30 aborts were spread across existing tests (`ForwardMode/globalfn.ll`, `ReverseMode/storeconstexpr.ll`, the `ProbProg` and `omp*` tests, …). The remaining failures are pre-existing CHECK-line drift for LLVM 23/24 IR printing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P65yn8LELKWU1dq6AQvA5f