### PR TITLE
MLIR: differentiate through debug intrinsics

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
@@ -215,6 +215,23 @@ struct LifetimeForwardInterface
   }
 };
 
+// A debug intrinsic narrates the primal: it names which source variable a
+// value stands for, and computes nothing. The primal copy in the generated
+// function keeps saying it; the derivative has nothing to add -- there is no
+// variable metadata under which a shadow could honestly be described. Like the
+// lifetime markers, the op is declared inactive, and this interface exists
+// because inactivity alone answers "what does it make active", not "what is
+// its tangent": an op whose operand is active is still asked for one.
+template <typename OpTy>
+struct NoTangentForwardInterface
+    : public AutoDiffOpInterface::ExternalModel<NoTangentForwardInterface<OpTy>,
+                                                OpTy> {
+  LogicalResult createForwardModeTangent(Operation *op, OpBuilder &builder,
+                                         MGradientUtils *gutils) const {
+    return success();
+  }
+};
+
 // After a memset the memory holds a fixed byte pattern, which depends on no
 // input, so its tangent is zero everywhere the memset reached. Forward mode
 // says that by clearing the shadow over the same range -- whatever derivative
@@ -848,6 +865,12 @@ void mlir::enzyme::registerLLVMDialectAutoDiffInterface(
         LifetimeForwardInterface<LLVM::LifetimeStartOp>>(*context);
     LLVM::LifetimeEndOp::attachInterface<
         LifetimeForwardInterface<LLVM::LifetimeEndOp>>(*context);
+    LLVM::DbgValueOp::attachInterface<
+        NoTangentForwardInterface<LLVM::DbgValueOp>>(*context);
+    LLVM::DbgDeclareOp::attachInterface<
+        NoTangentForwardInterface<LLVM::DbgDeclareOp>>(*context);
+    LLVM::DbgLabelOp::attachInterface<
+        NoTangentForwardInterface<LLVM::DbgLabelOp>>(*context);
     LLVM::MemsetOp::attachInterface<MemsetForwardInterface>(*context);
     LLVM::SelectOp::attachInterface<SelectActivityInterface>(*context);
     LLVM::StoreOp::attachInterface<LLVMStoreLike>(*context);

--- a/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
@@ -232,6 +232,29 @@ struct NoTangentForwardInterface
   }
 };
 
+// The reverse-mode side of the same statement. The activity tables say these
+// ops are inactive, but not every analyzer consults that when deciding what
+// to skip; owning the answer here keeps -g working regardless of which one
+// ran.
+template <typename OpTy>
+struct NoAdjointReverseInterface
+    : public ReverseAutoDiffOpInterface::ExternalModel<
+          NoAdjointReverseInterface<OpTy>, OpTy> {
+  LogicalResult createReverseModeAdjoint(Operation *op, OpBuilder &builder,
+                                         MGradientUtilsReverse *gutils,
+                                         SmallVector<Value> caches) const {
+    return success();
+  }
+
+  SmallVector<Value> cacheValues(Operation *op,
+                                 MGradientUtilsReverse *gutils) const {
+    return SmallVector<Value>();
+  }
+
+  void createShadowValues(Operation *op, OpBuilder &builder,
+                          MGradientUtilsReverse *gutils) const {}
+};
+
 // After a memset the memory holds a fixed byte pattern, which depends on no
 // input, so its tangent is zero everywhere the memset reached. Forward mode
 // says that by clearing the shadow over the same range -- whatever derivative
@@ -871,6 +894,12 @@ void mlir::enzyme::registerLLVMDialectAutoDiffInterface(
         NoTangentForwardInterface<LLVM::DbgDeclareOp>>(*context);
     LLVM::DbgLabelOp::attachInterface<
         NoTangentForwardInterface<LLVM::DbgLabelOp>>(*context);
+    LLVM::DbgValueOp::attachInterface<
+        NoAdjointReverseInterface<LLVM::DbgValueOp>>(*context);
+    LLVM::DbgDeclareOp::attachInterface<
+        NoAdjointReverseInterface<LLVM::DbgDeclareOp>>(*context);
+    LLVM::DbgLabelOp::attachInterface<
+        NoAdjointReverseInterface<LLVM::DbgLabelOp>>(*context);
     LLVM::MemsetOp::attachInterface<MemsetForwardInterface>(*context);
     LLVM::SelectOp::attachInterface<SelectActivityInterface>(*context);
     LLVM::StoreOp::attachInterface<LLVMStoreLike>(*context);

--- a/enzyme/Enzyme/MLIR/Implementations/LLVMDerivatives.td
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMDerivatives.td
@@ -12,6 +12,9 @@ def : InactiveOp<"LLVM", "StackRestoreOp">;
 def : InactiveOp<"LLVM", "NoAliasScopeDeclOp">;
 def : InactiveOp<"LLVM", "LifetimeStartOp">;
 def : InactiveOp<"LLVM", "LifetimeEndOp">;
+def : InactiveOp<"LLVM", "DbgValueOp">;
+def : InactiveOp<"LLVM", "DbgDeclareOp">;
+def : InactiveOp<"LLVM", "DbgLabelOp">;
 def : InactiveOp<"LLVM", "Prefetch">;
 def : InactiveOp<"LLVM", "MemsetOp">;
 

--- a/enzyme/test/MLIR/ForwardMode/dbg_intrinsics.mlir
+++ b/enzyme/test/MLIR/ForwardMode/dbg_intrinsics.mlir
@@ -1,0 +1,23 @@
+// RUN: %eopt %s --enzyme-wrap="infn=square outfn= argTys=enzyme_dup retTys=enzyme_dupnoneed mode=ForwardMode" | FileCheck %s
+
+// Debug intrinsics narrate the primal and compute nothing; -g must not stop
+// differentiation. The intrinsic stays on the primal values; the tangent has
+// nothing to add for it.
+
+#di_file = #llvm.di_file<"example.c" in "/tmp">
+#di_cu = #llvm.di_compile_unit<id = distinct[1]<>, sourceLanguage = DW_LANG_C11, file = #di_file, producer = "clang", emissionKind = Full>
+#di_sp = #llvm.di_subprogram<id = distinct[0]<>, compileUnit = #di_cu, scope = #di_file, name = "square", file = #di_file, line = 5, subprogramFlags = Definition>
+#di_var = #llvm.di_local_variable<scope = #di_sp, name = "x", file = #di_file, line = 5, arg = 1>
+llvm.func @square(%x: f64) -> f64 {
+  llvm.intr.dbg.value #di_var = %x : f64
+  %r = arith.mulf %x, %x : f64
+  llvm.return %r : f64
+}
+
+// CHECK-LABEL: llvm.func @square(%arg0: f64, %arg1: f64) -> f64
+// CHECK-NEXT:    llvm.intr.dbg.value #di_local_variable = %arg0 : f64
+// CHECK-NEXT:    %[[m0:.+]] = arith.mulf %arg1, %arg0 fastmath<fast> : f64
+// CHECK-NEXT:    %[[m1:.+]] = arith.mulf %arg1, %arg0 fastmath<fast> : f64
+// CHECK-NEXT:    %[[t:.+]] = arith.addf %[[m0]], %[[m1]] fastmath<fast> : f64
+// CHECK-NEXT:    %{{.+}} = arith.mulf %arg0, %arg0 : f64
+// CHECK-NEXT:    llvm.return %[[t]] : f64

--- a/enzyme/test/MLIR/ReverseMode/dbg_intrinsics.mlir
+++ b/enzyme/test/MLIR/ReverseMode/dbg_intrinsics.mlir
@@ -1,0 +1,21 @@
+// RUN: %eopt %s --enzyme-wrap="infn=square outfn= argTys=enzyme_active retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops --enzyme-simplify-math --canonicalize --cse | FileCheck %s
+
+// Debug intrinsics narrate the primal and compute nothing; -g must not stop
+// differentiation. The intrinsic stays on the primal values; the adjoint has
+// nothing to add for it.
+
+#di_file = #llvm.di_file<"example.c" in "/tmp">
+#di_cu = #llvm.di_compile_unit<id = distinct[1]<>, sourceLanguage = DW_LANG_C11, file = #di_file, producer = "clang", emissionKind = Full>
+#di_sp = #llvm.di_subprogram<id = distinct[0]<>, compileUnit = #di_cu, scope = #di_file, name = "square", file = #di_file, line = 5, subprogramFlags = Definition>
+#di_var = #llvm.di_local_variable<scope = #di_sp, name = "x", file = #di_file, line = 5, arg = 1>
+llvm.func @square(%x: f64) -> f64 {
+  llvm.intr.dbg.value #di_var = %x : f64
+  %r = arith.mulf %x, %x : f64
+  llvm.return %r : f64
+}
+
+// CHECK-LABEL: llvm.func @square(%arg0: f64, %arg1: f64) -> f64
+// CHECK-NEXT:    llvm.intr.dbg.value #di_local_variable = %arg0 : f64
+// CHECK-NEXT:    %[[m:.+]] = arith.mulf %arg1, %arg0 fastmath<fast> : f64
+// CHECK-NEXT:    %[[a:.+]] = arith.addf %[[m]], %[[m]] fastmath<fast> : f64
+// CHECK-NEXT:    llvm.return %[[a]] : f64


### PR DESCRIPTION
Compiling with `-g` stopped both AD modes at `llvm.intr.dbg.value` with *"could not compute the adjoint for this operation"* (reported from a plain `__enzyme_autodiff(square, x)` on compiler explorer).

A debug intrinsic narrates the primal — it names which source variable a value stands for, and computes nothing — so the primal copy in the generated function keeps saying it, and the derivative has nothing to add (there is no variable metadata under which a shadow could honestly be described).

- **`LLVMDerivatives.td`**: declare `DbgValueOp`/`DbgDeclareOp`/`DbgLabelOp` `InactiveOp`, so the reverse pass's fully-inactive skip covers them.
- **`LLVMAutoDiffOpInterfaceImpl.cpp`**: a `NoTangentForwardInterface` attached to the three — like the lifetime markers, inactivity alone answers *"what does it make active"*, not *"what is its tangent"*: forward mode still asks an op whose operand is active for one.

Tests: `test/MLIR/{ReverseMode,ForwardMode}/dbg_intrinsics.mlir` — `square(x) = x*x` with a `dbg.value` on the argument differentiates in both modes, the intrinsic staying on the primal value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD