### PR TITLE
Differentiate the CUDA memcpy family in forward mode

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -3483,10 +3483,23 @@ public:
                            isVolatile);
   }
 
+  /// Hook for emitting the shadow of a memory transfer which cannot be
+  /// expressed as an LLVM memcpy -- notably a CUDA host<->device copy, whose
+  /// shadow has to go back through the CUDA API because one or both sides live
+  /// in memory the host cannot address directly. `ddst`/`dsrc` are the shadow
+  /// (or, when inactive, primal) pointers of the segment being transferred,
+  /// already advanced to the segment start. `dsrc` is null when `zero` is set,
+  /// meaning the source is inactive float data and the `len` bytes at `ddst`
+  /// must be zeroed rather than copied.
+  using MemTransferEmitter =
+      llvm::function_ref<void(llvm::IRBuilder<> &B, llvm::Value *ddst,
+                              llvm::Value *dsrc, llvm::Value *len, bool zero)>;
+
   void visitMemTransferCommon(llvm::Intrinsic::ID ID, llvm::MaybeAlign srcAlign,
                               llvm::MaybeAlign dstAlign, llvm::CallInst &MTI,
                               llvm::Value *orig_dst, llvm::Value *orig_src,
-                              llvm::Value *new_size, llvm::Value *isVolatile) {
+                              llvm::Value *new_size, llvm::Value *isVolatile,
+                              MemTransferEmitter customEmit = {}) {
     using namespace llvm;
 
     if (gutils->isConstantValue(MTI.getOperand(0))) {
@@ -3808,9 +3821,24 @@ public:
           ddst = BuilderZ.CreateConstInBoundsGEP1_64(
               Type::getInt8Ty(ddst->getContext()), ddst, seg_start);
         }
-        CallInst *call;
         // TODO add gutils->runtimeActivity (correctness)
-        if (floatTy && gutils->isConstantValue(orig_src)) {
+        bool zero = floatTy && gutils->isConstantValue(orig_src);
+
+        if (customEmit) {
+          if (!zero) {
+            if (dsrc->getType()->isIntegerTy())
+              dsrc = BuilderZ.CreateIntToPtr(dsrc,
+                                             getInt8PtrTy(dsrc->getContext()));
+            if (seg_start != 0)
+              dsrc = BuilderZ.CreateConstInBoundsGEP1_64(
+                  Type::getInt8Ty(ddst->getContext()), dsrc, seg_start);
+          }
+          customEmit(BuilderZ, ddst, zero ? nullptr : dsrc, length, zero);
+          return;
+        }
+
+        CallInst *call;
+        if (zero) {
           call = BuilderZ.CreateMemSet(
               ddst, ConstantInt::get(Type::getInt8Ty(ddst->getContext()), 0),
               length, dalign, isVolatile);
@@ -6377,6 +6405,12 @@ public:
 
   void handleMPI(llvm::CallInst &call, llvm::Function *called,
                  llvm::StringRef funcName);
+
+  /// Differentiate a member of the CUDA memcpy family. Returns false if the
+  /// transfer is not handled in the current mode, leaving the caller to report
+  /// the missing derivative.
+  bool handleCudaMemTransfer(llvm::CallInst &call, llvm::Function *called,
+                             const CudaMemTransferInfo &CMT);
 
   bool handleKnownCallDerivatives(llvm::CallInst &call, llvm::Function *called,
                                   llvm::StringRef funcName,

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -2211,6 +2211,173 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
   llvm_unreachable("Unhandled MPI FUNCTION");
 }
 
+bool AdjointGenerator::handleCudaMemTransfer(CallInst &call, Function *called,
+                                             const CudaMemTransferInfo &CMT) {
+  // Reversing a device-side transfer needs an accumulating copy that runs in
+  // device memory, which cannot be emitted from the host; leave those modes to
+  // report a missing derivative rather than silently getting them wrong.
+  if (Mode != DerivativeMode::ForwardMode &&
+      Mode != DerivativeMode::ForwardModeError)
+    return false;
+
+  auto &ctx = call.getContext();
+  auto M = gutils->newFunc->getParent();
+  auto *I8Ptr = getInt8PtrTy(ctx);
+  auto *I8 = Type::getInt8Ty(ctx);
+
+  Value *origDst = call.getArgOperand(0);
+  Value *origSrc = call.getArgOperand(1);
+  Value *newSize = gutils->getNewFromOriginal(call.getArgOperand(2));
+
+  Value *kind =
+      CMT.kindIdx >= 0
+          ? gutils->getNewFromOriginal(call.getArgOperand(CMT.kindIdx))
+          : nullptr;
+  Value *stream =
+      CMT.streamIdx >= 0
+          ? gutils->getNewFromOriginal(call.getArgOperand(CMT.streamIdx))
+          : nullptr;
+
+  // Everything past (dst, src, size) -- the transfer kind and/or stream -- is
+  // replayed unchanged onto the shadow transfer.
+  SmallVector<Value *, 2> trailing;
+  SmallVector<ValueType, 5> valtys = {ValueType::Shadow, ValueType::Shadow,
+                                      ValueType::Primal};
+  for (size_t i = 3; i < call.arg_size(); ++i) {
+    trailing.push_back(gutils->getNewFromOriginal(call.getArgOperand(i)));
+    valtys.push_back(ValueType::Primal);
+  }
+
+  IRBuilder<> BundleB(gutils->getNewFromOriginal(&call));
+  auto Defs = gutils->getInvertedBundles(&call, valtys, BundleB,
+                                         /*lookup*/ false);
+
+  // Shadows arrive as i8*; a CUdeviceptr argument is an integer instead.
+  auto toArgTy = [](IRBuilder<> &B, Value *V, Type *T) -> Value * {
+    if (V->getType() == T)
+      return V;
+    if (T->isIntegerTy())
+      return B.CreatePtrToInt(V, T);
+    if (V->getType()->isIntegerTy())
+      return B.CreateIntToPtr(V, T);
+    return B.CreatePointerCast(V, T);
+  };
+
+  // Zero `len` bytes of the shadow destination, used when the source is
+  // inactive float data. Which primitive applies depends on where the
+  // destination lives.
+  auto emitZero = [&](IRBuilder<> &B, Value *ddst, Value *len) {
+    CudaMemSpace dstSpace = CMT.dstSpace;
+    if (dstSpace == CudaMemSpace::FromKind) {
+      if (auto CI = dyn_cast<ConstantInt>(kind)) {
+        switch (CI->getZExtValue()) {
+        case CudaMemcpyHostToHost:
+        case CudaMemcpyDeviceToHost:
+          dstSpace = CudaMemSpace::Host;
+          break;
+        case CudaMemcpyHostToDevice:
+        case CudaMemcpyDeviceToDevice:
+          dstSpace = CudaMemSpace::Device;
+          break;
+        default:
+          // cudaMemcpyDefault leaves the direction to unified addressing.
+          break;
+        }
+      }
+    }
+
+    if (dstSpace == CudaMemSpace::Host) {
+      B.CreateMemSet(ddst, ConstantInt::get(I8, 0), len, MaybeAlign());
+      return;
+    }
+
+    if (dstSpace == CudaMemSpace::Device) {
+      SmallVector<Value *, 4> args;
+      StringRef memsetName;
+      if (CMT.isRuntimeAPI) {
+        // cudaMemset(void *devPtr, int value, size_t count[, stream])
+        memsetName = stream ? "cudaMemsetAsync" : "cudaMemset";
+        args.push_back(ddst);
+        args.push_back(ConstantInt::get(Type::getInt32Ty(ctx), 0));
+      } else {
+        // cuMemsetD8(CUdeviceptr dst, unsigned char uc, size_t N[, stream])
+        memsetName = stream ? "cuMemsetD8Async"
+                            : (CMT.isV2 ? "cuMemsetD8_v2" : "cuMemsetD8");
+        args.push_back(toArgTy(B, ddst, origDst->getType()));
+        args.push_back(ConstantInt::get(I8, 0));
+      }
+      args.push_back(len);
+      if (stream)
+        args.push_back(stream);
+
+      SmallVector<Type *, 4> tys;
+      for (auto a : args)
+        tys.push_back(a->getType());
+      auto F = getOrInsertPerCallingConv(
+          *M, called, memsetName,
+          FunctionType::get(call.getType(), tys, false));
+      B.CreateCall(F, args);
+      return;
+    }
+
+    // The direction is only known at runtime. Stage a zeroed host buffer and
+    // let the runtime route the copy, rewriting the kind so that the source
+    // side is the host buffer we just built.
+    assert(kind && "runtime-API transfer without a kind argument");
+    auto *sizeTy = len->getType();
+    auto MallocF = M->getOrInsertFunction("malloc", I8Ptr, sizeTy);
+    Value *buf = B.CreateCall(MallocF, {len});
+    B.CreateMemSet(buf, ConstantInt::get(I8, 0), len, MaybeAlign());
+
+    // Each operation is bound before it is used, so that the order the IR is
+    // emitted in does not depend on argument evaluation order.
+    auto *kindTy = kind->getType();
+    Value *isDtoD = B.CreateICmpEQ(
+        kind, ConstantInt::get(kindTy, CudaMemcpyDeviceToDevice));
+    Value *asHtoD = B.CreateSelect(
+        isDtoD, ConstantInt::get(kindTy, CudaMemcpyHostToDevice), kind);
+    Value *isDtoH =
+        B.CreateICmpEQ(kind, ConstantInt::get(kindTy, CudaMemcpyDeviceToHost));
+    Value *adjusted = B.CreateSelect(
+        isDtoH, ConstantInt::get(kindTy, CudaMemcpyHostToHost), asHtoD);
+
+    SmallVector<Value *, 5> args = {ddst, buf, len, adjusted};
+    if (stream)
+      args.push_back(stream);
+    B.CreateCall(called, args, Defs);
+
+    // An async copy must complete before the staging buffer goes away.
+    if (stream) {
+      auto SyncF = getOrInsertPerCallingConv(
+          *M, called, "cudaStreamSynchronize",
+          FunctionType::get(call.getType(), {stream->getType()}, false));
+      B.CreateCall(SyncF, {stream});
+    }
+    auto FreeF = M->getOrInsertFunction("free", Type::getVoidTy(ctx), I8Ptr);
+    B.CreateCall(FreeF, {buf});
+  };
+
+  auto emit = [&](IRBuilder<> &B, Value *ddst, Value *dsrc, Value *len,
+                  bool zero) {
+    if (zero) {
+      emitZero(B, ddst, len);
+      return;
+    }
+    SmallVector<Value *, 5> args = {toArgTy(B, ddst, origDst->getType()),
+                                    toArgTy(B, dsrc, origSrc->getType()), len};
+    args.append(trailing.begin(), trailing.end());
+    auto cal = B.CreateCall(called, args, Defs);
+    cal->setAttributes(call.getAttributes());
+    cal->setCallingConv(call.getCallingConv());
+    cal->setDebugLoc(gutils->getNewFromOriginal(call.getDebugLoc()));
+  };
+
+  visitMemTransferCommon(Intrinsic::memcpy, /*srcAlign*/ MaybeAlign(1),
+                         /*dstAlign*/ MaybeAlign(1), call, origDst, origSrc,
+                         newSize, ConstantInt::getFalse(ctx), emit);
+  return true;
+}
+
 bool AdjointGenerator::handleKnownCallDerivatives(
     CallInst &call, Function *called, StringRef funcName,
     bool subsequent_calls_may_write, const std::vector<bool> &overwritten_args,
@@ -3736,6 +3903,12 @@ bool AdjointGenerator::handleKnownCallDerivatives(
       funcName == "__memset_chk") {
     visitMemSetCommon(call);
     return true;
+  }
+  // CUDA transfers behave like a memcpy, except that the shadow copy has to go
+  // back through the CUDA API since at least one side lives in device memory.
+  if (auto CMT = extractCudaMemTransfer(funcName)) {
+    if (handleCudaMemTransfer(call, called, *CMT))
+      return true;
   }
   if (funcName == "enzyme_zerotype") {
     IRBuilder<> BuilderZ(&call);

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -3690,7 +3690,8 @@ void TypeAnalyzer::visitMemTransferInst(llvm::MemTransferInst &MTI) {
   visitMemTransferCommon(MTI);
 }
 
-void TypeAnalyzer::visitMemTransferCommon(llvm::CallBase &MTI) {
+void TypeAnalyzer::visitMemTransferCommon(llvm::CallBase &MTI,
+                                          unsigned intArgsEnd) {
   if (MTI.getType()->isIntegerTy()) {
     updateAnalysis(&MTI, TypeTree(BaseType::Integer).Only(-1, &MTI), &MTI);
   }
@@ -3748,11 +3749,11 @@ void TypeAnalyzer::visitMemTransferCommon(llvm::CallBase &MTI) {
   updateAnalysis(MTI.getArgOperand(0), res, &MTI);
   updateAnalysis(MTI.getArgOperand(1), res, &MTI);
 #if LLVM_VERSION_MAJOR >= 14
-  for (unsigned i = 2; i < MTI.arg_size(); ++i)
+  unsigned numArgs = MTI.arg_size();
 #else
-  for (unsigned i = 2; i < MTI.getNumArgOperands(); ++i)
+  unsigned numArgs = MTI.getNumArgOperands();
 #endif
-  {
+  for (unsigned i = 2; i < std::min(numArgs, intArgsEnd); ++i) {
     updateAnalysis(MTI.getArgOperand(i),
                    TypeTree(BaseType::Integer).Only(-1, &MTI), &MTI);
   }
@@ -5394,6 +5395,22 @@ void TypeAnalyzer::visitCallBase(CallBase &call) {
     if (funcName == "memcpy" || funcName == "memmove") {
       // TODO have this call common mem transfer to copy data
       visitMemTransferCommon(call);
+      return;
+    }
+    // The CUDA memcpy family shares memcpy's (dst, src, size) prefix, so the
+    // same propagation of the pointee type between the two sides applies.
+    if (auto CMT = extractCudaMemTransfer(funcName)) {
+      // A CUdeviceptr is an integer at the LLVM level, but both sides of a
+      // transfer are pointers regardless of which one lives on the device.
+      updateAnalysis(call.getOperand(0),
+                     TypeTree(BaseType::Pointer).Only(-1, &call), &call);
+      updateAnalysis(call.getOperand(1),
+                     TypeTree(BaseType::Pointer).Only(-1, &call), &call);
+      // The length, and the transfer kind if there is one, are integers; the
+      // stream that may follow them is a pointer, so stop before it.
+      unsigned intArgsEnd =
+          CMT->streamIdx >= 0 ? (unsigned)CMT->streamIdx : (unsigned)-1;
+      visitMemTransferCommon(call, intArgsEnd);
       return;
     }
     if (funcName == "posix_memalign") {

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.h
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.h
@@ -410,7 +410,12 @@ public:
   void visitCallBase(llvm::CallBase &call);
 
   void visitMemTransferInst(llvm::MemTransferInst &MTI);
-  void visitMemTransferCommon(llvm::CallBase &MTI);
+  /// Propagate the pointee type between the two sides of a memory transfer.
+  /// Arguments from index 2 up to `intArgsEnd` are marked as integers; the
+  /// bound exists because a CUDA transfer carries a stream pointer after its
+  /// integer arguments, where a memcpy carries only the length and volatility.
+  void visitMemTransferCommon(llvm::CallBase &MTI,
+                              unsigned intArgsEnd = (unsigned)-1);
 
   void visitIntrinsicInst(llvm::IntrinsicInst &II);
 

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -3751,6 +3751,65 @@ llvm::Optional<BlasInfo> extractBLAS(llvm::StringRef in)
   return {};
 }
 
+#if LLVM_VERSION_MAJOR >= 16
+std::optional<CudaMemTransferInfo> extractCudaMemTransfer(llvm::StringRef in) {
+#else
+llvm::Optional<CudaMemTransferInfo> extractCudaMemTransfer(llvm::StringRef in) {
+#endif
+  // Driver API. The direction is baked into the name, and each entry point
+  // exists both with and without the "_v2" ABI suffix. CUdeviceptr arguments
+  // are plain integers rather than pointers.
+  struct DriverEntry {
+    const char *stem;
+    CudaMemSpace dst;
+    CudaMemSpace src;
+  };
+  static const DriverEntry DriverEntries[] = {
+      {"cuMemcpyHtoD", CudaMemSpace::Device, CudaMemSpace::Host},
+      {"cuMemcpyDtoH", CudaMemSpace::Host, CudaMemSpace::Device},
+      {"cuMemcpyDtoD", CudaMemSpace::Device, CudaMemSpace::Device},
+      // Unified-addressing copy: both sides are CUdeviceptr.
+      {"cuMemcpy", CudaMemSpace::Device, CudaMemSpace::Device},
+  };
+
+  for (auto &E : DriverEntries) {
+    for (bool async : {false, true}) {
+      for (bool v2 : {false, true}) {
+        // The unified-addressing cuMemcpy/cuMemcpyAsync have no _v2 form.
+        if (v2 && llvm::StringRef(E.stem) == "cuMemcpy")
+          continue;
+        std::string name =
+            (llvm::Twine(E.stem) + (async ? "Async" : "") + (v2 ? "_v2" : ""))
+                .str();
+        if (in != name)
+          continue;
+        return CudaMemTransferInfo{E.dst,
+                                   E.src,
+                                   /*kindIdx*/ -1,
+                                   async ? 3 : -1,
+                                   /*isRuntimeAPI*/ false,
+                                   v2};
+      }
+    }
+  }
+
+  // Runtime API. The direction is a runtime cudaMemcpyKind argument.
+  if (in == "cudaMemcpy")
+    return CudaMemTransferInfo{CudaMemSpace::FromKind, CudaMemSpace::FromKind,
+                               /*kindIdx*/ 3,
+                               /*streamIdx*/ -1,
+                               /*isRuntimeAPI*/ true,
+                               /*isV2*/ false};
+  if (in == "cudaMemcpyAsync")
+    return CudaMemTransferInfo{CudaMemSpace::FromKind, CudaMemSpace::FromKind,
+                               /*kindIdx*/ 3,
+                               /*streamIdx*/ 4,
+                               /*isRuntimeAPI*/ true,
+                               /*isV2*/ false};
+
+  return {};
+}
+
 llvm::Constant *getUndefinedValueForType(llvm::Module &M, llvm::Type *T,
                                          bool forceZero) {
   if (EnzymeUndefinedValueForType)

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -804,6 +804,50 @@ std::optional<BlasInfo> extractBLAS(llvm::StringRef in);
 llvm::Optional<BlasInfo> extractBLAS(llvm::StringRef in);
 #endif
 
+/// Which address space one side of a CUDA memory transfer lives in.
+enum class CudaMemSpace {
+  Host,
+  Device,
+  /// Only known from the cudaMemcpyKind argument of a runtime-API call.
+  FromKind,
+};
+
+/// A member of the CUDA memcpy family. Every such entry point -- both the
+/// driver API (cuMemcpy*) and the runtime API (cudaMemcpy*) -- takes
+/// (dst, src, size) as its leading arguments; the trailing arguments (transfer
+/// kind and/or stream) are replayed unchanged when differentiating.
+struct CudaMemTransferInfo {
+  /// Address space of the destination, as implied by the function name.
+  CudaMemSpace dstSpace;
+  /// Address space of the source, as implied by the function name.
+  CudaMemSpace srcSpace;
+  /// Argument index of the cudaMemcpyKind, or -1 for the driver API.
+  int kindIdx;
+  /// Argument index of the stream, or -1 if the transfer is synchronous.
+  int streamIdx;
+  /// True for the runtime API (cudaMemcpy*), false for the driver API.
+  bool isRuntimeAPI;
+  /// Whether the driver-API name carries the "_v2" ABI suffix, so that the
+  /// memset we emit alongside it targets the same ABI.
+  bool isV2;
+};
+
+/// If `in` names a member of the CUDA memcpy family, describe it.
+#if LLVM_VERSION_MAJOR >= 16
+std::optional<CudaMemTransferInfo> extractCudaMemTransfer(llvm::StringRef in);
+#else
+llvm::Optional<CudaMemTransferInfo> extractCudaMemTransfer(llvm::StringRef in);
+#endif
+
+/// Values of the CUDA runtime API's cudaMemcpyKind enum.
+enum CudaMemcpyKind {
+  CudaMemcpyHostToHost = 0,
+  CudaMemcpyHostToDevice = 1,
+  CudaMemcpyDeviceToHost = 2,
+  CudaMemcpyDeviceToDevice = 3,
+  CudaMemcpyDefault = 4,
+};
+
 std::vector<std::tuple<llvm::Type *, size_t, size_t>>
 parseTrueType(const llvm::MDNode *, DerivativeMode, bool const_src);
 

--- a/enzyme/test/Enzyme/ForwardMode/cuda/memcpy_driver.ll
+++ b/enzyme/test/Enzyme/ForwardMode/cuda/memcpy_driver.ll
@@ -1,0 +1,64 @@
+; RUN: if [ %llvmver -ge 15 ]; then %opt < %s %OPnewLoadEnzyme -enzyme-preopt=false -passes="enzyme" -S | FileCheck %s; fi
+
+; A round trip of a double through device memory: host -> device -> host. The
+; derivative has to repeat every transfer on the shadow buffers, which means
+; calling back into the CUDA driver API rather than emitting an LLVM memcpy.
+
+declare i32 @cuMemAlloc_v2(ptr, i64)
+declare i32 @cuMemFree_v2(i64)
+declare i32 @cuMemcpyHtoD_v2(i64, ptr, i64)
+declare i32 @cuMemcpyDtoH_v2(ptr, i64, i64)
+
+define double @roundtrip(ptr %host) {
+entry:
+  %devp = alloca i64
+  %a = call i32 @cuMemAlloc_v2(ptr %devp, i64 8)
+  %dev = load i64, ptr %devp
+  %c1 = call i32 @cuMemcpyHtoD_v2(i64 %dev, ptr %host, i64 8)
+  %out = alloca double
+  %c2 = call i32 @cuMemcpyDtoH_v2(ptr %out, i64 %dev, i64 8)
+  %v = load double, ptr %out
+  %fr = call i32 @cuMemFree_v2(i64 %dev)
+  ret double %v
+}
+
+declare double @__enzyme_fwddiff(...)
+
+define double @test(ptr %host, ptr %dhost) {
+  %r = call double (...) @__enzyme_fwddiff(ptr @roundtrip, metadata !"enzyme_dup", ptr %host, ptr %dhost)
+  ret double %r
+}
+
+; CHECK: define internal double @fwddifferoundtrip(ptr %host, ptr %"host'")
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %"devp'ipa" = alloca i64
+; CHECK-NEXT:   store i64 0, ptr %"devp'ipa"
+; CHECK-NEXT:   %devp = alloca i64
+; CHECK-NEXT:   %{{.+}} = call i32 @cuMemAlloc_v2(ptr %"devp'ipa", i64 8)
+; CHECK-NEXT:   %[[shadowdev:.+]] = load ptr, ptr %"devp'ipa"
+; CHECK-NEXT:   %{{.+}} = call i32 @cuMemsetD8_v2(ptr nonnull %[[shadowdev]], i8 0, i64 8)
+; CHECK-NEXT:   %a = call i32 @cuMemAlloc_v2(ptr %devp, i64 8)
+; CHECK-NEXT:   %"dev'ipl" = load i64, ptr %"devp'ipa"
+; CHECK-NEXT:   %dev = load i64, ptr %devp
+; CHECK-NEXT:   %[[h1:.+]] = inttoptr i64 %"dev'ipl" to ptr
+; CHECK-NEXT:   %[[h2:.+]] = ptrtoint ptr %[[h1]] to i64
+; CHECK-NEXT:   %{{.+}} = call i32 @cuMemcpyHtoD_v2(i64 %[[h2]], ptr %"host'", i64 8)
+; CHECK-NEXT:   %c1 = call i32 @cuMemcpyHtoD_v2(i64 %dev, ptr %host, i64 8)
+; CHECK-NEXT:   %"out'ipa" = alloca double
+; CHECK-NEXT:   store double 0.000000e+00, ptr %"out'ipa"
+; CHECK-NEXT:   %out = alloca double
+; CHECK-NEXT:   %[[d1:.+]] = inttoptr i64 %"dev'ipl" to ptr
+; CHECK-NEXT:   %[[d2:.+]] = ptrtoint ptr %[[d1]] to i64
+; CHECK-NEXT:   %{{.+}} = call i32 @cuMemcpyDtoH_v2(ptr %"out'ipa", i64 %[[d2]], i64 8)
+; CHECK-NEXT:   %c2 = call i32 @cuMemcpyDtoH_v2(ptr %out, i64 %dev, i64 8)
+; CHECK-NEXT:   %"v'ipl" = load double, ptr %"out'ipa"
+; CHECK-NEXT:   %fr = call i32 @cuMemFree_v2(i64 %dev)
+; CHECK-NEXT:   %{{.+}} = icmp ne i64 %dev, %"dev'ipl"
+; CHECK-NEXT:   br i1 %{{.+}}, label %free0.i, label %__enzyme_checked_free_1_cuMemFree_v2.exit
+
+; CHECK: free0.i:
+; CHECK-NEXT:   %{{.+}} = call i32 @cuMemFree_v2(i64 %"dev'ipl")
+; CHECK-NEXT:   br label %__enzyme_checked_free_1_cuMemFree_v2.exit
+
+; CHECK: __enzyme_checked_free_1_cuMemFree_v2.exit:
+; CHECK-NEXT:   ret double %"v'ipl"

--- a/enzyme/test/Enzyme/ForwardMode/cuda/memcpy_renamed.ll
+++ b/enzyme/test/Enzyme/ForwardMode/cuda/memcpy_renamed.ll
@@ -1,0 +1,39 @@
+; RUN: if [ %llvmver -ge 15 ]; then %opt < %s %OPnewLoadEnzyme -enzyme-preopt=false -passes="enzyme" -S | FileCheck %s; fi
+
+; Julia reaches the CUDA driver through lazily bound declarations named
+; "ejlstr$<function>$<library>", tagging them with the real entry point in
+; enzyme_math. Any helper Enzyme introduces alongside them (here the memset
+; that zeroes a freshly allocated shadow buffer) has to follow the same naming
+; convention, or it will not resolve when the module is JIT linked.
+
+declare i32 @"ejlstr$cuMemAlloc_v2$libcuda.so.1"(ptr, i64) "enzyme_math"="cuMemAlloc_v2"
+declare i32 @"ejlstr$cuMemFree_v2$libcuda.so.1"(i64) "enzyme_math"="cuMemFree_v2"
+declare i32 @"ejlstr$cuMemcpyHtoD_v2$libcuda.so.1"(i64, ptr, i64) "enzyme_math"="cuMemcpyHtoD_v2"
+declare i32 @"ejlstr$cuMemcpyDtoH_v2$libcuda.so.1"(ptr, i64, i64) "enzyme_math"="cuMemcpyDtoH_v2"
+
+define double @roundtrip(ptr %host) {
+entry:
+  %devp = alloca i64
+  %a = call i32 @"ejlstr$cuMemAlloc_v2$libcuda.so.1"(ptr %devp, i64 8)
+  %dev = load i64, ptr %devp
+  %c1 = call i32 @"ejlstr$cuMemcpyHtoD_v2$libcuda.so.1"(i64 %dev, ptr %host, i64 8)
+  %out = alloca double
+  %c2 = call i32 @"ejlstr$cuMemcpyDtoH_v2$libcuda.so.1"(ptr %out, i64 %dev, i64 8)
+  %v = load double, ptr %out
+  %fr = call i32 @"ejlstr$cuMemFree_v2$libcuda.so.1"(i64 %dev)
+  ret double %v
+}
+
+declare double @__enzyme_fwddiff(...)
+
+define double @test(ptr %host, ptr %dhost) {
+  %r = call double (...) @__enzyme_fwddiff(ptr @roundtrip, metadata !"enzyme_dup", ptr %host, ptr %dhost)
+  ret double %r
+}
+
+; CHECK: define internal double @fwddifferoundtrip(ptr %host, ptr %"host'")
+; CHECK: call i32 @"ejlstr$cuMemsetD8_v2$libcuda.so.1"(
+; CHECK: call i32 @"ejlstr$cuMemcpyHtoD_v2$libcuda.so.1"(i64 %{{.+}}, ptr %"host'", i64 8)
+; CHECK: call i32 @"ejlstr$cuMemcpyDtoH_v2$libcuda.so.1"(ptr %"out'ipa", i64 %{{.+}}, i64 8)
+; CHECK: %"v'ipl" = load double, ptr %"out'ipa"
+; CHECK: call i32 @"ejlstr$cuMemFree_v2$libcuda.so.1"(i64 %"dev'ipl")

--- a/enzyme/test/Enzyme/ForwardMode/cuda/memcpy_runtime.ll
+++ b/enzyme/test/Enzyme/ForwardMode/cuda/memcpy_runtime.ll
@@ -1,0 +1,38 @@
+; RUN: if [ %llvmver -ge 15 ]; then %opt < %s %OPnewLoadEnzyme -enzyme-preopt=false -passes="enzyme" -S | FileCheck %s; fi
+
+; Same round trip as memcpy_driver.ll, but through the CUDA runtime API, where
+; the direction of the transfer is a cudaMemcpyKind argument that is replayed
+; unchanged on the shadow.
+
+declare i32 @cudaMalloc(ptr, i64)
+declare i32 @cudaFree(ptr)
+declare i32 @cudaMemcpy(ptr, ptr, i64, i32)
+
+define double @roundtrip(ptr %host) {
+entry:
+  %devp = alloca ptr
+  %a = call i32 @cudaMalloc(ptr %devp, i64 8)
+  %dev = load ptr, ptr %devp
+  ; cudaMemcpyHostToDevice
+  %c1 = call i32 @cudaMemcpy(ptr %dev, ptr %host, i64 8, i32 1)
+  %out = alloca double
+  ; cudaMemcpyDeviceToHost
+  %c2 = call i32 @cudaMemcpy(ptr %out, ptr %dev, i64 8, i32 2)
+  %v = load double, ptr %out
+  %fr = call i32 @cudaFree(ptr %dev)
+  ret double %v
+}
+
+declare double @__enzyme_fwddiff(...)
+
+define double @test(ptr %host, ptr %dhost) {
+  %r = call double (...) @__enzyme_fwddiff(ptr @roundtrip, metadata !"enzyme_dup", ptr %host, ptr %dhost)
+  ret double %r
+}
+
+; CHECK: define internal double @fwddifferoundtrip(ptr %host, ptr %"host'")
+; CHECK: %{{.+}} = call i32 @cudaMemcpy(ptr %[[shadowdev:.+]], ptr %"host'", i64 8, i32 1)
+; CHECK-NEXT: %c1 = call i32 @cudaMemcpy(ptr %dev, ptr %host, i64 8, i32 1)
+; CHECK: %{{.+}} = call i32 @cudaMemcpy(ptr %"out'ipa", ptr %[[shadowdev]], i64 8, i32 2)
+; CHECK-NEXT: %c2 = call i32 @cudaMemcpy(ptr %out, ptr %dev, i64 8, i32 2)
+; CHECK: %"v'ipl" = load double, ptr %"out'ipa"

--- a/enzyme/test/Integration/ForwardMode/cudamemcpy.cpp
+++ b/enzyme/test/Integration/ForwardMode/cudamemcpy.cpp
@@ -1,0 +1,96 @@
+// RUN: if [ %llvmver -ge 12 ]; then %clang++ -fno-exceptions -std=c++11 -O0 %s -S -emit-llvm -o - %loadClangEnzyme | %lli -; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang++ -fno-exceptions -std=c++11 -O1 %s -S -emit-llvm -o - %loadClangEnzyme | %lli -; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang++ -fno-exceptions -std=c++11 -O2 %s -S -emit-llvm -o - %loadClangEnzyme | %lli -; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang++ -fno-exceptions -std=c++11 -O3 %s -S -emit-llvm -o - %loadClangEnzyme | %lli -; fi
+// RUN: if [ %llvmver -ge 12 ]; then %clang++ -fno-exceptions -std=c++11 -O2 %s -S -emit-llvm -o - %loadClangEnzyme -mllvm -enzyme-inline=1 | %lli -; fi
+
+// Forward-mode differentiation of code that stages data through the CUDA
+// runtime API. The device side is emulated on the host -- what matters is that
+// Enzyme repeats every transfer on the shadow buffers by calling back into the
+// same CUDA entry points, so the tangent follows the data.
+
+#include "../test_utils.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+extern "C" {
+
+enum cudaMemcpyKind {
+  cudaMemcpyHostToHost = 0,
+  cudaMemcpyHostToDevice = 1,
+  cudaMemcpyDeviceToHost = 2,
+  cudaMemcpyDeviceToDevice = 3,
+  cudaMemcpyDefault = 4,
+};
+
+// Count the transfers so the test can tell that the shadow ones really happen.
+int num_htod = 0;
+int num_dtoh = 0;
+
+__attribute__((noinline)) int cudaMalloc(void **ptr, size_t size) {
+  *ptr = malloc(size);
+  return 0;
+}
+
+__attribute__((noinline)) int cudaFree(void *ptr) {
+  free(ptr);
+  return 0;
+}
+
+__attribute__((noinline)) int cudaMemset(void *dst, int v, size_t n) {
+  memset(dst, v, n);
+  return 0;
+}
+
+__attribute__((noinline)) int cudaMemcpy(void *dst, const void *src, size_t n,
+                                         cudaMemcpyKind kind) {
+  if (kind == cudaMemcpyHostToDevice)
+    num_htod++;
+  if (kind == cudaMemcpyDeviceToHost)
+    num_dtoh++;
+  memcpy(dst, src, n);
+  return 0;
+}
+}
+
+// x -> device -> back to host, then summed as squares.
+__attribute__((noinline)) double staged_sum(const double *x, size_t n) {
+  void *dev;
+  cudaMalloc(&dev, n * sizeof(double));
+  cudaMemcpy(dev, x, n * sizeof(double), cudaMemcpyHostToDevice);
+
+  double *scratch = (double *)malloc(n * sizeof(double));
+  cudaMemcpy(scratch, dev, n * sizeof(double), cudaMemcpyDeviceToHost);
+
+  double res = 0;
+  for (size_t i = 0; i < n; i++)
+    res += scratch[i] * scratch[i];
+
+  free(scratch);
+  cudaFree(dev);
+  return res;
+}
+
+extern double __enzyme_fwddiff(void *, ...);
+
+int main() {
+  const size_t N = 4;
+  double x[N] = {1.0, 2.0, 3.0, 4.0};
+  double dx[N] = {1.0, 0.0, 0.0, 0.0};
+
+  // d/dx sum(x_i^2) contracted with dx == 2 * (x . dx) == 2 * 1.0 == 2.0
+  double dres = __enzyme_fwddiff((void *)staged_sum, x, dx, N);
+  APPROX_EQ(dres, 2.0, 1e-10);
+
+  // Both the primal and the shadow have to be transferred each way.
+  APPROX_EQ((double)num_htod, 2.0, 1e-10);
+  APPROX_EQ((double)num_dtoh, 2.0, 1e-10);
+
+  double dx2[N] = {0.0, 1.0, 1.0, 0.0};
+  // 2 * (2*1 + 3*1) == 10
+  double dres2 = __enzyme_fwddiff((void *)staged_sum, x, dx2, N);
+  APPROX_EQ(dres2, 10.0, 1e-10);
+
+  return 0;
+}


### PR DESCRIPTION
Neither the driver API (`cuMemcpy{HtoD,DtoH,DtoD}[Async][_v2]`, and the unified
`cuMemcpy[Async]`) nor the runtime API (`cudaMemcpy[Async]`) had a derivative,
so staging data through device memory failed outright. This is the error
reported in EnzymeAD/Enzyme.jl#3442:

```
No forward mode derivative found for cuMemcpyDtoHAsync_v2
```

A CUDA transfer behaves exactly like a memcpy, except that the shadow copy has
to go back through the CUDA API rather than becoming an `llvm.memcpy`, since at
least one side generally lives in memory the host cannot address. So rather
than a parallel implementation, `visitMemTransferCommon` grows an optional
emitter hook: the CUDA path reuses its type segmentation, activity handling and
zeroing of inactive float sources, and only the emission of the copy differs.

Type analysis learns to propagate the pointee type between the two sides, that
a `CUdeviceptr` is a pointer despite being an integer, and to stop marking
trailing arguments as integers before the stream pointer a CUDA transfer
carries where a memcpy carries only volatility.

Reverse mode still reports a missing derivative rather than answering
incorrectly; accumulating into device memory needs a copy that runs on the
device, which cannot be emitted from the host.

### Testing

Three lit tests — driver API, runtime API, and the `ejlstr$fn$lib` naming a
frontend may use — plus `Integration/ForwardMode/cudamemcpy.cpp`, which checks
the tangent numerically against a mocked CUDA runtime and confirms both the
primal and the shadow are transferred each way. Passes `-O0` through `-O3`.

Full unit suite on LLVM 16: 1193 pass, 11 xfail, 1 fail — that failure is
`ReverseModeVector/partial_int_window.ll`, which fails identically on unmodified
`main` with this local LLVM 16 build. Format (clang-format 16) and
`check_emission_order.py` clean.

### Relationship to the other PRs

Split up at review request; this one is now just the transfer derivatives.

* #3111 (merged) — `getOrInsertPerCallingConv` and the pre-existing call sites
  that needed it.
* #3112 (merged) — recognizing the CUDA deallocations, which these tests rely on
  because they free the device buffers they allocate.
* #3113 — the cuBLAS `_v2` forward-mode scalar result. Independent of this;
  can land in either order.

Remaining gaps in EnzymeAD/Enzyme.jl#3442 after all four: `cublasGemmEx` is not
recognized by `extractBLAS`; a forward-mode shadow placeholder for a `cmpxchg`
result is never replaced, tripping the verifier inside CUDA.jl's memory pool;
and the shadow chain for a `CuArray` breaks at `Managed{DeviceMemory}`, which is
type-inactive because `DeviceMemory` is an untyped byte buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6a8BiaAKpUTgP86mQ9ZKP