### PR TITLE
ReverseRetOpt: bail on ops whose outputs do not line up with their activities

### DIFF
--- a/enzyme/Enzyme/MLIR/Dialect/Ops.cpp
+++ b/enzyme/Enzyme/MLIR/Dialect/Ops.cpp
@@ -813,6 +813,11 @@ public:
         continue;
       }
 
+      // An op whose outputs do not line up with its activities (there is no
+      // verifier saying they must) is left for the AD pass to diagnose;
+      // reading on would walk off the ends of the ranges.
+      if (out_idx >= (int64_t)uop.getOutputs().size())
+        return failure();
       mlir::Value res = uop.getOutputs()[out_idx];
 
       switch (val) {
@@ -821,6 +826,8 @@ public:
         // active -> const(if dres == 0)
         // active -> constnoneed(both)
 
+        if (in_idx >= (int64_t)uop.getInputs().size())
+          return failure();
         mlir::Value dres = uop.getInputs()[in_idx];
         in_idx++;
 
@@ -866,6 +873,8 @@ public:
       case Activity::enzyme_activenoneed:
         // activenoneed -> constnoneed
         {
+          if (in_idx >= (int64_t)uop.getInputs().size())
+            return failure();
           mlir::Value dres = uop.getInputs()[in_idx];
           in_idx++;
           auto new_act = iattr;
@@ -926,6 +935,8 @@ public:
       auto val = iattr.getValue();
 
       if (val == Activity::enzyme_active) {
+        if (out_idx >= (int64_t)uop.getOutputs().size())
+          return failure();
         mlir::Value res = uop.getOutputs()[out_idx];
         if (!res.use_empty()) {
           out_ty.push_back(res.getType());

--- a/enzyme/test/MLIR/Passes/reverseretopt_inconsistent.mlir
+++ b/enzyme/test/MLIR/Passes/reverseretopt_inconsistent.mlir
@@ -1,0 +1,23 @@
+// RUN: %eopt --canonicalize %s | FileCheck %s
+
+// An enzyme.autodiff whose outputs do not line up with its activities: an
+// enzyme_active return claims a primal among the results, but the op carries
+// only the gradient (the shape a __enzyme_autodiff call raises to when the
+// return is mis-said as active rather than activenoneed). There is no
+// verifier saying the ranges must line up, so the canonicalizer used to walk
+// off their ends; it must leave the op for the AD pass to diagnose instead.
+
+module {
+  llvm.func @square(%x: f64) -> f64 {
+    %r = llvm.fmul %x, %x : f64
+    llvm.return %r : f64
+  }
+  llvm.func @dsquare(%x: f64) -> f64 {
+    %cst = arith.constant 1.000000e+00 : f64
+    %0 = enzyme.autodiff @square(%x, %cst) {activity = [#enzyme<activity enzyme_active>], ret_activity = [#enzyme<activity enzyme_active>]} : (f64, f64) -> f64
+    llvm.return %0 : f64
+  }
+}
+
+// CHECK-LABEL: llvm.func @dsquare
+// CHECK: enzyme.autodiff @square


### PR DESCRIPTION
`enzyme.autodiff` has no verifier relating its result count to its activity attributes, so a canonicalization pattern can meet an op whose ranges do not line up. The shape a `__enzyme_autodiff` call raises to when the return is mis-said as `enzyme_active` rather than `enzyme_activenoneed` (fixed on the producer side in Enzyme-JAX#2824) **segfaulted** `ReverseRetOpt` walking `getOutputs()`/`getInputs()` past their ends — on as little as differentiating `square(x) = x*x` from C.

Bounds-check the four indexed reads and `return failure()`, leaving the op intact for the AD pass to diagnose properly. Regression test: the 11-line crasher canonicalizes without crashing, op retained.

Companions: Enzyme-JAX#2824 (producer fix), #3117 (debug intrinsics, the other blocker for the same C sample under `-g`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD