### PR TITLE
Describe the __enzyme_* call markers in one place

### DIFF
--- a/enzyme/BUILD
+++ b/enzyme/BUILD
@@ -965,6 +965,7 @@ cc_library(
         "Enzyme/MLIR/Interfaces/*.h",
         "Enzyme/MLIR/Analysis/*.h",
         "Enzyme/MLIR/Implementations/*.h",
+        "Enzyme/EnzymeCallMarkers.h",
         "Enzyme/Utils.h",
         "Enzyme/TypeAnalysis/*.h",
     ]),

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -75,6 +75,7 @@
 
 #include "ActivityAnalysis.h"
 #include "DiffeGradientUtils.h"
+#include "EnzymeCallMarkers.h"
 #include "EnzymeLogic.h"
 #include "GradientUtils.h"
 #include "PassUtils.h"
@@ -173,6 +174,20 @@ castToDiffeFunctionArgType(IRBuilder<> &Builder, llvm::CallInst *CI,
     return nullptr;
   }
   return Builder.CreateBitCast(value, destType);
+}
+
+static DIFFE_TYPE toDiffeType(enzyme_markers::MarkerActivity activity) {
+  switch (activity) {
+  case enzyme_markers::MarkerActivity::Const:
+    return DIFFE_TYPE::CONSTANT;
+  case enzyme_markers::MarkerActivity::Dup:
+    return DIFFE_TYPE::DUP_ARG;
+  case enzyme_markers::MarkerActivity::DupNoNeed:
+    return DIFFE_TYPE::DUP_NONEED;
+  case enzyme_markers::MarkerActivity::Out:
+    return DIFFE_TYPE::OUT_DIFF;
+  }
+  llvm_unreachable("unknown marker activity");
 }
 
 #if LLVM_VERSION_MAJOR > 16
@@ -705,10 +720,36 @@ public:
 
       // handle metadata
       while (metaString && startsWith(*metaString, "enzyme_")) {
+        // What a marker names and what it takes for itself are described once,
+        // in EnzymeCallMarkers.h, so that the MLIR raising of the same call
+        // reads it the same way. Only what a marker then does with what it
+        // took is particular to it.
+        auto marker = enzyme_markers::lookupEnzymeMarker(*metaString);
+        if (!marker) {
+          EmitFailure("IllegalDiffeType", CI->getDebugLoc(), CI,
+                      "illegal enzyme metadata classification ", *CI,
+                      *metaString);
+          return {};
+        }
+
+        if (marker->activity)
+          opt_ty = toDiffeType(*marker->activity);
+
+        if (marker->extraOperands) {
+          if ((size_t)i + marker->extraOperands >= CI->arg_size()) {
+            EmitFailure("EnzymeCallingError", CI->getDebugLoc(), CI,
+                        "Too few arguments to Enzyme call ", *CI);
+            return {};
+          }
+          i += marker->extraOperands;
+        }
+
+        // A flag configures the call; nothing after it is an argument.
+        skipArg = marker->role == enzyme_markers::MarkerRole::CallFlag;
+
         if (*metaString == "enzyme_not_overwritten") {
           overwritten = false;
         } else if (*metaString == "enzyme_byref") {
-          ++i;
           if (!isa<ConstantInt>(CI->getArgOperand(i))) {
             EmitFailure("IllegalAllocatedSize", CI->getDebugLoc(), CI,
                         "illegal enzyme byref size ", *CI->getArgOperand(i),
@@ -717,13 +758,8 @@ public:
           }
           byRefSize = cast<ConstantInt>(CI->getArgOperand(i))->getZExtValue();
           assert(byRefSize > 0);
-          skipArg = true;
-          break;
-        } else if (*metaString == "enzyme_dup") {
-          opt_ty = DIFFE_TYPE::DUP_ARG;
-        } else if (*metaString == "enzyme_dupv") {
-          opt_ty = DIFFE_TYPE::DUP_ARG;
-          ++i;
+        } else if (*metaString == "enzyme_dupv" ||
+                   *metaString == "enzyme_dupnoneedv") {
           Value *offset_arg = CI->getArgOperand(i);
           if (offset_arg->getType()->isIntegerTy()) {
             batchOffset = offset_arg;
@@ -734,31 +770,8 @@ public:
                         *CI->getArgOperand(i), " in", *CI);
             return {};
           }
-        } else if (*metaString == "enzyme_dupnoneed") {
-          opt_ty = DIFFE_TYPE::DUP_NONEED;
-        } else if (*metaString == "enzyme_dupnoneedv") {
-          opt_ty = DIFFE_TYPE::DUP_NONEED;
-          ++i;
-          Value *offset_arg = CI->getArgOperand(i);
-          if (offset_arg->getType()->isIntegerTy()) {
-            batchOffset = offset_arg;
-          } else {
-            EmitFailure("IllegalVectorOffset", CI->getDebugLoc(), CI,
-                        "enzyme_batch must be followd by an integer "
-                        "offset.",
-                        *CI->getArgOperand(i), " in", *CI);
-            return {};
-          }
-        } else if (*metaString == "enzyme_out") {
-          opt_ty = DIFFE_TYPE::OUT_DIFF;
-        } else if (*metaString == "enzyme_const") {
-          opt_ty = DIFFE_TYPE::CONSTANT;
-        } else if (*metaString == "enzyme_noret") {
-          skipArg = true;
-          break;
         } else if (*metaString == "enzyme_allocated") {
           assert(!sizeOnly);
-          ++i;
           if (!isa<ConstantInt>(CI->getArgOperand(i))) {
             EmitFailure("IllegalAllocatedSize", CI->getDebugLoc(), CI,
                         "illegal enzyme allocated size ", *CI->getArgOperand(i),
@@ -767,78 +780,33 @@ public:
           }
           allocatedTapeSize =
               cast<ConstantInt>(CI->getArgOperand(i))->getZExtValue();
-          skipArg = true;
-          break;
         } else if (*metaString == "enzyme_tape") {
           assert(!sizeOnly);
-          ++i;
           tape = CI->getArgOperand(i);
           tapeIsPointer = true;
-          skipArg = true;
-          break;
         } else if (*metaString == "enzyme_nofree") {
           assert(!sizeOnly);
           freeMemory = false;
-          skipArg = true;
-          break;
         } else if (*metaString == "enzyme_runtime_activity") {
           runtimeActivity = true;
-          skipArg = true;
-          break;
         } else if (*metaString == "enzyme_strong_zero") {
           strongZero = true;
-          skipArg = true;
-          break;
-        } else if (*metaString == "enzyme_primal_return") {
-          skipArg = true;
-          break;
-        } else if (*metaString == "enzyme_const_return") {
-          skipArg = true;
-          break;
-        } else if (*metaString == "enzyme_active_return") {
-          skipArg = true;
-          break;
-        } else if (*metaString == "enzyme_dup_return") {
-          skipArg = true;
-          break;
-        } else if (*metaString == "enzyme_width") {
-          ++i;
-          skipArg = true;
-          break;
         } else if (*metaString == "enzyme_interface") {
-          ++i;
           dynamic_interface = CI->getArgOperand(i);
-          skipArg = true;
-          break;
         } else if (*metaString == "enzyme_trace") {
-          trace = CI->getArgOperand(++i);
-          opt_ty = DIFFE_TYPE::CONSTANT;
-          skipArg = true;
-          break;
+          trace = CI->getArgOperand(i);
         } else if (*metaString == "enzyme_duptrace") {
-          trace = CI->getArgOperand(++i);
+          trace = CI->getArgOperand(i);
           diffeTrace = true;
-          opt_ty = DIFFE_TYPE::CONSTANT;
-          skipArg = true;
-          break;
         } else if (*metaString == "enzyme_likelihood") {
-          likelihood = CI->getArgOperand(++i);
-          opt_ty = DIFFE_TYPE::CONSTANT;
-          skipArg = true;
-          break;
+          likelihood = CI->getArgOperand(i);
         } else if (*metaString == "enzyme_duplikelihood") {
-          likelihood = CI->getArgOperand(++i);
-          diffeLikelihood = CI->getArgOperand(++i);
-          opt_ty = DIFFE_TYPE::DUP_ARG;
-          skipArg = true;
-          break;
+          likelihood = CI->getArgOperand(i - 1);
+          diffeLikelihood = CI->getArgOperand(i);
         } else if (*metaString == "enzyme_observations") {
-          observations = CI->getArgOperand(++i);
-          opt_ty = DIFFE_TYPE::CONSTANT;
-          skipArg = true;
-          break;
+          observations = CI->getArgOperand(i);
         } else if (*metaString == "enzyme_active_rand_var") {
-          Value *string = CI->getArgOperand(++i);
+          Value *string = CI->getArgOperand(i);
           StringRef const_string;
           if (getConstantStringInfo(string, const_string)) {
             ActiveRandomVariables.insert(const_string);
@@ -848,14 +816,13 @@ public:
                 "active variable address must be a compile-time constant", *CI,
                 *metaString);
           }
-          skipArg = true;
-          break;
-        } else {
-          EmitFailure("IllegalDiffeType", CI->getDebugLoc(), CI,
-                      "illegal enzyme metadata classification ", *CI,
-                      *metaString);
-          return {};
         }
+        // The rest -- the activities, enzyme_interleave, enzyme_width and the
+        // *_return flags -- are wholly described by the table.
+
+        if (skipArg)
+          break;
+
         if (sizeOnly) {
           assert(opt_ty);
           constants.push_back(*opt_ty);

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -176,20 +176,6 @@ castToDiffeFunctionArgType(IRBuilder<> &Builder, llvm::CallInst *CI,
   return Builder.CreateBitCast(value, destType);
 }
 
-static DIFFE_TYPE toDiffeType(enzyme_markers::MarkerActivity activity) {
-  switch (activity) {
-  case enzyme_markers::MarkerActivity::Const:
-    return DIFFE_TYPE::CONSTANT;
-  case enzyme_markers::MarkerActivity::Dup:
-    return DIFFE_TYPE::DUP_ARG;
-  case enzyme_markers::MarkerActivity::DupNoNeed:
-    return DIFFE_TYPE::DUP_NONEED;
-  case enzyme_markers::MarkerActivity::Out:
-    return DIFFE_TYPE::OUT_DIFF;
-  }
-  llvm_unreachable("unknown marker activity");
-}
-
 #if LLVM_VERSION_MAJOR > 16
 static std::optional<StringRef> getMetadataName(llvm::Value *res);
 #else
@@ -733,7 +719,7 @@ public:
         }
 
         if (marker->activity)
-          opt_ty = toDiffeType(*marker->activity);
+          opt_ty = *marker->activity;
 
         if (marker->extraOperands) {
           if ((size_t)i + marker->extraOperands >= CI->arg_size()) {

--- a/enzyme/Enzyme/EnzymeCallMarkers.h
+++ b/enzyme/Enzyme/EnzymeCallMarkers.h
@@ -44,15 +44,27 @@ enum class MarkerRole {
   Modifier,
 };
 
-/// The activities a marker can name. Kept apart from DIFFE_TYPE so this header
-/// stays free of the rest of Enzyme; each reader maps it to its own.
-enum class MarkerActivity { Const, Dup, DupNoNeed, Out };
+} // namespace enzyme_markers
+
+/// Potential differentiable argument classifications
+enum class DIFFE_TYPE {
+  OUT_DIFF = 0, // add differential to an output struct. Only for scalar values
+                // in ReverseMode variants.
+  DUP_ARG = 1,  // duplicate the argument and store differential inside.
+               // For references, pointers, or integers in ReverseMode variants.
+               // For all types in ForwardMode variants.
+  CONSTANT = 2,  // no differential. Usable everywhere.
+  DUP_NONEED = 3 // duplicate this argument and store differential inside, but
+                 // don't need the forward. Same as DUP_ARG otherwise.
+};
+
+namespace enzyme_markers {
 
 struct MarkerInfo {
   MarkerRole role;
   /// Set where the role is Activity, and for the few call flags that also fix
   /// the activity of what they name.
-  std::optional<MarkerActivity> activity;
+  std::optional<DIFFE_TYPE> activity;
   /// Operands the marker itself takes, before whatever follows it.
   unsigned extraOperands;
 };
@@ -63,25 +75,25 @@ struct MarkerInfo {
 /// error it is rather than carrying on, since guessing at an unknown marker is
 /// how an argument gets read as a marker.
 inline std::optional<MarkerInfo> lookupEnzymeMarker(llvm::StringRef name) {
-  auto activity = [](MarkerActivity a, unsigned extra = 0) {
+  auto activity = [](DIFFE_TYPE a, unsigned extra = 0) {
     return MarkerInfo{MarkerRole::Activity, a, extra};
   };
   auto flag = [](unsigned extra = 0) {
     return MarkerInfo{MarkerRole::CallFlag, std::nullopt, extra};
   };
-  auto flagWithActivity = [](MarkerActivity a, unsigned extra) {
+  auto flagWithActivity = [](DIFFE_TYPE a, unsigned extra) {
     return MarkerInfo{MarkerRole::CallFlag, a, extra};
   };
 
   return llvm::StringSwitch<std::optional<MarkerInfo>>(name)
       // Activities.
-      .Case("enzyme_const", activity(MarkerActivity::Const))
-      .Case("enzyme_dup", activity(MarkerActivity::Dup))
-      .Case("enzyme_dupnoneed", activity(MarkerActivity::DupNoNeed))
-      .Case("enzyme_out", activity(MarkerActivity::Out))
+      .Case("enzyme_const", activity(DIFFE_TYPE::CONSTANT))
+      .Case("enzyme_dup", activity(DIFFE_TYPE::DUP_ARG))
+      .Case("enzyme_dupnoneed", activity(DIFFE_TYPE::DUP_NONEED))
+      .Case("enzyme_out", activity(DIFFE_TYPE::OUT_DIFF))
       // Vector activities, each followed by the offset between lanes.
-      .Case("enzyme_dupv", activity(MarkerActivity::Dup, 1))
-      .Case("enzyme_dupnoneedv", activity(MarkerActivity::DupNoNeed, 1))
+      .Case("enzyme_dupv", activity(DIFFE_TYPE::DUP_ARG, 1))
+      .Case("enzyme_dupnoneedv", activity(DIFFE_TYPE::DUP_NONEED, 1))
       // Where the shadows are.
       .Case("enzyme_interleave",
             MarkerInfo{MarkerRole::Interleave, std::nullopt, 0})
@@ -104,17 +116,17 @@ inline std::optional<MarkerInfo> lookupEnzymeMarker(llvm::StringRef name) {
       .Case("enzyme_width", flag(1))
       .Case("enzyme_interface", flag(1))
       .Case("enzyme_active_rand_var", flag(1))
-      .Case("enzyme_trace", flagWithActivity(MarkerActivity::Const, 1))
-      .Case("enzyme_duptrace", flagWithActivity(MarkerActivity::Const, 1))
-      .Case("enzyme_likelihood", flagWithActivity(MarkerActivity::Const, 1))
-      .Case("enzyme_observations", flagWithActivity(MarkerActivity::Const, 1))
-      .Case("enzyme_duplikelihood", flagWithActivity(MarkerActivity::Dup, 2))
+      .Case("enzyme_trace", flagWithActivity(DIFFE_TYPE::CONSTANT, 1))
+      .Case("enzyme_duptrace", flagWithActivity(DIFFE_TYPE::CONSTANT, 1))
+      .Case("enzyme_likelihood", flagWithActivity(DIFFE_TYPE::CONSTANT, 1))
+      .Case("enzyme_observations", flagWithActivity(DIFFE_TYPE::CONSTANT, 1))
+      .Case("enzyme_duplikelihood", flagWithActivity(DIFFE_TYPE::DUP_ARG, 2))
       .Default(std::nullopt);
 }
 
 /// Whether an activity is one that a shadow goes with.
-inline bool markerActivityTakesShadow(MarkerActivity a) {
-  return a == MarkerActivity::Dup || a == MarkerActivity::DupNoNeed;
+inline bool markerActivityTakesShadow(DIFFE_TYPE a) {
+  return a == DIFFE_TYPE::DUP_ARG || a == DIFFE_TYPE::DUP_NONEED;
 }
 
 /// Where the primals stop and the shadows start.

--- a/enzyme/Enzyme/EnzymeCallMarkers.h
+++ b/enzyme/Enzyme/EnzymeCallMarkers.h
@@ -1,0 +1,147 @@
+//===- EnzymeCallMarkers.h - The __enzyme_* call grammar --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// The arguments of an `__enzyme_autodiff`/`__enzyme_fwddiff` call are a small
+// language: marker globals that either name the activity of the argument after
+// them or configure the call as a whole, the arguments they speak for, and the
+// shadows that go with those.
+//
+// More than one place has to read it -- the LLVM pass that lowers the call, and
+// the MLIR raising that turns it into an enzyme.autodiff/enzyme.fwddiff op --
+// and a marker read as an argument, or an argument read as a marker, is a
+// silently wrong derivative rather than an error. So the names, what each one
+// takes, and where the shadows sit are written here once, over no IR in
+// particular, and each reader drives its own walk with them.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ENZYME_CALL_MARKERS_H
+#define ENZYME_CALL_MARKERS_H
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSwitch.h"
+
+#include <optional>
+
+namespace enzyme_markers {
+
+/// What a marker does to the call it appears in.
+enum class MarkerRole {
+  /// Names the activity of the argument that follows it.
+  Activity,
+  /// Says the shadows come after all of the primals rather than beside each
+  /// one, in the same order.
+  Interleave,
+  /// Configures the call rather than an argument: nothing follows it that is
+  /// an argument.
+  CallFlag,
+  /// Changes how the argument that follows is read without naming an activity.
+  Modifier,
+};
+
+/// The activities a marker can name. Kept apart from DIFFE_TYPE so this header
+/// stays free of the rest of Enzyme; each reader maps it to its own.
+enum class MarkerActivity { Const, Dup, DupNoNeed, Out };
+
+struct MarkerInfo {
+  MarkerRole role;
+  /// Set where the role is Activity, and for the few call flags that also fix
+  /// the activity of what they name.
+  std::optional<MarkerActivity> activity;
+  /// Operands the marker itself takes, before whatever follows it.
+  unsigned extraOperands;
+};
+
+/// The one description of the `__enzyme_*` argument markers.
+///
+/// Returns nothing for a name this does not know -- callers report that as the
+/// error it is rather than carrying on, since guessing at an unknown marker is
+/// how an argument gets read as a marker.
+inline std::optional<MarkerInfo> lookupEnzymeMarker(llvm::StringRef name) {
+  auto activity = [](MarkerActivity a, unsigned extra = 0) {
+    return MarkerInfo{MarkerRole::Activity, a, extra};
+  };
+  auto flag = [](unsigned extra = 0) {
+    return MarkerInfo{MarkerRole::CallFlag, std::nullopt, extra};
+  };
+  auto flagWithActivity = [](MarkerActivity a, unsigned extra) {
+    return MarkerInfo{MarkerRole::CallFlag, a, extra};
+  };
+
+  return llvm::StringSwitch<std::optional<MarkerInfo>>(name)
+      // Activities.
+      .Case("enzyme_const", activity(MarkerActivity::Const))
+      .Case("enzyme_dup", activity(MarkerActivity::Dup))
+      .Case("enzyme_dupnoneed", activity(MarkerActivity::DupNoNeed))
+      .Case("enzyme_out", activity(MarkerActivity::Out))
+      // Vector activities, each followed by the offset between lanes.
+      .Case("enzyme_dupv", activity(MarkerActivity::Dup, 1))
+      .Case("enzyme_dupnoneedv", activity(MarkerActivity::DupNoNeed, 1))
+      // Where the shadows are.
+      .Case("enzyme_interleave",
+            MarkerInfo{MarkerRole::Interleave, std::nullopt, 0})
+      // How the argument after is read.
+      .Case("enzyme_not_overwritten",
+            MarkerInfo{MarkerRole::Modifier, std::nullopt, 0})
+      // Whole-call flags that take nothing.
+      .Case("enzyme_noret", flag())
+      .Case("enzyme_nofree", flag())
+      .Case("enzyme_runtime_activity", flag())
+      .Case("enzyme_strong_zero", flag())
+      .Case("enzyme_primal_return", flag())
+      .Case("enzyme_const_return", flag())
+      .Case("enzyme_active_return", flag())
+      .Case("enzyme_dup_return", flag())
+      // Whole-call flags that take a value.
+      .Case("enzyme_byref", flag(1))
+      .Case("enzyme_allocated", flag(1))
+      .Case("enzyme_tape", flag(1))
+      .Case("enzyme_width", flag(1))
+      .Case("enzyme_interface", flag(1))
+      .Case("enzyme_active_rand_var", flag(1))
+      .Case("enzyme_trace", flagWithActivity(MarkerActivity::Const, 1))
+      .Case("enzyme_duptrace", flagWithActivity(MarkerActivity::Const, 1))
+      .Case("enzyme_likelihood", flagWithActivity(MarkerActivity::Const, 1))
+      .Case("enzyme_observations", flagWithActivity(MarkerActivity::Const, 1))
+      .Case("enzyme_duplikelihood", flagWithActivity(MarkerActivity::Dup, 2))
+      .Default(std::nullopt);
+}
+
+/// Whether an activity is one that a shadow goes with.
+inline bool markerActivityTakesShadow(MarkerActivity a) {
+  return a == MarkerActivity::Dup || a == MarkerActivity::DupNoNeed;
+}
+
+/// Where the primals stop and the shadows start.
+struct InterleaveSplit {
+  /// One past the last operand that can be a primal.
+  unsigned primalEnd;
+  /// The first shadow operand, meaningful only when `interleaved`.
+  unsigned shadowStart;
+  bool interleaved;
+};
+
+/// Find `enzyme_interleave` among the operands, which has to be done before
+/// walking them: it says where the shadows are, and the walk needs that from
+/// the first argument on.
+///
+/// `markerAt(i)` gives the marker name operand `i` reads, if it reads one.
+template <typename MarkerAtFn>
+InterleaveSplit findEnzymeInterleave(unsigned first, unsigned count,
+                                     MarkerAtFn markerAt) {
+  for (unsigned i = first; i < count; ++i) {
+    std::optional<llvm::StringRef> name = markerAt(i);
+    if (name && *name == "enzyme_interleave")
+      return {/*primalEnd=*/i, /*shadowStart=*/i + 1, /*interleaved=*/true};
+  }
+  return {/*primalEnd=*/count, /*shadowStart=*/0, /*interleaved=*/false};
+}
+
+} // namespace enzyme_markers
+
+#endif // ENZYME_CALL_MARKERS_H

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -426,17 +426,7 @@ enum class ReturnType {
   Void,
 };
 
-/// Potential differentiable argument classifications
-enum class DIFFE_TYPE {
-  OUT_DIFF = 0, // add differential to an output struct. Only for scalar values
-                // in ReverseMode variants.
-  DUP_ARG = 1,  // duplicate the argument and store differential inside.
-               // For references, pointers, or integers in ReverseMode variants.
-               // For all types in ForwardMode variants.
-  CONSTANT = 2,  // no differential. Usable everywhere.
-  DUP_NONEED = 3 // duplicate this argument and store differential inside, but
-                 // don't need the forward. Same as DUP_ARG otherwise.
-};
+#include "EnzymeCallMarkers.h"
 
 enum class BATCH_TYPE {
   SCALAR = 0,


### PR DESCRIPTION
The arguments of an `__enzyme_autodiff`/`__enzyme_fwddiff` call are a small language: marker globals that either name the activity of the argument after them or configure the call as a whole, the arguments they speak for, and the shadows that go with those.

`Enzyme.cpp` reads it. So must the MLIR raising in Enzyme-JAX that turns the same call into an `enzyme.autodiff`/`enzyme.fwddiff` op (EnzymeAD/Enzyme-JAX#2785) — and written twice they drift. A marker read as an argument, or an argument read as a marker, is a wrong derivative rather than an error.

So the names, what each one takes, and where `enzyme_interleave` puts the shadows move to `Enzyme/EnzymeCallMarkers.h`, over no IR in particular:

```cpp
std::optional<MarkerInfo> lookupEnzymeMarker(llvm::StringRef name);

template <typename MarkerAtFn>
InterleaveSplit findEnzymeInterleave(unsigned first, unsigned count, MarkerAtFn markerAt);
```

`MarkerInfo` carries the role (activity / interleave / call flag / modifier), the activity where it names one, and how many operands the marker takes for itself. Each reader drives its own walk with that — the per-IR parts (byval, casts, width, tape) stay where they are.

`Enzyme.cpp`'s `while (metaString ...)` chain now gets the classification, the activity and the operand count from the table, and keeps only what each marker then *does* with what it took. Its 25-way string comparison for "which marker is this and how many operands does it eat" is gone; an unknown marker is rejected by the table rather than by the chain's fallthrough.

## Testing

`check-enzyme` on this tree is **748/1051 red before any change here**, so it is not usable as an absolute gate. It is usable as a differential one: the set of failing tests is byte-identical before and after, so none of the 292 that pass regressed. Worth a reviewer knowing that is the extent of what was verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
