### PR TITLE
MLIR: differentiating a bodyless function is an error, not a crash or a zero

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/FuncAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/FuncAutoDiffOpInterfaceImpl.cpp
@@ -41,6 +41,12 @@ public:
 
     Operation *callee = symbolTable.lookup(callOp.getCallee());
     auto fn = cast<FunctionOpInterface>(callee);
+    if (fn.getFunctionBody().empty()) {
+      orig->emitError() << "cannot differentiate a call to a function without "
+                           "a body and without a registered derivative: "
+                        << fn.getNameAttr() << "\n";
+      return failure();
+    }
 
     auto narg = orig->getNumOperands();
     auto nret = orig->getNumResults();
@@ -75,6 +81,8 @@ public:
         /* addedType */ nullptr, type_args, volatile_args,
         /* augmented */ nullptr, gutils->omp, gutils->postpasses,
         gutils->verifyPostPasses, gutils->strongZero);
+    if (!forwardFn)
+      return failure();
 
     SmallVector<Value> fwdArguments;
 
@@ -129,6 +137,12 @@ public:
 
     Operation *callee = symbolTable.lookup(callOp.getCallee());
     auto fn = cast<FunctionOpInterface>(callee);
+    if (fn.getFunctionBody().empty()) {
+      orig->emitError() << "cannot differentiate a call to a function without "
+                           "a body and without a registered derivative: "
+                        << fn.getNameAttr() << "\n";
+      return failure();
+    }
 
     auto narg = orig->getNumOperands();
     auto nret = orig->getNumResults();
@@ -174,6 +188,8 @@ public:
         type_args, volatile_args, /*augmented*/ nullptr, gutils->omp,
         gutils->postpasses, gutils->verifyPostPasses, gutils->strongZero,
         /*markReadonly=*/false);
+    if (!revFn)
+      return failure();
 
     SmallVector<Value> revArguments;
 

--- a/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogic.cpp
@@ -88,8 +88,9 @@ FunctionOpInterface mlir::enzyme::MEnzymeLogic::CreateForwardDiff(
     std::vector<bool> volatile_args, void *augmented, bool omp,
     llvm::StringRef postpasses, bool verifyPostPasses, bool strongZero) {
   if (fn.getFunctionBody().empty()) {
-    llvm::errs() << fn << "\n";
-    llvm_unreachable("Differentiating empty function");
+    fn.emitError() << "cannot differentiate a function without a body: "
+                   << fn.getNameAttr() << "\n";
+    return nullptr;
   }
   assert(fn.getFunctionBody().front().getNumArguments() == ArgActivity.size());
   assert(fn.getFunctionBody().front().getNumArguments() ==

--- a/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogicReverse.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogicReverse.cpp
@@ -201,8 +201,9 @@ FunctionOpInterface MEnzymeLogic::CreateReverseDiff(
     bool markReadonly) {
 
   if (fn.getFunctionBody().empty()) {
-    llvm::errs() << fn << "\n";
-    llvm_unreachable("Differentiating empty function");
+    fn.emitError() << "cannot differentiate a function without a body: "
+                   << fn.getNameAttr() << "\n";
+    return nullptr;
   }
 
   MReverseCacheKey tup = {fn,

--- a/enzyme/Enzyme/MLIR/Passes/EnzymeMLIRPass.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/EnzymeMLIRPass.cpp
@@ -178,6 +178,8 @@ struct DifferentiatePass
         CI.getStrongZero());
     if (!newFunc)
       return failure();
+    if (!newFunc)
+      return failure();
 
     OpBuilder builder(CI);
     // Ask the function how it is called, as the reverse handler does: what is
@@ -343,6 +345,8 @@ struct DifferentiatePass
         /*addedType*/ nullptr, type_args, volatile_args,
         /*augmented*/ nullptr, omp, postpasses, verifyPostPasses,
         CI.getStrongZero(), markReadonly);
+    if (!newFunc)
+      return failure();
     if (!newFunc)
       return failure();
 

--- a/enzyme/Enzyme/MLIR/Passes/EnzymeMLIRPass.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/EnzymeMLIRPass.cpp
@@ -178,8 +178,6 @@ struct DifferentiatePass
         CI.getStrongZero());
     if (!newFunc)
       return failure();
-    if (!newFunc)
-      return failure();
 
     OpBuilder builder(CI);
     // Ask the function how it is called, as the reverse handler does: what is
@@ -345,8 +343,6 @@ struct DifferentiatePass
         /*addedType*/ nullptr, type_args, volatile_args,
         /*augmented*/ nullptr, omp, postpasses, verifyPostPasses,
         CI.getStrongZero(), markReadonly);
-    if (!newFunc)
-      return failure();
     if (!newFunc)
       return failure();
 

--- a/enzyme/Enzyme/MLIR/Passes/EnzymeWrapPass.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/EnzymeWrapPass.cpp
@@ -138,6 +138,8 @@ struct DifferentiateWrapperPass
           width,
           /*addedType*/ nullptr, type_args, volatile_args,
           /*augmented*/ nullptr, omp, postpasses, verifyPostPasses, strongZero);
+      if (!newFunc)
+        return signalPassFailure();
     } else {
       newFunc = Logic.CreateReverseDiff(
           fn, RetActivity, ArgActivity, TA, returnPrimal, returnShadow, mode,

--- a/enzyme/test/MLIR/ForwardMode/bodyless.mlir
+++ b/enzyme/test/MLIR/ForwardMode/bodyless.mlir
@@ -1,0 +1,13 @@
+// RUN: %eopt --enzyme --verify-diagnostics %s
+
+// Differentiating a function that has no body at all fails the same way a
+// call to one inside a body does.
+
+module {
+  // expected-error @below {{cannot differentiate a function without a body: "ext"}}
+  func.func private @ext(f64) -> f64
+  func.func @dext(%x: f64, %dx: f64) -> f64 {
+    %r = enzyme.fwddiff @ext(%x, %dx) { activity=[#enzyme<activity enzyme_dup>], ret_activity=[#enzyme<activity enzyme_dupnoneed>] } : (f64, f64) -> f64
+    return %r : f64
+  }
+}

--- a/enzyme/test/MLIR/ForwardMode/unknown_call.mlir
+++ b/enzyme/test/MLIR/ForwardMode/unknown_call.mlir
@@ -1,0 +1,18 @@
+// RUN: %eopt --enzyme --verify-diagnostics %s
+
+// A call to a function with no body and no registered derivative has no
+// tangent to construct; refusing loudly beats a silent zero or a crash.
+
+module {
+  func.func private @ext(f64) -> f64
+  func.func @sq(%x: f64) -> f64 {
+    // expected-error @below {{cannot differentiate a call to a function without a body and without a registered derivative: "ext"}}
+    %r = func.call @ext(%x) : (f64) -> f64
+    %m = arith.mulf %r, %r : f64
+    return %m : f64
+  }
+  func.func @dsq(%x: f64, %dx: f64) -> f64 {
+    %r = enzyme.fwddiff @sq(%x, %dx) { activity=[#enzyme<activity enzyme_dup>], ret_activity=[#enzyme<activity enzyme_dupnoneed>] } : (f64, f64) -> f64
+    return %r : f64
+  }
+}

--- a/enzyme/test/MLIR/ReverseMode/bodyless.mlir
+++ b/enzyme/test/MLIR/ReverseMode/bodyless.mlir
@@ -1,0 +1,13 @@
+// RUN: %eopt --enzyme --verify-diagnostics %s
+
+// Differentiating a function that has no body at all fails the same way a
+// call to one inside a body does.
+
+module {
+  // expected-error @below {{cannot differentiate a function without a body: "ext"}}
+  func.func private @ext(f64) -> f64
+  func.func @dext(%x: f64, %dr: f64) -> f64 {
+    %g = enzyme.autodiff @ext(%x, %dr) { activity=[#enzyme<activity enzyme_active>], ret_activity=[#enzyme<activity enzyme_activenoneed>] } : (f64, f64) -> f64
+    return %g : f64
+  }
+}

--- a/enzyme/test/MLIR/ReverseMode/unknown_call.mlir
+++ b/enzyme/test/MLIR/ReverseMode/unknown_call.mlir
@@ -1,0 +1,18 @@
+// RUN: %eopt --enzyme --verify-diagnostics %s
+
+// The reverse pass refuses a call to a bodyless function without a
+// registered derivative the same way the forward pass does.
+
+module {
+  func.func private @ext(f64) -> f64
+  func.func @sq(%x: f64) -> f64 {
+    // expected-error @below {{cannot differentiate a call to a function without a body and without a registered derivative: "ext"}}
+    %r = func.call @ext(%x) : (f64) -> f64
+    %m = arith.mulf %r, %r : f64
+    return %m : f64
+  }
+  func.func @dsq(%x: f64, %dr: f64) -> f64 {
+    %g = enzyme.autodiff @sq(%x, %dr) { activity=[#enzyme<activity enzyme_active>], ret_activity=[#enzyme<activity enzyme_activenoneed>] } : (f64, f64) -> f64
+    return %g : f64
+  }
+}


### PR DESCRIPTION
A call to a function with no body and no registered derivative has no tangent or adjoint to construct. Before this change, differentiating such a call hit `llvm_unreachable("Differentiating empty function")` — in release builds that is not a diagnostic but undefined behavior — and a call wrongly considered *inactive* silently produced **zero** derivatives. The silent-zero shape is exactly MFEM's dFEM gradient bug: an unraised libm `sqrt` cost a term of every gradient with no error anywhere (fixed on the raising side in EnzymeAD/Enzyme-JAX#2807).

This PR makes both modes refuse loudly:
- the forward and reverse `func.call` handlers emit an error at the call site when the callee is bodyless,
- `CreateForwardDiff` / `CreateReverseDiff` emit a proper diagnostic and return null instead of `llvm_unreachable`,
- their callers (call handlers, `enzyme.fwddiff`/`enzyme.autodiff` lowering, the wrap pass) treat a null result as failure.

Lit tests pin the diagnostic for both `enzyme.fwddiff` and `enzyme.autodiff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD