### PR TITLE
Size a cloned or zeroed alloca from its type

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
@@ -19,12 +19,16 @@
 #include "Interfaces/GradientUtilsReverse.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/DialectRegistry.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
 #include "mlir/Support/LogicalResult.h"
 
 using namespace mlir;
 using namespace mlir::enzyme;
 
 namespace {
+
+static mlir::Value allocaExtent(mlir::OpBuilder &builder,
+                                mlir::LLVM::AllocaOp alloca);
 #include "Implementations/LLVMDerivatives.inc"
 
 // Lets activity analysis treat llvm.store generically via StoreLikeInterface.
@@ -171,15 +175,11 @@ public:
   LogicalResult zeroInPlace(Type self, OpBuilder &builder, Location loc,
                             Value val) const {
     if (auto allocaOp = val.getDefiningOp<LLVM::AllocaOp>()) {
+      Value size = allocaExtent(builder, allocaOp);
+      if (!size)
+        return failure();
       Value zero =
           LLVM::ConstantOp::create(builder, loc, builder.getI8IntegerAttr(0));
-      auto elemType = cast<AutoDiffTypeInterface>(allocaOp.getElemType());
-      unsigned byteSize = elemType.getApproxSize() / 8;
-      Value byteValue = LLVM::ConstantOp::create(
-          builder, loc, builder.getI64IntegerAttr(byteSize));
-      Value arraySize = LLVM::SExtOp::create(builder, loc, byteValue.getType(),
-                                             allocaOp.getArraySize());
-      Value size = LLVM::MulOp::create(builder, loc, arraySize, byteValue);
       LLVM::MemsetOp::create(builder, loc, val, zero, size,
                              /*isVolatile=*/false);
       return success();
@@ -535,7 +535,29 @@ struct PtrExtent {
   Value ptr;  // pointer the extent was found on; the queried one by default
 };
 
-static PtrExtent findPtrExtent(Value ptr) {
+static Value normalizeSizeToI64(OpBuilder &builder, Location loc, Value size);
+
+// An alloca says how much it is: the size of the element type, that many times.
+// Nothing has to have annotated it, and `builder` is only used to say the
+// product, next to the copy that wants it.
+static Value allocaExtent(OpBuilder &builder, LLVM::AllocaOp alloca) {
+  auto dl = DataLayout::closest(alloca);
+  uint64_t elemBytes = dl.getTypeSize(alloca.getElemType());
+  auto i64Ty = builder.getIntegerType(64);
+  Value bytes = LLVM::ConstantOp::create(builder, alloca.getLoc(), i64Ty,
+                                         builder.getI64IntegerAttr(elemBytes));
+  Value count =
+      normalizeSizeToI64(builder, alloca.getLoc(), alloca.getArraySize());
+  if (!count)
+    return nullptr;
+  Value size = LLVM::MulOp::create(builder, alloca.getLoc(), bytes, count);
+  return size;
+}
+
+// `builder` may be null where the caller has nowhere to put an op; the extent
+// of an alloca is the one that has to be said rather than found, so that is the
+// case it gives up on.
+static PtrExtent findPtrExtent(Value ptr, OpBuilder *builder = nullptr) {
   if (auto allocOp = ptr.getDefiningOp<llvm_ext::AllocOp>())
     return {allocOp.getSize(), ptr};
 
@@ -553,6 +575,13 @@ static PtrExtent findPtrExtent(Value ptr) {
       if (auto psh = dyn_cast<llvm_ext::PtrSizeHintOp>(castUser))
         return {psh.getSize(), cast.getRes()};
   }
+
+  // Last, since a hint is what someone meant and this is only what the type
+  // says.
+  if (builder)
+    if (auto alloca = ptr.getDefiningOp<LLVM::AllocaOp>())
+      if (Value size = allocaExtent(*builder, alloca))
+        return {size, ptr};
 
   return {nullptr, ptr};
 }
@@ -590,7 +619,7 @@ struct PointerClonableTypeInterface
     : public ClonableTypeInterface::ExternalModel<PointerClonableTypeInterface,
                                                   LLVM::LLVMPointerType> {
   mlir::Value cloneValue(Type self, OpBuilder &builder, Value value) const {
-    PtrExtent extent = findPtrExtent(value);
+    PtrExtent extent = findPtrExtent(value, &builder);
     if (!extent.size) {
       llvm::errs() << "cannot find size of ptr: " << value << "\n";
       return nullptr;

--- a/enzyme/Enzyme/MLIR/Passes/EnzymeWrapPass.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/EnzymeWrapPass.cpp
@@ -10,6 +10,7 @@
 // ops.
 //===----------------------------------------------------------------------===//
 
+#include "Dialect/LLVMExt/LLVMExt.h"
 #include "Dialect/Ops.h"
 #include "Interfaces/GradientUtils.h"
 #include "Interfaces/GradientUtilsReverse.h"
@@ -21,6 +22,8 @@
 #include "mlir/Interfaces/FunctionInterfaces.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 
 #define DEBUG_TYPE "enzyme"
 

--- a/enzyme/Enzyme/MLIR/Passes/Passes.td
+++ b/enzyme/Enzyme/MLIR/Passes/Passes.td
@@ -123,8 +123,11 @@ def DifferentiateWrapperPass : Pass<"enzyme-wrap"> {
     "arith::ArithDialect",
     "complex::ComplexDialect",
     "cf::ControlFlowDialect",
+    "tensor::TensorDialect",
     "enzyme::EnzymeDialect",
-    "memref::MemRefDialect"
+    "memref::MemRefDialect",
+    "mlir::LLVM::LLVMDialect",
+    "mlir::enzyme::llvm_ext::LLVMExtDialect"
   ];
   let options = [
     Option<

--- a/enzyme/test/MLIR/ReverseMode/llvm.mlir
+++ b/enzyme/test/MLIR/ReverseMode/llvm.mlir
@@ -203,12 +203,12 @@ func.func @dalloca_zero(%x: f64, %dr: f64) -> f64 {
 }
 
 // CHECK:  llvm.func @diffealloca_zero(%[[x:.+]]: f64, %[[dr:.+]]: f64) -> f64 attributes {sym_visibility = "private"} {
-// CHECK-NEXT:    %[[c8_i64:.+]] = llvm.mlir.constant(8 : i64) : i64
+// CHECK-NEXT:    %[[c1_i64:.+]] = llvm.mlir.constant(1 : i64) : i64
 // CHECK-NEXT:    %[[c0_i8:.+]] = llvm.mlir.constant(0 : i8) : i8
+// CHECK-NEXT:    %[[c8_i64:.+]] = llvm.mlir.constant(8 : i64) : i64
 // CHECK-NEXT:    %[[c1:.+]] = arith.constant 1 : i32
 // CHECK:         %[[dptr:.+]] = llvm.alloca %[[c1]] x f64 : (i32) -> !llvm.ptr
-// CHECK-NEXT:    %[[ext:.+]] = llvm.sext %[[c1]] : i32 to i64
-// CHECK-NEXT:    %[[size:.+]] = llvm.mul %[[ext]], %[[c8_i64]] : i64
+// CHECK-NEXT:    %[[size:.+]] = llvm.mul %[[c8_i64]], %[[c1_i64]] : i64
 // CHECK-NEXT:    "llvm.intr.memset"(%[[dptr]], %[[c0_i8]], %[[size]]) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
 
 

--- a/enzyme/test/MLIR/ReverseMode/scf_for_checkpointing_alloca.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_for_checkpointing_alloca.mlir
@@ -1,0 +1,41 @@
+// RUN: %eopt %s --enzyme-wrap="infn=main outfn= argTys=enzyme_active retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops --canonicalize --enzyme-simplify-math | FileCheck %s
+
+// Checkpointing a loop that mutates a buffer it reached through a plain
+// llvm.alloca: nothing hints the pointer's extent, but the alloca's type
+// already says it -- element size times array size. The clone buffers must be
+// sized 4 (one f32) with no ptr_size_hint anywhere in sight.
+
+module {
+  func.func @main(%x: f32) -> f32 {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %one = llvm.mlir.constant(1 : i64) : i64
+    %f1 = arith.constant 1.0 : f32
+    %init = arith.constant 2.0 : f32
+
+    %p = llvm.alloca %one x f32 : (i64) -> !llvm.ptr
+    llvm.store %init, %p : f32, !llvm.ptr
+
+    %0 = scf.for %i = %c0 to %c8 step %c1 iter_args(%it = %x) -> (f32) {
+      %v = llvm.load %p : !llvm.ptr -> f32
+      %m = arith.mulf %v, %it : f32
+      %n = arith.addf %v, %f1 : f32
+      llvm.store %n, %p : f32, !llvm.ptr
+      scf.yield %m : f32
+    } {enzyme.enable_checkpointing = true,
+       enzyme.checkpoint_period = 4 : i64}
+
+    return %0 : f32
+  }
+}
+
+// CHECK-LABEL: func.func @main(
+// CHECK: %[[ELEM:.+]] = llvm.mlir.constant(4 : i64) : i64
+// The shadow of the buffer is zeroed over the computed extent.
+// CHECK: %[[ZSZ:.+]] = llvm.mul %[[ELEM]], %{{.+}} : i64
+// CHECK: "llvm.intr.memset"(%{{.+}}, %{{.+}}, %[[ZSZ]])
+// Each checkpoint clone is allocated and filled over that same extent.
+// CHECK: %[[SZ:.+]] = llvm.mul %[[ELEM]], %{{.+}} : i64
+// CHECK: %[[CLONE:.+]] = llvm_ext.alloc %[[SZ]] : (i64) -> !llvm.ptr
+// CHECK: llvm_ext.memcpy %[[CLONE]], %{{.+}}, %[[SZ]]


### PR DESCRIPTION
An `llvm.alloca` with no `llvm_ext.ptr_size_hint` could not be cloned for checkpointing: `findPtrExtent` only knew hints and `llvm_ext.alloc` sizes, and `cloneValue` errored with "cannot find size of ptr". But an alloca already says how much it is — the DataLayout size of the element type, that many times — so compute that, as a last resort behind the hints.

`zeroInPlace` had its own copy of this arithmetic, with two bugs the new `allocaExtent` does not have: a same-width `llvm.sext` of an i64 array size (invalid IR, caught by the verifier) and an element size approximated by `getApproxSize()/8` instead of the DataLayout. It now calls `allocaExtent` too.

Also declares the LLVM and LLVMExt dialects as dependents of `enzyme-wrap`: cloning a pointer creates `llvm_ext.alloc`/`llvm_ext.memcpy` (and now `llvm.mul`), and if the input module contains no llvm_ext op the dialect was never loaded, so op creation failed — a fatal error in a Debug build and a hard-to-track segfault in a Release one. The existing checkpointing tests never saw this because their size hints load the dialect at parse time.

Split out of #3079 per review: the extent computation is independent of llvm.func call support. On this branch the alloca path is reachable through checkpointing of loops that mutate an alloca'd buffer (the new test); under #3079 it also becomes what caches pointer arguments of differentiated calls once overwritten-args support lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD