### PR TITLE
Differentiate an llvm.func in forward mode

### DIFF
--- a/enzyme/Enzyme/MLIR/Dialect/Ops.cpp
+++ b/enzyme/Enzyme/MLIR/Dialect/Ops.cpp
@@ -225,8 +225,10 @@ LogicalResult
 ForwardDiffOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   // TODO: Verify that the result type is same as the type of the referenced
   // func.func op.
-  auto global =
-      symbolTable.lookupNearestSymbolFrom<func::FuncOp>(*this, getFnAttr());
+  // Any function will do, as for enzyme.autodiff below -- what is being
+  // differentiated is often an llvm.func.
+  auto global = symbolTable.lookupNearestSymbolFrom<FunctionOpInterface>(
+      *this, getFnAttr());
   if (!global)
     return emitOpError("'")
            << getFn() << "' does not reference a valid global funcOp";

--- a/enzyme/Enzyme/MLIR/Passes/EnzymeMLIRPass.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/EnzymeMLIRPass.cpp
@@ -180,9 +180,18 @@ struct DifferentiatePass
       return failure();
 
     OpBuilder builder(CI);
-    auto dCI = func::CallOp::create(builder, CI.getLoc(), newFunc.getName(),
-                                    newFunc.getResultTypes(), args);
-    if (dCI.getNumResults() != CI.getNumResults()) {
+    // Ask the function how it is called, as the reverse handler does: what is
+    // being differentiated is often an llvm.func, and a func.call to one of
+    // those is not a call at all.
+    auto iface = dyn_cast<AutoDiffFunctionInterface>(newFunc.getOperation());
+    if (!iface) {
+      newFunc.getOperation()->emitError()
+          << "this function operation does not implement "
+             "AutoDiffFunctionInterface";
+      return failure();
+    }
+    Operation *dCI = iface.createCall(builder, CI.getLoc(), args);
+    if (dCI->getNumResults() != CI.getNumResults()) {
       CI.emitError() << "Incorrect number of results for enzyme operation: "
                      << *CI << " expected " << *dCI;
       return failure();

--- a/enzyme/test/MLIR/ForwardMode/llvm_func.mlir
+++ b/enzyme/test/MLIR/ForwardMode/llvm_func.mlir
@@ -1,0 +1,30 @@
+// RUN: %eopt --enzyme --canonicalize --remove-unnecessary-enzyme-ops %s | FileCheck %s
+
+// What enzyme.fwddiff names is not always a func.func. Anything raised from
+// LLVM gives an llvm.func, and forward mode turned that down twice over: the
+// verifier looked the callee up as a func.func, and the pass wrote a func.call
+// to whatever came back. enzyme.autodiff has always taken either.
+
+module {
+  llvm.func @square(%x: f64) -> f64 {
+    %r = arith.mulf %x, %x : f64
+    llvm.return %r : f64
+  }
+
+  llvm.func @dsquare(%x: f64, %dx: f64) -> f64 {
+    %r = enzyme.fwddiff @square(%x, %dx) { activity=[#enzyme<activity enzyme_dup>], ret_activity=[#enzyme<activity enzyme_dupnoneed>] } : (f64, f64) -> f64
+    llvm.return %r : f64
+  }
+}
+
+// The derivative is an llvm.func too, and is called as one.
+
+// CHECK:       llvm.func @dsquare(%[[x:.+]]: f64, %[[dx:.+]]: f64) -> f64
+// CHECK:         %[[c:.+]] = llvm.call @fwddiffesquare(%[[x]], %[[dx]]) : (f64, f64) -> f64
+// CHECK:         llvm.return %[[c]] : f64
+
+// CHECK:       llvm.func @fwddiffesquare(%[[px:.+]]: f64, %[[pdx:.+]]: f64) -> f64
+// CHECK:         %[[a:.+]] = arith.mulf %[[pdx]], %[[px]] fastmath<fast> : f64
+// CHECK:         %[[b:.+]] = arith.mulf %[[pdx]], %[[px]] fastmath<fast> : f64
+// CHECK:         %[[s:.+]] = arith.addf %[[a]], %[[b]] fastmath<fast> : f64
+// CHECK:         llvm.return %[[s]] : f64


### PR DESCRIPTION
What `enzyme.fwddiff` names is not always a `func.func`: anything raised from LLVM gives an `llvm.func`. Forward mode turned that down twice over.

**The verifier looked the callee up as a `func.func`**, so the op did not get past verification at all:

```
error: 'enzyme.fwddiff' op 'square' does not reference a valid global funcOp
```

**The pass wrote a `func.call`** to whatever came back, which is not how an `llvm.func` is called.

Reverse mode has always taken either — `AutoDiffOp::verifySymbolUses` looks up a `FunctionOpInterface`, and `HandleAutoDiffReverse` asks the function how it is called through `AutoDiffFunctionInterface::createCall`, which `llvm.func` implements via `AutoDiffLLVMFuncOpFunctionInterface`. Forward mode now does the same.

## Test

`test/MLIR/ForwardMode/llvm_func.mlir` — `enzyme.fwddiff` over an `llvm.func`. On main it stops at the verifier; here the derivative is an `llvm.func` too and is called as one.

159/160 of `check-enzymemlir` pass; the one failure is `ReverseMode/linalg.mlir`, which fails on main too.

## Context

Split out of #3086 on review — it is about which dialect the differentiated function is in, not about the `__enzyme_*` markers. Both are needed for EnzymeAD/Enzyme-JAX#2778, where the function being differentiated is always an `llvm.func`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD