### PR TITLE
Join a map of sets by what the other side has

### DIFF
--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowLattice.h
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowLattice.h
@@ -253,31 +253,18 @@ public:
   ChangeResult join(const AbstractDenseLattice &other) {
     const auto &rhs =
         static_cast<const MapOfSetsLattice<KeyT, ElementT> &>(other);
-    llvm::SmallDenseSet<DistinctAttr> keys;
-    auto lhsRange = llvm::make_first_range(map);
-    auto rhsRange = llvm::make_first_range(rhs.map);
-    keys.insert(lhsRange.begin(), lhsRange.end());
-    keys.insert(rhsRange.begin(), rhsRange.end());
 
+    // A key only this side has is left as it is, so only the other side's keys
+    // are worth walking. Taking the union of both first meant every join cost
+    // the size of what had been accumulated, which in a fixpoint is joined into
+    // over and over by something small.
     ChangeResult result = ChangeResult::NoChange;
-    for (DistinctAttr key : keys) {
-      auto lhsIt = map.find(key);
-      auto rhsIt = rhs.map.find(key);
-      assert(lhsIt != map.end() || rhsIt != rhs.map.end());
-
-      // If present in both, join.
-      if (lhsIt != map.end() && rhsIt != rhs.map.end()) {
-        result |= lhsIt->getSecond().join(rhsIt->getSecond());
-        continue;
-      }
-
-      // Copy from RHS if available only there.
-      if (lhsIt == map.end()) {
-        map.try_emplace(rhsIt->getFirst(), rhsIt->getSecond());
+    for (const auto &it : rhs.map) {
+      auto [lhsIt, inserted] = map.try_emplace(it.getFirst(), it.getSecond());
+      if (inserted)
         result = ChangeResult::Change;
-      }
-
-      // Do nothing if available only in LHS.
+      else
+        result |= lhsIt->getSecond().join(it.getSecond());
     }
     return result;
   }


### PR DESCRIPTION
`MapOfSetsLattice::join` took the union of both sides' keys into a `SmallDenseSet` and walked that, looking each key up in both maps:

```cpp
llvm::SmallDenseSet<DistinctAttr> keys;
keys.insert(lhsRange.begin(), lhsRange.end());
keys.insert(rhsRange.begin(), rhsRange.end());

for (DistinctAttr key : keys) {
  auto lhsIt = map.find(key);
  auto rhsIt = rhs.map.find(key);
  ...
  // Do nothing if available only in LHS.
}
```

A key only the left side has is left exactly as it was — the loop says so — so building and walking the left side's keys was work for the keys that were going to be skipped. A fixpoint joins into an accumulated lattice over and over with something small, so paying the size of the accumulation on every join is pure overhead.

Walking the right-hand side's keys and `try_emplace`-ing gives the same result — present, join; absent, insert — with one lookup per key of the right-hand side and no set built to find them.

## What this is and is not

Profiling a slow MFEM compile through the raising path (EnzymeAD/Enzyme-JAX#2778) put **52%** of samples in this one function, so it looked like the culprit. It is not: with only this change the same run still passed 600 s, and the profile simply moved to **78%** in the same place. The actual cause was a `DataFlowSolver` shared across every function of the module, fixed in #3091, after which that run takes 3.7 s.

So this is a cleanup of provably wasted work rather than the fix for anything, and it is offered on that basis.

162/163 of `check-enzymemlir` pass; the one failure is `ReverseMode/linalg.mlir`, which fails on main too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
