### PR TITLE
A result nothing differentiates has no shadow to be given

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/CoreDialectsAutoDiffImplementations.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/CoreDialectsAutoDiffImplementations.cpp
@@ -238,6 +238,8 @@ LogicalResult mlir::enzyme::detail::memoryIdentityForwardHandler(
     }
   }
   for (auto &&[i, oval] : llvm::enumerate(orig->getResults())) {
+    if (gutils->isConstantValue(oval))
+      continue;
     Value sval;
     if (gutils->width == 1) {
       sval = shadows[0]->getResult(i);

--- a/enzyme/test/MLIR/ForwardMode/inactive_result.mlir
+++ b/enzyme/test/MLIR/ForwardMode/inactive_result.mlir
@@ -1,0 +1,37 @@
+// RUN: %eopt --enzyme --canonicalize --remove-unnecessary-enzyme-ops %s | FileCheck %s
+
+// The index is read out of memory that is being differentiated, so the load is
+// reached, but an i64 is nothing to differentiate and no shadow was ever made
+// for it. The memory-identity handler set a shadow on every result all the
+// same, and setDiffe went looking for the one that was not there.
+
+module {
+  func.func @f(%idx: memref<?xi64>, %data: memref<?xf64>) {
+    %c0 = arith.constant 0 : index
+    %i = memref.load %idx[%c0] : memref<?xi64>
+    %j = arith.index_cast %i : i64 to index
+    %v = memref.load %data[%j] : memref<?xf64>
+    %s = arith.mulf %v, %v : f64
+    memref.store %s, %data[%j] : memref<?xf64>
+    return
+  }
+
+  func.func @df(%idx: memref<?xi64>, %didx: memref<?xi64>, %data: memref<?xf64>, %ddata: memref<?xf64>) {
+    enzyme.fwddiff @f(%idx, %didx, %data, %ddata) { activity=[#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_dup>], ret_activity=[] } : (memref<?xi64>, memref<?xi64>, memref<?xf64>, memref<?xf64>) -> ()
+    return
+  }
+}
+
+// The index is read once, from the primal, and the tangent of v*v is 2*v*dv.
+
+// CHECK: func.func private @fwddiffef(%[[idx:.+]]: memref<?xi64>, %[[didx:.+]]: memref<?xi64>, %[[data:.+]]: memref<?xf64>, %[[ddata:.+]]: memref<?xf64>)
+// CHECK:         %[[i:.+]] = memref.load %[[idx]]
+// CHECK-NEXT:    %[[j:.+]] = arith.index_cast %[[i]] : i64 to index
+// CHECK-NEXT:    %[[dv:.+]] = memref.load %[[ddata]]{{\[}}%[[j]]] : memref<?xf64>
+// CHECK-NEXT:    %[[v:.+]] = memref.load %[[data]]{{\[}}%[[j]]] : memref<?xf64>
+// CHECK-NEXT:    %[[a:.+]] = arith.mulf %[[dv]], %[[v]] fastmath<fast> : f64
+// CHECK-NEXT:    %[[b:.+]] = arith.mulf %[[dv]], %[[v]] fastmath<fast> : f64
+// CHECK-NEXT:    %[[ds:.+]] = arith.addf %[[a]], %[[b]] fastmath<fast> : f64
+// CHECK-NEXT:    %[[s:.+]] = arith.mulf %[[v]], %[[v]] : f64
+// CHECK-NEXT:    memref.store %[[ds]], %[[ddata]]{{\[}}%[[j]]]
+// CHECK-NEXT:    memref.store %[[s]], %[[data]]{{\[}}%[[j]]]


### PR DESCRIPTION
`forceAugmentedReturns` makes a shadow placeholder for a result only where the result is not constant:

```cpp
for (auto res : inst->getResults()) {
  if (isConstantValue(res))
    continue;
  ...
  auto anti = enzyme::PlaceholderOp::create(BuilderZ, res.getLoc(), antiTy);
  invertedPointers.map(res, anti);
}
```

`memoryIdentityForwardHandler` set a shadow on **every** result of the op it handles, constant or not, and `setDiffe` then went looking for the placeholder that was never made:

```cpp
auto found = invertedPointers.lookupOrNull(val);
assert(found != nullptr);              // says nothing in a release build
auto placeholder = found.getDefiningOp<enzyme::PlaceholderOp>();
```

so a release build read a null `Value` instead — the crash lands in `Value::getDefiningOp()`, two frames from anything that mentions a shadow. `setDiffe` asserts `!isConstantValue(val)` one frame up, for the same reason.

An op reaches this handler for what its **operands** read, not for what it returns, so a constant result is an ordinary thing to have: MFEM's dFEM kernels load an index out of the very memory being differentiated, and an `i64` is nothing to differentiate. The shadow op is still worth building — it is what the active operands are read through — so only the setting is skipped.

## Test

`test/MLIR/ForwardMode/inactive_result.mlir` — an `i64` index loaded from a `memref<?xi64>` that is itself `enzyme_dup`, used to index the `f64` data being differentiated. Aborts on main.

162/163 of `check-enzymemlir` pass; the one failure is `ReverseMode/linalg.mlir`, which fails on main too.

## Context

Found in EnzymeAD/Enzyme-JAX#2778, on MFEM's `tests/unit/dfem/test_diffusion.cpp`, once forward-mode calls were raised at all (EnzymeAD/Enzyme-JAX#2785).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD