### PR TITLE
MLIR: carry access alignment into memref/LLVM/affine load-store adjoints

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
@@ -825,6 +825,7 @@ struct AffineLoadOpInterfaceReverse
         }
 
         if (!gutils->AtomicAdd) {
+          auto alignAttr = loadOp->getAttrOfType<IntegerAttr>("alignment");
           bool hasIndex = loadOp.getAffineMap().getNumDims() > 0;
           // if index had to be cached, the pop is not necessarily a valid index
           if (hasIndex) {
@@ -833,21 +834,28 @@ struct AffineLoadOpInterfaceReverse
                                  loadOp.getAffineMap(), retrievedArguments,
                                  indices);
 
-            Value loadedGradient = memref::LoadOp::create(
+            auto loadedGradientOp = memref::LoadOp::create(
                 builder, loadOp.getLoc(), memrefGradient, indices);
+            loadedGradientOp.setAlignmentAttr(alignAttr);
             Value addedGradient = iface.createAddOp(builder, loadOp.getLoc(),
-                                                    loadedGradient, gradient);
-            memref::StoreOp::create(builder, loadOp.getLoc(), addedGradient,
-                                    memrefGradient, indices);
+                                                    loadedGradientOp, gradient);
+            auto storeGradientOp =
+                memref::StoreOp::create(builder, loadOp.getLoc(), addedGradient,
+                                        memrefGradient, indices);
+            storeGradientOp.setAlignmentAttr(alignAttr);
           } else {
-            Value loadedGradient = affine::AffineLoadOp::create(
+            auto loadedGradientOp = affine::AffineLoadOp::create(
                 builder, loadOp.getLoc(), memrefGradient, loadOp.getAffineMap(),
                 ArrayRef<Value>(retrievedArguments));
+            if (alignAttr)
+              loadedGradientOp->setAttr("alignment", alignAttr);
             Value addedGradient = iface.createAddOp(builder, loadOp.getLoc(),
-                                                    loadedGradient, gradient);
-            affine::AffineStoreOp::create(
+                                                    loadedGradientOp, gradient);
+            auto storeGradientOp = affine::AffineStoreOp::create(
                 builder, loadOp.getLoc(), addedGradient, memrefGradient,
                 loadOp.getAffineMap(), ArrayRef<Value>(retrievedArguments));
+            if (alignAttr)
+              storeGradientOp->setAttr("alignment", alignAttr);
           }
         } else {
           bool hasIndex = loadOp.getAffineMap().getNumDims() > 0;
@@ -956,6 +964,7 @@ struct AffineStoreOpInterfaceReverse
       }
 
       bool hasIndex = storeOp.getAffineMap().getNumDims() > 0;
+      auto alignAttr = storeOp->getAttrOfType<IntegerAttr>("alignment");
 
       if (!iface.isMutable()) {
         if (!gutils->isConstantValue(val)) {
@@ -965,12 +974,17 @@ struct AffineStoreOpInterfaceReverse
             computeAffineIndices(builder, storeOp.getLoc(),
                                  storeOp.getAffineMap(), retrievedArguments,
                                  indices);
-            loadedGradient = memref::LoadOp::create(builder, storeOp.getLoc(),
-                                                    memrefGradient, indices);
+            auto loadedGradientOp = memref::LoadOp::create(
+                builder, storeOp.getLoc(), memrefGradient, indices);
+            loadedGradientOp.setAlignmentAttr(alignAttr);
+            loadedGradient = loadedGradientOp;
           } else {
-            loadedGradient = affine::AffineLoadOp::create(
+            auto loadedGradientOp = affine::AffineLoadOp::create(
                 builder, storeOp.getLoc(), memrefGradient,
                 storeOp.getAffineMap(), ArrayRef<Value>(retrievedArguments));
+            if (alignAttr)
+              loadedGradientOp->setAttr("alignment", alignAttr);
+            loadedGradient = loadedGradientOp;
           }
           gutils->addToDiffe(val, loadedGradient, builder);
         }
@@ -985,12 +999,15 @@ struct AffineStoreOpInterfaceReverse
           computeAffineIndices(builder, storeOp.getLoc(),
                                storeOp.getAffineMap(), retrievedArguments,
                                indices);
-          memref::StoreOp::create(builder, storeOp.getLoc(), zero,
-                                  memrefGradient, indices);
+          auto zeroStoreOp = memref::StoreOp::create(
+              builder, storeOp.getLoc(), zero, memrefGradient, indices);
+          zeroStoreOp.setAlignmentAttr(alignAttr);
         } else {
-          affine::AffineStoreOp::create(builder, storeOp.getLoc(), zero,
-                                        memrefGradient, storeOp.getAffineMap(),
-                                        ArrayRef<Value>(retrievedArguments));
+          auto zeroStoreOp = affine::AffineStoreOp::create(
+              builder, storeOp.getLoc(), zero, memrefGradient,
+              storeOp.getAffineMap(), ArrayRef<Value>(retrievedArguments));
+          if (alignAttr)
+            zeroStoreOp->setAttr("alignment", alignAttr);
         }
       }
     }

--- a/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
@@ -333,13 +333,15 @@ struct LoadOpInterfaceReverse
         Value addrGradient = gutils->popCache(caches.front(), builder);
 
         if (!gutils->AtomicAdd) {
-          Value loadedGradient = LLVM::LoadOp::create(builder, loadOp.getLoc(),
-                                                      iface, addrGradient);
+          Value loadedGradient = LLVM::LoadOp::create(
+              builder, loadOp.getLoc(), iface, addrGradient,
+              loadOp.getAlignment().value_or(0));
           Value addedGradient = iface.createAddOp(builder, loadOp.getLoc(),
                                                   loadedGradient, gradient);
 
           LLVM::StoreOp::create(builder, loadOp.getLoc(), addedGradient,
-                                addrGradient);
+                                addrGradient,
+                                loadOp.getAlignment().value_or(0));
         } else {
           LLVM::AtomicRMWOp::create(builder, loadOp.getLoc(),
                                     LLVM::AtomicBinOp::fadd, addrGradient,
@@ -402,7 +404,8 @@ struct StoreOpInterfaceReverse
       if (!iface.isMutable()) {
         if (!gutils->isConstantValue(val)) {
           Value loadedGradient = LLVM::LoadOp::create(
-              builder, storeOp.getLoc(), val.getType(), addrGradient);
+              builder, storeOp.getLoc(), val.getType(), addrGradient,
+              storeOp.getAlignment().value_or(0));
           gutils->addToDiffe(val, loadedGradient, builder);
         }
 
@@ -410,7 +413,8 @@ struct StoreOpInterfaceReverse
             cast<AutoDiffTypeInterface>(gutils->getShadowType(val.getType()))
                 .createNullValue(builder, op->getLoc());
 
-        LLVM::StoreOp::create(builder, storeOp.getLoc(), zero, addrGradient);
+        LLVM::StoreOp::create(builder, storeOp.getLoc(), zero, addrGradient,
+                              storeOp.getAlignment().value_or(0));
       }
     }
 

--- a/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
@@ -64,14 +64,16 @@ struct LoadOpInterfaceReverse
         }
 
         if (!gutils->AtomicAdd) {
-          Value loadedGradient =
+          auto loadedGradientOp =
               memref::LoadOp::create(builder, loadOp.getLoc(), memrefGradient,
                                      ArrayRef<Value>(retrievedArguments));
+          loadedGradientOp.setAlignmentAttr(loadOp.getAlignmentAttr());
           Value addedGradient = iface.createAddOp(builder, loadOp.getLoc(),
-                                                  loadedGradient, gradient);
-          memref::StoreOp::create(builder, loadOp.getLoc(), addedGradient,
-                                  memrefGradient,
-                                  ArrayRef<Value>(retrievedArguments));
+                                                  loadedGradientOp, gradient);
+          auto storeGradientOp = memref::StoreOp::create(
+              builder, loadOp.getLoc(), addedGradient, memrefGradient,
+              ArrayRef<Value>(retrievedArguments));
+          storeGradientOp.setAlignmentAttr(loadOp.getAlignmentAttr());
         } else {
           setDerivativeFastMath(enzyme::AtomicRMWOp::create(
               builder, loadOp.getLoc(), gradient.getType(),
@@ -150,18 +152,21 @@ struct StoreOpInterfaceReverse
 
       if (!iface.isMutable()) {
         if (!gutils->isConstantValue(val)) {
-          Value loadedGradient =
+          auto loadedGradientOp =
               memref::LoadOp::create(builder, storeOp.getLoc(), memrefGradient,
                                      ArrayRef<Value>(retrievedArguments));
-          gutils->addToDiffe(val, loadedGradient, builder);
+          loadedGradientOp.setAlignmentAttr(storeOp.getAlignmentAttr());
+          gutils->addToDiffe(val, loadedGradientOp, builder);
         }
 
         auto zero =
             cast<AutoDiffTypeInterface>(gutils->getShadowType(val.getType()))
                 .createNullValue(builder, op->getLoc());
 
-        memref::StoreOp::create(builder, storeOp.getLoc(), zero, memrefGradient,
-                                ArrayRef<Value>(retrievedArguments));
+        auto zeroStoreOp = memref::StoreOp::create(
+            builder, storeOp.getLoc(), zero, memrefGradient,
+            ArrayRef<Value>(retrievedArguments));
+        zeroStoreOp.setAlignmentAttr(storeOp.getAlignmentAttr());
       }
     }
     return success();

--- a/enzyme/test/MLIR/ReverseMode/affine_load_store_alignment.mlir
+++ b/enzyme/test/MLIR/ReverseMode/affine_load_store_alignment.mlir
@@ -1,0 +1,25 @@
+// RUN: %eopt %s --enzyme-wrap="infn=square_ip outfn= argTys=enzyme_dup,enzyme_const retTys= mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops --flatten-enzyme-caches --canonicalize --enzyme-simplify-math --canonicalize --cse | FileCheck %s
+
+// An over-aligned affine access carries its alignment (the discardable
+// "alignment" attribute the raising path records) into the reverse pass: the
+// shadow load/store the load and store adjoints build must keep it, or the
+// shadow buffer is accessed under-aligned. The atomic path already forwarded
+// it; the non-atomic path now does too.
+
+func.func @square_ip(%arg0: memref<?xf32>, %ub: index) {
+  affine.for %iv = 0 to %ub {
+    %v = affine.load %arg0[2 * %iv] {alignment = 16 : i64} : memref<?xf32>
+    %sq = arith.mulf %v, %v : f32
+    affine.store %sq, %arg0[2 * %iv + 1] {alignment = 16 : i64} : memref<?xf32>
+    affine.yield
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @square_ip(
+// The store adjoint loads and zeroes the shadow slot.
+// CHECK:         memref.load %arg1[%{{.+}}] {alignment = 16 : i64} : memref<?xf32>
+// CHECK:         memref.store %cst, %arg1[%{{.+}}] {alignment = 16 : i64} : memref<?xf32>
+// The load adjoint accumulates into the shadow slot.
+// CHECK:         memref.load %arg1[%{{.+}}] {alignment = 16 : i64} : memref<?xf32>
+// CHECK:         memref.store %{{.+}}, %arg1[%{{.+}}] {alignment = 16 : i64} : memref<?xf32>

--- a/enzyme/test/MLIR/ReverseMode/llvm_load_store_alignment.mlir
+++ b/enzyme/test/MLIR/ReverseMode/llvm_load_store_alignment.mlir
@@ -1,0 +1,32 @@
+// RUN: %eopt --enzyme --canonicalize --remove-unnecessary-enzyme-ops --enzyme-simplify-math --lower-llvm-ext --canonicalize %s | FileCheck %s
+
+// An over-aligned llvm.load/llvm.store keeps its alignment in the reverse pass:
+// the shadow load/store the load and store adjoints build must carry the same
+// alignment as the primal, or the shadow pointer is accessed under-aligned.
+
+module {
+llvm.func @loadstore(%a: !llvm.ptr, %b: f32) -> f32 {
+  %sz = arith.constant 32 : i64
+  llvm_ext.ptr_size_hint %a, %sz : !llvm.ptr, i64
+  llvm.store %b, %a {alignment = 16 : i64} : f32, !llvm.ptr
+  %0 = llvm.load %a {alignment = 16 : i64} : !llvm.ptr -> f32
+  llvm.return %0 : f32
+}
+
+func.func @dloadstore(%a: !llvm.ptr, %da: !llvm.ptr, %b: f32, %dres: f32) -> f32 {
+  %res = enzyme.autodiff @loadstore(%a, %da, %b, %dres)
+    {
+      activity=[#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_active>],
+      ret_activity=[#enzyme<activity enzyme_activenoneed>]
+    } : (!llvm.ptr, !llvm.ptr, f32, f32) -> f32
+  return %res : f32
+}
+}
+
+// CHECK-LABEL:  llvm.func @diffeloadstore(
+// The load adjoint accumulates into the shadow pointer.
+// CHECK:          llvm.load %[[da:.+]] {alignment = 16 : i64} : !llvm.ptr -> f32
+// CHECK:          llvm.store %{{.+}}, %[[da]] {alignment = 16 : i64} : f32, !llvm.ptr
+// The store adjoint loads and zeroes the shadow pointer.
+// CHECK:          llvm.load %[[da]] {alignment = 16 : i64} : !llvm.ptr -> f32
+// CHECK:          llvm.store %{{.+}}, %[[da]] {alignment = 16 : i64} : f32, !llvm.ptr

--- a/enzyme/test/MLIR/ReverseMode/memref_load_store_alignment.mlir
+++ b/enzyme/test/MLIR/ReverseMode/memref_load_store_alignment.mlir
@@ -1,0 +1,22 @@
+// RUN: %eopt %s --enzyme-wrap="infn=loadstore outfn= argTys=enzyme_dup,enzyme_dup retTys= mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops --flatten-enzyme-caches --canonicalize --enzyme-simplify-math --canonicalize --cse | FileCheck %s
+
+// An over-aligned memref access keeps its alignment in the reverse pass: the
+// shadow load/store the load and store adjoints build must carry the same
+// alignment as the primal, or the shadow buffer is accessed under-aligned.
+
+func.func @loadstore(%arg0: memref<?xf32>, %arg1: memref<?xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %v = memref.load %arg0[%c0] {alignment = 16 : i64} : memref<?xf32>
+  %sq = arith.mulf %v, %v : f32
+  memref.store %sq, %arg1[%c1] {alignment = 16 : i64} : memref<?xf32>
+  return
+}
+
+// CHECK-LABEL: func.func @loadstore(
+// The store adjoint loads and zeroes the store's shadow slot.
+// CHECK:         memref.load %arg3[%c1] {alignment = 16 : i64} : memref<?xf32>
+// CHECK:         memref.store %cst, %arg3[%c1] {alignment = 16 : i64} : memref<?xf32>
+// The load adjoint accumulates into the load's shadow slot.
+// CHECK:         memref.load %arg1[%c0] {alignment = 16 : i64} : memref<?xf32>
+// CHECK:         memref.store %{{.+}}, %arg1[%c0] {alignment = 16 : i64} : memref<?xf32>


### PR DESCRIPTION
The reverse-mode adjoints for `memref.load`/`memref.store`, `llvm.load`/`llvm.store`, and `affine.load`/`affine.store` build shadow load/store ops from the primal but did not forward the primal's alignment, so the shadow buffer was accessed at the element's *natural* alignment. An over-aligned primal (e.g. a vectorized stack access) then gets an under-aligned adjoint — the same defect class as Enzyme-JAX #2817, where a dropped alloca alignment left an aligned SSE access on a misaligned address and faulted.

In each dialect the atomic path already forwarded the alignment; the non-atomic path did not:

- **`MemRefAutoDiffOpInterfaceImpl.cpp`**: non-atomic accumulation + store adjoint now `setAlignmentAttr` from the primal.
- **`LLVMAutoDiffOpInterfaceImpl.cpp`**: load/store adjoints forward `getAlignment()`.
- **`AffineAutoDiffOpInterfaceImpl.cpp`**: the non-atomic path forwards the discardable `"alignment"` attribute the raising path records — onto the reverse `memref` ops (`setAlignmentAttr`) and, when the reverse stays affine, re-attached for `LowerAlignedAffineAccesses` to promote (matching the atomic sibling in the same function).

Each only copies the alignment the primal already carried — a no-op for naturally-aligned accesses.

Tests (`test/MLIR/ReverseMode/`): `memref_load_store_alignment.mlir`, `llvm_load_store_alignment.mlir`, `affine_load_store_alignment.mlir` each differentiate an `{alignment = 16}` load/store pair and check the generated shadow accesses keep `alignment = 16`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
