### PR TITLE
Give math.fma a derivative

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/MathDerivatives.td
+++ b/enzyme/Enzyme/MLIR/Implementations/MathDerivatives.td
@@ -10,6 +10,13 @@ def : MLIRDerivative<"math", "ExpOp", (Op $x),
                       (CheckedMulF (DiffeRet), (ExpF $x))
                     ]
                   >;
+def : MLIRDerivative<"math", "FmaOp", (Op $x, $y, $z),
+                    [
+                      (CheckedMulF (DiffeRet), $y),
+                      (CheckedMulF (DiffeRet), $x),
+                      (DiffeRet)
+                    ]
+                  >;
 def : MLIRDerivative<"math", "SinOp", (Op $x),
                     [
                       (CheckedMulF (DiffeRet), (CosF $x))

--- a/enzyme/test/MLIR/ForwardMode/fma.mlir
+++ b/enzyme/test/MLIR/ForwardMode/fma.mlir
@@ -1,0 +1,21 @@
+// RUN: %eopt --enzyme --canonicalize --remove-unnecessary-enzyme-ops --canonicalize --enzyme-simplify-math --cse %s | FileCheck %s
+
+module {
+  func.func @fma(%x: f64, %y: f64, %z: f64) -> f64 {
+    %res = math.fma %x, %y, %z : f64
+    return %res : f64
+  }
+
+  func.func @dfma(%x: f64, %dx: f64, %y: f64, %dy: f64, %z: f64, %dz: f64) -> f64 {
+    %r = enzyme.fwddiff @fma(%x, %dx, %y, %dy, %z, %dz) { activity=[#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_dup>, #enzyme<activity enzyme_dup>], ret_activity=[#enzyme<activity enzyme_dupnoneed>] } : (f64, f64, f64, f64, f64, f64) -> f64
+    return %r : f64
+  }
+}
+
+// CHECK:  func.func private @fwddiffefma(%[[x:.+]]: f64, %[[dx:.+]]: f64, %[[y:.+]]: f64, %[[dy:.+]]: f64, %[[z:.+]]: f64, %[[dz:.+]]: f64) -> f64 {
+// CHECK-NEXT:    %[[a:.+]] = arith.mulf %[[dx]], %[[y]] fastmath<fast> : f64
+// CHECK-NEXT:    %[[b:.+]] = arith.mulf %[[dy]], %[[x]] fastmath<fast> : f64
+// CHECK-NEXT:    %[[s:.+]] = arith.addf %[[a]], %[[b]] fastmath<fast> : f64
+// CHECK-NEXT:    %[[r:.+]] = arith.addf %[[s]], %[[dz]] fastmath<fast> : f64
+// CHECK-NEXT:    return %[[r]] : f64
+// CHECK-NEXT:  }

--- a/enzyme/test/MLIR/ReverseMode/math.mlir
+++ b/enzyme/test/MLIR/ReverseMode/math.mlir
@@ -61,3 +61,24 @@ func.func @dabsf(%x: f64, %dr: f64) -> f64 {
 // CHECK-NEXT:    %[[res:.+]] = arith.select %[[ge_z]], %[[dr]], %[[negdr]] : f64
 // CHECK-NEXT:    return %[[res]] : f64
 // CHECK-NEXT:  }
+
+// -----
+
+func.func @fma(%x: f64, %y: f64, %z: f64) -> f64 {
+  %res = math.fma %x, %y, %z : f64
+  return %res : f64
+}
+
+func.func @dfma(%x: f64, %y: f64, %z: f64, %dr: f64) -> (f64, f64, f64) {
+  %0:3 = enzyme.autodiff @fma(%x, %y, %z, %dr) { activity=[#enzyme<activity enzyme_active>, #enzyme<activity enzyme_active>, #enzyme<activity enzyme_active>], ret_activity=[#enzyme<activity enzyme_activenoneed>] } : (f64, f64, f64, f64) -> (f64, f64, f64)
+  return %0#0, %0#1, %0#2 : f64, f64, f64
+}
+
+// The addend carries the adjoint through untouched; each factor takes it
+// scaled by the other.
+
+// CHECK: func.func private @diffefma(%[[x:.+]]: f64, %[[y:.+]]: f64, %[[z:.+]]: f64, %[[dr:.+]]: f64) -> (f64, f64, f64) {
+// CHECK-NEXT:    %[[dx:.+]] = arith.mulf %[[dr]], %[[y]] fastmath<fast> : f64
+// CHECK-NEXT:    %[[dy:.+]] = arith.mulf %[[dr]], %[[x]] fastmath<fast> : f64
+// CHECK-NEXT:    return %[[dx]], %[[dy]], %[[dr]] : f64, f64, f64
+// CHECK-NEXT:  }


### PR DESCRIPTION
`math.fma(a, b, c)` is `a * b + c` and had no entry in `MathDerivatives.td`, so anything reaching it stopped at:

```
error: could not compute the adjoint for this operation
  %36 = "math.fma"(%35, %17, %33) : (f64, f64, f64) -> f64
```

MFEM's dFEM kernels reach it all over — the Jacobian determinants and geometric factors are written as fused multiply-adds — and neither `test_functional_gradient.cpp` nor `test_second_derivative.cpp` would compile.

Each factor takes the adjoint scaled by the other; the addend carries it through untouched:

```tablegen
def : MLIRDerivative<"math", "FmaOp", (Op $x, $y, $z),
                    [
                      (CheckedMulF (DiffeRet), $y),
                      (CheckedMulF (DiffeRet), $x),
                      (DiffeRet)
                    ]
                  >;
```

Forward mode falls out of the reverse rules (`ForwardFromSummedReverse`) the way it does for the rest of this file, giving `dx*y + dy*x + dz`.

## Tests

- `test/MLIR/ReverseMode/math.mlir` — a case appended alongside the existing sqrt/atan/absf ones.
- `test/MLIR/ForwardMode/fma.mlir` — new.

159/160 of `check-enzymemlir` pass; the one failure is `ReverseMode/linalg.mlir`, which fails on main too ("tensor semantics not yet supported").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD