### PR TITLE
Keep phis contiguous after inverting a phi's incoming values

### DIFF
--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -6725,6 +6725,24 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
           which->addIncoming(val, cast<BasicBlock>(getNewFromOriginal(
                                       phi->getIncomingBlock(i))));
         }
+        // Inverting an incoming value can emit instructions into this block
+        // above `which` (e.g. materializing the shadow of a value defined in
+        // the header), which leaves the phis no longer contiguous at the block
+        // start and produces IR the verifier rejects. Restore the invariant.
+        {
+          BasicBlock *PB = which->getParent();
+          SmallVector<PHINode *, 4> phis;
+          for (auto &I : *PB)
+            if (auto *P = dyn_cast<PHINode>(&I))
+              phis.push_back(P);
+          Instruction *at = &*PB->begin();
+          for (auto *P : phis) {
+            if (P != at)
+              P->moveBefore(at);
+            else
+              at = P->getNextNode();
+          }
+        }
         return which;
       }
     }


### PR DESCRIPTION
In invertPointerM's PHINode case, inverting an incoming value can emit instructions into the phi's own block above the shadow phi just created -- materializing the shadow of a value defined in the loop header inserts an alloca, a store and byte-wise zeroing between the canonical IV phi and the shadow phi. That leaves the block's phis no longer contiguous at the block start, and the resulting IR is rejected:

  Instruction does not dominate all uses!
  PHI nodes not grouped at top of basic block!
  function failed verification

One misplacement produces both complaints: the cache store for the primal phi is then emitted at getFirstNonPHI(), which now precedes that phi's definition.

Re-group the block's phis at the block start once the incoming values have been inverted.

Note this restores the invariant rather than preventing the insertion; the cleaner fix is to correct whichever builder positions the shadow-materialization machinery above the phis.

Workaround for https://github.com/EnzymeAD/Enzyme/issues/3029, though you might want to find the proper cause @wsmoses 