### PR TITLE
Declare helper entry points under the caller's naming convention

### DIFF
--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -1017,7 +1017,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
             /*count*/ count,
             /*datatype*/ datatype,
             /*op (MPI_SUM)*/
-            getOrInsertOpFloatSum(*gutils->newFunc->getParent(),
+            getOrInsertOpFloatSum(*gutils->newFunc->getParent(), called,
                                   MPI_OP_Ptr_type, MPI_OP_type, CT,
                                   root->getType(), Builder2),
             /*int root*/ root,
@@ -2098,7 +2098,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
             /*recvcount*/ sendcount,
             /*recvtype*/ sendtype,
             /*op (MPI_SUM)*/
-            getOrInsertOpFloatSum(*gutils->newFunc->getParent(),
+            getOrInsertOpFloatSum(*gutils->newFunc->getParent(), called,
                                   MPI_OP_Ptr_type, MPI_OP_type, CT,
                                   call.getType(), Builder2),
             /*comm*/ comm,
@@ -2480,8 +2480,8 @@ bool AdjointGenerator::handleKnownCallDerivatives(
             call.getOperand(4)->getType(), call.getOperand(4)->getType(),
         };
         FunctionType *FT = FunctionType::get(call.getType(), types, false);
-        auto F = called->getParent()->getOrInsertFunction(
-            "gsl_sf_legendre_deriv_array_e", FT);
+        auto F = getOrInsertPerCallingConv(*called->getParent(), called,
+                                           "gsl_sf_legendre_deriv_array_e", FT);
 
         llvm::Value *args[6] = {
             gutils->lookupM(gutils->getNewFromOriginal(call.getOperand(0)),
@@ -2498,8 +2498,8 @@ bool AdjointGenerator::handleKnownCallDerivatives(
         Type *typesS[] = {args[1]->getType()};
         FunctionType *FTS =
             FunctionType::get(args[1]->getType(), typesS, false);
-        auto FS = called->getParent()->getOrInsertFunction(
-            "gsl_sf_legendre_array_n", FTS);
+        auto FS = getOrInsertPerCallingConv(*called->getParent(), called,
+                                            "gsl_sf_legendre_array_n", FTS);
         Value *alSize = Builder2.CreateCall(FS, args[1]);
         Value *tmp = CreateAllocation(Builder2, types[2], alSize);
         Value *dtmp = CreateAllocation(Builder2, types[2], alSize);
@@ -3829,8 +3829,9 @@ bool AdjointGenerator::handleKnownCallDerivatives(
       IRBuilder<> Builder2(&call);
       getReverseBuilder(Builder2);
       val = gutils->lookupM(val, Builder2);
-      auto FreeFunc = gutils->newFunc->getParent()->getOrInsertFunction(
-          "cuStreamDestroy", call.getType(), PT);
+      auto FreeFunc = getOrInsertPerCallingConv(
+          *gutils->newFunc->getParent(), called, "cuStreamDestroy",
+          FunctionType::get(call.getType(), {PT}, false));
       Value *nargs[] = {val};
       Builder2.CreateCall(FreeFunc, nargs);
     }
@@ -3924,8 +3925,8 @@ bool AdjointGenerator::handleKnownCallDerivatives(
                 BuilderZ.CreateMemSet(dst_arg, val_arg, len_arg, MaybeAlign());
               } else if (funcName == "cudaMalloc") {
                 Type *tys[] = {PT, val_arg->getType(), len_arg->getType()};
-                auto F = M->getOrInsertFunction(
-                    "cudaMemset",
+                auto F = getOrInsertPerCallingConv(
+                    *M, called, "cudaMemset",
                     FunctionType::get(call.getType(), tys, false));
                 Value *nargs[] = {dst_arg, val_arg, len_arg};
                 auto memset = cast<CallInst>(BuilderZ.CreateCall(F, nargs));
@@ -3934,8 +3935,8 @@ bool AdjointGenerator::handleKnownCallDerivatives(
                          funcName == "cudaMallocFromPoolAsync") {
                 Type *tys[] = {PT, val_arg->getType(), len_arg->getType(),
                                stream->getType()};
-                auto F = M->getOrInsertFunction(
-                    "cudaMemsetAsync",
+                auto F = getOrInsertPerCallingConv(
+                    *M, called, "cudaMemsetAsync",
                     FunctionType::get(call.getType(), tys, false));
                 Value *nargs[] = {dst_arg, val_arg, len_arg, stream};
                 auto memset = cast<CallInst>(BuilderZ.CreateCall(F, nargs));
@@ -3943,8 +3944,8 @@ bool AdjointGenerator::handleKnownCallDerivatives(
               } else if (funcName == "cuMemAllocAsync") {
                 Type *tys[] = {PT, val_arg->getType(), len_arg->getType(),
                                stream->getType()};
-                auto F = M->getOrInsertFunction(
-                    "cuMemsetD8Async",
+                auto F = getOrInsertPerCallingConv(
+                    *M, called, "cuMemsetD8Async",
                     FunctionType::get(call.getType(), tys, false));
                 Value *nargs[] = {dst_arg, val_arg, len_arg, stream};
                 auto memset = cast<CallInst>(BuilderZ.CreateCall(F, nargs));
@@ -3952,8 +3953,10 @@ bool AdjointGenerator::handleKnownCallDerivatives(
               } else if (funcName == "cuMemAlloc" ||
                          funcName == "cuMemAlloc_v2") {
                 Type *tys[] = {PT, val_arg->getType(), len_arg->getType()};
-                auto F = M->getOrInsertFunction(
-                    "cuMemsetD8",
+                auto F = getOrInsertPerCallingConv(
+                    *M, called,
+                    funcName == "cuMemAlloc_v2" ? "cuMemsetD8_v2"
+                                                : "cuMemsetD8",
                     FunctionType::get(call.getType(), tys, false));
                 Value *nargs[] = {dst_arg, val_arg, len_arg};
                 auto memset = cast<CallInst>(BuilderZ.CreateCall(F, nargs));
@@ -3999,30 +4002,37 @@ bool AdjointGenerator::handleKnownCallDerivatives(
                       M->getOrInsertFunction("free", VoidTy, IntPtrTy);
                   Builder2.CreateCall(FreeFunc, tofree);
                 } else if (funcName == "cuMemAllocAsync") {
-                  auto FreeFunc = M->getOrInsertFunction(
-                      "cuMemFreeAsync", VoidTy, IntPtrTy, streamL->getType());
+                  auto FreeFunc = getOrInsertPerCallingConv(
+                      *M, called, "cuMemFreeAsync",
+                      FunctionType::get(VoidTy, {IntPtrTy, streamL->getType()},
+                                        false));
                   Value *nargs[] = {tofree, streamL};
                   Builder2.CreateCall(FreeFunc, nargs);
                 } else if (funcName == "cuMemAlloc" ||
                            funcName == "cuMemAlloc_v2") {
-                  auto FreeFunc =
-                      M->getOrInsertFunction("cuMemFree", VoidTy, IntPtrTy);
+                  auto FreeFunc = getOrInsertPerCallingConv(
+                      *M, called, "cuMemFree",
+                      FunctionType::get(VoidTy, {IntPtrTy}, false));
                   Value *nargs[] = {tofree};
                   Builder2.CreateCall(FreeFunc, nargs);
                 } else if (funcName == "cudaMalloc") {
-                  auto FreeFunc =
-                      M->getOrInsertFunction("cudaFree", VoidTy, IntPtrTy);
+                  auto FreeFunc = getOrInsertPerCallingConv(
+                      *M, called, "cudaFree",
+                      FunctionType::get(VoidTy, {IntPtrTy}, false));
                   Value *nargs[] = {tofree};
                   Builder2.CreateCall(FreeFunc, nargs);
                 } else if (funcName == "cudaMallocAsync" ||
                            funcName == "cudaMallocFromPoolAsync") {
-                  auto FreeFunc = M->getOrInsertFunction(
-                      "cudaFreeAsync", VoidTy, IntPtrTy, streamL->getType());
+                  auto FreeFunc = getOrInsertPerCallingConv(
+                      *M, called, "cudaFreeAsync",
+                      FunctionType::get(VoidTy, {IntPtrTy, streamL->getType()},
+                                        false));
                   Value *nargs[] = {tofree, streamL};
                   Builder2.CreateCall(FreeFunc, nargs);
                 } else if (funcName == "cudaMallocHost") {
-                  auto FreeFunc =
-                      M->getOrInsertFunction("cudaFreeHost", VoidTy, IntPtrTy);
+                  auto FreeFunc = getOrInsertPerCallingConv(
+                      *M, called, "cudaFreeHost",
+                      FunctionType::get(VoidTy, {IntPtrTy}, false));
                   Value *nargs[] = {tofree};
                   Builder2.CreateCall(FreeFunc, nargs);
                 } else
@@ -4079,27 +4089,34 @@ bool AdjointGenerator::handleKnownCallDerivatives(
         auto FreeFunc = M->getOrInsertFunction("free", VoidTy, IntPtrTy);
         Builder2.CreateCall(FreeFunc, tofree);
       } else if (funcName == "cuMemAllocAsync") {
-        auto FreeFunc = M->getOrInsertFunction("cuMemFreeAsync", VoidTy,
-                                               IntPtrTy, streamL->getType());
+        auto FreeFunc = getOrInsertPerCallingConv(
+            *M, called, "cuMemFreeAsync",
+            FunctionType::get(VoidTy, {IntPtrTy, streamL->getType()}, false));
         Value *nargs[] = {tofree, streamL};
         Builder2.CreateCall(FreeFunc, nargs);
       } else if (funcName == "cuMemAlloc" || funcName == "cuMemAlloc_v2") {
-        auto FreeFunc = M->getOrInsertFunction("cuMemFree", VoidTy, IntPtrTy);
+        auto FreeFunc = getOrInsertPerCallingConv(
+            *M, called, "cuMemFree",
+            FunctionType::get(VoidTy, {IntPtrTy}, false));
         Value *nargs[] = {tofree};
         Builder2.CreateCall(FreeFunc, nargs);
       } else if (funcName == "cudaMalloc") {
-        auto FreeFunc = M->getOrInsertFunction("cudaFree", VoidTy, IntPtrTy);
+        auto FreeFunc = getOrInsertPerCallingConv(
+            *M, called, "cudaFree",
+            FunctionType::get(VoidTy, {IntPtrTy}, false));
         Value *nargs[] = {tofree};
         Builder2.CreateCall(FreeFunc, nargs);
       } else if (funcName == "cudaMallocAsync" ||
                  funcName == "cudaMallocFromPoolAsync") {
-        auto FreeFunc = M->getOrInsertFunction("cudaFreeAsync", VoidTy,
-                                               IntPtrTy, streamL->getType());
+        auto FreeFunc = getOrInsertPerCallingConv(
+            *M, called, "cudaFreeAsync",
+            FunctionType::get(VoidTy, {IntPtrTy, streamL->getType()}, false));
         Value *nargs[] = {tofree, streamL};
         Builder2.CreateCall(FreeFunc, nargs);
       } else if (funcName == "cudaMallocHost") {
-        auto FreeFunc =
-            M->getOrInsertFunction("cudaFreeHost", VoidTy, IntPtrTy);
+        auto FreeFunc = getOrInsertPerCallingConv(
+            *M, called, "cudaFreeHost",
+            FunctionType::get(VoidTy, {IntPtrTy}, false));
         Value *nargs[] = {tofree};
         Builder2.CreateCall(FreeFunc, nargs);
       } else

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -2195,6 +2195,16 @@ Function *getOrInsertDifferentialFloatMemmove(
                                             atomic);
 }
 
+FunctionCallee getOrInsertPerCallingConv(Module &M, Function *templateFn,
+                                         StringRef callee, FunctionType *FT) {
+  auto res = M.getOrInsertFunction(
+      getRenamedPerCallingConv(templateFn->getName(), callee), FT);
+  if (auto F = dyn_cast<Function>(res.getCallee()))
+    if (!F->hasFnAttribute("enzyme_math"))
+      F->addFnAttr("enzyme_math", callee);
+  return res;
+}
+
 Function *getOrInsertCheckedFree(Module &M, CallInst *call, Type *Ty,
                                  unsigned width) {
   FunctionType *FreeTy = call->getFunctionType();
@@ -2489,9 +2499,10 @@ llvm::Function *getOrInsertDifferentialMPI_Wait(llvm::Module &M,
   return F;
 }
 
-llvm::Value *getOrInsertOpFloatSum(llvm::Module &M, llvm::Type *OpPtr,
-                                   llvm::Type *OpType, ConcreteType CT,
-                                   llvm::Type *intType, IRBuilder<> &B2) {
+llvm::Value *getOrInsertOpFloatSum(llvm::Module &M, llvm::Function *templateFn,
+                                   llvm::Type *OpPtr, llvm::Type *OpType,
+                                   ConcreteType CT, llvm::Type *intType,
+                                   IRBuilder<> &B2) {
   std::string name = "__enzyme_mpi_sum" + CT.str();
   assert(CT.isFloat());
   auto FlT = CT.isFloat();
@@ -2571,10 +2582,13 @@ llvm::Value *getOrInsertOpFloatSum(llvm::Module &M, llvm::Type *OpPtr,
   llvm::Type *rtypes[] = {getInt8PtrTy(M.getContext()), intType, OpPtr};
   FunctionType *RFT = FunctionType::get(intType, rtypes, false);
 
-  Constant *RF = M.getNamedValue("MPI_Op_create");
+  std::string opCreate =
+      getRenamedPerCallingConv(templateFn->getName(), "MPI_Op_create");
+  Constant *RF = M.getNamedValue(opCreate);
   if (!RF) {
-    RF =
-        cast<Function>(M.getOrInsertFunction("MPI_Op_create", RFT).getCallee());
+    RF = cast<Function>(
+        getOrInsertPerCallingConv(M, templateFn, "MPI_Op_create", RFT)
+            .getCallee());
   } else {
     RF = ConstantExpr::getBitCast(RF, getUnqual(RFT));
   }

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -1283,9 +1283,12 @@ static inline llvm::Value *getMPIMemberPtr(llvm::IRBuilder<> &B, llvm::Value *V,
   }
 }
 
-llvm::Value *getOrInsertOpFloatSum(llvm::Module &M, llvm::Type *OpPtr,
-                                   llvm::Type *OpType, ConcreteType CT,
-                                   llvm::Type *intType, llvm::IRBuilder<> &B2);
+/// `templateFn` is the MPI entry point this reduction is being built for; the
+/// MPI_Op_create it needs is named to match.
+llvm::Value *getOrInsertOpFloatSum(llvm::Module &M, llvm::Function *templateFn,
+                                   llvm::Type *OpPtr, llvm::Type *OpType,
+                                   ConcreteType CT, llvm::Type *intType,
+                                   llvm::IRBuilder<> &B2);
 
 class AssertingReplacingVH final : public llvm::CallbackVH {
 public:
@@ -2564,6 +2567,18 @@ static inline std::string getRenamedPerCallingConv(llvm::StringRef caller,
   }
   return callee.str();
 }
+
+/// Declare `callee` in `M` under whatever naming convention the frontend used
+/// to reach `templateFn`, recording the plain name in enzyme_math so that the
+/// declaration is still recognized afterwards. A helper introduced next to a
+/// call has to follow that call's convention to resolve at link time: Julia,
+/// for one, names its lazily bound ccalls "ejlstr$<function>$<library>" and
+/// loads those libraries RTLD_LOCAL, so a plainly named declaration would not
+/// be reachable via dlsym.
+llvm::FunctionCallee getOrInsertPerCallingConv(llvm::Module &M,
+                                               llvm::Function *templateFn,
+                                               llvm::StringRef callee,
+                                               llvm::FunctionType *FT);
 
 static inline std::string convertSRetTypeToString(llvm::Type *T) {
   return std::to_string((size_t)T);

--- a/enzyme/test/Enzyme/ReverseMode/gsl_sf_legendre_array_e_renamed.ll
+++ b/enzyme/test/Enzyme/ReverseMode/gsl_sf_legendre_array_e_renamed.ll
@@ -1,0 +1,31 @@
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme-preopt=false -enzyme -mem2reg -instsimplify -simplifycfg -S | FileCheck %s; fi
+; RUN: %opt < %s %newLoadEnzyme -enzyme-preopt=false -passes="enzyme,function(mem2reg,instsimplify,%simplifycfg)" -S | FileCheck %s
+
+; Same as gsl_sf_legendre_array_e.ll, but reached the way Julia reaches a
+; ccall: through a lazily bound declaration named "ejlstr$<function>$<library>"
+; that carries the real entry point in enzyme_math. The two GSL entry points
+; the derivative needs have to be declared under the same convention, or they
+; will not resolve when the module is JIT linked.
+
+declare dso_local i32 @"ejlstr$gsl_sf_legendre_array_e$libgsl.so"(i32, i32, double, double, double*) local_unnamed_addr "enzyme_math"="gsl_sf_legendre_array_e"
+
+define dso_local void @tester(i32 %a0, i32 %a1, double %x, double %a3, double* %a4) {
+entry:
+  %c = call i32 @"ejlstr$gsl_sf_legendre_array_e$libgsl.so"(i32 %a0, i32 %a1, double %x, double %a3, double* %a4)
+  ret void
+}
+
+define double @test_derivative(double %x, double %y) {
+entry:
+  %0 = tail call double (...) @__enzyme_autodiff(void (i32, i32, double, double, double*)* @tester, i32 0, i32 10, double %x, metadata !"enzyme_const", double %y, double* null, double* null)
+  ret double %0
+}
+
+; Function Attrs: nounwind
+declare double @__enzyme_autodiff(...)
+
+; CHECK: define internal { double } @diffetester(i32 %a0, i32 %a1, double %x, double %a3, double* %a4, double* %"a4'")
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %c = call i32 @"ejlstr$gsl_sf_legendre_array_e$libgsl.so"(i32 %a0, i32 %a1, double %x, double %a3, double* %a4)
+; CHECK-NEXT:   %[[as:.+]] = call i32 @"ejlstr$gsl_sf_legendre_array_n$libgsl.so"(i32 %a1)
+; CHECK: call i32 @"ejlstr$gsl_sf_legendre_deriv_array_e$libgsl.so"(i32 %a0, i32 %a1, double %x, double %a3, double* %{{.+}}, double* %{{.+}})


### PR DESCRIPTION
Enzyme sometimes needs a second entry point from a library it is already
calling: the deriv/size variants next to a GSL Legendre evaluation, the
`MPI_Op_create` behind an MPI reduction, the free that undoes an allocation, or
the stream destroy that undoes a stream create.

A frontend does not have to reach that library by its plain symbol name. Julia
names its lazily bound ccalls `ejlstr$<function>$<library>` and loads those
libraries `RTLD_LOCAL`, so a plainly named declaration is not reachable via
`dlsym` and fails when the module is JIT linked. The MPI profiling interface
likewise expects `PMPI_` callers to keep calling `PMPI_` entry points.

`Utils` already has `getRenamedPerCallingConv` for exactly this, and the MPI
and BLAS derivative paths use it — but several other sites still declared their
helper with a plain name.

### The helper

`getOrInsertPerCallingConv` wraps what those working paths were open coding:
rename per the caller's convention, then record the plain name in
`enzyme_math` so the declaration is still recognized afterwards.

```cpp
FunctionCallee getOrInsertPerCallingConv(Module &M, Function *templateFn,
                                         StringRef callee, FunctionType *FT);
```

### Sites adapted

| Site | Emitted next to |
|---|---|
| `gsl_sf_legendre_deriv_array_e`, `gsl_sf_legendre_array_n` | `gsl_sf_legendre_array_e` |
| `MPI_Op_create` | the reduction's MPI entry point |
| `cuStreamDestroy` | `cuStreamCreate` |
| `cuMemsetD8{,_v2,Async}`, `cudaMemset{,Async}` | the shadow allocation they zero |
| `cuMemFree{,Async}`, `cudaFree{,Async,Host}` | the allocation they release |

`getOrInsertOpFloatSum` now takes the MPI entry point it is being built for, so
it can name `MPI_Op_create` to match; both call sites pass it through.

The CUDA memsets additionally now match the ABI of the allocation they pair
with — `cuMemsetD8` takes an `unsigned int` length where `cuMemsetD8_v2` takes a
`size_t`, and `cuMemAlloc_v2` was previously paired with the v1 memset.

### Deliberately not changed

Sites that declare something other than a library entry point: LLVM and Julia
intrinsics (`llvm.julia.*`, `julia.write_barrier`, `llvm.enzyme.*`), Enzyme's
own runtime helpers (`__enzyme_*`, `enzyme.sparse.*`), and libc
(`malloc`/`free`/`realloc`/`puts`/`exit`, `malloc_usable_size`) — none of which
a frontend renames. `omp_get_thread_num`/`omp_get_max_threads` are emitted for
the enclosing function rather than alongside a particular call, so there is no
template to follow. The Rust and Swift deallocations have the same shape but no
convention currently applies to them, so they are left as they are.

### Testing

New `gsl_sf_legendre_array_e_renamed.ll` covers a **non-CUDA** path: the same
function as the existing GSL test, reached through an `ejlstr$…` declaration,
checking that both helpers come out renamed. Verified it fails without the fix
(bare `@gsl_sf_legendre_array_n`) and passes with it.

Full unit suite on LLVM 16: 1189 pass, 11 xfail, 1 fail — the one failure is
`ReverseModeVector/partial_int_window.ll`, which fails identically on
unmodified `main` with the same local LLVM 16 build. Format (clang-format 16),
`check_emission_order.py` and `check_llvm_api.py` all clean.

Split out of #3102 at review request; that PR now builds on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6a8BiaAKpUTgP86mQ9ZKP
