### PR TITLE
Say an unknown summary set the way the readers of summaries read it

### DIFF
--- a/enzyme/Enzyme/MLIR/Analysis/ActivityAnnotations.cpp
+++ b/enzyme/Enzyme/MLIR/Analysis/ActivityAnnotations.cpp
@@ -502,10 +502,10 @@ static void deserializePointsTo(
     auto pointer = cast<DistinctAttr>(pair[0]);
     auto pointsToSet = enzyme::ValueOriginSet::getUndefined();
     if (auto strAttr = dyn_cast<StringAttr>(pair[1])) {
-      if (strAttr.getValue() == "unknown") {
+      if (strAttr.getValue() == enzyme::unknownSetString) {
         (void)pointsToSet.markUnknown();
       } else {
-        assert(strAttr.getValue() == "undefined" &&
+        assert(strAttr.getValue() == enzyme::undefinedSetString &&
                "unrecognized points-to destination");
       }
     } else {
@@ -576,10 +576,19 @@ void enzyme::DenseActivityAnnotationAnalysis::processCallToSummarizedFunc(
 
   for (const auto &[destClass, sourceOrigins] : summary) {
     ValueOriginSet callerOrigins;
-    for (Attribute sourceOrigin : sourceOrigins.getElements()) {
-      unsigned argNumber =
-          cast<ArgumentOriginAttr>(sourceOrigin).getArgNumber();
-      (void)callerOrigins.join(argumentOrigins[argNumber]);
+    // A callee that could not say where this memory came from says nothing
+    // narrower to the caller either; only a set that names its origins has
+    // arguments to translate.
+    if (sourceOrigins.isUndefined())
+      continue;
+    if (sourceOrigins.isUnknown()) {
+      (void)callerOrigins.markUnknown();
+    } else {
+      for (Attribute sourceOrigin : sourceOrigins.getElements()) {
+        unsigned argNumber =
+            cast<ArgumentOriginAttr>(sourceOrigin).getArgNumber();
+        (void)callerOrigins.join(argumentOrigins[argNumber]);
+      }
     }
 
     AliasClassSet callerDestClasses;
@@ -758,6 +767,15 @@ void enzyme::DenseBackwardActivityAnnotationAnalysis::
 
     if (destOrigins.isUndefined())
       continue;
+
+    // A callee that could not say which of its arguments this memory flows back
+    // to leaves every one of the caller's classes a candidate.
+    if (sourceOrigins.isUndefined())
+      continue;
+    if (sourceOrigins.isUnknown()) {
+      changed |= before->markAllOriginsUnknown();
+      continue;
+    }
 
     // Get the source alias classes
     AliasClassSet callerSourceClasses;

--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.cpp
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.cpp
@@ -454,6 +454,16 @@ void enzyme::PointsToPointerAnalysis::processCallToSummarizedFunc(
     if (!calleePointsTo)
       continue;
 
+    // A callee that could not say what this argument ends up pointing to says
+    // nothing narrower to the caller either.
+    if (calleePointsTo->isUnknown()) {
+      changed |= after->insert(arg->getAliasClassesObject(),
+                               AliasClassSet::getUnknown());
+      continue;
+    }
+    if (calleePointsTo->isUndefined())
+      continue;
+
     for (DistinctAttr ac : calleePointsTo->getElements()) {
       if (!isa<PseudoAliasClassAttr>(ac.getReferencedAttr())) {
         // Fresh classes go in directly

--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowLattice.h
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowLattice.h
@@ -326,18 +326,22 @@ private:
 
     for (const auto &[srcClass, destClasses] : map) {
       SmallVector<Attribute> pair = {srcClass};
-      SmallVector<Attribute> aliasClasses;
+      // Unknown and undefined are said as the bare marker string, the way
+      // serializeSetNaive says them and the way the readers of these summaries
+      // look for them. Wrapped in the list they read as one more element of a
+      // known set, and get cast to whatever the elements are supposed to be.
       if (destClasses.isUnknown()) {
-        aliasClasses.push_back(StringAttr::get(ctx, unknownSetString));
+        pair.push_back(StringAttr::get(ctx, unknownSetString));
       } else if (destClasses.isUndefined()) {
-        aliasClasses.push_back(StringAttr::get(ctx, undefinedSetString));
+        pair.push_back(StringAttr::get(ctx, undefinedSetString));
       } else {
+        SmallVector<Attribute> aliasClasses;
         for (const Attribute &destClass : destClasses.getElements()) {
           aliasClasses.push_back(destClass);
         }
         llvm::sort(aliasClasses, sortAttributes);
+        pair.push_back(ArrayAttr::get(ctx, aliasClasses));
       }
-      pair.push_back(ArrayAttr::get(ctx, aliasClasses));
       pointsToArray.push_back(ArrayAttr::get(ctx, pair));
     }
     llvm::sort(pointsToArray, [&](Attribute a, Attribute b) {

--- a/enzyme/test/MLIR/ActivityAnalysis/Summaries/unknown.mlir
+++ b/enzyme/test/MLIR/ActivityAnalysis/Summaries/unknown.mlir
@@ -1,0 +1,34 @@
+// RUN: %eopt --print-activity-analysis='relative verbose' --split-input-file %s | FileCheck %s
+
+// @callee writes through its pointer and then does something the analysis
+// cannot see past, so its dense origins map goes unknown. serializeMapOfSetsNaive
+// used to say that as a one-element list, ["<unknown>"], while every reader of
+// these summaries -- and serializeSetNaive, which writes the sparse ones --
+// says and expects the bare marker. The list read as a set of one known origin,
+// whose element was then cast from a StringAttr to an OriginAttr and indexed
+// with whatever came out.
+
+func.func @callee(%p: !llvm.ptr, %v: f64) {
+  llvm.store %v, %p : f64, !llvm.ptr
+  llvm.inline_asm has_side_effects "nop", "" : () -> ()
+  return
+}
+
+// CHECK-LABEL: processing function @callee
+// CHECK: forward value origins:
+// CHECK-NEXT: originates from "<unknown>"
+
+func.func @caller(%p: !llvm.ptr, %v: f64) -> f64 {
+  call @callee(%p, %v) : (!llvm.ptr, f64) -> ()
+  %r = llvm.load %p {tag = "reload"} : !llvm.ptr -> f64
+  return %r : f64
+}
+
+// The caller reads what the callee wrote, so what it loads is of unknown
+// origin too -- not of no origin, which is what a dropped marker would say.
+
+// CHECK-LABEL: processing function @caller
+// CHECK: forward value origins:
+// CHECK-NEXT: originates from "<unknown>"
+// CHECK: "reload"(#0)
+// CHECK-NEXT: sources: "<unknown>"


### PR DESCRIPTION
`serializeSetNaive` says an unknown or undefined set as the bare marker string, and every reader of these summaries looks for exactly that. `serializeMapOfSetsNaive` said it as a one-element list instead:

```mlir
[#distinct, ["<unknown>"]]     rather than     [#distinct, "<unknown>"]
```

So the marker branch in both `deserializePointsTo` functions was dead, and the list read as a set of one known element. That element, a `StringAttr`, was then `cast` unchecked to `DistinctAttr` / `OriginAttr` and its arg number used as an index — `argNumber=336934464` into a six-element vector, in MFEM's dFEM tests, which segfaulted three of them (EnzymeAD/Enzyme-JAX#2778):

```
#4  mlir::enzyme::SetLattice<mlir::enzyme::OriginAttr>::join(...)
#5  mlir::enzyme::DenseActivityAnnotationAnalysis::processCallToSummarizedFunc(...)
#6  mlir::enzyme::DenseActivityAnnotationAnalysis::visitCallControlFlowTransfer(...)
```

One of the two readers was also comparing against `"unknown"`/`"undefined"` without the angle brackets, so even given the right shape it would not have recognised them.

Reading the marker correctly then hands the consumers an unknown set where they had only ever seen defined ones, and `getElements` asserts on those. So the three places that translate a callee's summary to its caller now answer it:

- forward dense origins: unknown origins stay unknown
- backward dense origins: memory whose sinks the callee could not name leaves every one of the caller's classes a candidate
- points-to: an argument the callee could not track leaves the caller pointing to unknown

Dropping it would have been the unsound direction — "came from nowhere" reads as inactive.

Test is `test/MLIR/ActivityAnalysis/Summaries/unknown.mlir`; it fails on `main` with the assertion (release: the segfault) and checks both that the marker round-trips and that the caller inherits the unknown rather than an empty set.
