### PR TITLE
Give llvm.intr.memset a forward-mode rule

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
@@ -215,6 +215,44 @@ struct LifetimeForwardInterface
   }
 };
 
+// After a memset the memory holds a fixed byte pattern, which depends on no
+// input, so its tangent is zero everywhere the memset reached. Forward mode
+// says that by clearing the shadow over the same range -- whatever derivative
+// the memory carried before is gone along with the value it belonged to.
+//
+// llvm.intr.memset is declared inactive, which is about what it makes active
+// and not about whether the derivative needs it said.
+struct MemsetForwardInterface
+    : public AutoDiffOpInterface::ExternalModel<MemsetForwardInterface,
+                                                LLVM::MemsetOp> {
+  LogicalResult createForwardModeTangent(Operation *op, OpBuilder &builder,
+                                         MGradientUtils *gutils) const {
+    auto memset = cast<LLVM::MemsetOp>(op);
+    // Memory nothing differentiates has no shadow to clear.
+    if (gutils->isConstantValue(memset.getDst()))
+      return success();
+
+    // A byte something differentiates is splatted across the memory, and its
+    // tangent would have to be splatted across the shadow. Nothing produces
+    // that today, and guessing at it would quietly zero a derivative.
+    if (!gutils->isConstantValue(memset.getVal()))
+      return op->emitError()
+             << "could not compute the tangent of a memset whose value is "
+                "differentiated "
+             << *op;
+
+    Value shadow = gutils->invertPointerM(memset.getDst(), builder);
+    auto newOp = cast<LLVM::MemsetOp>(gutils->getNewFromOriginal(op));
+    Value zero = LLVM::ConstantOp::create(builder, op->getLoc(),
+                                          newOp.getVal().getType(),
+                                          builder.getI8IntegerAttr(0));
+    auto shadowOp = cast<LLVM::MemsetOp>(builder.clone(*newOp));
+    shadowOp.getDstMutable().assign(shadow);
+    shadowOp.getValMutable().assign(zero);
+    return success();
+  }
+};
+
 struct GEPOpInterfaceReverse
     : public ReverseAutoDiffOpInterface::ExternalModel<GEPOpInterfaceReverse,
                                                        LLVM::GEPOp> {
@@ -735,6 +773,7 @@ void mlir::enzyme::registerLLVMDialectAutoDiffInterface(
         LifetimeForwardInterface<LLVM::LifetimeStartOp>>(*context);
     LLVM::LifetimeEndOp::attachInterface<
         LifetimeForwardInterface<LLVM::LifetimeEndOp>>(*context);
+    LLVM::MemsetOp::attachInterface<MemsetForwardInterface>(*context);
     LLVM::SelectOp::attachInterface<SelectActivityInterface>(*context);
     LLVM::StoreOp::attachInterface<LLVMStoreLike>(*context);
     LLVM::LoadOp::attachInterface<LoadOpInterfaceReverse>(*context);

--- a/enzyme/test/MLIR/ForwardMode/memset.mlir
+++ b/enzyme/test/MLIR/ForwardMode/memset.mlir
@@ -1,0 +1,89 @@
+// RUN: %eopt --split-input-file --enzyme --canonicalize --remove-unnecessary-enzyme-ops %s | FileCheck %s
+
+// After a memset the memory holds a fixed byte pattern, which depends on no
+// input, so its tangent is zero everywhere the memset reached. Forward mode
+// says that by clearing the shadow over the same range.
+//
+// llvm.intr.memset is declared InactiveOp, which attaches an ActivityOpInterface
+// and nothing else, so forward mode had no rule for it and stopped at "could not
+// compute the adjoint for this operation". Being inactive is about what an op
+// makes active, not about whether the derivative needs it said.
+
+module {
+  llvm.func @f(%p: !llvm.ptr) {
+    %c0 = llvm.mlir.constant(0 : i8) : i8
+    %n = llvm.mlir.constant(8 : i64) : i64
+    %v = llvm.load %p : !llvm.ptr -> f64
+    %s = arith.mulf %v, %v : f64
+    llvm.store %s, %p : f64, !llvm.ptr
+    "llvm.intr.memset"(%p, %c0, %n) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    llvm.return
+  }
+
+  func.func @df(%p: !llvm.ptr, %dp: !llvm.ptr) {
+    enzyme.fwddiff @f(%p, %dp) { activity=[#enzyme<activity enzyme_dup>], ret_activity=[] } : (!llvm.ptr, !llvm.ptr) -> ()
+    return
+  }
+}
+
+// CHECK: llvm.func @fwddiffef(%[[p:.+]]: !llvm.ptr, %[[dp:.+]]: !llvm.ptr)
+// CHECK-DAG:     %[[zero:.+]] = llvm.mlir.constant(0 : i8) : i8
+// CHECK-DAG:     %[[len:.+]] = llvm.mlir.constant(8 : i64) : i64
+// CHECK:         llvm.store %{{.+}}, %[[dp]] : f64, !llvm.ptr
+// CHECK:         llvm.store %{{.+}}, %[[p]] : f64, !llvm.ptr
+// CHECK-DAG:     "llvm.intr.memset"(%[[dp]], %[[zero]], %[[len]])
+// CHECK-DAG:     "llvm.intr.memset"(%[[p]], %[[zero]], %[[len]])
+
+// -----
+
+// The byte written says nothing about the tangent: whatever pattern the primal
+// gets, the shadow gets zeros.
+
+module {
+  llvm.func @g(%p: !llvm.ptr) {
+    %c7 = llvm.mlir.constant(7 : i8) : i8
+    %n = llvm.mlir.constant(8 : i64) : i64
+    %v = llvm.load %p : !llvm.ptr -> f64
+    %s = arith.mulf %v, %v : f64
+    llvm.store %s, %p : f64, !llvm.ptr
+    "llvm.intr.memset"(%p, %c7, %n) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    llvm.return
+  }
+
+  func.func @dg(%p: !llvm.ptr, %dp: !llvm.ptr) {
+    enzyme.fwddiff @g(%p, %dp) { activity=[#enzyme<activity enzyme_dup>], ret_activity=[] } : (!llvm.ptr, !llvm.ptr) -> ()
+    return
+  }
+}
+
+// CHECK: llvm.func @fwddiffeg(%[[p2:.+]]: !llvm.ptr, %[[dp2:.+]]: !llvm.ptr)
+// CHECK-DAG:     %[[seven:.+]] = llvm.mlir.constant(7 : i8) : i8
+// CHECK-DAG:     %[[zero2:.+]] = llvm.mlir.constant(0 : i8) : i8
+// CHECK-DAG:     "llvm.intr.memset"(%[[dp2]], %[[zero2]], %{{.+}})
+// CHECK-DAG:     "llvm.intr.memset"(%[[p2]], %[[seven]], %{{.+}})
+
+// -----
+
+// Memory nothing differentiates has no shadow to clear, so there is only the
+// one memset.
+
+module {
+  llvm.func @h(%p: !llvm.ptr, %c: !llvm.ptr) {
+    %c0 = llvm.mlir.constant(0 : i8) : i8
+    %n = llvm.mlir.constant(8 : i64) : i64
+    %v = llvm.load %p : !llvm.ptr -> f64
+    %s = arith.mulf %v, %v : f64
+    llvm.store %s, %p : f64, !llvm.ptr
+    "llvm.intr.memset"(%c, %c0, %n) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    llvm.return
+  }
+
+  func.func @dh(%p: !llvm.ptr, %dp: !llvm.ptr, %c: !llvm.ptr) {
+    enzyme.fwddiff @h(%p, %dp, %c) { activity=[#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_const>], ret_activity=[] } : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    return
+  }
+}
+
+// CHECK: llvm.func @fwddiffeh(%[[p3:.+]]: !llvm.ptr, %[[dp3:.+]]: !llvm.ptr, %[[c:.+]]: !llvm.ptr)
+// CHECK:         "llvm.intr.memset"(%[[c]], %{{.+}}, %{{.+}})
+// CHECK-NOT:     llvm.intr.memset


### PR DESCRIPTION
After a memset the memory holds a fixed byte pattern, which depends on no input, so its tangent is zero everywhere the memset reached. Forward mode says that by clearing the shadow over the same range — whatever derivative the memory carried before is gone along with the value it belonged to.

`llvm.intr.memset` is declared `InactiveOp`, which attaches an `ActivityOpInterface` and nothing else, so forward mode had no rule for it and stopped at

```
could not compute the adjoint for this operation "llvm.intr.memset"(%arg3, %1, %2) ...
```

on three of MFEM's dFEM test files (EnzymeAD/Enzyme-JAX#2778), which memset their local tensors before filling them. Being inactive is about what an op makes *active*, not about whether the derivative needs it said — same shape as the lifetime markers in #3093.

Two details worth stating:

- **The byte written says nothing about the tangent.** Whatever pattern the primal gets, the shadow gets zeros. Cloning the value across would be wrong for a non-zero pattern; it only looks right because the usual case is `memset(p, 0, n)`, where the two coincide.
- **A byte that is itself differentiated** would have to have its tangent splatted across the shadow. Nothing produces that today, and guessing would quietly zero a derivative, so that case is an error rather than a silent answer. (This mirrors the LLVM side, which emits `couldn't handle non constant inst in memset to propagate differential to`.)

Test is `test/MLIR/ForwardMode/memset.mlir`: the zero case, a non-zero pattern, and a memset of memory nothing differentiates.

Reverse mode still has no rule; it wants the shadow cleared in the reverse pass, and is left for a follow-up.
