### PR TITLE
Utils: read argument-memory effects in isReadOnly/isWriteOnly

### DIFF
--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -1763,12 +1763,18 @@ static inline bool isReadOnly(const llvm::Function *F, ssize_t arg = -1) {
         F->hasParamAttribute(arg, llvm::Attribute::ReadNone))
       return true;
 #if LLVM_VERSION_MAJOR >= 16
-    // Later LLVM folds readonly/readnone into the memory(...) attribute,
-    // whose per-location effects can also say argument memory is only read
-    // even when the function writes elsewhere.
-    if (!llvm::isModSet(F->getMemoryEffects().getModRef(
-            llvm::MemoryEffects::Location::ArgMem)))
-      return true;
+    // Later LLVM folds readonly/readnone into the memory(...) attribute. The
+    // argument's bytes must not be written through the argument pointers
+    // (ArgMem) nor through anything else that could alias them (Other);
+    // inaccessible memory cannot alias an argument, so it alone may be
+    // written.
+    {
+      auto ME = F->getMemoryEffects();
+      if (!llvm::isModSet(
+              ME.getModRef(llvm::MemoryEffects::Location::ArgMem)) &&
+          !llvm::isModSet(ME.getModRef(llvm::MemoryEffects::Location::Other)))
+        return true;
+    }
 #endif
     // if (F->getAttributes().hasParamAttribute(arg, "enzyme_ReadOnly") ||
     //     F->getAttributes().hasParamAttribute(arg, "enzyme_ReadNone"))
@@ -1785,12 +1791,16 @@ static inline bool isReadOnly(const llvm::CallBase *call, ssize_t arg = -1) {
 #if LLVM_VERSION_MAJOR >= 16
   if (arg != -1) {
     // Use the callee's effects only under a matching calling convention,
-    // for the same reason as the attribute path below.
+    // for the same reason as the attribute path below. As above, both the
+    // argument-memory and aliasable-other locations must be write-free.
     auto F2 = getFunctionFromCall(call);
-    if (!F2 || F2->getCallingConv() == call->getCallingConv())
-      if (!llvm::isModSet(call->getMemoryEffects().getModRef(
-              llvm::MemoryEffects::Location::ArgMem)))
+    if (!F2 || F2->getCallingConv() == call->getCallingConv()) {
+      auto ME = call->getMemoryEffects();
+      if (!llvm::isModSet(
+              ME.getModRef(llvm::MemoryEffects::Location::ArgMem)) &&
+          !llvm::isModSet(ME.getModRef(llvm::MemoryEffects::Location::Other)))
         return true;
+    }
   }
 #endif
 
@@ -1898,12 +1908,16 @@ static inline bool isWriteOnly(const llvm::Function *F, ssize_t arg = -1) {
         F->hasParamAttribute(arg, llvm::Attribute::ReadNone))
       return true;
 #if LLVM_VERSION_MAJOR >= 16
-    // As in isReadOnly: the memory(...) attribute's per-location effects can
-    // say argument memory is never read even when the function reads
-    // elsewhere.
-    if (!llvm::isRefSet(F->getMemoryEffects().getModRef(
-            llvm::MemoryEffects::Location::ArgMem)))
-      return true;
+    // As in isReadOnly: the argument's bytes must be unread both through the
+    // argument pointers and through anything that could alias them; only
+    // inaccessible memory may be read.
+    {
+      auto ME = F->getMemoryEffects();
+      if (!llvm::isRefSet(
+              ME.getModRef(llvm::MemoryEffects::Location::ArgMem)) &&
+          !llvm::isRefSet(ME.getModRef(llvm::MemoryEffects::Location::Other)))
+        return true;
+    }
 #endif
   }
   return false;
@@ -1918,10 +1932,13 @@ static inline bool isWriteOnly(const llvm::CallBase *call, ssize_t arg = -1) {
 #if LLVM_VERSION_MAJOR >= 16
   if (arg != -1) {
     auto F2 = getFunctionFromCall(call);
-    if (!F2 || F2->getCallingConv() == call->getCallingConv())
-      if (!llvm::isRefSet(call->getMemoryEffects().getModRef(
-              llvm::MemoryEffects::Location::ArgMem)))
+    if (!F2 || F2->getCallingConv() == call->getCallingConv()) {
+      auto ME = call->getMemoryEffects();
+      if (!llvm::isRefSet(
+              ME.getModRef(llvm::MemoryEffects::Location::ArgMem)) &&
+          !llvm::isRefSet(ME.getModRef(llvm::MemoryEffects::Location::Other)))
         return true;
+    }
   }
 #endif
 #else

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -1762,6 +1762,14 @@ static inline bool isReadOnly(const llvm::Function *F, ssize_t arg = -1) {
     if (F->hasParamAttribute(arg, llvm::Attribute::ReadOnly) ||
         F->hasParamAttribute(arg, llvm::Attribute::ReadNone))
       return true;
+#if LLVM_VERSION_MAJOR >= 16
+    // Later LLVM folds readonly/readnone into the memory(...) attribute,
+    // whose per-location effects can also say argument memory is only read
+    // even when the function writes elsewhere.
+    if (!llvm::isModSet(F->getMemoryEffects().getModRef(
+            llvm::MemoryEffects::Location::ArgMem)))
+      return true;
+#endif
     // if (F->getAttributes().hasParamAttribute(arg, "enzyme_ReadOnly") ||
     //     F->getAttributes().hasParamAttribute(arg, "enzyme_ReadNone"))
     //   return true;
@@ -1774,6 +1782,17 @@ static inline bool isReadOnly(const llvm::CallBase *call, ssize_t arg = -1) {
     return true;
   if (arg != -1 && call->onlyReadsMemory(arg))
     return true;
+#if LLVM_VERSION_MAJOR >= 16
+  if (arg != -1) {
+    // Use the callee's effects only under a matching calling convention,
+    // for the same reason as the attribute path below.
+    auto F2 = getFunctionFromCall(call);
+    if (!F2 || F2->getCallingConv() == call->getCallingConv())
+      if (!llvm::isModSet(call->getMemoryEffects().getModRef(
+              llvm::MemoryEffects::Location::ArgMem)))
+        return true;
+  }
+#endif
 
   if (auto F = getFunctionFromCall(call)) {
     // Do not use function attrs for if different calling conv, such as a julia
@@ -1878,6 +1897,14 @@ static inline bool isWriteOnly(const llvm::Function *F, ssize_t arg = -1) {
     if (F->hasParamAttribute(arg, llvm::Attribute::WriteOnly) ||
         F->hasParamAttribute(arg, llvm::Attribute::ReadNone))
       return true;
+#if LLVM_VERSION_MAJOR >= 16
+    // As in isReadOnly: the memory(...) attribute's per-location effects can
+    // say argument memory is never read even when the function reads
+    // elsewhere.
+    if (!llvm::isRefSet(F->getMemoryEffects().getModRef(
+            llvm::MemoryEffects::Location::ArgMem)))
+      return true;
+#endif
   }
   return false;
 }
@@ -1888,6 +1915,15 @@ static inline bool isWriteOnly(const llvm::CallBase *call, ssize_t arg = -1) {
     return true;
   if (arg != -1 && call->onlyWritesMemory(arg))
     return true;
+#if LLVM_VERSION_MAJOR >= 16
+  if (arg != -1) {
+    auto F2 = getFunctionFromCall(call);
+    if (!F2 || F2->getCallingConv() == call->getCallingConv())
+      if (!llvm::isRefSet(call->getMemoryEffects().getModRef(
+              llvm::MemoryEffects::Location::ArgMem)))
+        return true;
+  }
+#endif
 #else
   if (call->hasFnAttr(llvm::Attribute::WriteOnly) ||
       call->hasFnAttr(llvm::Attribute::ReadNone))

--- a/enzyme/test/Enzyme/ReverseMode/argmemro.ll
+++ b/enzyme/test/Enzyme/ReverseMode/argmemro.ll
@@ -1,0 +1,41 @@
+; RUN: if [ %llvmver -ge 16 ]; then %opt < %s %newLoadEnzyme -passes="enzyme" -enzyme-preopt=false -S | FileCheck %s; fi
+
+; A call whose memory(...) attribute leaves argument memory read-only does
+; not write the active slot it is handed, even when the function may write
+; elsewhere -- so an inactive observer between the store and the load needs
+; no derivative, and the reverse pass may recompute the load from the
+; primal instead of demanding one.
+
+declare void @observe(double* nocapture) "enzyme_inactive" nofree memory(argmem: read, inaccessiblemem: readwrite)
+
+define double @sumsq(double* %arr, i64 %n) {
+entry:
+  br label %loop
+
+loop:
+  %i = phi i64 [ 0, %entry ], [ %inext, %loop ]
+  %sum = phi double [ 0.000000e+00, %entry ], [ %sum2, %loop ]
+  %g = getelementptr inbounds double, double* %arr, i64 %i
+  call void @observe(double* %g)
+  %v = load double, double* %g, align 8
+  %sq = fmul double %v, %v
+  %sum2 = fadd double %sum, %sq
+  %inext = add nuw nsw i64 %i, 1
+  %cmp = icmp eq i64 %inext, %n
+  br i1 %cmp, label %exit, label %loop
+
+exit:
+  ret double %sum2
+}
+
+declare double @__enzyme_autodiff(...)
+
+define double @dsumsq(double* %arr, double* %darr, i64 %n) {
+entry:
+  %r = call double (...) @__enzyme_autodiff(double (double*, i64)* @sumsq, metadata !"enzyme_dup", double* %arr, double* %darr, i64 %n)
+  ret double %r
+}
+
+; CHECK: define internal void @diffesumsq(ptr readonly captures(none) %arr, ptr captures(none) %"arr'", i64 %n, double %differeturn)
+; CHECK: %v_unwrap = load double, ptr %g_unwrap
+; CHECK: %"g'ipg_unwrap" = getelementptr inbounds double, ptr %"arr'"

--- a/enzyme/test/Enzyme/ReverseMode/argmemro.ll
+++ b/enzyme/test/Enzyme/ReverseMode/argmemro.ll
@@ -36,6 +36,54 @@ entry:
   ret double %r
 }
 
-; CHECK: define internal void @diffesumsq(ptr readonly captures(none) %arr, ptr captures(none) %"arr'", i64 %n, double %differeturn)
-; CHECK: %v_unwrap = load double, ptr %g_unwrap
-; CHECK: %"g'ipg_unwrap" = getelementptr inbounds double, ptr %"arr'"
+; A second observer whose unlisted "other" memory may be written: even though
+; argument memory itself is read-only, the written other memory can alias the
+; bytes the argument points to, so the loaded value cannot be recomputed in
+; the reverse pass -- it must be cached from the forward pass instead.
+
+; enzyme_no_escaping_allocation keeps the check about caching: without it,
+; opaque-pointer IR cannot rule out an allocation being stored into the
+; argument (typed IR can, from the pointee type), and the inactive fallback
+; is skipped altogether on newer LLVM.
+declare void @observe2(double* nocapture) "enzyme_inactive" "enzyme_no_escaping_allocation" nofree memory(readwrite, argmem: read)
+
+define double @sumsq2(double* %arr, i64 %n) {
+entry:
+  br label %loop
+
+loop:
+  %i = phi i64 [ 0, %entry ], [ %inext, %loop ]
+  %sum = phi double [ 0.000000e+00, %entry ], [ %sum2, %loop ]
+  %g = getelementptr inbounds double, double* %arr, i64 %i
+  call void @observe2(double* %g)
+  %v = load double, double* %g, align 8
+  %sq = fmul double %v, %v
+  %sum2 = fadd double %sum, %sq
+  %inext = add nuw nsw i64 %i, 1
+  %cmp = icmp eq i64 %inext, %n
+  br i1 %cmp, label %exit, label %loop
+
+exit:
+  ret double %sum2
+}
+
+define double @dsumsq2(double* %arr, double* %darr, i64 %n) {
+entry:
+  %r = call double (...) @__enzyme_autodiff(double (double*, i64)* @sumsq2, metadata !"enzyme_dup", double* %arr, double* %darr, i64 %n)
+  ret double %r
+}
+
+; The attribute spelling of the arguments differs between typed-pointer
+; (LLVM 16, "double* nocapture readonly") and opaque-pointer IR
+; ("ptr readonly captures(none)"), so the arguments are matched loosely.
+
+; CHECK: define internal void @diffesumsq({{.*}} %arr, {{.*}} %"arr'", i64 %n, double %differeturn)
+; CHECK: %v_unwrap = load double, {{(double\*|ptr)}} %g_unwrap
+; CHECK: %"g'ipg_unwrap" = getelementptr inbounds double, {{(double\*|ptr)}} %"arr'"
+
+; The observe2 version caches %v in the forward loop rather than reloading it
+; in the reverse.
+; CHECK: define internal void @diffesumsq2({{.*}} %arr, {{.*}} %"arr'", i64 %n, double %differeturn)
+; CHECK: @malloc(
+; CHECK: %[[v2:.+]] = load double, {{(double\*|ptr)}} %g
+; CHECK: store double %[[v2]], {{(double\*|ptr)}} %


### PR DESCRIPTION
Later LLVM folds `readonly`/`readnone` into the `memory(...)` attribute, and its per-location effects can say argument memory is only read (or only written) even when the function touches other memory. `isReadOnly` and `isWriteOnly` consulted only the whole-function queries (`onlyReadsMemory`/`onlyWritesMemory`) and parameter attributes, so a call marked `memory(argmem: read, inaccessiblemem: readwrite)` still counted as writing its pointer arguments — and an `enzyme_inactive` observer of active memory demanded a derivative it cannot have ("No augmented forward pass found").

Consult the `ArgMem` row of the memory effects for the per-argument questions, on both the `Function` and `CallBase` variants; the callee's effects are used only under a matching calling convention, for the same Julia-wrapper reason as the existing attribute path. Guarded on LLVM ≥ 16 where `MemoryEffects` exists.

The included test differentiates a loop whose loads sit behind such an observer call: before this change Enzyme refuses outright; with it, the reverse pass recomputes the load from the primal (`%v_unwrap`) and accumulates into the shadow.

Companion to the same-day mem2reg change on the MLIR side (EnzymeAD/Enzyme-JAX#2799).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD