### PR TITLE
PreserveNVVM: let the math preservation skip the linkage promotion

### DIFF
--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -3480,6 +3480,11 @@ extern "C" void registerEnzymeAndPassPipeline(llvm::PassBuilder &PB,
           MPM.addPass(PreserveNVVMNewPM(/*Begin*/ true));
           return true;
         }
+        if (Name == "preserve-nvvm-inline-only") {
+          MPM.addPass(
+              PreserveNVVMNewPM(/*Begin*/ true, /*PromoteMathLinkage*/ false));
+          return true;
+        }
         if (Name == "preserve-nvvm-end") {
           MPM.addPass(PreserveNVVMNewPM(/*Begin*/ false));
           return true;

--- a/enzyme/Enzyme/PreserveNVVM.cpp
+++ b/enzyme/Enzyme/PreserveNVVM.cpp
@@ -81,7 +81,14 @@ void markFunctionInactive(Function &F) {
 }
 
 //! Returns whether changed.
-bool preserveLinkage(bool Begin, Function &F, bool Inlining = true) {
+// `PromoteLinkage` is what keeps a definition alive until Enzyme has seen it:
+// promoted to external, nothing internalizes or drops it. A consumer that
+// keeps the definitions alive its own way (the Reactant raising pipeline
+// consumes the math calls itself) can pass false and only toggle inlining --
+// the call sites still have to survive recognizably, but the definitions need
+// no export.
+bool preserveLinkage(bool Begin, Function &F, bool Inlining = true,
+                     bool PromoteLinkage = true) {
   if (Begin && !F.hasFnAttribute("prev_fixup")) {
     F.addFnAttr("prev_fixup");
     if (F.hasFnAttribute(Attribute::AlwaysInline))
@@ -92,8 +99,10 @@ bool preserveLinkage(bool Begin, Function &F, bool Inlining = true) {
       F.removeFnAttr(Attribute::AlwaysInline);
       F.addFnAttr(Attribute::NoInline);
     }
-    F.addFnAttr("prev_linkage", std::to_string(F.getLinkage()));
-    F.setLinkage(Function::LinkageTypes::ExternalLinkage);
+    if (PromoteLinkage) {
+      F.addFnAttr("prev_linkage", std::to_string(F.getLinkage()));
+      F.setLinkage(Function::LinkageTypes::ExternalLinkage);
+    }
     return true;
   }
   return false;
@@ -342,7 +351,7 @@ handleCustomDerivative(llvm::Module &M, llvm::GlobalVariable &g,
   globalsToErase.push_back(&g);
 }
 
-bool preserveNVVM(bool Begin, Module &M) {
+bool preserveNVVM(bool Begin, Module &M, bool PromoteMathLinkage = true) {
   bool changed = false;
   constexpr static const char gradient_handler_name[] =
       "__enzyme_register_gradient";
@@ -963,7 +972,8 @@ bool preserveNVVM(bool Begin, Module &M) {
         F.addFnAttr("implements", found->second.second);
         F.addFnAttr("implements2", found->second.first);
         F.addFnAttr("enzyme_math", found->second.first);
-        changed |= preserveLinkage(Begin, F);
+        changed |=
+            preserveLinkage(Begin, F, /*Inlining*/ true, PromoteMathLinkage);
       }
     } else if (F.getName() == "_ZL21__internal_float2halffRjS_" ||
                F.getName() == "_ZL4hlog6__half" ||
@@ -989,7 +999,8 @@ bool preserveNVVM(bool Begin, Module &M) {
                F.getName() == "_ZL32__internal_device_bfloat162floatt") {
       changed = true;
       if (Begin) {
-        changed |= preserveLinkage(Begin, F);
+        changed |=
+            preserveLinkage(Begin, F, /*Inlining*/ true, PromoteMathLinkage);
       }
     }
     if (!Begin && F.hasFnAttribute("prev_fixup")) {
@@ -1004,9 +1015,14 @@ bool preserveNVVM(bool Begin, Module &M) {
       } else {
         F.removeFnAttr(Attribute::NoInline);
       }
-      int64_t val;
-      F.getFnAttribute("prev_linkage").getValueAsString().getAsInteger(10, val);
-      F.setLinkage((Function::LinkageTypes)val);
+      if (F.hasFnAttribute("prev_linkage")) {
+        int64_t val;
+        F.getFnAttribute("prev_linkage")
+            .getValueAsString()
+            .getAsInteger(10, val);
+        F.setLinkage((Function::LinkageTypes)val);
+        F.removeFnAttr("prev_linkage");
+      }
     }
   }
   return changed;
@@ -1018,10 +1034,14 @@ class PreserveNVVM final : public ModulePass {
 public:
   static char ID;
   bool Begin;
-  PreserveNVVM(bool Begin = true) : ModulePass(ID), Begin(Begin) {}
+  bool PromoteMathLinkage;
+  PreserveNVVM(bool Begin = true, bool PromoteMathLinkage = true)
+      : ModulePass(ID), Begin(Begin), PromoteMathLinkage(PromoteMathLinkage) {}
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {}
-  bool runOnModule(Module &M) override { return preserveNVVM(Begin, M); }
+  bool runOnModule(Module &M) override {
+    return preserveNVVM(Begin, M, PromoteMathLinkage);
+  }
 };
 
 class PreserveNVVMFn final : public FunctionPass {
@@ -1047,8 +1067,8 @@ static RegisterPass<PreserveNVVM> X("preserve-nvvm", "Preserve NVVM Pass");
 static RegisterPass<PreserveNVVMFn> XFn("preserve-nvvm-fn",
                                         "Preserve NVVM Pass");
 
-ModulePass *createPreserveNVVMPass(bool Begin) {
-  return new PreserveNVVM(Begin);
+ModulePass *createPreserveNVVMPass(bool Begin, bool PromoteMathLinkage) {
+  return new PreserveNVVM(Begin, PromoteMathLinkage);
 }
 
 FunctionPass *createPreserveNVVMFnPass(bool Begin) {
@@ -1066,7 +1086,7 @@ extern "C" void AddPreserveNVVMPass(LLVMPassManagerRef PM, uint8_t Begin) {
 
 PreserveNVVMNewPM::Result
 PreserveNVVMNewPM::run(llvm::Module &M, llvm::ModuleAnalysisManager &MAM) {
-  bool changed = preserveNVVM(Begin, M);
+  bool changed = preserveNVVM(Begin, M, PromoteMathLinkage);
   return changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }
 llvm::AnalysisKey PreserveNVVMNewPM::Key;

--- a/enzyme/Enzyme/PreserveNVVM.h
+++ b/enzyme/Enzyme/PreserveNVVM.h
@@ -35,7 +35,13 @@ class ModulePass;
 class FunctionPass;
 } // namespace llvm
 
-llvm::ModulePass *createPreserveNVVMPass(bool Begin);
+// `PromoteMathLinkage` controls whether the preserved libdevice/math
+// definitions are also promoted to external linkage so they survive to
+// Enzyme. A consumer whose pipeline keeps them alive its own way (Reactant's
+// raising consumes the math calls itself) passes false and gets only the
+// inlining toggle.
+llvm::ModulePass *createPreserveNVVMPass(bool Begin,
+                                         bool PromoteMathLinkage = true);
 llvm::FunctionPass *createPreserveNVVMFnPass(bool Begin);
 
 class PreserveNVVMNewPM final : public PassParent<PreserveNVVMNewPM> {
@@ -43,11 +49,13 @@ class PreserveNVVMNewPM final : public PassParent<PreserveNVVMNewPM> {
 
 private:
   bool Begin;
+  bool PromoteMathLinkage;
   static llvm::AnalysisKey Key;
 
 public:
   using Result = llvm::PreservedAnalyses;
-  PreserveNVVMNewPM(bool Begin) : Begin(Begin) {}
+  PreserveNVVMNewPM(bool Begin, bool PromoteMathLinkage = true)
+      : Begin(Begin), PromoteMathLinkage(PromoteMathLinkage) {}
 
   Result run(llvm::Module &M, llvm::ModuleAnalysisManager &MAM);
 

--- a/enzyme/test/Enzyme/PreserveNVVM/inline_only.ll
+++ b/enzyme/test/Enzyme/PreserveNVVM/inline_only.ll
@@ -1,0 +1,30 @@
+; RUN: %opt < %s %newLoadEnzyme -passes="preserve-nvvm" -S | FileCheck %s --check-prefix=PROMOTE
+; RUN: %opt < %s %newLoadEnzyme -passes="preserve-nvvm-inline-only" -S | FileCheck %s --check-prefix=INLINEONLY
+; RUN: %opt < %s %newLoadEnzyme -passes="preserve-nvvm-inline-only,preserve-nvvm-end" -S | FileCheck %s --check-prefix=RESTORED
+
+; Preserving a libdevice definition normally promotes it to external linkage
+; so nothing internalizes or drops it before Enzyme has seen it. A pipeline
+; that keeps the definitions alive its own way only needs the calls to stay
+; recognizable -- noinline -- and the definition's linkage left alone, so a
+; formerly-internal function is not exported as a strong symbol by every
+; translation unit. preserve-nvvm-end undoes the inlining toggle either way.
+
+define internal double @__nv_sin(double %x) alwaysinline {
+  ret double %x
+}
+
+define double @caller(double %x) {
+  %r = call double @__nv_sin(double %x)
+  ret double %r
+}
+
+; PROMOTE: define dso_local double @__nv_sin(double %x) #[[ATTR:[0-9]+]]
+; PROMOTE: attributes #[[ATTR]] = { noinline {{.*}}"prev_fixup" "prev_linkage"="7" }
+
+; INLINEONLY: define internal double @__nv_sin(double %x) #[[ATTR:[0-9]+]]
+; INLINEONLY-NOT: prev_linkage
+; INLINEONLY: attributes #[[ATTR]] = { noinline {{.*}}"prev_fixup" }
+
+; RESTORED: define internal double @__nv_sin(double %x) #[[ATTR:[0-9]+]]
+; RESTORED-NOT: prev_fixup
+; RESTORED: attributes #[[ATTR]] = { alwaysinline


### PR DESCRIPTION
Preserving a libdevice definition does two things: `noinline`, so calls survive recognizably to Enzyme, and a promotion to external linkage, so nothing internalizes or drops the definition first. A consumer whose pipeline keeps the definitions alive its own way needs only the first — Reactant's raising consumes the math calls itself — and under it the promotion is a cost: every translation unit exports a strong copy of a formerly-internal function.

`PreserveNVVMNewPM` and `createPreserveNVVMPass` gain `PromoteMathLinkage` (default true; only the libdevice/half-wrapper sections consult it — custom derivatives and inactive-fn registrations promote as before). The `Begin=false` restore now checks `prev_linkage` is present before reading it, and takes the attribute away once restored. Exposed as `preserve-nvvm-inline-only`; the new lit test pins all three behaviors (promote, inline-only, restore).

Companion to EnzymeAD/Reactant#67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD