### PR TITLE
Load adjoint: a mutable type takes a shadow, not an accumulation

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
@@ -606,10 +606,22 @@ struct AffineLoadOpInterfaceReverse
 
   void createShadowValues(Operation *op, OpBuilder &builder,
                           MGradientUtilsReverse *gutils) const {
-    // auto loadOp = cast<memref::LoadOp>(op);
-    // Value memref = loadOp.getMemref();
-    // Value shadow = gutils->getShadowValue(memref);
-    // Do nothing yet. In the future support memref<memref<...>>
+    auto loadOp = cast<affine::AffineLoadOp>(op);
+    Value memref = loadOp.getMemref();
+    auto iface = dyn_cast<AutoDiffTypeInterface>(loadOp.getType());
+    // What a load of a mutable type reads is itself a handle on active memory,
+    // so what stands for it is the handle held at the same place in the shadow:
+    // the same load, off the shadow memref. Reading it out is the whole of the
+    // derivative -- see the adjoint above, which leaves it alone.
+    if (!iface || !iface.isMutable())
+      return;
+    if (gutils->isConstantValue(loadOp) || gutils->isConstantValue(memref))
+      return;
+    Value memrefShadow = gutils->invertPointerM(memref, builder);
+    auto newLoad = cast<affine::AffineLoadOp>(gutils->getNewFromOriginal(op));
+    auto shadowLoad = cast<affine::AffineLoadOp>(builder.clone(*newLoad));
+    shadowLoad.getMemrefMutable().assign(memrefShadow);
+    gutils->setInvertedPointer(loadOp.getResult(), shadowLoad.getResult());
   }
 };
 

--- a/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
@@ -518,8 +518,11 @@ struct AffineLoadOpInterfaceReverse
     Value memref = loadOp.getMemref();
 
     if (auto iface = dyn_cast<AutoDiffTypeInterface>(loadOp.getType())) {
+      // A mutable type's derivative is a shadow, not a value to add into: there
+      // is nothing to accumulate here, the same way the store adjoint has
+      // nothing to take back out. Loading a pointer is the case in hand.
       if (!gutils->isConstantValue(loadOp) &&
-          !gutils->isConstantValue(memref)) {
+          !gutils->isConstantValue(memref) && !iface.isMutable()) {
         Value gradient = gutils->diffe(loadOp, builder);
         Value memrefGradient = gutils->popCache(caches.front(), builder);
 

--- a/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
@@ -303,8 +303,22 @@ struct LoadOpInterfaceReverse
 
   void createShadowValues(Operation *op, OpBuilder &builder,
                           MGradientUtilsReverse *gutils) const {
-    // auto loadOp = cast<LLVM::LoadOp>(op);
-    // Value ptr = loadOp.getAddr();
+    auto loadOp = cast<LLVM::LoadOp>(op);
+    Value addr = loadOp.getAddr();
+    auto iface = dyn_cast<AutoDiffTypeInterface>(loadOp.getType());
+    // What a load of a mutable type reads is itself a handle on active memory,
+    // so what stands for it is the handle held at the same place in the shadow:
+    // the same load, off the shadow address. Reading it out is the whole of the
+    // derivative -- see the adjoint above, which leaves it alone.
+    if (!iface || !iface.isMutable())
+      return;
+    if (gutils->isConstantValue(loadOp) || gutils->isConstantValue(addr))
+      return;
+    Value addrShadow = gutils->invertPointerM(addr, builder);
+    auto newLoad = cast<LLVM::LoadOp>(gutils->getNewFromOriginal(op));
+    auto shadowLoad = cast<LLVM::LoadOp>(builder.clone(*newLoad));
+    shadowLoad.getAddrMutable().assign(addrShadow);
+    gutils->setInvertedPointer(loadOp.getResult(), shadowLoad.getResult());
   }
 };
 

--- a/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
@@ -262,7 +262,11 @@ struct LoadOpInterfaceReverse
     Value addr = loadOp.getAddr();
 
     if (auto iface = dyn_cast<AutoDiffTypeInterface>(loadOp.getType())) {
-      if (!gutils->isConstantValue(loadOp) && !gutils->isConstantValue(addr)) {
+      // A mutable type's derivative is a shadow, not a value to add into: there
+      // is nothing to accumulate here, the same way the store adjoint below has
+      // nothing to take back out. Loading a pointer is the case in hand.
+      if (!gutils->isConstantValue(loadOp) && !gutils->isConstantValue(addr) &&
+          !iface.isMutable()) {
         Value gradient = gutils->diffe(loadOp, builder);
         Value addrGradient = gutils->popCache(caches.front(), builder);
 

--- a/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
@@ -49,8 +49,11 @@ struct LoadOpInterfaceReverse
     Value memref = loadOp.getMemref();
 
     if (auto iface = dyn_cast<AutoDiffTypeInterface>(loadOp.getType())) {
+      // A mutable type's derivative is a shadow, not a value to add into: there
+      // is nothing to accumulate here, the same way the store adjoint below has
+      // nothing to take back out. Loading a pointer is the case in hand.
       if (!gutils->isConstantValue(loadOp) &&
-          !gutils->isConstantValue(memref)) {
+          !gutils->isConstantValue(memref) && !iface.isMutable()) {
         Value gradient = gutils->diffe(loadOp, builder);
         Value memrefGradient = gutils->popCache(caches.front(), builder);
 

--- a/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
@@ -107,10 +107,22 @@ struct LoadOpInterfaceReverse
 
   void createShadowValues(Operation *op, OpBuilder &builder,
                           MGradientUtilsReverse *gutils) const {
-    // auto loadOp = cast<memref::LoadOp>(op);
-    // Value memref = loadOp.getMemref();
-    // Value shadow = gutils->getShadowValue(memref);
-    // Do nothing yet. In the future support memref<memref<...>>
+    auto loadOp = cast<memref::LoadOp>(op);
+    Value memref = loadOp.getMemref();
+    auto iface = dyn_cast<AutoDiffTypeInterface>(loadOp.getType());
+    // What a load of a mutable type reads is itself a handle on active memory,
+    // so what stands for it is the handle held at the same place in the shadow:
+    // the same load, off the shadow memref. Reading it out is the whole of the
+    // derivative -- see the adjoint above, which leaves it alone.
+    if (!iface || !iface.isMutable())
+      return;
+    if (gutils->isConstantValue(loadOp) || gutils->isConstantValue(memref))
+      return;
+    Value memrefShadow = gutils->invertPointerM(memref, builder);
+    auto newLoad = cast<memref::LoadOp>(gutils->getNewFromOriginal(op));
+    auto shadowLoad = cast<memref::LoadOp>(builder.clone(*newLoad));
+    shadowLoad.getMemrefMutable().assign(memrefShadow);
+    gutils->setInvertedPointer(loadOp.getResult(), shadowLoad.getResult());
   }
 };
 

--- a/enzyme/test/MLIR/ReverseMode/ptr_load.mlir
+++ b/enzyme/test/MLIR/ReverseMode/ptr_load.mlir
@@ -62,3 +62,41 @@ func.func @df_memref(%m: memref<?x!llvm.ptr>, %dm: memref<?x!llvm.ptr>, %out: !l
 // CHECK:         llvm.store %[[new2]], %[[dp2]] : f64, !llvm.ptr
 // CHECK-NOT:     enzyme.placeholder
 // CHECK:         return
+
+// -----
+
+// And through affine.load, where the map rather than an index operand picks the
+// element out.
+
+func.func @f_affine(%m: memref<?x!llvm.ptr>, %out: !llvm.ptr) {
+  affine.for %i = 0 to 4 {
+    %p = affine.load %m[%i] : memref<?x!llvm.ptr>
+    %v = llvm.load %p : !llvm.ptr -> f64
+    %s = arith.mulf %v, %v : f64
+    llvm.store %s, %out : f64, !llvm.ptr
+  }
+  return
+}
+
+func.func @df_affine(%m: memref<?x!llvm.ptr>, %dm: memref<?x!llvm.ptr>, %out: !llvm.ptr, %dout: !llvm.ptr) {
+  enzyme.autodiff @f_affine(%m, %dm, %out, %dout) { activity=[#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_dup>], ret_activity=[] } : (memref<?x!llvm.ptr>, memref<?x!llvm.ptr>, !llvm.ptr, !llvm.ptr) -> ()
+  return
+}
+
+// The shadow pointer is read out of the shadow memref on the way forward and
+// kept, and the reverse loop accumulates through what it kept.
+
+// CHECK: func.func private @diffef_affine(%[[m3:.+]]: memref<?x!llvm.ptr>, %[[dm3:.+]]: memref<?x!llvm.ptr>, %[[out3:.+]]: !llvm.ptr, %[[dout3:.+]]: !llvm.ptr)
+// CHECK-NOT:     enzyme.placeholder
+// CHECK:         %[[cache:.+]] = memref.alloc() : memref<4x!llvm.ptr>
+// CHECK:         affine.for %[[iv:.+]] = 0 to 4 {
+// CHECK:           %[[dp3:.+]] = affine.load %[[dm3]]{{\[}}%[[iv]]] : memref<?x!llvm.ptr>
+// CHECK:           memref.store %[[dp3]], %[[cache]]{{\[}}%[[iv]]]
+// CHECK:           affine.load %[[m3]]{{\[}}%[[iv]]] : memref<?x!llvm.ptr>
+// CHECK:         affine.for
+// CHECK:           %[[rdp3:.+]] = memref.load %[[cache]]
+// CHECK:           %[[old3:.+]] = llvm.load %[[rdp3]] : !llvm.ptr -> f64
+// CHECK:           %[[new3:.+]] = arith.addf %[[old3]], %{{.+}} fastmath<fast> : f64
+// CHECK:           llvm.store %[[new3]], %[[rdp3]] : f64, !llvm.ptr
+// CHECK-NOT:     enzyme.placeholder
+// CHECK:         return

--- a/enzyme/test/MLIR/ReverseMode/ptr_load.mlir
+++ b/enzyme/test/MLIR/ReverseMode/ptr_load.mlir
@@ -3,6 +3,8 @@
 // Loading a pointer out of a pointer gives an active value whose derivative is
 // a shadow pointer, not a number to accumulate. The load adjoints used to reach
 // for createAddOp on it all the same, and a pointer has no addition to give.
+// What stands for it is the handle held at the same place in the shadow: the
+// same load, off the shadow address.
 
 llvm.func @f_llvm(%pp: !llvm.ptr, %out: !llvm.ptr) {
   %p = llvm.load %pp : !llvm.ptr -> !llvm.ptr
@@ -17,16 +19,19 @@ func.func @df_llvm(%pp: !llvm.ptr, %dpp: !llvm.ptr, %out: !llvm.ptr, %dout: !llv
   return
 }
 
-// The pointer load is replayed and the gradient goes to the shadow it stands
-// for; nothing is added into the pointer itself.
+// The shadow pointer is read out of the shadow of %pp, and d(v*v) = 2v lands
+// through it. Nothing is added into the pointer itself, and the shadow is a
+// real value rather than a placeholder left standing.
 
 // CHECK: llvm.func @diffef_llvm(%[[pp:.+]]: !llvm.ptr, %[[dpp:.+]]: !llvm.ptr, %[[out:.+]]: !llvm.ptr, %[[dout:.+]]: !llvm.ptr)
-// CHECK:         %[[shadow:.+]] = "enzyme.placeholder"() : () -> !llvm.ptr
+// CHECK-NOT:     enzyme.placeholder
+// CHECK:         %[[dp:.+]] = llvm.load %[[dpp]] : !llvm.ptr -> !llvm.ptr
 // CHECK:         %[[p:.+]] = llvm.load %[[pp]] : !llvm.ptr -> !llvm.ptr
 // CHECK:         %[[v:.+]] = llvm.load %[[p]] : !llvm.ptr -> f64
-// CHECK:         %[[old:.+]] = llvm.load %[[shadow]] : !llvm.ptr -> f64
+// CHECK:         %[[old:.+]] = llvm.load %[[dp]] : !llvm.ptr -> f64
 // CHECK:         %[[new:.+]] = arith.addf %[[old]], %{{.+}} fastmath<fast> : f64
-// CHECK:         llvm.store %[[new]], %[[shadow]] : f64, !llvm.ptr
+// CHECK:         llvm.store %[[new]], %[[dp]] : f64, !llvm.ptr
+// CHECK-NOT:     enzyme.placeholder
 // CHECK:         llvm.return
 
 // -----
@@ -47,6 +52,13 @@ func.func @df_memref(%m: memref<?x!llvm.ptr>, %dm: memref<?x!llvm.ptr>, %out: !l
   return
 }
 
-// CHECK: func.func private @diffef_memref
-// CHECK:         memref.load
+// CHECK: func.func private @diffef_memref(%[[m:.+]]: memref<?x!llvm.ptr>, %[[dm:.+]]: memref<?x!llvm.ptr>, %[[out2:.+]]: !llvm.ptr, %[[dout2:.+]]: !llvm.ptr)
+// CHECK-NOT:     enzyme.placeholder
+// CHECK:         %[[dp2:.+]] = memref.load %[[dm]]{{\[}}%{{.+}}] : memref<?x!llvm.ptr>
+// CHECK:         %[[p2:.+]] = memref.load %[[m]]{{\[}}%{{.+}}] : memref<?x!llvm.ptr>
+// CHECK:         %[[v2:.+]] = llvm.load %[[p2]] : !llvm.ptr -> f64
+// CHECK:         %[[old2:.+]] = llvm.load %[[dp2]] : !llvm.ptr -> f64
+// CHECK:         %[[new2:.+]] = arith.addf %[[old2]], %{{.+}} fastmath<fast> : f64
+// CHECK:         llvm.store %[[new2]], %[[dp2]] : f64, !llvm.ptr
+// CHECK-NOT:     enzyme.placeholder
 // CHECK:         return

--- a/enzyme/test/MLIR/ReverseMode/ptr_load.mlir
+++ b/enzyme/test/MLIR/ReverseMode/ptr_load.mlir
@@ -1,0 +1,52 @@
+// RUN: %eopt --split-input-file --enzyme --canonicalize --remove-unnecessary-enzyme-ops %s | FileCheck %s
+
+// Loading a pointer out of a pointer gives an active value whose derivative is
+// a shadow pointer, not a number to accumulate. The load adjoints used to reach
+// for createAddOp on it all the same, and a pointer has no addition to give.
+
+llvm.func @f_llvm(%pp: !llvm.ptr, %out: !llvm.ptr) {
+  %p = llvm.load %pp : !llvm.ptr -> !llvm.ptr
+  %v = llvm.load %p : !llvm.ptr -> f64
+  %s = arith.mulf %v, %v : f64
+  llvm.store %s, %out : f64, !llvm.ptr
+  llvm.return
+}
+
+func.func @df_llvm(%pp: !llvm.ptr, %dpp: !llvm.ptr, %out: !llvm.ptr, %dout: !llvm.ptr) {
+  enzyme.autodiff @f_llvm(%pp, %dpp, %out, %dout) { activity=[#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_dup>], ret_activity=[] } : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  return
+}
+
+// The pointer load is replayed and the gradient goes to the shadow it stands
+// for; nothing is added into the pointer itself.
+
+// CHECK: llvm.func @diffef_llvm(%[[pp:.+]]: !llvm.ptr, %[[dpp:.+]]: !llvm.ptr, %[[out:.+]]: !llvm.ptr, %[[dout:.+]]: !llvm.ptr)
+// CHECK:         %[[shadow:.+]] = "enzyme.placeholder"() : () -> !llvm.ptr
+// CHECK:         %[[p:.+]] = llvm.load %[[pp]] : !llvm.ptr -> !llvm.ptr
+// CHECK:         %[[v:.+]] = llvm.load %[[p]] : !llvm.ptr -> f64
+// CHECK:         %[[old:.+]] = llvm.load %[[shadow]] : !llvm.ptr -> f64
+// CHECK:         %[[new:.+]] = arith.addf %[[old]], %{{.+}} fastmath<fast> : f64
+// CHECK:         llvm.store %[[new]], %[[shadow]] : f64, !llvm.ptr
+// CHECK:         llvm.return
+
+// -----
+
+// The same through memref, where the pointer comes out of a memref<?x!llvm.ptr>.
+
+func.func @f_memref(%m: memref<?x!llvm.ptr>, %out: !llvm.ptr) {
+  %c0 = arith.constant 0 : index
+  %p = memref.load %m[%c0] : memref<?x!llvm.ptr>
+  %v = llvm.load %p : !llvm.ptr -> f64
+  %s = arith.mulf %v, %v : f64
+  llvm.store %s, %out : f64, !llvm.ptr
+  return
+}
+
+func.func @df_memref(%m: memref<?x!llvm.ptr>, %dm: memref<?x!llvm.ptr>, %out: !llvm.ptr, %dout: !llvm.ptr) {
+  enzyme.autodiff @f_memref(%m, %dm, %out, %dout) { activity=[#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_dup>], ret_activity=[] } : (memref<?x!llvm.ptr>, memref<?x!llvm.ptr>, !llvm.ptr, !llvm.ptr) -> ()
+  return
+}
+
+// CHECK: func.func private @diffef_memref
+// CHECK:         memref.load
+// CHECK:         return


### PR DESCRIPTION
A mutable type's derivative is a shadow, not a number. Loading a pointer out of a pointer gives an active value whose gradient is the shadow pointer, and there is no adding one pointer to another. Two things were missing.

## 1. The adjoint accumulated into it

All three **store** adjoints already say the right thing:

```cpp
if (!iface.isMutable()) {
  if (!gutils->isConstantValue(val)) { ...accumulate... }
  ...
}
```

All three **load** adjoints did not, so each reached `PointerTypeInterface::createAddOp`, which is `llvm_unreachable("TODO")`. MFEM's `fem/test_fe_compatibility.cpp` took the trap, and because trap-only bodies fold together the stack pointed at `ArrayTypeInterface::createConjOp` — several frames from anything that named a pointer.

No working case is lost by skipping: the only types this newly skips are the ones whose `createAddOp` could not have returned.

## 2. The loaded shadow was never given a value

Skipping the accumulation is only half of it. The loaded pointer still had no shadow, so it kept the `enzyme.placeholder` that stood in for one and nothing downstream could resolve it.

What a load of a mutable type reads is itself a handle on active memory, so what stands for it is the handle held at the same place in the shadow — the same load, off the shadow address. `llvm.getelementptr` already does exactly this one op along:

```cpp
auto baseShadow = gutils->invertPointerM(base, builder);
auto shadowGep = cast<LLVM::GEPOp>(builder.clone(*newGep));
shadowGep.getBaseMutable().assign(baseShadow);
gutils->setInvertedPointer(gep.getRes(), shadowGep->getResult(0));
```

`createShadowValues` on the three loads now agrees with it.

Both changes cover `LLVM::LoadOp`, `memref::LoadOp` and `affine::AffineLoadOp`.

## Test

`test/MLIR/ReverseMode/ptr_load.mlir` — a pointer loaded from a pointer, and the same through `memref<?x!llvm.ptr>`. Both abort on main. The gradient reaches the pointee through the shadow read out of the shadow address, and no placeholder is left standing.

160/161 of `check-enzymemlir` pass; the one failure is `ReverseMode/linalg.mlir`, which fails on main too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
