### PR TITLE
Report mismatched activity as a warning, not just an -Rpass remark

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -1044,7 +1044,8 @@ public:
               if (diff)
                 needs_writebarrier = true;
             } else
-              EmitWarning("MixedActivityError", I, ss.str());
+              EmitWarningAlways("MixedActivityError", I, ss.str(),
+                                MixedActivityHint);
           }
         }
       }
@@ -1306,7 +1307,8 @@ public:
                     if (valueop)
                       needs_writebarrier = true;
                   } else
-                    EmitWarning("MixedActivityError", I, ss.str());
+                    EmitWarningAlways("MixedActivityError", I, ss.str(),
+                                      MixedActivityHint);
                 }
               }
             }

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -2651,7 +2651,8 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
                       str.c_str(), wrap(ri), ErrorType::MixedActivityError,
                       gutils, wrap(orig_oldval), wrap(&BuilderZ)));
                 else
-                  EmitWarning("MixedActivityError", *ri, ss.str());
+                  EmitWarningAlways("MixedActivityError", *ri, ss.str(),
+                                    MixedActivityHint);
               }
             }
           }
@@ -3237,7 +3238,8 @@ void createTerminator(DiffeGradientUtils *gutils, BasicBlock *oBB,
                   str.c_str(), wrap(inst), ErrorType::MixedActivityError,
                   gutils, wrap(ret), wrap(&nBuilder)));
             else
-              EmitWarning("MixedActivityError", *inst, ss.str());
+              EmitWarningAlways("MixedActivityError", *inst, ss.str(),
+                                MixedActivityHint);
           }
         }
       }

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -6138,7 +6138,8 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
                     str.c_str(), wrap(arg), ErrorType::MixedActivityError, this,
                     wrap(op), wrap(&bb)));
               else
-                EmitWarning("MixedActivityError", *arg, ss.str());
+                EmitWarningAlways("MixedActivityError", *arg, ss.str(),
+                                  MixedActivityHint);
             }
           }
         }
@@ -6252,7 +6253,8 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
                                             ErrorType::MixedActivityError, this,
                                             wrap(tval), wrap(&bb)));
         else
-          EmitWarning("MixedActivityError", *arg, ss.str());
+          EmitWarningAlways("MixedActivityError", *arg, ss.str(),
+                            MixedActivityHint);
       }
       if (!itval) {
         itval = invertPointerM(tval, bb, TT);
@@ -6272,7 +6274,8 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
                                             ErrorType::MixedActivityError, this,
                                             wrap(fval), wrap(&bb)));
         else
-          EmitWarning("MixedActivityError", *arg, ss.str());
+          EmitWarningAlways("MixedActivityError", *arg, ss.str(),
+                            MixedActivityHint);
       }
       if (!ifval) {
         ifval = invertPointerM(fval, bb, TT);
@@ -6624,7 +6627,8 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
                                               ErrorType::MixedActivityError,
                                               this, wrap(preval), wrap(&pre)));
             else
-              EmitWarning("MixedActivityError", *phi, ss.str());
+              EmitWarningAlways("MixedActivityError", *phi, ss.str(),
+                                MixedActivityHint);
           }
           if (!val) {
             val = invertPointerM(preval, pre, TT);
@@ -6697,7 +6701,8 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
                                               ErrorType::MixedActivityError,
                                               this, wrap(preval), wrap(&pre)));
             else
-              EmitWarning("MixedActivityError", *phi, ss.str());
+              EmitWarningAlways("MixedActivityError", *phi, ss.str(),
+                                MixedActivityHint);
           }
           if (!val) {
             val = invertPointerM(preval, pre, TT);

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -193,16 +193,41 @@ public:
                 const llvm::Function *CodeRegion);
 };
 
+/// Emit a diagnostic which is always shown, unlike EmitWarning which requires
+/// the user to opt in with -Rpass=enzyme. Use this for messages which describe
+/// a potential correctness problem (e.g. mismatched activity) as opposed to a
+/// performance note.
+template <typename... Args>
+void EmitWarningAlways(llvm::StringRef RemarkName,
+                       const llvm::DiagnosticLocation &Loc,
+                       const llvm::Function &F, const Args &...args) {
+  // DiagnosticInfoUnsupported does not copy its message, so keep the backing
+  // storage alive until diagnose() returns.
+  std::string str = "Enzyme: ";
+  llvm::raw_string_ostream ss(str);
+  (ss << ... << args);
+  F.getContext().diagnose(EnzymeWarning(str, Loc, &F));
+}
+
+template <typename... Args>
+void EmitWarningAlways(llvm::StringRef RemarkName, const llvm::Instruction &I,
+                       const Args &...args) {
+  EmitWarningAlways(RemarkName, I.getDebugLoc(), *I.getParent()->getParent(),
+                    args...);
+}
+
 template <typename... Args>
 void EmitWarningAlways(llvm::StringRef RemarkName, const llvm::Function &F,
                        const Args &...args) {
-  llvm::LLVMContext &Ctx = F.getContext();
-  std::string str;
-  llvm::raw_string_ostream ss(str);
-  (ss << ... << args);
-  auto R = llvm::OptimizationRemark("enzyme", RemarkName, &F) << ss.str();
-  Ctx.diagnose((EnzymeWarning(ss.str(), F.getSubprogram(), &F)));
+  EmitWarningAlways(RemarkName, F.getSubprogram(), F, args...);
 }
+
+/// Remedy appended to mismatched-activity warnings, which are emitted when a
+/// value Enzyme proved inactive is used where an active value may be required.
+static constexpr const char *MixedActivityHint =
+    ". If this value may be active at runtime, enable runtime activity "
+    "analysis (pass \"enzyme_runtime_activity\" to __enzyme_autodiff); "
+    "otherwise its derivative will be assumed zero.";
 
 template <typename... Args>
 void EmitWarning(llvm::StringRef RemarkName, const llvm::Function &F,

--- a/enzyme/test/Integration/ReverseMode/warn_mixed_activity.c
+++ b/enzyme/test/Integration/ReverseMode/warn_mixed_activity.c
@@ -1,0 +1,28 @@
+// Mismatched activity is a correctness concern, so it is reported as an
+// ordinary warning rather than requiring the user to pass -Rpass=enzyme.
+
+// RUN: %clang -std=c11 -g -O1 %s -S -emit-llvm -o /dev/null %loadClangEnzyme -Xclang -verify -mllvm -enzyme-postopt=0
+// RUN: %clang -std=c11 -g -O2 %s -S -emit-llvm -o /dev/null %loadClangEnzyme -Xclang -verify -mllvm -enzyme-postopt=0
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O1 %s -S -emit-llvm -o /dev/null %newLoadClangEnzyme -Xclang -verify -mllvm -enzyme-postopt=0; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang -std=c11 -g -O2 %s -S -emit-llvm -o /dev/null %newLoadClangEnzyme -Xclang -verify -mllvm -enzyme-postopt=0; fi
+
+// It remains a warning rather than an error, so compilation still succeeds.
+
+// RUN: %clang -std=c11 -g -O2 %s -S -emit-llvm -o /dev/null %loadClangEnzyme -mllvm -enzyme-postopt=0 2>&1 | FileCheck %s
+// CHECK: warning: Enzyme: Mismatched activity
+// CHECK-SAME: enzyme_runtime_activity
+
+extern void __enzyme_autodiff(void *, ...);
+extern int enzyme_const, enzyme_dup;
+
+struct Container {
+  double *data;
+};
+
+void f(struct Container *c, double *q) {
+  c->data = q; // expected-warning-re {{Enzyme: Mismatched activity for:{{.*}}enzyme_runtime_activity{{.*}}}}
+}
+
+void run(struct Container *c, struct Container *dc, double *q) {
+  __enzyme_autodiff((void *)f, enzyme_dup, c, dc, enzyme_const, q);
+}


### PR DESCRIPTION
## Problem

Mismatched-activity diagnostics — the ones that tell a user they may need runtime activity — never appear in a normal `clang` build with the Enzyme plugin attached.

`EmitWarning` routes every message through an `llvm::OptimizationRemark` gated on:

```cpp
if (Ctx.getDiagHandlerPtr()->isPassedOptRemarkEnabled("enzyme")) { ... }
```

Remarks are opt-in in clang, so unless you pass `-Rpass=enzyme` (or `-mllvm -enzyme-print-perf`), the message is built and dropped. All nine `MixedActivityError` sites used that path, so a user silently gets a zero derivative with no indication anything was wrong.

There was already a second path, `EmitWarningAlways`, which emits a real `DS_Warning` diagnostic — but it only accepted a `Function` (no instruction/debug-loc overload) and was used at three unrelated call sites.

## Change

- Rework `EmitWarningAlways` into a general warning helper with `Instruction` and `Function` overloads. It emits an `EnzymeWarning` (`DiagnosticInfoUnsupported` at `DS_Warning`), which clang surfaces as an ordinary `warning:` with source location.
- Route the `MixedActivityError` sites through it and append a hint pointing at `enzyme_runtime_activity`. The `CustomErrorHandler` branches (Enzyme.jl) are untouched.

This stays a warning rather than an error; compilation still succeeds.

## Result

Plain `clang -O2 -g`, no extra flags:

```
mixed.c:7:13: warning: Enzyme: Mismatched activity for:   store ptr %q, ptr %c, ... const val: ptr %q.
If this value may be active at runtime, enable runtime activity analysis (pass "enzyme_runtime_activity"
to __enzyme_autodiff); otherwise its derivative will be assumed zero.
    c->data = q;
            ^
1 warning generated.
```

## Testing

New `enzyme/test/Integration/ReverseMode/warn_mixed_activity.c` covers legacy- and new-PM plugin loading and the warning text, via both `-Xclang -verify` and `FileCheck`.

Locally on LLVM 15: `check-enzyme` (1038), `check-activityanalysis`, `check-typeanalysis`, `check-enzyme-batch`, `check-enzyme-probprog`, and `check-enzyme-integration` (147 passed, 5 expectedly failed) all clean. `Enzyme/ReverseModeVector/partial_int_window.ll` fails, but it fails identically on unmodified `main` — pre-existing, unrelated to this change.

## Note for review

I deliberately did **not** promote the other `EmitWarning` categories. `CannotDeduceType` is arguably also correctness-relevant, but the load handler at `AdjointGenerator.h:420` is guarded by `looseTypeAnalysis || true` and so fires on essentially every unresolved load; the perf categories are worse (one integration test emits 72 "Load may need caching" remarks). Promoting either would drown the mixed-activity signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCicE3j1cDSaLivwBpTgSG