### PR TITLE
Keep a branch's condition when neither successor takes an argument

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/CoreDialectsAutoDiffImplementations.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/CoreDialectsAutoDiffImplementations.cpp
@@ -96,8 +96,11 @@ void mlir::enzyme::detail::branchingForwardHandler(Operation *inst,
   SmallVector<Value> newVals;
 
   SmallVector<int32_t> segSizes;
-  // Keep non-differentiated, non-forwarded operands
-  size_t non_forwarded = 0;
+  // Keep non-differentiated, non-forwarded operands. These are the ones ahead
+  // of the first operand any successor forwards -- a condition, a switch value.
+  // When no successor takes an operand there is no such boundary to find, and
+  // every operand the op has is one of these.
+  size_t non_forwarded = binst->getNumOperands();
   for (size_t i = 0; i < newInst->getNumSuccessors(); i++) {
     auto ops = binst.getSuccessorOperands(i).getForwardedOperands();
     if (ops.empty())

--- a/enzyme/test/MLIR/ForwardMode/branch_no_block_args.mlir
+++ b/enzyme/test/MLIR/ForwardMode/branch_no_block_args.mlir
@@ -1,0 +1,40 @@
+// RUN: %eopt --enzyme --remove-unnecessary-enzyme-ops %s | FileCheck %s
+
+// branchingForwardHandler copies the operands ahead of the first one any
+// successor forwards -- for cf.cond_br that is the condition -- and it found
+// that boundary by looking for a successor that forwards something. Neither
+// block here takes an argument, so there was nothing to find and the boundary
+// stayed at 0: the condition was dropped and the tangent came out as
+//
+//   "cf.cond_br"()[^bb1, ^bb2] <{operandSegmentSizes = array<i32: 0, 0, 0>}>
+//
+// which fails the verifier with "expected 1 or more operands, but found 0".
+
+module {
+  func.func private @f(%p: !llvm.ptr, %n: i64) {
+    %z = arith.constant 0 : i64
+    %c = arith.cmpi eq, %n, %z : i64
+    %v = llvm.load %p : !llvm.ptr -> f64
+    %s = arith.mulf %v, %v : f64
+    llvm.store %s, %p : f64, !llvm.ptr
+    cf.cond_br %c, ^bb1, ^bb2
+  ^bb1:
+    llvm.intr.trap
+    llvm.unreachable
+  ^bb2:
+    return
+  }
+
+  func.func @df(%p: !llvm.ptr, %dp: !llvm.ptr, %n: i64) {
+    enzyme.fwddiff @f(%p, %dp, %n) { activity=[#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_const>], ret_activity=[] } : (!llvm.ptr, !llvm.ptr, i64) -> ()
+    return
+  }
+}
+
+// CHECK: func.func private @fwddiffef(%[[p:.+]]: !llvm.ptr, %[[dp:.+]]: !llvm.ptr, %[[n:.+]]: i64)
+// CHECK:         %[[c:.+]] = arith.cmpi eq, %[[n]], %{{.+}} : i64
+// CHECK:         cf.cond_br %[[c]], ^[[bb1:.+]], ^[[bb2:.+]]
+// CHECK:       ^[[bb1]]:
+// CHECK:         llvm.intr.trap
+// CHECK:       ^[[bb2]]:
+// CHECK:         return


### PR DESCRIPTION
`branchingForwardHandler` copies the operands ahead of the first one any successor forwards — for `cf.cond_br` that is the condition, for a switch the value — and it located that boundary by scanning for a successor that forwards something:

```cpp
size_t non_forwarded = 0;
for (...) {
  auto ops = binst.getSuccessorOperands(i).getForwardedOperands();
  if (ops.empty()) continue;
  non_forwarded = ops.getBeginOperandIndex();
  break;
}
```

When no successor takes an argument the scan finds nothing and the boundary stays at 0, so no operand is copied at all. The tangent came out as

```mlir
"cf.cond_br"()[^bb1, ^bb2] <{operandSegmentSizes = array<i32: 0, 0, 0>}> : () -> ()
```

which fails the verifier with `'cf.cond_br' op expected 1 or more operands, but found 0`.

There being no forwarded operand does not mean there is no boundary; it means the boundary is past every operand the op has.

Three of MFEM's dFEM test files hit this (EnzymeAD/Enzyme-JAX#2778) on the bounds check in `tensor_ndarray::set_layout`, whose two arms take nothing:

```mlir
cf.cond_br %1, ^bb1, ^bb2
^bb1:
  llvm.return
^bb2:
  llvm.intr.trap
  llvm.unreachable
```

Test is `test/MLIR/ForwardMode/branch_no_block_args.mlir`.
