### PR TITLE
Give lifetime markers a forward-mode rule

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
@@ -191,6 +191,30 @@ public:
   bool isZeroAttr(Type self, Attribute attr) const { return false; }
 };
 
+// A lifetime marker says when the memory it names is live. The shadow is
+// memory too and lives exactly as long, so the tangent is the same marker said
+// again of the shadow. The op is declared inactive, which is about what it
+// makes active and not about whether the derivative needs it said: a barrier is
+// inactive too and still has to be there.
+template <typename OpTy>
+struct LifetimeForwardInterface
+    : public AutoDiffOpInterface::ExternalModel<LifetimeForwardInterface<OpTy>,
+                                                OpTy> {
+  LogicalResult createForwardModeTangent(Operation *op, OpBuilder &builder,
+                                         MGradientUtils *gutils) const {
+    auto ltOp = cast<OpTy>(op);
+    // Memory nothing differentiates has no shadow whose lifetime this could be.
+    if (gutils->isConstantValue(ltOp.getPtr()))
+      return success();
+
+    Value shadow = gutils->invertPointerM(ltOp.getPtr(), builder);
+    auto newOp = cast<OpTy>(gutils->getNewFromOriginal(op));
+    auto shadowOp = cast<OpTy>(builder.clone(*newOp));
+    shadowOp.getPtrMutable().assign(shadow);
+    return success();
+  }
+};
+
 struct GEPOpInterfaceReverse
     : public ReverseAutoDiffOpInterface::ExternalModel<GEPOpInterfaceReverse,
                                                        LLVM::GEPOp> {
@@ -707,6 +731,10 @@ void mlir::enzyme::registerLLVMDialectAutoDiffInterface(
     LLVM::LLVMStructType::attachInterface<StructTypeInterface>(*context);
     LLVM::LLVMArrayType::attachInterface<ArrayTypeInterface>(*context);
 
+    LLVM::LifetimeStartOp::attachInterface<
+        LifetimeForwardInterface<LLVM::LifetimeStartOp>>(*context);
+    LLVM::LifetimeEndOp::attachInterface<
+        LifetimeForwardInterface<LLVM::LifetimeEndOp>>(*context);
     LLVM::SelectOp::attachInterface<SelectActivityInterface>(*context);
     LLVM::StoreOp::attachInterface<LLVMStoreLike>(*context);
     LLVM::LoadOp::attachInterface<LoadOpInterfaceReverse>(*context);

--- a/enzyme/test/MLIR/ForwardMode/inactive_op.mlir
+++ b/enzyme/test/MLIR/ForwardMode/inactive_op.mlir
@@ -1,0 +1,67 @@
+// RUN: %eopt --split-input-file --enzyme --canonicalize --remove-unnecessary-enzyme-ops %s | FileCheck %s
+
+// A lifetime marker says when the memory it names is live. The shadow is memory
+// too and lives exactly as long, so the tangent is the same marker said again of
+// the shadow.
+//
+// llvm.intr.lifetime.start is declared InactiveOp, which attaches an
+// ActivityOpInterface and nothing else, so forward mode had no rule for it and
+// stopped at "could not compute the adjoint for this operation". Being inactive
+// is about what an op makes active, not about whether the derivative needs it
+// said -- a barrier is inactive too and still has to be there.
+
+module {
+  llvm.func @f(%p: !llvm.ptr) {
+    "llvm.intr.lifetime.start"(%p) : (!llvm.ptr) -> ()
+    %v = llvm.load %p : !llvm.ptr -> f64
+    %s = arith.mulf %v, %v : f64
+    llvm.store %s, %p : f64, !llvm.ptr
+    "llvm.intr.lifetime.end"(%p) : (!llvm.ptr) -> ()
+    llvm.return
+  }
+
+  func.func @df(%p: !llvm.ptr, %dp: !llvm.ptr) {
+    enzyme.fwddiff @f(%p, %dp) { activity=[#enzyme<activity enzyme_dup>], ret_activity=[] } : (!llvm.ptr, !llvm.ptr) -> ()
+    return
+  }
+}
+
+// Both the primal and its shadow are marked, and the tangent of v*v is 2*v*dv.
+
+// CHECK: llvm.func @fwddiffef(%[[p:.+]]: !llvm.ptr, %[[dp:.+]]: !llvm.ptr)
+// CHECK-DAG:     llvm.intr.lifetime.start %[[dp]] : !llvm.ptr
+// CHECK-DAG:     llvm.intr.lifetime.start %[[p]] : !llvm.ptr
+// CHECK:         %[[dv:.+]] = llvm.load %[[dp]] : !llvm.ptr -> f64
+// CHECK:         %[[v:.+]] = llvm.load %[[p]] : !llvm.ptr -> f64
+// CHECK:         %[[a:.+]] = arith.mulf %[[dv]], %[[v]] fastmath<fast> : f64
+// CHECK:         %[[b:.+]] = arith.mulf %[[dv]], %[[v]] fastmath<fast> : f64
+// CHECK:         %[[ds:.+]] = arith.addf %[[a]], %[[b]] fastmath<fast> : f64
+// CHECK:         llvm.store %[[ds]], %[[dp]] : f64, !llvm.ptr
+// CHECK-DAG:     llvm.intr.lifetime.end %[[dp]] : !llvm.ptr
+// CHECK-DAG:     llvm.intr.lifetime.end %[[p]] : !llvm.ptr
+
+// -----
+
+// Memory nothing differentiates has no shadow whose lifetime this could be, so
+// there is only the one marker.
+
+module {
+  llvm.func @g(%p: !llvm.ptr, %c: !llvm.ptr) {
+    "llvm.intr.lifetime.start"(%c) : (!llvm.ptr) -> ()
+    %v = llvm.load %p : !llvm.ptr -> f64
+    %s = arith.mulf %v, %v : f64
+    llvm.store %s, %p : f64, !llvm.ptr
+    "llvm.intr.lifetime.end"(%c) : (!llvm.ptr) -> ()
+    llvm.return
+  }
+
+  func.func @dg(%p: !llvm.ptr, %dp: !llvm.ptr, %c: !llvm.ptr) {
+    enzyme.fwddiff @g(%p, %dp, %c) { activity=[#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_const>], ret_activity=[] } : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    return
+  }
+}
+
+// CHECK: llvm.func @fwddiffeg(%[[p2:.+]]: !llvm.ptr, %[[dp2:.+]]: !llvm.ptr, %[[c:.+]]: !llvm.ptr)
+// CHECK:         llvm.intr.lifetime.start %[[c]] : !llvm.ptr
+// CHECK-NOT:     llvm.intr.lifetime.start
+// CHECK:         llvm.intr.lifetime.end %[[c]] : !llvm.ptr


### PR DESCRIPTION
`llvm.intr.lifetime.start`/`end` are declared `InactiveOp`, which attaches an `ActivityOpInterface` and nothing else. Forward mode then had no rule for them and stopped at

```
could not compute the adjoint for this operation "llvm.intr.lifetime.start"
```

36 times across MFEM's dFEM tests (EnzymeAD/Enzyme-JAX#2778) — every stack buffer in a dFEM kernel.

Being inactive is about what an op makes *active*, not about whether the derivative needs it said — a barrier is inactive too and still has to be there. So rather than skipping inactive ops wholesale (the first version of this PR, which would have silently dropped things like `syncthreads`), this gives the two lifetime ops an `AutoDiffOpInterface`:

- pointer is differentiable → clone the marker onto the shadow. The shadow is memory that lives exactly as long as the primal, so the tangent is the same marker said again of it.
- pointer is constant → there is no shadow whose lifetime this could be, and the primal marker alone is the whole answer.

Test is `test/MLIR/ForwardMode/inactive_op.mlir`, covering both cases.
