### PR TITLE
Use hasTerminator() in freeCache

### DIFF
--- a/enzyme/Enzyme/DiffeGradientUtils.cpp
+++ b/enzyme/Enzyme/DiffeGradientUtils.cpp
@@ -915,8 +915,7 @@ CallInst *DiffeGradientUtils::freeCache(BasicBlock *forwardPreheader,
   tbuild.setFastMathFlags(getFast());
 
   // ensure we are before the terminator if it exists
-  if (tbuild.GetInsertBlock()->size() &&
-      tbuild.GetInsertBlock()->getTerminator()) {
+  if (hasTerminator(tbuild.GetInsertBlock())) {
     tbuild.SetInsertPoint(tbuild.GetInsertBlock()->getTerminator());
   }
 


### PR DESCRIPTION
Noticed this was missing @wsmoses 

LLVM's BasicBlock::getTerminator() asserts hasTerminator() rather than returning null, so the null-check idiom aborts with

  BasicBlock.h: getTerminator:
  `hasTerminator() && "cannot get terminator of non-well-formed block"'

whenever freeCache runs on a reverse block that is still under construction and so legitimately has no terminator yet. Reached via forceAugmentedReturns -> getContext -> getDynamicLoopLimit -> createCacheForScope, differentiating a loop whose trip count cannot be derived statically.

This was the last remaining use of the old idiom; the other sites already go through the Utils.h hasTerminator() wrapper, which this now matches. The preceding size() check becomes redundant, since hasTerminator() already implies a non-empty block.