### PR TITLE
Add clang enzyme_notypeanalysis and enzyme_ta_norecur attributes

### DIFF
--- a/enzyme/Enzyme/Clang/EnzymeClang.cpp
+++ b/enzyme/Enzyme/Clang/EnzymeClang.cpp
@@ -319,18 +319,20 @@ static clang::FrontendPluginRegistry::Add<EnzymeAction<EnzymePlugin>>
 #if LLVM_VERSION_MAJOR > 10
 namespace {
 
+bool isGlobalDecl(const Decl *D) {
+  auto VD = dyn_cast<VarDecl>(D);
+  return VD && VD->hasGlobalStorage();
+}
+
 /// Shared check for the registration attributes which apply to both functions
 /// and global variables.
 bool appertainsToFunctionOrGlobal(Sema &S, const ParsedAttr &Attr,
                                   const Decl *D) {
-  if (isa<FunctionDecl>(D))
+  if (isa<FunctionDecl>(D) || isGlobalDecl(D))
     return true;
-  if (auto VD = dyn_cast<VarDecl>(D)) {
-    if (VD->hasGlobalStorage())
-      return true;
-  }
+
   S.Diag(Attr.getLoc(), diag::warn_attribute_wrong_decl_type_str)
-      << Attr << "functions and globals";
+      << Attr << " applies to functions and globals only";
   return false;
 }
 
@@ -681,71 +683,19 @@ struct EnzymeNoTypeAnalysisAttrInfo : public ParsedAttrInfo {
 
   bool diagAppertainsToDecl(Sema &S, const ParsedAttr &Attr,
                             const Decl *D) const override {
-    // Attribute appertains to functions
-    if (isa<FunctionDecl>(D))
-      return true;
-    S.Diag(Attr.getLoc(), diag::warn_attribute_wrong_decl_type_str)
-        << Attr << "appertains only to functions";
-    return false;
+    return appertainsToFunctionOrGlobal(S, Attr, D);
   }
 
   AttrHandling handleDeclAttribute(Sema &S, Decl *D,
                                    const ParsedAttr &Attr) const override {
-    if (Attr.getNumArgs() != 0) {
-      S.Diag(Attr.getLoc(), diag::err_attribute_too_many_arguments)
-        << Attr << 0;
-      return AttributeNotApplied;
-    }
-    D->addAttr(AnnotateAttr::Create(
-        S.Context, "enzyme_notypeanalysis", nullptr, 0, Attr.getRange()));
-    return AttributeApplied;
+    // For now enzyme::notypeanalysis corresponds to the internal attribute enzyme_ta_norecur
+    return handleEnzymeMarkerAttr(S, D, Attr, "enzyme_notypeanalysis",
+                                    /*FnAnnotation*/ "enzyme_ta_norecur",
+                                    /*VarAnnotation*/ "enzyme_ta_norecur");
   }
 };
 
 static ParsedAttrInfoRegistry::Add<EnzymeNoTypeAnalysisAttrInfo> enzyme_notypeanalysis("enzyme_notypeanalysis", "");
-
-struct EnzymeTANoRecurAttrInfo : public ParsedAttrInfo {
-  EnzymeTANoRecurAttrInfo() {
-    static constexpr Spelling S[] = {
-      {ParsedAttr::AS_GNU, "enzyme_ta_norecur"},
-#if LLVM_VERSION_MAJOR > 17
-      {ParsedAttr::AS_C23, "enzyme_ta_norecur"},
-#else
-      {ParsedAttr::AS_C2x, "enzyme_ta_norecur"},
-#endif
-      {ParsedAttr::AS_CXX11, "enzyme_ta_norecur"},
-      {ParsedAttr::AS_CXX11, "enzyme::ta_norecur"}
-    };
-    Spellings = S;
-  }
-
-  bool diagAppertainsToDecl(Sema &S, const ParsedAttr &Attr,
-                            const Decl *D) const override {
-    // Attribute appertains to functions and globals
-    if (isa<FunctionDecl>(D))
-      return true;
-    if (auto VD = dyn_cast<VarDecl>(D); VD->hasGlobalStorage())
-      return true;
-    S.Diag(Attr.getLoc(), diag::warn_attribute_wrong_decl_type_str)
-        << Attr << "appertains only to globals";
-    return false;
-  }
-
-  AttrHandling handleDeclAttribute(Sema &S, Decl *D,
-                                   const ParsedAttr &Attr) const override {
-    if (Attr.getNumArgs() != 0) {
-      S.Diag(Attr.getLoc(), diag::err_attribute_too_many_arguments)
-        << Attr << 0;
-      return AttributeNotApplied;
-    }
-    D->addAttr(AnnotateAttr::Create(
-        S.Context, "enzyme_ta_norecur", nullptr, 0, Attr.getRange()));
-    return AttributeApplied;
-  }
-};
-
-static ParsedAttrInfoRegistry::Add<EnzymeTANoRecurAttrInfo> enzyme_ta_norecur(
-    "enzyme_ta_norecur", "");
 
 } // namespace
 

--- a/enzyme/Enzyme/Clang/EnzymeClang.cpp
+++ b/enzyme/Enzyme/Clang/EnzymeClang.cpp
@@ -663,6 +663,90 @@ struct EnzymeSparseAccumulateAttrInfo : public ParsedAttrInfo {
 
 static ParsedAttrInfoRegistry::Add<EnzymeSparseAccumulateAttrInfo>
     SparseX("enzyme_sparse_accumulate", "");
+
+struct EnzymeNoTypeAnalysisAttrInfo : public ParsedAttrInfo {
+  EnzymeNoTypeAnalysisAttrInfo() {
+    static constexpr Spelling S[] = {
+      {ParsedAttr::AS_GNU, "enzyme_notypeanalysis"},
+#if LLVM_VERSION_MAJOR > 17
+      {ParsedAttr::AS_C23, "enzyme_notypeanalysis"},
+#else
+      {ParsedAttr::AS_C2x, "enzyme_notypeanalysis"},
+#endif
+      {ParsedAttr::AS_CXX11, "enzyme_notypeanalysis"},
+      {ParsedAttr::AS_CXX11, "enzyme::notypeanalysis"}
+    };
+    Spellings = S;
+  }
+
+  bool diagAppertainsToDecl(Sema &S, const ParsedAttr &Attr,
+                            const Decl *D) const override {
+    // Attribute appertains to functions
+    if (isa<FunctionDecl>(D))
+      return true;
+    S.Diag(Attr.getLoc(), diag::warn_attribute_wrong_decl_type_str)
+        << Attr << "appertains only to functions";
+    return false;
+  }
+
+  AttrHandling handleDeclAttribute(Sema &S, Decl *D,
+                                   const ParsedAttr &Attr) const override {
+    if (Attr.getNumArgs() != 0) {
+      S.Diag(Attr.getLoc(), diag::err_attribute_too_many_arguments)
+        << Attr << 0;
+      return AttributeNotApplied;
+    }
+    D->addAttr(AnnotateAttr::Create(
+        S.Context, "enzyme_notypeanalysis", nullptr, 0, Attr.getRange()));
+    return AttributeApplied;
+  }
+};
+
+static ParsedAttrInfoRegistry::Add<EnzymeNoTypeAnalysisAttrInfo> enzyme_notypeanalysis("enzyme_notypeanalysis", "");
+
+struct EnzymeTANoRecurAttrInfo : public ParsedAttrInfo {
+  EnzymeTANoRecurAttrInfo() {
+    static constexpr Spelling S[] = {
+      {ParsedAttr::AS_GNU, "enzyme_ta_norecur"},
+#if LLVM_VERSION_MAJOR > 17
+      {ParsedAttr::AS_C23, "enzyme_ta_norecur"},
+#else
+      {ParsedAttr::AS_C2x, "enzyme_ta_norecur"},
+#endif
+      {ParsedAttr::AS_CXX11, "enzyme_ta_norecur"},
+      {ParsedAttr::AS_CXX11, "enzyme::ta_norecur"}
+    };
+    Spellings = S;
+  }
+
+  bool diagAppertainsToDecl(Sema &S, const ParsedAttr &Attr,
+                            const Decl *D) const override {
+    // Attribute appertains to functions and globals
+    if (isa<FunctionDecl>(D))
+      return true;
+    if (auto VD = dyn_cast<VarDecl>(D); VD->hasGlobalStorage())
+      return true;
+    S.Diag(Attr.getLoc(), diag::warn_attribute_wrong_decl_type_str)
+        << Attr << "appertains only to globals";
+    return false;
+  }
+
+  AttrHandling handleDeclAttribute(Sema &S, Decl *D,
+                                   const ParsedAttr &Attr) const override {
+    if (Attr.getNumArgs() != 0) {
+      S.Diag(Attr.getLoc(), diag::err_attribute_too_many_arguments)
+        << Attr << 0;
+      return AttributeNotApplied;
+    }
+    D->addAttr(AnnotateAttr::Create(
+        S.Context, "enzyme_ta_norecur", nullptr, 0, Attr.getRange()));
+    return AttributeApplied;
+  }
+};
+
+static ParsedAttrInfoRegistry::Add<EnzymeTANoRecurAttrInfo> enzyme_ta_norecur(
+    "enzyme_ta_norecur", "");
+
 } // namespace
 
 #endif

--- a/enzyme/Enzyme/Clang/EnzymeClang.cpp
+++ b/enzyme/Enzyme/Clang/EnzymeClang.cpp
@@ -688,14 +688,16 @@ struct EnzymeNoTypeAnalysisAttrInfo : public ParsedAttrInfo {
 
   AttrHandling handleDeclAttribute(Sema &S, Decl *D,
                                    const ParsedAttr &Attr) const override {
-    // For now enzyme::notypeanalysis corresponds to the internal attribute enzyme_ta_norecur
+    // For now enzyme::notypeanalysis corresponds to the internal attribute
+    // enzyme_ta_norecur
     return handleEnzymeMarkerAttr(S, D, Attr, "enzyme_notypeanalysis",
-                                    /*FnAnnotation*/ "enzyme_ta_norecur",
-                                    /*VarAnnotation*/ "enzyme_ta_norecur");
+                                  /*FnAnnotation*/ "enzyme_ta_norecur",
+                                  /*VarAnnotation*/ "enzyme_ta_norecur");
   }
 };
 
-static ParsedAttrInfoRegistry::Add<EnzymeNoTypeAnalysisAttrInfo> enzyme_notypeanalysis("enzyme_notypeanalysis", "");
+static ParsedAttrInfoRegistry::Add<EnzymeNoTypeAnalysisAttrInfo>
+    enzyme_notypeanalysis("enzyme_notypeanalysis", "");
 
 } // namespace
 

--- a/enzyme/Enzyme/PreserveNVVM.cpp
+++ b/enzyme/Enzyme/PreserveNVVM.cpp
@@ -484,6 +484,30 @@ bool preserveNVVM(bool Begin, Module &M,
               replacements.push_back(Constant::getNullValue(CAOp->getType()));
               continue;
             }
+
+            if (AS == "enzyme_notypeanalysis" && Func) {
+              Func->addAttribute(
+                  AttributeList::FunctionIndex,
+                  Attribute::get(Func->getContext(), "enzyme_notypeanalysis"));
+              changed = true;
+              replacements.push_back(Constant::getNullValue(CAOp->getType()));
+              continue;
+            }
+
+            if (AS == "enzyme_ta_norecur" && (Glob || Func)) {
+              if (Glob) {
+                Glob->setMetadata("enzyme_ta_norecur",
+                                  MDNode::get(Glob->getContext(), {}));
+              } else if (Func) {
+                Func->addAttribute(
+                    AttributeList::FunctionIndex,
+                    Attribute::get(Func->getContext(), "enzyme_ta_norecur"));
+              }
+              changed = true;
+              replacements.push_back(Constant::getNullValue(CAOp->getType()));
+              continue;
+            }
+
             replacements.push_back(cast<Constant>(CAOp));
           }
           GA->setInitializer(ConstantArray::get(CA->getType(), replacements));

--- a/enzyme/Enzyme/PreserveNVVM.cpp
+++ b/enzyme/Enzyme/PreserveNVVM.cpp
@@ -485,15 +485,6 @@ bool preserveNVVM(bool Begin, Module &M,
               continue;
             }
 
-            if (AS == "enzyme_notypeanalysis" && Func) {
-              Func->addAttribute(
-                  AttributeList::FunctionIndex,
-                  Attribute::get(Func->getContext(), "enzyme_notypeanalysis"));
-              changed = true;
-              replacements.push_back(Constant::getNullValue(CAOp->getType()));
-              continue;
-            }
-
             if (AS == "enzyme_ta_norecur" && (Glob || Func)) {
               if (Glob) {
                 Glob->setMetadata("enzyme_ta_norecur",

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -1165,8 +1165,8 @@ void TypeAnalyzer::updateAnalysis(Value *Val, TypeTree Data, Value *Origin) {
   }
 
   if (auto GV = dyn_cast<GlobalVariable>(Val)) {
-    if (hasMetadata(GV, "enzyme_ta_norecur")) {
-      llvm:errs() << "Skipping updateAnalysis (enzyme_ta_norecur) " << GV->getName() << "\n"; 
+    if (EnzymePrintType && hasMetadata(GV, "enzyme_ta_norecur")) {
+      llvm:errs() << "Skipping updateAnalysis " << GV->getName() << "\n"; 
       return;
     }
   }

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -1166,6 +1166,7 @@ void TypeAnalyzer::updateAnalysis(Value *Val, TypeTree Data, Value *Origin) {
 
   if (auto GV = dyn_cast<GlobalVariable>(Val)) {
     if (hasMetadata(GV, "enzyme_ta_norecur"))
+      llvm:errs() << "Skipping updateAnalysis (enzyme_ta_norecur) " << GV->getName() << "\n"; 
       return;
   }
 

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -1165,9 +1165,10 @@ void TypeAnalyzer::updateAnalysis(Value *Val, TypeTree Data, Value *Origin) {
   }
 
   if (auto GV = dyn_cast<GlobalVariable>(Val)) {
-    if (hasMetadata(GV, "enzyme_ta_norecur"))
+    if (hasMetadata(GV, "enzyme_ta_norecur")) {
       llvm:errs() << "Skipping updateAnalysis (enzyme_ta_norecur) " << GV->getName() << "\n"; 
       return;
+    }
   }
 
   if (auto CE = dyn_cast<ConstantExpr>(Val)) {

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -1165,8 +1165,9 @@ void TypeAnalyzer::updateAnalysis(Value *Val, TypeTree Data, Value *Origin) {
   }
 
   if (auto GV = dyn_cast<GlobalVariable>(Val)) {
-    if (EnzymePrintType && hasMetadata(GV, "enzyme_ta_norecur")) {
-      llvm:errs() << "Skipping updateAnalysis " << GV->getName() << "\n"; 
+    if (hasMetadata(GV, "enzyme_ta_norecur")) {
+      if (EnzymePrintType)
+        llvm::errs() << "Skipping updateAnalysis " << GV->getName() << "\n";
       return;
     }
   }

--- a/enzyme/test/Integration/ReverseMode/notypeanalysis.c
+++ b/enzyme/test/Integration/ReverseMode/notypeanalysis.c
@@ -1,0 +1,30 @@
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -c %s %newLoadClangEnzyme -o -; fi
+
+#include <stdlib.h>
+
+extern int enzyme_const, enzyme_out;
+double __enzyme_autodiff(void*, ...);
+
+union DoublePtr {
+    long addrInt;
+    double *ptr;
+};
+
+__attribute__((enzyme_notypeanalysis))
+static union DoublePtr dPtr;
+
+double divide(double x, double y) {
+    double tmp = x / y;
+
+    // Access pointer part of dPtr
+    *dPtr.ptr = x;
+
+    // Access long int part of dPtr. Without enzyme_notypeanalysis,
+    // this would cause a type analysis conflict.
+    return tmp + dPtr.addrInt;
+}
+
+double d_divide(double x) {
+    double y = 3.0;
+    return __enzyme_autodiff((void*)divide, enzyme_out, x, enzyme_const, y);
+}


### PR DESCRIPTION
Adding clang attributes for the enzyme_notypeanalysis  and enzyme_ta_norecur flags used by Enzyme.

enzyme_notypeanalysis:
https://github.com/search?q=repo%3AEnzymeAD%2FEnzyme+enzyme_notypeanalysis&type=code

enzyme_ta_norecur:
https://github.com/search?q=repo%3AEnzymeAD%2FEnzyme+enzyme_ta_norecur&type=code