### PR TITLE
Drop identity address-space casts in the Julia alloca lowering

### DIFF
--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -3180,10 +3180,8 @@ bool AdjointGenerator::handleKnownCallDerivatives(
                           getUnqual(anti->getType()->getPointerElementType()));
                   }
 #endif
-                  if (int AS = cast<PointerType>(anti->getType())
-                                   ->getAddressSpace()) {
-                    llvm::PointerType *PT = changePointerAddrSpace(
-                        cast<PointerType>(anti->getType()), AS);
+                  auto PT = cast<PointerType>(anti->getType());
+                  if (PT->getAddressSpace()) {
                     replacement = bb.CreateAddrSpaceCast(replacement, PT);
                     cast<Instruction>(replacement)
                         ->setMetadata(
@@ -3412,9 +3410,8 @@ bool AdjointGenerator::handleKnownCallDerivatives(
               replacement, getUnqual(call.getType()->getPointerElementType()));
       }
 #endif
-      if (int AS = cast<PointerType>(call.getType())->getAddressSpace()) {
-        llvm::PointerType *PT =
-            changePointerAddrSpace(cast<PointerType>(call.getType()), AS);
+      auto PT = cast<PointerType>(call.getType());
+      if (PT->getAddressSpace()) {
         replacement = B.CreateAddrSpaceCast(replacement, PT);
         cast<Instruction>(replacement)
             ->setMetadata("enzyme_backstack",


### PR DESCRIPTION
Follow-up to #3071, which flagged these two sites as visibly identity operations once `changePointerAddrSpace` made the intent explicit.

Both bind `AS` from the very pointer type they then rebuild with that same `AS`:

```cpp
if (int AS = cast<PointerType>(anti->getType())->getAddressSpace()) {
  llvm::PointerType *PT =
      changePointerAddrSpace(cast<PointerType>(anti->getType()), AS);
  replacement = bb.CreateAddrSpaceCast(replacement, PT);
```

`changePointerAddrSpace(PT, PT->getAddressSpace())` is `PT`. Pointer types are uniqued on `(pointee, address space)` with typed pointers and on `(context, address space)` with opaque ones, so reconstructing by either route hands back the same `Type *`. So this becomes:

```cpp
auto PT = cast<PointerType>(anti->getType());
if (PT->getAddressSpace()) {
  replacement = bb.CreateAddrSpaceCast(replacement, PT);
```

The `cast<PointerType>` was already unconditional (it was inside the `if` condition), so hoisting it changes nothing.

No functional change.

## Testing

Built against LLVM **15, 16, 21, 23, and 24** — all clean.

`check-enzyme` failure sets diffed against the merge base: **zero changes** on LLVM 15, 16, and 24 (1038/2, 1038/2, 292/748 respectively — identical sets before and after).

Two caveats worth stating rather than burying:

**No lit test covers this path.** I checked directly — no test in `test/Enzyme` produces `enzyme_backstack` metadata in its output, which is emitted at exactly these two sites. So the suite result above is evidence of no collateral damage, not of the path itself being exercised. The argument for correctness is the uniquing identity above.

**Two tests that do touch neighbouring code are nondeterministic**, which is worth knowing independently of this PR. Running `ReverseMode/combined_nort.ll` through the *same* binary twice gives a different module each time:

```
$ for i in 1 2 3 4 5 6; do opt ... combined_nort.ll | grep -c addrspacecast; done
97 98 97 98 97 97
```

and `combined_rt.ll` differs by ~480 lines run-to-run. Part of it is `enzyme_sret`, whose value is `std::to_string((size_t)T)` — a raw pointer address — and part is cache-index numbering that reorders a switch. I initially read this as a regression from this change before running the same-binary control; flagging it in case it is news. Neither test reaches the code changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P65yn8LELKWU1dq6AQvA5f