### PR TITLE
Remove a pop nobody reads when its cache has no other pop

### DIFF
--- a/enzyme/Enzyme/MLIR/Passes/RemoveUnusedEnzymeOps.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/RemoveUnusedEnzymeOps.cpp
@@ -237,6 +237,48 @@ struct PopSimplify : public OpRewritePattern<enzyme::PopOp> {
   }
 };
 
+// A pop nobody reads is worth keeping only for what it does to the cache: it
+// moves the stack on for whatever pops next. When it is the one pop its cache
+// has, there is no next, and the whole cache is dead -- so the pushes go with
+// it, in the one rewrite. Taking the pop alone would leave a cache pushed and
+// never popped, which is worse than what was there before.
+//
+// PopSimplify cannot reach these: it pairs a pop with the push that dominates
+// it and gives up when the two are in different blocks, which is exactly the
+// shape reverse mode leaves behind for a branch whose adjoint turned out empty.
+struct DeadPopSimplify : public OpRewritePattern<enzyme::PopOp> {
+  using OpRewritePattern<enzyme::PopOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(enzyme::PopOp pop,
+                                PatternRewriter &rewriter) const final {
+    if (!pop.getResult().use_empty())
+      return failure();
+
+    auto init = pop.getCache().getDefiningOp<enzyme::InitOp>();
+    if (!init)
+      return failure();
+
+    // Anything else holding the cache could be reading the stack in a way this
+    // cannot see; only a cache that is nothing but pushed and popped is known.
+    SmallVector<enzyme::PushOp> pushes;
+    for (Operation *user : init.getResult().getUsers()) {
+      if (user == pop)
+        continue;
+      if (auto push = dyn_cast<enzyme::PushOp>(user)) {
+        pushes.push_back(push);
+        continue;
+      }
+      return failure();
+    }
+
+    rewriter.eraseOp(pop);
+    for (enzyme::PushOp push : pushes)
+      rewriter.eraseOp(push);
+    rewriter.eraseOp(init);
+    return success();
+  }
+};
+
 struct GetSimplify : public OpRewritePattern<enzyme::GetOp> {
   using OpRewritePattern<enzyme::GetOp>::OpRewritePattern;
 
@@ -331,8 +373,8 @@ struct IgnoreDerivativesSimplifyPattern
 
 static void applyPatterns(Operation *op) {
   RewritePatternSet patterns(op->getContext());
-  patterns.insert<PopSimplify, GetSimplify, PushSimplify, SetSimplify,
-                  InitSimplify, IgnoreDerivativesSimplifyPattern>(
+  patterns.insert<PopSimplify, DeadPopSimplify, GetSimplify, PushSimplify,
+                  SetSimplify, InitSimplify, IgnoreDerivativesSimplifyPattern>(
       op->getContext());
 
   GreedyRewriteConfig config;
@@ -354,8 +396,8 @@ static void applyPatternsToEnzymeOps(Operation *op,
     return;
 
   RewritePatternSet patterns(op->getContext());
-  patterns.insert<PopSimplify, GetSimplify, PushSimplify, SetSimplify,
-                  InitSimplify>(op->getContext());
+  patterns.insert<PopSimplify, DeadPopSimplify, GetSimplify, PushSimplify,
+                  SetSimplify, InitSimplify>(op->getContext());
 
   GreedyRewriteConfig config;
   config.enableFolding();

--- a/enzyme/test/MLIR/Passes/dead_pop.mlir
+++ b/enzyme/test/MLIR/Passes/dead_pop.mlir
@@ -1,0 +1,67 @@
+// RUN: %eopt --split-input-file --remove-unnecessary-enzyme-ops %s | FileCheck %s
+
+// Reverse mode caches the branch it took, then finds the adjoint of both arms
+// empty. What is left is a cache pushed in one block and popped in another,
+// whose popped value nobody reads. PopSimplify cannot pair these -- it gives up
+// when the push and the pop are in different blocks -- so the init survived all
+// the way to LLVM translation, which has no lowering for it:
+//
+//   cannot be converted to LLVM IR: missing `LLVMTranslationDialectInterface`
+//   registration for dialect for op: enzyme.init
+//
+// A pop nobody reads is worth keeping only for what it does to the cache, and
+// when it is the one pop that cache has there is nothing left to do it for.
+
+module {
+  llvm.func @dead(%p: !llvm.ptr, %n: i64) {
+    %m1 = arith.constant -1 : i32
+    %z = arith.constant 0 : i64
+    %c0 = "enzyme.init"() : () -> !enzyme.Cache<i32>
+    %c1 = "enzyme.init"() : () -> !enzyme.Cache<i32>
+    %cmp = arith.cmpi eq, %n, %z : i64
+    "enzyme.push"(%c1, %m1) : (!enzyme.Cache<i32>, i32) -> ()
+    "enzyme.push"(%c0, %m1) : (!enzyme.Cache<i32>, i32) -> ()
+    cf.cond_br %cmp, ^bb2, ^bb1
+  ^bb1:
+    llvm.intr.trap
+    %0 = "enzyme.pop"(%c0) : (!enzyme.Cache<i32>) -> i32
+    cf.br ^bb3
+  ^bb2:
+    %1 = "enzyme.pop"(%c1) : (!enzyme.Cache<i32>) -> i32
+    cf.br ^bb3
+  ^bb3:
+    llvm.return
+  }
+}
+
+// CHECK-LABEL: llvm.func @dead
+// CHECK-NOT:     enzyme.init
+// CHECK-NOT:     enzyme.push
+// CHECK-NOT:     enzyme.pop
+
+// -----
+
+// A cache with a second pop is a stack being read: dropping the first would
+// hand the second the wrong value.
+
+module {
+  llvm.func @live(%p: !llvm.ptr, %n: i64) -> i32 {
+    %m1 = arith.constant -1 : i32
+    %m2 = arith.constant -2 : i32
+    %z = arith.constant 0 : i64
+    %c = "enzyme.init"() : () -> !enzyme.Cache<i32>
+    %cmp = arith.cmpi eq, %n, %z : i64
+    "enzyme.push"(%c, %m1) : (!enzyme.Cache<i32>, i32) -> ()
+    "enzyme.push"(%c, %m2) : (!enzyme.Cache<i32>, i32) -> ()
+    cf.br ^bb1
+  ^bb1:
+    %0 = "enzyme.pop"(%c) : (!enzyme.Cache<i32>) -> i32
+    %1 = "enzyme.pop"(%c) : (!enzyme.Cache<i32>) -> i32
+    llvm.return %1 : i32
+  }
+}
+
+// CHECK-LABEL: llvm.func @live
+// CHECK:         enzyme.init
+// CHECK:         "enzyme.pop"
+// CHECK:         "enzyme.pop"


### PR DESCRIPTION
Reverse mode caches the branch it took, then finds the adjoint of both arms empty. What is left is a cache pushed in one block and popped in another, whose popped value nobody reads:

```mlir
%0 = "enzyme.init"() : () -> !enzyme.Cache<i32>
"enzyme.push"(%0, %c-1_i32) : (!enzyme.Cache<i32>, i32) -> ()
cf.cond_br %3, ^bb2, ^bb1
^bb1:
  llvm.intr.trap
  %5 = "enzyme.pop"(%0) : (!enzyme.Cache<i32>) -> i32   // %5 unused
```

`PopSimplify` cannot pair those — it gives up when the push and the pop are in different blocks, to avoid pairing across something that may run more than once — so nothing removed the pop, the pop held the pushes, the pushes held the init, and the init reached LLVM translation:

```
cannot be converted to LLVM IR: missing `LLVMTranslationDialectInterface`
registration for dialect for op: enzyme.init
```

which is what MFEM's `tests/unit/enzyme/test_enzyme_reverse_tape.cpp` failed with (EnzymeAD/Enzyme-JAX#2778).

A pop nobody reads is worth keeping only for what it does to the cache: it moves the stack on for whatever pops next. When it is the one pop that cache has, there is no next, and the whole cache is dead — so **the pushes and the init go with it, in the one rewrite**. Taking the pop alone would leave a cache pushed and never popped, which is worse than what was there before.

A cache held by anything other than a push or a pop could be read in a way this cannot see, so those are left alone.

Test is `test/MLIR/Passes/dead_pop.mlir`: the dead cache goes entirely (init, pushes and pop), and a cache with a second pop — a stack genuinely being read — is untouched.
