### PR TITLE
Permit an unwrap's operand lookup to fail, and rebuild uncacheable values

### DIFF
--- a/enzyme/Enzyme/CacheUtility.h
+++ b/enzyme/Enzyme/CacheUtility.h
@@ -364,7 +364,10 @@ public:
   lookupM(llvm::Value *val, llvm::IRBuilder<> &BuilderM,
           const llvm::ValueToValueMapTy &incoming_availalble =
               llvm::ValueToValueMapTy(),
-          bool tryLegalityCheck = true, llvm::BasicBlock *scope = nullptr) = 0;
+          bool tryLegalityCheck = true, llvm::BasicBlock *scope = nullptr,
+          /// If set, return null when the value cannot be made available in
+          /// scope, rather than failing.
+          bool permitFailure = false) = 0;
 
   virtual bool assumeDynamicLoopOfSizeOne(llvm::Loop *L) const = 0;
 

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -961,7 +961,8 @@ Value *GradientUtils::unwrapM(Value *const val, IRBuilder<> &BuilderM,
           }                                                                    \
         origParent = lookupInst;                                               \
         if (!noLookup)                                                         \
-          ___res = lookupM(v, Builder, available, v != val, origParent);       \
+          ___res = lookupM(v, Builder, available, v != val, origParent,        \
+                           /*permitFailure*/ true);                            \
       }                                                                        \
       if (___res)                                                              \
         assert(___res->getType() == vty && "uw");                              \
@@ -2158,7 +2159,8 @@ Value *GradientUtils::unwrapM(Value *const val, IRBuilder<> &BuilderM,
                   if (!noLookup) {
                     BasicBlock *nS2 = nextScope;
                     Value *v = inst;
-                    ___res = lookupM(v, B, prevAvailable, v != val, nS2);
+                    ___res = lookupM(v, B, prevAvailable, v != val, nS2,
+                                     /*permitFailure*/ true);
                   }
                 }
                 if (___res)
@@ -2459,7 +2461,11 @@ endCheck:
         }
       }
     auto toreturn = lookupM(nval, BuilderM, available,
-                            /*tryLegalRecomputeCheck*/ false, scope);
+                            /*tryLegalRecomputeCheck*/ false, scope,
+                            /*permitFailure*/ unwrapMode ==
+                                UnwrapMode::AttemptFullUnwrapWithLookup);
+    if (!toreturn)
+      return nullptr;
     assert(val->getType() == toreturn->getType());
     return toreturn;
   }

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -972,7 +972,8 @@ Value *GradientUtils::unwrapM(Value *const val, IRBuilder<> &BuilderM,
       if (found != available.end() && !found->second)                          \
         ___res = nullptr;                                                      \
       else {                                                                   \
-        ___res = lookupM(v, Builder, available, v != val, origParent);         \
+        ___res = lookupM(v, Builder, available, v != val, origParent,          \
+                         /*permitFailure*/ true);                              \
         if (___res && ___res->getType() != vty) {                              \
           llvm::errs() << *newFunc << "\n";                                    \
           llvm::errs() << " v = " << *v << " res = " << *___res << "\n";       \
@@ -6784,7 +6785,8 @@ end:;
 
 Value *GradientUtils::lookupM(Value *val, IRBuilder<> &BuilderM,
                               const ValueToValueMapTy &incoming_available,
-                              bool tryLegalRecomputeCheck, BasicBlock *scope) {
+                              bool tryLegalRecomputeCheck, BasicBlock *scope,
+                              bool permitFailure) {
 
   assert(mode == DerivativeMode::ReverseModePrimal ||
          mode == DerivativeMode::ReverseModeGradient ||
@@ -7040,6 +7042,11 @@ Value *GradientUtils::lookupM(Value *val, IRBuilder<> &BuilderM,
 
   assert(inst->getName() != "<badref>");
   val = fixLCSSA(inst, scope);
+  if (isa<UndefValue>(val) && permitFailure) {
+    // scope is unreachable from the definition of inst, so there is no value
+    // to be had here. The caller is expected to cache instead.
+    return nullptr;
+  }
   if (isa<UndefValue>(val)) {
     llvm::errs() << *oldFunc << "\n";
     llvm::errs() << *newFunc << "\n";
@@ -7106,6 +7113,22 @@ Value *GradientUtils::lookupM(Value *val, IRBuilder<> &BuilderM,
     } else {
       if (isa<LoadInst>(prelcssaInst)) {
       }
+    }
+  }
+
+  // A value which may not be stored to the tape, such as a julia decayed
+  // pointer, has to be rebuilt from its operands here. Those operands are
+  // themselves cacheable, so unwrap with a lookup fallback rather than falling
+  // through to the caching below, which would produce a cache of the
+  // uncacheable value itself.
+  if (hasNoCache(inst)) {
+    auto op = unwrapM(prelcssaInst, BuilderM, available,
+                      UnwrapMode::AttemptFullUnwrapWithLookup, scope);
+    if (op) {
+      assert(op->getType() == inst->getType());
+      if (!reduceRegister)
+        lookup_cache[BuilderM.GetInsertBlock()][val] = op;
+      return op;
     }
   }
 

--- a/enzyme/Enzyme/GradientUtils.h
+++ b/enzyme/Enzyme/GradientUtils.h
@@ -532,7 +532,8 @@ public:
                        const llvm::ValueToValueMapTy &incoming_availalble =
                            llvm::ValueToValueMapTy(),
                        bool tryLegalRecomputeCheck = true,
-                       llvm::BasicBlock *scope = nullptr) override;
+                       llvm::BasicBlock *scope = nullptr,
+                       bool permitFailure = false) override;
 
   llvm::Value *invertPointerM(llvm::Value *val, llvm::IRBuilder<> &BuilderM);
   llvm::Value *invertPointerM(llvm::Value *val, llvm::IRBuilder<> &BuilderM,

--- a/enzyme/test/Enzyme/ReverseMode/lcssa_unwrap_decayed.ll
+++ b/enzyme/test/Enzyme/ReverseMode/lcssa_unwrap_decayed.ll
@@ -1,0 +1,107 @@
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme-preopt=false -enzyme-julia-addr-load -enzyme -S | FileCheck %s; fi
+; RUN: %opt < %s %newLoadEnzyme -enzyme-preopt=false -enzyme-julia-addr-load -passes="enzyme" -S | FileCheck %s
+
+; The reverse of L62.i needs the address of the double array, which is reached
+; by loading an index out of one array and using it to index another. That
+; address is a julia decayed pointer, so it may not be stored to the tape, and
+; the block defining it is not reachable from the scope the reverse pass asks
+; for it in, so it cannot be looked up either. Enzyme used to assert with
+; "undef value upon lcssa"; the whole chain has to be rebuilt in the reverse.
+
+source_filename = "start"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128-ni:10:11:12:13"
+target triple = "x86_64-linux-gnu"
+
+define "enzyme_type"="{[-1]:Float@double}" double @indexed_by_load({ {} addrspace(10)*, {} addrspace(10)*, [1 x {} addrspace(10)*] } "enzyme_type"="{[-1]:Pointer, [-1,0]:Pointer, [16,0,0,0]:Pointer, [16,0,0,0,-1]:Float@double}" %0) #1 {
+entry:
+  %.fca.2.0.extract = extractvalue { {} addrspace(10)*, {} addrspace(10)*, [1 x {} addrspace(10)*] } %0, 2, 0
+  br i1 false, label %exit, label %L8.i.lr.ph
+
+L8.i.lr.ph:                                       ; preds = %entry
+  br label %L8.i
+
+L8.i:                                             ; preds = %L34.i, %L8.i.lr.ph
+  br label %pass.i
+
+L23.i:                                            ; preds = %pass.i
+  %1 = addrspacecast {} addrspace(10)* %getfield6.i to i32 addrspace(13)* addrspace(11)*
+  %arrayptr19.i16 = load i32 addrspace(13)*, i32 addrspace(13)* addrspace(11)* %1, align 16
+  %arrayref20.i = load i32, i32 addrspace(13)* %arrayptr19.i16, align 4
+  %2 = zext i32 %arrayref20.i to i64
+  %3 = add nsw i64 %2, 0
+  %4 = getelementptr inbounds { {} addrspace(10)*, i32 }, { {} addrspace(10)*, i32 } addrspace(13)* null, i64 %3
+  %arrayref25.i = load { {} addrspace(10)*, i32 }, { {} addrspace(10)*, i32 } addrspace(13)* %4, align 8
+  br label %pass24.i
+
+L34.i:                                            ; preds = %pass.i
+  br i1 false, label %exit, label %L8.i
+
+L62.i:                                            ; No predecessors!
+  %5 = addrspacecast {} addrspace(10)* %arrayref32.i to double addrspace(13)* addrspace(11)*
+  %arrayptr44.i22 = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %5, align 8
+  %value_phi50.i54 = load double, double addrspace(13)* %arrayptr44.i22, align 8
+  %6 = fadd double 0.000000e+00, %value_phi50.i54
+  br label %L90.i
+
+L90.i:                                            ; preds = %L62.i
+  br label %exit
+
+pass.i:                                           ; preds = %L8.i
+  %getfield6.i = load atomic {} addrspace(10)*, {} addrspace(10)* addrspace(11)* null unordered, align 8
+  br i1 false, label %L34.i, label %L23.i
+
+pass24.i:                                         ; preds = %L23.i
+  %7 = extractvalue { {} addrspace(10)*, i32 } %arrayref25.i, 1
+  %8 = zext i32 %7 to i64
+  %9 = add nsw i64 %8, 0
+  %10 = addrspacecast {} addrspace(10)* %.fca.2.0.extract to {} addrspace(10)* addrspace(13)* addrspace(11)*
+  %arrayptr29.i19 = load {} addrspace(10)* addrspace(13)*, {} addrspace(10)* addrspace(13)* addrspace(11)* %10, align 8
+  %11 = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)* addrspace(13)* %arrayptr29.i19, i64 %9
+  %arrayref32.i = load {} addrspace(10)*, {} addrspace(10)* addrspace(13)* %11, align 8
+  ret double 0.000000e+00
+
+exit:                            ; preds = %L90.i, %L34.i, %entry
+  %value_phi106.i = phi double [ 0.000000e+00, %entry ], [ %6, %L90.i ], [ 0.000000e+00, %L34.i ]
+  ret double %value_phi106.i
+}
+
+declare double @__enzyme_autodiff(...)
+
+define double @dsquare({ {} addrspace(10)*, {} addrspace(10)*, [1 x {} addrspace(10)*] } %q, { {} addrspace(10)*, {} addrspace(10)*, [1 x {} addrspace(10)*] } %dq) {
+entry:
+  %call = tail call double (...) @__enzyme_autodiff(i8* bitcast (double ({ {} addrspace(10)*, {} addrspace(10)*, [1 x {} addrspace(10)*] })* @indexed_by_load to i8*), metadata !"enzyme_dup", { {} addrspace(10)*, {} addrspace(10)*, [1 x {} addrspace(10)*] } zeroinitializer, { {} addrspace(10)*, {} addrspace(10)*, [1 x {} addrspace(10)*] } zeroinitializer)
+  ret double 0.000000e+00
+}
+
+attributes #1 = { "enzyme_ta_norecur" }
+
+; CHECK: define internal void @diffeindexed_by_load(
+; CHECK: invertL62.i:
+; CHECK-NEXT:   %13 = load double, double* %"'de", align 8
+; CHECK-NEXT:   store double 0.000000e+00, double* %"'de", align 8
+; CHECK-NEXT:   %14 = load double, double* %"value_phi50.i54'de", align 8
+; CHECK-NEXT:   %15 = fadd fast double %14, %13
+; CHECK-NEXT:   store double %15, double* %"value_phi50.i54'de", align 8
+; CHECK-NEXT:   %16 = load double, double* %"value_phi50.i54'de", align 8
+; CHECK-NEXT:   store double 0.000000e+00, double* %"value_phi50.i54'de", align 8
+; CHECK-NEXT:   %"'ipc1_unwrap" = addrspacecast {} addrspace(10)* %".fca.2.0.extract'ipev" to {} addrspace(10)* addrspace(13)* addrspace(11)*
+; CHECK-NEXT:   %"arrayptr29.i19'il_phi_unwrap" = load {} addrspace(10)* addrspace(13)*, {} addrspace(10)* addrspace(13)* addrspace(11)* %"'ipc1_unwrap", align 8
+; CHECK-NEXT:   %getfield6.i_unwrap = load atomic {} addrspace(10)*, {} addrspace(10)* addrspace(11)* null unordered, align 8
+; CHECK-NEXT:   %_unwrap = addrspacecast {} addrspace(10)* %getfield6.i_unwrap to i32 addrspace(13)* addrspace(11)*
+; CHECK-NEXT:   %arrayptr19.i16_unwrap = load i32 addrspace(13)*, i32 addrspace(13)* addrspace(11)* %_unwrap, align 16
+; CHECK-NEXT:   %arrayref20.i_unwrap = load i32, i32 addrspace(13)* %arrayptr19.i16_unwrap, align 4
+; CHECK-NEXT:   %_unwrap2 = zext i32 %arrayref20.i_unwrap to i64
+; CHECK-NEXT:   %_unwrap3 = add nsw i64 %_unwrap2, 0
+; CHECK-NEXT:   %_unwrap4 = getelementptr inbounds { {} addrspace(10)*, i32 }, { {} addrspace(10)*, i32 } addrspace(13)* null, i64 %_unwrap3
+; CHECK-NEXT:   %arrayref25.i_unwrap = load { {} addrspace(10)*, i32 }, { {} addrspace(10)*, i32 } addrspace(13)* %_unwrap4, align 8
+; CHECK-NEXT:   %_unwrap5 = extractvalue { {} addrspace(10)*, i32 } %arrayref25.i_unwrap, 1
+; CHECK-NEXT:   %_unwrap6 = zext i32 %_unwrap5 to i64
+; CHECK-NEXT:   %_unwrap7 = add nsw i64 %_unwrap6, 0
+; CHECK-NEXT:   %"'ipg_unwrap" = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)* addrspace(13)* %"arrayptr29.i19'il_phi_unwrap", i64 %_unwrap7
+; CHECK-NEXT:   %"arrayref32.i'il_phi_unwrap" = load {} addrspace(10)*, {} addrspace(10)* addrspace(13)* %"'ipg_unwrap", align 8
+; CHECK-NEXT:   %"'ipc_unwrap" = addrspacecast {} addrspace(10)* %"arrayref32.i'il_phi_unwrap" to double addrspace(13)* addrspace(11)*
+; CHECK-NEXT:   %"arrayptr44.i22'il_phi_unwrap" = load double addrspace(13)*, double addrspace(13)* addrspace(11)* %"'ipc_unwrap", align 8
+; CHECK-NEXT:   %17 = load double, double addrspace(13)* %"arrayptr44.i22'il_phi_unwrap", align 8
+; CHECK-NEXT:   %18 = fadd fast double %17, %16
+; CHECK-NEXT:   store double %18, double addrspace(13)* %"arrayptr44.i22'il_phi_unwrap", align 8
+; CHECK-NEXT:   ret void


### PR DESCRIPTION
Fixes the julia 1.10 half of https://github.com/EnzymeAD/Enzyme.jl/issues/3443.

## The failure

A reverse mode gradient over a loop nest which indexes one array by a value loaded from another aborts with

```
GradientUtils.cpp:7053: GradientUtils::lookupM(...):
  Assertion `0 && "undef value upon lcssa"' failed.
```

licm hoists the memoryref adjustment and gvn inserts a critical edge block, so the value being requested is defined in a block the reverse of the earlier loop cannot reach.

## Cause

`getOpFullest` in `AttemptSingleUnwrap` mode looks up the operands of the value being unwrapped:

```cpp
      auto found = available.find(v);
      if (found != available.end() && !found->second)
        ___res = nullptr;
      else {
        ___res = lookupM(v, Builder, available, v != val, origParent);
```

`lookupM` has no failure path. Its first step is `fixLCSSA(inst, scope)`, which can only produce undef when `scope` is not forward reachable from the definition of `inst`, and it then asserts. Every caller of `unwrapM` already treats a null result as "cache rather than recompute" (`if (!vals[i]) { eraseBlocks(...); goto endCheck; }`), so the failure has a place to go; it just cannot be expressed.

This adds a `permitFailure` flag to `lookupM` which returns null on that undef rather than asserting, and passes it for those operand lookups.

## Second layer

Falling back to a cache then hit Julia's `GCInvariantVerifier`:

```
Illegal store of decayed value
  store i32 addrspace(13)* addrspace(11)* %302, i32 addrspace(13)* addrspace(11)* addrspace(10)* %303
```

The value being cached was an addrspace(11) pointer. `hasNoCache` already knows these must never be stored to the tape, and `cacheForReverse` asserts on them, but `lookupM`'s caching path never consults it. Such a value is rebuilt from its operands here instead; the operands are ordinary cacheable values, so the recursion terminates.

## Testing

* `check-enzyme` on this branch: 1045 passed, 1 failed. Identical to `main` at 26050c49 — `ReverseModeVector/partial_int_window.ll` fails there too, unrelated to this change.
* Enzyme.jl test suite against a libEnzyme built from this branch: julia 1.10 → 170596 pass, julia 1.11 → 217974 pass, julia 1.12 → 217979 pass. No failures on any of them.
* The reduced Enzyme.jl reproducer from the issue goes from aborting to returning the correct gradient on 1.10, and is unaffected on 1.11/1.12 (where it fails earlier for a different, separately fixed, reason).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gizy1otrmhHZv7Z2HUWZAc
