### PR TITLE
Add a sumMIT integration test for the Enzyme AD material tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,10 +27,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     container:
       image: ${{ (contains(matrix.os, 'linux') && 'ghcr.io/enzymead/reactant-docker-images_24.04@sha256:2d3132895ab3c3a593cb494fad4ce1e17f4c145771a92809f070805d0250ac71' ) || '' }}
-    env:
-      # sumMIT is a private repository, so its clone needs a token with read access.
-      # Forks do not receive secrets, so the sumMIT tests are skipped there.
-      SUMMIT_TOKEN: ${{ secrets.SUMMIT_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -65,7 +61,12 @@ jobs:
         working-directory: build
         run: make -j `nproc`
       - name: "Run tests"
-        if: matrix.package != 'summit' || env.SUMMIT_TOKEN != ''
+        # sumMIT is private, so its clone needs SUMMIT_TOKEN. Forks are not given
+        # secrets, so skip there; anywhere else a missing or expired token must
+        # fail rather than quietly turn the job green without running anything.
+        if: matrix.package != 'summit' || github.event.pull_request.head.repo.fork != true
+        env:
+          SUMMIT_TOKEN: ${{ secrets.SUMMIT_TOKEN }}
         run: |
           bash integration/${{ matrix.package }}/run.sh ${{ matrix.llvm }} ${PWD}/build/Enzyme `nproc`
         shell: bash

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,6 +27,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     container:
       image: ${{ (contains(matrix.os, 'linux') && 'ghcr.io/enzymead/reactant-docker-images_24.04@sha256:2d3132895ab3c3a593cb494fad4ce1e17f4c145771a92809f070805d0250ac71' ) || '' }}
+    env:
+      # sumMIT is a private repository, so its clone needs a token with read access.
+      # Forks do not receive secrets, so the sumMIT tests are skipped there.
+      SUMMIT_TOKEN: ${{ secrets.SUMMIT_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -38,9 +42,12 @@ jobs:
         package:
           - mfem
           - gridkit
+          - summit
         exclude:
           - os: linux-x86-a2-48-a100-4gpu
             package: gridkit
+          - os: linux-x86-a2-48-a100-4gpu
+            package: summit
     steps:
       - uses: actions/checkout@v7
       - name: add llvm
@@ -58,6 +65,7 @@ jobs:
         working-directory: build
         run: make -j `nproc`
       - name: "Run tests"
+        if: matrix.package != 'summit' || env.SUMMIT_TOKEN != ''
         run: |
           bash integration/${{ matrix.package }}/run.sh ${{ matrix.llvm }} ${PWD}/build/Enzyme `nproc`
         shell: bash

--- a/integration/summit/run.sh
+++ b/integration/summit/run.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+# set explicitly, the workflow invokes this as `bash run.sh`, which ignores the shebang
+set -e
+
+echo "Running sumMIT integration tests"
+
+CLANGV=$1
+ENZYME_DIR=$2
+NPROC=${3:-`nproc`}
+LLDENZYME=$ENZYME_DIR/LLDEnzyme-$CLANGV.so
+
+# sumMIT lives in a private repository, so the workflow forwards SUMMIT_TOKEN, a
+# token with read access to it. Without one the clone below cannot succeed.
+SUMMIT_URL=${SUMMIT_URL:-https://${SUMMIT_TOKEN:+x-access-token:$SUMMIT_TOKEN@}github.com/MIT-PSAAP-IV/sumMIT.git}
+# the Enzyme tests live on the enzyme-ad branch; switch to main once it lands
+SUMMIT_BRANCH=${SUMMIT_BRANCH:-enzyme-ad}
+
+echo "CLANGV: $CLANGV"
+echo "ENZYME_DIR: $ENZYME_DIR"
+echo "LLDENZYME: $LLDENZYME"
+echo "NPROC: $NPROC"
+echo "SUMMIT_BRANCH: $SUMMIT_BRANCH"
+
+if [ ! -f "$LLDENZYME" ]; then
+    echo "LLDEnzyme plugin not found at $LLDENZYME" >&2
+    exit 1
+fi
+
+WORKDIR=$PWD
+
+echo "Installing dependencies"
+apt-get update
+# lld is required because sumMIT links the Enzyme tests through LLDEnzyme, the
+# remaining packages are sumMIT's documented dependency set (doc/wiki/installing)
+apt-get install -y \
+    lld-$CLANGV gfortran cmake git ca-certificates \
+    libgtest-dev libopenmpi-dev libmetis-dev libparmetis-dev \
+    petsc-dev slepc-dev libhdf5-dev libhdf5-openmpi-dev \
+    libeigen3-dev libgsl-dev libyaml-cpp-dev libjsoncpp-dev \
+    libvtk9-dev python3-vtk9 qtbase5-dev qtchooser qt5-qmake qttools5-dev-tools \
+    pybind11-dev libpython3-dev python3-pip
+
+echo "Building pyre"
+# pyre is not packaged for Ubuntu, so build it from source. The clone cannot be
+# shallow because pyre derives its version with git describe, which needs tags.
+git clone https://github.com/pyre/pyre.git
+cmake -S pyre -B pyre-build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_PREFIX_PATH="/usr" \
+    -DCMAKE_MODULE_PATH="$WORKDIR/pyre/.cmake" \
+    -DCMAKE_INSTALL_PREFIX="$WORKDIR/pyre-install"
+cmake --build pyre-build --target install -j $NPROC
+
+echo "Cloning sumMIT"
+git clone --depth 1 -b $SUMMIT_BRANCH "$SUMMIT_URL" sumMIT
+
+echo "Writing sumMIT toolchain file"
+# sumMIT resolves its dependencies through a toolchain file rather than through
+# plain cmake variables; see doc/wiki/installing/cmake.md in the sumMIT tree
+cat > $WORKDIR/enzyme_toolchain.cmake <<EOF
+include(summit_init)
+
+set(CMAKE_C_COMPILER "clang-$CLANGV" CACHE FILEPATH "" FORCE)
+set(CMAKE_CXX_COMPILER "clang++-$CLANGV" CACHE FILEPATH "" FORCE)
+set(CMAKE_Fortran_COMPILER "gfortran" CACHE FILEPATH "" FORCE)
+
+set(SYS_PREFIX "/usr")
+
+set(HDF5_PREFER_PARALLEL ON)
+set(PYBIND11_FINDPYTHON ON)
+
+summit_set_dependency(Eigen3   "\${SYS_PREFIX}"                              "Eigen3::Eigen")
+summit_set_dependency(GTEST    "\${SYS_PREFIX}"                              "GTest::gtest")
+summit_set_dependency(GSL      "\${SYS_PREFIX}"                              "GSL::gsl")
+summit_set_dependency(HDF5     "\${SYS_PREFIX}"                              "HDF5::HDF5")
+summit_set_dependency(METIS    "\${SYS_PREFIX}"                              "METIS::METIS")
+summit_set_dependency(MPI      "\${SYS_PREFIX}/lib/x86_64-linux-gnu/openmpi" "MPI::MPI_CXX")
+summit_set_dependency(ParMETIS "\${SYS_PREFIX}"                              "ParMETIS::ParMETIS")
+summit_set_dependency(PETSc    "\${SYS_PREFIX}"                              "PETSc::PETSc")
+summit_set_dependency(pybind11 "\${SYS_PREFIX}"                              "pybind11::module")
+summit_set_dependency(PYRE     "$WORKDIR/pyre-install"                       "pyre::pyre")
+summit_set_dependency(Python   "\${SYS_PREFIX}"                              "Python3::Python")
+summit_set_dependency(SLEPc    "\${SYS_PREFIX}"                              "SLEPc::SLEPc")
+summit_set_dependency(VTK      "\${SYS_PREFIX}"                              "VTK::CommonCore")
+summit_set_dependency(VTK      "\${SYS_PREFIX}"                              "VTK::IOXML")
+summit_set_dependency(VTK      "\${SYS_PREFIX}"                              "VTK::CommonDataModel")
+summit_set_dependency(yaml-cpp "\${SYS_PREFIX}"                              "yaml-cpp")
+
+list(REMOVE_DUPLICATES CMAKE_PREFIX_PATH)
+set(CMAKE_PREFIX_PATH "\${CMAKE_PREFIX_PATH}" CACHE STRING "" FORCE)
+summit_generate_features_file()
+EOF
+
+echo "Configuring sumMIT"
+cmake -S sumMIT -B summit-build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_TOOLCHAIN_FILE=$WORKDIR/enzyme_toolchain.cmake \
+    -DSUMMIT_COMPILER_SET=CLANG \
+    -DSUMMIT_BUILD_TESTING=ON \
+    -DSUMMIT_DEBUG=OFF \
+    -DWITH_ENZYME=ON \
+    -DSUMMIT_ENZYME_LLD_PLUGIN=$LLDENZYME
+
+# The Enzyme test drivers are EXCLUDE_FROM_ALL, and the ctest name of each one is
+# its target name, so ask ctest which ones exist rather than hardcoding the list.
+TARGETS=`ctest --test-dir summit-build -N -R enzyme | sed -n 's/^ *Test *#[0-9]*: *//p'`
+
+if [ -z "$TARGETS" ]; then
+    echo "No sumMIT Enzyme tests were registered" >&2
+    exit 1
+fi
+
+echo "Building Enzyme test drivers:"
+echo "$TARGETS"
+cmake --build summit-build --target $TARGETS -j $NPROC
+
+ctest --test-dir summit-build -R enzyme --output-on-failure

--- a/integration/summit/run.sh
+++ b/integration/summit/run.sh
@@ -60,7 +60,9 @@ cmake -S pyre -B pyre-build \
 cmake --build pyre-build --target install -j $NPROC
 
 echo "Cloning sumMIT"
-git clone --depth 1 -b $SUMMIT_BRANCH "$SUMMIT_URL" sumMIT
+# not shallow: summit_getVersion runs git describe --tags --long --always, and
+# without tags reachable from HEAD that yields a bare sha, which sumMIT rejects
+git clone -b $SUMMIT_BRANCH "$SUMMIT_URL" sumMIT
 
 echo "Writing sumMIT toolchain file"
 # sumMIT resolves its dependencies through a toolchain file rather than through

--- a/integration/summit/run.sh
+++ b/integration/summit/run.sh
@@ -11,7 +11,14 @@ NPROC=${3:-`nproc`}
 LLDENZYME=$ENZYME_DIR/LLDEnzyme-$CLANGV.so
 
 # sumMIT lives in a private repository, so the workflow forwards SUMMIT_TOKEN, a
-# token with read access to it. Without one the clone below cannot succeed.
+# token with read access to it. Fail early rather than on a bare git credential
+# prompt, so an expired or missing token is obvious from the log.
+if [ -z "$SUMMIT_URL" ] && [ -z "$SUMMIT_TOKEN" ]; then
+    echo "SUMMIT_TOKEN is empty; cloning the private sumMIT repository needs a token" >&2
+    echo "with read access to MIT-PSAAP-IV/sumMIT. If the secret exists, it has" >&2
+    echo "most likely expired and needs to be reissued." >&2
+    exit 1
+fi
 SUMMIT_URL=${SUMMIT_URL:-https://${SUMMIT_TOKEN:+x-access-token:$SUMMIT_TOKEN@}github.com/MIT-PSAAP-IV/sumMIT.git}
 # the Enzyme tests live on the enzyme-ad branch; switch to main once it lands
 SUMMIT_BRANCH=${SUMMIT_BRANCH:-enzyme-ad}


### PR DESCRIPTION
Adds an integration test that builds [sumMIT](https://github.com/MIT-PSAAP-IV/sumMIT) against a freshly built Enzyme and runs its Enzyme-based material consistency tests, which come from MIT-PSAAP-IV/sumMIT#3. Those tests check Enzyme's forward- and reverse-mode derivatives of a material's `Constitutive` routine against finite differences, so this catches Enzyme regressions against that workload.

### `integration/summit/run.sh`

Follows the existing gridkit/mfem pattern (`CLANGV`, `ENZYME_DIR`, `NPROC`):

1. Installs sumMIT's documented apt dependencies, plus `lld-$CLANGV` since the tests link through `LLDEnzyme`
2. Builds pyre from source — it is not packaged for Ubuntu
3. Clones sumMIT at its branch tip, so it tracks latest rather than a pinned commit
4. Generates the toolchain file sumMIT's CMake requires, with `SUMMIT_ENZYME_LLD_PLUGIN` pointed at `$ENZYME_DIR/LLDEnzyme-$CLANGV.so`
5. Asks `ctest -N -R enzyme` which drivers are registered and builds only those — they are `EXCLUDE_FROM_ALL`, so building all of `tests` would be far more work than needed
6. Runs them with `ctest --output-on-failure`

### Workflow

`summit` joins the matrix, excluded on the GPU runner since these are CPU-only material tests.

### Verification

Ran the full CI sequence in the workflow's container image (install LLVM 18 → build LLDEnzyme → run the script):

```
[100%] Linking CXX executable bin/TEST.unit.materials.gent-compressible.gent_enzyme_test
    Start 208: TEST.unit.materials.gent-compressible.gent_enzyme_test
[ RUN      ] enzyme_test.gentCompressibleStress
[       OK ] enzyme_test.gentCompressibleStress
[ RUN      ] enzyme_test.gentCompressibleTangent
[       OK ] enzyme_test.gentCompressibleTangent
100% tests passed, 0 tests failed out of 1
```

The link succeeding is itself evidence the plugin ran, since `__enzyme_autodiff` is otherwise undefined.

### Before this can go green

- [ ] **A `SUMMIT_TOKEN` secret** on this repo (fine-grained PAT, read access to `MIT-PSAAP-IV/sumMIT`). sumMIT is private. Forks do not receive secrets, so the run step is gated on the token being present and **skips** rather than failing on an unauthenticated clone. Until the secret exists the summit entry skips everywhere, so a green check does not yet mean the tests ran.
- [ ] **MIT-PSAAP-IV/sumMIT#3 to merge**, after which `SUMMIT_BRANCH` moves from `enzyme-ad` to `main` (there is a comment marking the spot). This mirrors the mfem script, which tracks `dfem-dev`.

### Note on runtime

Measured ~5 min on a 192-core box; the sumMIT build is LTO-heavy, so expect roughly 15–25 min on the 32-core runner against the job's 45-minute timeout. It should fit, but it will be the slowest integration job — worth bumping `timeout-minutes` if it proves tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153oy7Y659Q3AriKGbkUJpg