### PR TITLE
Do not walk one map while inserting into it

### DIFF
--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowLattice.h
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowLattice.h
@@ -254,6 +254,12 @@ public:
     const auto &rhs =
         static_cast<const MapOfSetsLattice<KeyT, ElementT> &>(other);
 
+    // Joining with itself says nothing new, and the loop below walks the other
+    // side's map while inserting into this one, which the rehash would not
+    // survive. Say the first, which settles the second.
+    if (this == &rhs)
+      return ChangeResult::NoChange;
+
     // A key only this side has is left as it is, so only the other side's keys
     // are worth walking. Taking the union of both first meant every join cost
     // the size of what had been accumulated, which in a fixpoint is joined into


### PR DESCRIPTION
#3090 made `MapOfSetsLattice::join` walk the other side's map and `try_emplace` into this one:

```cpp
for (const auto &it : rhs.map) {
  auto [lhsIt, inserted] = map.try_emplace(it.getFirst(), it.getSecond());
  ...
}
```

That is right where the two are different objects, and not where they are the same one: the insert can rehash the map being walked, and the iterator does not survive it. The version it replaced happened to be safe here only because it walked a separately-built set of keys.

Joining a lattice with itself says nothing new, so saying that settles it.

Found while looking for something else, and kept as its own change rather than folded into #3090, which has landed. I have not managed to make a case that reaches it — a lattice is not normally joined with itself — so this is a guard against a shape the loop cannot handle rather than a fix for an observed crash, and it is offered on that basis.

162/163 of `check-enzymemlir` pass; the one failure is `ReverseMode/linalg.mlir`, which fails on main too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD