### PR TITLE
Recognize the CUDA deallocations

### DIFF
--- a/enzyme/Enzyme/LibraryFuncs.h
+++ b/enzyme/Enzyme/LibraryFuncs.h
@@ -117,6 +117,15 @@ static inline bool isAllocationFunction(const llvm::StringRef name,
   }
 }
 
+/// Return whether a given function frees a CUDA allocation. Their first
+/// argument is the allocation being freed, which for the driver API is a
+/// CUdeviceptr -- an integer at the LLVM level rather than a pointer.
+static inline bool isCudaDeallocationFunction(const llvm::StringRef name) {
+  return name == "cuMemFree" || name == "cuMemFree_v2" ||
+         name == "cuMemFreeAsync" || name == "cudaFree" ||
+         name == "cudaFreeAsync" || name == "cudaFreeHost";
+}
+
 /// Return whether a given function is a known C/C++ memory deallocation
 /// function For updating below one should read MemoryBuiltins.cpp,
 /// TargetLibraryInfo.cpp
@@ -134,6 +143,10 @@ static inline bool isDeallocationFunction(const llvm::StringRef name,
     if (name == "__rust_dealloc")
       return true;
     if (name == "swift_release")
+      return true;
+    // Counterparts of the CUDA allocations recognized in
+    // AdjointGenerator::handleKnownCallDerivatives.
+    if (isCudaDeallocationFunction(name))
       return true;
     return false;
   }

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -5587,8 +5587,17 @@ void TypeAnalyzer::visitCallBase(CallBase &call) {
       return;
     }
     if (isDeallocationFunction(funcName, TLI)) {
+      bool cudaFree = isCudaDeallocationFunction(funcName);
       size_t Idx = 0;
       for (auto &Arg : ci->args()) {
+        // The allocation freed by the CUDA driver API is a CUdeviceptr, an
+        // integer at the LLVM level, but still a pointer.
+        if (Idx == 0 && cudaFree) {
+          updateAnalysis(call.getOperand(Idx),
+                         TypeTree(BaseType::Pointer).Only(-1, &call), &call);
+          Idx++;
+          continue;
+        }
         if (Arg.getType()->isIntegerTy()) {
           updateAnalysis(call.getOperand(Idx),
                          TypeTree(BaseType::Integer).Only(-1, &call), &call);

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -2259,8 +2259,11 @@ Function *getOrInsertCheckedFree(Module &M, CallInst *call, Type *Ty,
 
   auto primal = F->arg_begin();
   Argument *first_shadow = F->arg_begin() + 1;
-  addFunctionNoCapture(F, 0);
-  addFunctionNoCapture(F, 1);
+  // A CUdeviceptr is passed as an integer, which cannot carry nocapture.
+  if (Ty->isPointerTy()) {
+    addFunctionNoCapture(F, 0);
+    addFunctionNoCapture(F, 1);
+  }
 
   Value *isNotEqual = EntryBuilder.CreateICmpNE(primal, first_shadow);
   EntryBuilder.CreateCondBr(isNotEqual, free0, end);

--- a/enzyme/test/Enzyme/ForwardMode/cudafree.ll
+++ b/enzyme/test/Enzyme/ForwardMode/cudafree.ll
@@ -1,0 +1,77 @@
+; RUN: if [ %llvmver -ge 15 ]; then %opt < %s %OPnewLoadEnzyme -enzyme-preopt=false -passes="enzyme" -S | FileCheck %s; fi
+
+; Enzyme already knows how to give a CUDA allocation a shadow, but the frees
+; that release one were not recognized as deallocations, so differentiating one
+; reported a missing derivative and the shadow was leaked. Both APIs have to
+; work: the runtime API, whose allocation is an ordinary pointer, and the
+; driver API, whose CUdeviceptr is an integer -- the latter also covers the
+; checked-free wrapper, which must not put nocapture on a non-pointer.
+
+declare i32 @cudaMalloc(ptr, i64)
+declare i32 @cudaFree(ptr)
+declare i32 @cuMemAlloc_v2(ptr, i64)
+declare i32 @cuMemFree_v2(i64)
+
+define double @runtime(double %x) {
+entry:
+  %pp = alloca ptr
+  %a = call i32 @cudaMalloc(ptr %pp, i64 8)
+  %p = load ptr, ptr %pp
+  store double %x, ptr %p
+  %v = load double, ptr %p
+  %f = call i32 @cudaFree(ptr %p)
+  ret double %v
+}
+
+define double @driver(double %x) {
+entry:
+  %pp = alloca i64
+  %a = call i32 @cuMemAlloc_v2(ptr %pp, i64 8)
+  %d = load i64, ptr %pp
+  %p = inttoptr i64 %d to ptr
+  store double %x, ptr %p
+  %v = load double, ptr %p
+  %f = call i32 @cuMemFree_v2(i64 %d)
+  ret double %v
+}
+
+declare double @__enzyme_fwddiff(...)
+
+define double @test_runtime(double %x, double %dx) {
+  %r = call double (...) @__enzyme_fwddiff(ptr @runtime, double %x, double %dx)
+  ret double %r
+}
+
+define double @test_driver(double %x, double %dx) {
+  %r = call double (...) @__enzyme_fwddiff(ptr @driver, double %x, double %dx)
+  ret double %r
+}
+
+; The shadow allocation is zeroed, carries the tangent, and is released next to
+; the primal through the checked free.
+
+; CHECK: define internal double @fwddifferuntime(double %x, double %"x'")
+; CHECK: call i32 @cudaMalloc(ptr %"pp'ipa", i64 8)
+; CHECK: call i32 @cudaMemset(
+; CHECK: %a = call i32 @cudaMalloc(ptr %pp, i64 8)
+; CHECK: store double %"x'", ptr %"p'ipl"
+; CHECK: %"v'ipl" = load double, ptr %"p'ipl"
+; CHECK: %f = call i32 @cudaFree(ptr %p)
+; CHECK: icmp ne ptr %p, %"p'ipl"
+; CHECK: call i32 @cudaFree(ptr %"p'ipl")
+; CHECK: ret double %"v'ipl"
+
+; CHECK: define internal double @fwddiffedriver(double %x, double %"x'")
+; CHECK: call i32 @cuMemAlloc_v2(ptr %"pp'ipa", i64 8)
+; CHECK: call i32 @cuMemsetD8_v2(
+; CHECK: %a = call i32 @cuMemAlloc_v2(ptr %pp, i64 8)
+; CHECK: store double %"x'", ptr %"p'ipc"
+; CHECK: %"v'ipl" = load double, ptr %"p'ipc"
+; CHECK: %f = call i32 @cuMemFree_v2(i64 %d)
+; CHECK: icmp ne i64 %d, %"d'ipl"
+; CHECK: call i32 @cuMemFree_v2(i64 %"d'ipl")
+; CHECK: ret double %"v'ipl"
+
+; A CUdeviceptr is passed as an integer, so the checked-free wrapper built for
+; it must leave nocapture off its parameters.
+; CHECK: define internal void @__enzyme_checked_free_1_cuMemFree_v2(i64 %0, i64 %1)


### PR DESCRIPTION
Enzyme already gives a CUDA allocation a shadow — `cuMemAlloc`, `cudaMalloc` and
friends are handled in `handleKnownCallDerivatives` — but the frees that release
one were never added to `isDeallocationFunction`. Differentiating a function
that frees device memory reported a missing derivative, and the shadow
allocation was leaked:

```
No forward mode derivative found for cuMemFree_v2
```

Adding `cuMemFree{,_v2,Async}` and `cudaFree{,Async,Host}` lets the existing
deallocation path handle them, freeing the shadow alongside the primal through
the checked-free wrapper. Two adjustments were needed for the driver API, whose
`CUdeviceptr` is an integer rather than a pointer:

* `getOrInsertCheckedFree` put `nocapture` on the wrapper's parameters, which is
  invalid on a non-pointer and produced a module that failed the verifier
  (`Attribute 'nocapture' applied to incompatible type!`).
* Type analysis marks integer arguments of a deallocation as `Integer`. That is
  right for a size or a flag, but the first argument is the allocation being
  freed, so for these it is a pointer.

27 lines of source across three files.

### Testing

New `ForwardMode/cudafree.ll` covers both APIs — the runtime one, whose
allocation is an ordinary pointer, and the driver one, whose `CUdeviceptr` is an
integer — and checks that the shadow allocation is zeroed, carries the tangent,
and is released next to the primal. It also pins that
`__enzyme_checked_free_1_cuMemFree_v2` takes bare `i64` parameters, covering the
`nocapture` fix. Verified the test fails without the change and passes with it.

Full unit suite on LLVM 15 and LLVM 16: 1190 pass, 11 xfail, 1 fail — the single
failure is `ReverseModeVector/partial_int_window.ll`, which fails identically on
unmodified `main` with these local LLVM builds. Format (clang-format 16) and
`check_emission_order.py` clean.

Split out of #3102 at review request: it is independent of the CUDA transfer
derivatives, though that PR's tests do free their device buffers, so it builds
on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6a8BiaAKpUTgP86mQ9ZKP
