### PR TITLE
Route getFirstNonPHI through a Utils.h wrapper

### DIFF
--- a/enzyme/Enzyme/CacheUtility.cpp
+++ b/enzyme/Enzyme/CacheUtility.cpp
@@ -128,7 +128,7 @@ InsertNewCanonicalIV(Loop *L, Type *Ty, const llvm::Twine &Name) {
   IRBuilder<> B(Header, Header->begin());
   PHINode *CanonicalIV = B.CreatePHI(Ty, 1, Name);
 
-  B.SetInsertPoint(Header->getFirstNonPHIOrDbg());
+  B.SetInsertPoint(getFirstNonPHIOrDbg(Header));
   Instruction *Inc = cast<Instruction>(
       B.CreateAdd(CanonicalIV, ConstantInt::get(Ty, 1), Name + ".next",
                   /*NUW*/ true, /*NSW*/ true));

--- a/enzyme/Enzyme/CacheUtility.cpp
+++ b/enzyme/Enzyme/CacheUtility.cpp
@@ -255,8 +255,7 @@ void RemoveRedundantIVs(
 
     // We place that at first non phi as it may produce a non-phi instruction
     // and must thus be expanded after all phi's
-    Value *NewIV =
-        Exp.expandCodeFor(S, Tmp->getType(), Header->getFirstNonPHI());
+    Value *NewIV = Exp.expandCodeFor(S, Tmp->getType(), getFirstNonPHI(Header));
 
     // Explicity preserve wrap behavior from original iv. This is necessary
     // until this PR in llvm is merged:
@@ -283,7 +282,7 @@ void RemoveRedundantIVs(
   }
 
   // Replace existing increments with canonical Increment
-  Increment->moveAfter(CanonicalIV->getParent()->getFirstNonPHI());
+  Increment->moveAfter(getFirstNonPHI(CanonicalIV->getParent()));
   SmallVector<Instruction *, 1> toErase;
   for (auto use : CanonicalIV->users()) {
     auto BO = dyn_cast<BinaryOperator>(use);
@@ -397,7 +396,7 @@ void CanonicalizeLatches(const Loop *L, BasicBlock *Header,
 
   // Replace previous increment usage with new increment value
   if (Increment) {
-    Increment->moveAfter(CanonicalIV->getParent()->getFirstNonPHI());
+    Increment->moveAfter(getFirstNonPHI(CanonicalIV->getParent()));
 
     if (latches.size() == 1 && isa<BranchInst>(latches[0]->getTerminator()) &&
         cast<BranchInst>(latches[0]->getTerminator())->isConditional())
@@ -1500,7 +1499,7 @@ void CacheUtility::storeInstructionInCache(LimitContext ctx,
   if (&*inst->getParent()->rbegin() != inst) {
     auto pn = dyn_cast<PHINode>(inst);
     Instruction *putafter = (pn && pn->getNumIncomingValues() > 0)
-                                ? (inst->getParent()->getFirstNonPHI())
+                                ? (getFirstNonPHI(inst->getParent()))
                                 : getNextNonDebugInstruction(inst);
     assert(putafter);
     v.SetInsertPoint(putafter);

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -347,7 +347,7 @@ static bool ReplaceOriginalCall(IRBuilder<> &Builder, Value *ret,
       ((mode == DerivativeMode::ForwardMode ||
         mode == DerivativeMode::ForwardModeError) &&
        DL.getTypeSizeInBits(retType) == DL.getTypeSizeInBits(diffretType))) {
-    IRBuilder<> EB(CI->getFunction()->getEntryBlock().getFirstNonPHI());
+    IRBuilder<> EB(getFirstNonPHI(&CI->getFunction()->getEntryBlock()));
     auto AL = EB.CreateAlloca(retType);
     Builder.CreateStore(diffret,
                         Builder.CreatePointerCast(AL, getUnqual(diffretType)));
@@ -1891,7 +1891,7 @@ public:
     assert(!sampleFunctions.empty() || !observeFunctions.empty());
 
     bool autodiff = dtrace || dlikelihood;
-    IRBuilder<> AllocaBuilder(CI->getParent()->getFirstNonPHI());
+    IRBuilder<> AllocaBuilder(getFirstNonPHI(CI->getParent()));
 
     if (!likelihood) {
       likelihood = AllocaBuilder.CreateAlloca(AllocaBuilder.getDoubleTy(),
@@ -2511,7 +2511,7 @@ public:
             CI->moveBefore(B2);
             CI->setOperand(0, si->getFalseValue());
             if (CI->getNumUses() != 0) {
-              IRBuilder<> P(post->getFirstNonPHI());
+              IRBuilder<> P(getFirstNonPHI(post));
               auto merge = P.CreatePHI(CI->getType(), 2);
               merge->addIncoming(cloned, sel1);
               merge->addIncoming(CI, sel2);

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -1844,7 +1844,7 @@ void restoreCache(
         IRBuilder<> BuilderZ(newi->getNextNode());
         if (isa<PHINode>(m.first.first)) {
           BuilderZ.SetInsertPoint(
-              cast<Instruction>(newi)->getParent()->getFirstNonPHI());
+              getFirstNonPHI(cast<Instruction>(newi)->getParent()));
         }
         Value *nexti = gutils->cacheForReverse(BuilderZ, newi, m.second,
                                                /*replace*/ false);
@@ -2617,7 +2617,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
             IRBuilder<> BuilderZ(cast<Instruction>(newi)->getNextNode());
             if (isa<PHINode>(newi)) {
               BuilderZ.SetInsertPoint(
-                  cast<Instruction>(newi)->getParent()->getFirstNonPHI());
+                  getFirstNonPHI(cast<Instruction>(newi)->getParent()));
             }
             gutils->cacheForReverse(BuilderZ, newi,
                                     getIndex(&I, CacheType::Self, BuilderZ));
@@ -2913,7 +2913,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
   CloneFunctionInto(NewF, nf, VMap, CloneFunctionChangeType::LocalChangesOnly,
                     Returns, "", nullptr);
 
-  IRBuilder<> ib(NewF->getEntryBlock().getFirstNonPHI());
+  IRBuilder<> ib(getFirstNonPHI(&NewF->getEntryBlock()));
 
   AllocaInst *ret = noReturn ? nullptr : ib.CreateAlloca(RetType);
 
@@ -2952,7 +2952,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
       j->setName("tape");
       tapeMemory = j;
       // if structs were supported by openmp we could do this, but alas, no
-      // IRBuilder<> B(NewF->getEntryBlock().getFirstNonPHI());
+      // IRBuilder<> B(getFirstNonPHI(&NewF->getEntryBlock()));
       // tapeMemory = B.CreateAlloca(j->getType());
       // B.CreateStore(j, tapeMemory);
     } else {
@@ -2981,7 +2981,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
         auto inst = cast<Instruction>(VMap[v]);
         IRBuilder<> ib(inst->getNextNode());
         if (isa<PHINode>(inst))
-          ib.SetInsertPoint(inst->getParent()->getFirstNonPHI());
+          ib.SetInsertPoint(getFirstNonPHI(inst->getParent()));
         Value *Idxs[] = {ib.getInt32(0), ib.getInt32(i)};
         Value *gep = tapeMemory;
         if (!removeTapeStruct) {
@@ -5994,7 +5994,7 @@ llvm::Function *EnzymeLogic::CreateBatch(RequestContext context,
   // unwrap arguments
   ValueMap<const Value *, std::vector<Value *>> vectorizedValues;
   auto entry = std::next(NewF->begin());
-  IRBuilder<> Builder2(entry->getFirstNonPHI());
+  IRBuilder<> Builder2(getFirstNonPHI(&*entry));
   Builder2.SetCurrentDebugLocation(DebugLoc());
   for (unsigned i = 0; i < FTy->getNumParams(); ++i) {
     Argument *orig_arg = tobatch->arg_begin() + i;

--- a/enzyme/Enzyme/FunctionUtils.cpp
+++ b/enzyme/Enzyme/FunctionUtils.cpp
@@ -1408,7 +1408,7 @@ static void SimplifyMPIQueries(Function &NewF, FunctionAnalysisManager &FAM) {
       }
     }
     if (auto II = dyn_cast<InvokeInst>(res)) {
-      B.SetInsertPoint(II->getNormalDest()->getFirstNonPHI());
+      B.SetInsertPoint(getFirstNonPHI(II->getNormalDest()));
     } else {
       B.SetInsertPoint(res->getNextNode());
     }
@@ -1424,7 +1424,7 @@ static void SimplifyMPIQueries(Function &NewF, FunctionAnalysisManager &FAM) {
       B.CreateStore(B.CreateLoad(AI->getAllocatedType(), AI), AI2);
       Bound->setArgOperand(i, AI2);
       if (auto II = dyn_cast<InvokeInst>(Bound)) {
-        B.SetInsertPoint(II->getNormalDest()->getFirstNonPHI());
+        B.SetInsertPoint(getFirstNonPHI(II->getNormalDest()));
       } else {
         B.SetInsertPoint(Bound->getNextNode());
       }
@@ -6447,7 +6447,7 @@ std::optional<std::string> fixSparse_inner(Instruction *cur, llvm::Function &F,
     }
 
   if (auto PN = dyn_cast<PHINode>(cur)) {
-    B.SetInsertPoint(PN->getParent()->getFirstNonPHI());
+    B.SetInsertPoint(getFirstNonPHI(PN->getParent()));
     if (SE.isSCEVable(PN->getType())) {
       auto S = SE.getSCEV(PN);
 
@@ -6472,7 +6472,7 @@ std::optional<std::string> fixSparse_inner(Instruction *cur, llvm::Function &F,
         for (auto U : cur->users()) {
           push(U);
         }
-        auto point = PN->getParent()->getFirstNonPHI();
+        auto point = getFirstNonPHI(PN->getParent());
         auto tmp = cast<PHINode>(pushcse(B.CreatePHI(cur->getType(), 1)));
         cur->replaceAllUsesWith(tmp);
         cur->eraseFromParent();
@@ -8440,7 +8440,7 @@ void fixSparseIndices(llvm::Function &F, llvm::FunctionAnalysisManager &FAM,
 
       Value *LoopCount = nullptr;
 
-      IRBuilder<> B(L->getHeader()->getFirstNonPHI());
+      IRBuilder<> B(getFirstNonPHI(L->getHeader()));
       {
 #if LLVM_VERSION_MAJOR >= 22
         SCEVExpander Exp(SE, "sparseenzyme");

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -506,7 +506,7 @@ Value *GradientUtils::getOrInsertTotalMultiplicativeProduct(Value *val,
     One = ConstantVector::getSplat(VTy->getElementCount(), One);
   }
   PN->addIncoming(One, lc.preheader);
-  lbuilder.SetInsertPoint(lc.header->getFirstNonPHI());
+  lbuilder.SetInsertPoint(getFirstNonPHI(lc.header));
   if (auto inst = dyn_cast<Instruction>(val)) {
     if (DT.dominates(PN, inst))
       lbuilder.SetInsertPoint(inst->getNextNode());
@@ -6597,7 +6597,7 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
       }
 
       if (EnzymeVectorSplitPhi && width > 1) {
-        IRBuilder<> postPhi(NewV->getParent()->getFirstNonPHI());
+        IRBuilder<> postPhi(getFirstNonPHI(NewV->getParent()));
         Type *shadowTy = getShadowType(phi->getType());
         PHINode *tmp = bb.CreatePHI(shadowTy, phi->getNumIncomingValues());
 

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -2352,6 +2352,14 @@ getIntrinsicDeclaration(llvm::Module *M, llvm::Intrinsic::ID id,
 #endif
 }
 
+static inline llvm::Instruction *getFirstNonPHI(llvm::BasicBlock *B) {
+#if LLVM_VERSION_MAJOR >= 18
+  return &*B->getFirstNonPHIIt();
+#else
+  return B->getFirstNonPHI();
+#endif
+}
+
 static inline llvm::Instruction *getFirstNonPHIOrDbg(llvm::BasicBlock *B) {
 #if LLVM_VERSION_MAJOR >= 20
   return &*B->getFirstNonPHIOrDbg();

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -2354,16 +2354,20 @@ getIntrinsicDeclaration(llvm::Module *M, llvm::Intrinsic::ID id,
 
 static inline llvm::Instruction *getFirstNonPHI(llvm::BasicBlock *B) {
 #if LLVM_VERSION_MAJOR >= 18
+  // NOLINTNEXTLINE(enzyme-first-non-phi): this is the wrapper
   return &*B->getFirstNonPHIIt();
 #else
+  // NOLINTNEXTLINE(enzyme-first-non-phi): this is the wrapper
   return B->getFirstNonPHI();
 #endif
 }
 
 static inline llvm::Instruction *getFirstNonPHIOrDbg(llvm::BasicBlock *B) {
 #if LLVM_VERSION_MAJOR >= 20
+  // NOLINTNEXTLINE(enzyme-first-non-phi): this is the wrapper
   return &*B->getFirstNonPHIOrDbg();
 #else
+  // NOLINTNEXTLINE(enzyme-first-non-phi): this is the wrapper
   return B->getFirstNonPHIOrDbg();
 #endif
 }

--- a/enzyme/scripts/check_llvm_api.py
+++ b/enzyme/scripts/check_llvm_api.py
@@ -50,9 +50,21 @@ from a deliberate opaque pointer.
 
 MLIR's unrelated `LLVM::LLVMPointerType::get` is not affected and not flagged.
 
+`BasicBlock::getFirstNonPHI` and friends
+----------------------------------------
+
+    BB->getFirstNonPHI()                // removed on LLVM main
+
+LLVM removed the instruction-returning `getFirstNonPHI` (llvm-project
+62c5ede9fd14), leaving the iterator-flavoured `getFirstNonPHIIt` -- which in
+turn does not exist before LLVM 18. `getFirstNonPHIOrDbg` changed its return
+type to an iterator in LLVM 20 the same way. Utils.h wraps both; call the
+free functions `getFirstNonPHI(BB)` / `getFirstNonPHIOrDbg(BB)` instead of
+any member spelling.
+
 Suppress a false positive with `// NOLINT(<check>)` on the flagged line, or
 `// NOLINTNEXTLINE(<check>)` on the line before it, where `<check>` is
-`terminator-null-test` or `enzyme-pointer-type`.
+`terminator-null-test`, `enzyme-pointer-type` or `enzyme-first-non-phi`.
 """
 
 import argparse
@@ -83,12 +95,26 @@ POINTER_TYPE = re.compile(
     r"(?<![\w:])(?:llvm::)?PointerType::(?:get|getUnqual)\s*\("
 )
 
+# Member-call spellings of the getFirstNonPHI family. The Utils.h wrappers are
+# free functions, so `getFirstNonPHI(BB)` does not match: only `X->` / `X.`
+# calls do. `getFirstNonPHIOrDbgOrLifetime` is not matched (the `\s*\(` must
+# follow one of the listed suffixes immediately).
+FIRST_NON_PHI = re.compile(r"(?:->|\.)\s*getFirstNonPHI(?:It|OrDbg)?\s*\(")
+
 CHECKS = [
     (
         "terminator-null-test",
         TERMINATOR_NULL_TEST,
         "getTerminator() used as a null test; this returns null only through "
         "LLVM 22 and asserts from LLVM 23 on. Use hasTerminator(BB) from "
+        "Utils.h.",
+    ),
+    (
+        "enzyme-first-non-phi",
+        FIRST_NON_PHI,
+        "getFirstNonPHI/getFirstNonPHIIt/getFirstNonPHIOrDbg called as a "
+        "member; no one spelling exists on every supported LLVM. Use the "
+        "free functions getFirstNonPHI(BB) / getFirstNonPHIOrDbg(BB) from "
         "Utils.h.",
     ),
     (


### PR DESCRIPTION
LLVM removed the deprecated BasicBlock::getFirstNonPHI (llvm-project
62c5ede9fd14), leaving only the iterator-flavoured getFirstNonPHIIt.
Add a getFirstNonPHI(BasicBlock*) shim alongside the existing
getFirstNonPHIOrDbg wrappers and move the 19 call sites onto it. The
iterator overload has been available since LLVM 18, so older LLVMs keep
the old spelling.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
