### PR TITLE
Give each differentiated function its own dataflow solver

### DIFF
--- a/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.cpp
@@ -51,9 +51,11 @@ mlir::enzyme::MGradientUtils::MGradientUtils(
       returnPrimals(returnPrimals), returnShadows(returnShadows), width(width),
       ArgDiffeTypes(ArgDiffeTypes_), RetDiffeTypes(ReturnActivity) {
   if (Logic.solver) {
+    dataflowSolver = std::make_unique<DataFlowSolver>(
+        DataFlowConfig().setInterprocedural(false));
     dataflowActivityAnalyzer =
         std::make_unique<enzyme::DataFlowActivityAnalyzer>(
-            *Logic.solver, oldFunc_, ArgDiffeTypes_, ReturnActivity);
+            *dataflowSolver, oldFunc_, ArgDiffeTypes_, ReturnActivity);
   }
 }
 

--- a/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.h
+++ b/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.h
@@ -33,6 +33,12 @@ public:
   SmallPtrSet<Block *, 4> blocksNotForAnalysis;
   DenseMap<Operation *, bool> readOnlyCache;
   std::unique_ptr<enzyme::ActivityAnalyzer> activityAnalyzer;
+  // The solver the annotations below were run in. One per function being
+  // differentiated: a DataFlowSolver keeps every lattice it has ever made, and
+  // these analyses are not interprocedural, so one shared across a module's
+  // worth of functions only makes each of them join against all the ones
+  // before. Declared ahead of the analyzer, which refers to it.
+  std::unique_ptr<DataFlowSolver> dataflowSolver;
   std::unique_ptr<enzyme::DataFlowActivityAnalyzer> dataflowActivityAnalyzer;
 
   MTypeAnalysis &TA;


### PR DESCRIPTION
`MEnzymeLogic` holds one `DataFlowSolver` for a whole run of the pass:

```cpp
MEnzymeLogic::MEnzymeLogic(bool dataflowActivity)
    : solver(dataflowActivity ? new DataFlowSolver(
                                    DataFlowConfig().setInterprocedural(false))
                              : nullptr) {}
```

and every function differentiated runs its activity annotations into that one solver. A `DataFlowSolver` owns every lattice it has ever created, so the state grows with each function analysed, and the map-of-sets joins the annotation analyses spend their time in grow with it.

Nothing is gained by the sharing. The annotation analyses are not interprocedural and say so themselves:

```cpp
ForwardActivityAnnotationAnalysis(DataFlowSolver &solver)
    : SparseForwardDataFlowAnalysis(solver) {
  assert(!solver.getConfig().isInterprocedural());
}
```

so nothing carries from one function to the next — only the cost does.

The solver cannot simply be reset on the `Logic`: differentiating a callee while differentiating its caller would leave the outer `DataFlowActivityAnalyzer` holding a reference to a solver that had been replaced. So it is handed to the `MGradientUtils` that uses it, which owns it for exactly as long as it is needed.

## Measured

MFEM's `tests/unit/dfem/test_diffusion.cpp` (EnzymeAD/Enzyme-JAX#2778) raised to MLIR and stopped just before the AD pass — 158 `enzyme.fwddiff` ops — then `enzymexlamlir-opt --pass-pipeline="builtin.module(enzyme{dataflow })"`:

| | time | peak RSS |
|---|---|---|
| before | > 600 s (killed) | 11.7 GB |
| after | **3.7 s** | **430 MB** |

One `enzyme.fwddiff` on its own took 0.25 s before this change, so 158 of them should have been about 40 s. The gap was the accumulation.

For what it is worth, #3090 (a wasted key-union in `MapOfSetsLattice::join`, which profiling showed at 52% and then 78% of samples) does **not** account for this on its own: with that fix alone the same run still passed 600 s. It is worth having, but this is the one that mattered.

162/163 of `check-enzymemlir` pass; the one failure is `ReverseMode/linalg.mlir`, which fails on main too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD