### PR TITLE
Skip phis with no incoming values when placing a nulled shadow

### DIFF
--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -5577,11 +5577,13 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
           // Go one after since otherwise we won't be able
           // to use in the store.
           arg = arg->getNextNode();
-          while (auto PN = dyn_cast<PHINode>(arg)) {
-            if (PN->getNumIncomingValues() == 0)
-              break;
-            arg = PN->getNextNode();
-          }
+          // Skip every phi, including ones whose incoming values have not been
+          // filled in yet: a shadow phi created by the PHINode case below has
+          // no incoming values until after it has recursed into this function
+          // for each incoming value, and stopping on it would insert these
+          // stores above a phi.
+          while (isa<PHINode>(arg))
+            arg = arg->getNextNode();
           bb.SetInsertPoint(arg);
         }
         auto alloc = bb.CreateAlloca(oval->getType());


### PR DESCRIPTION
When invertPointerM nulls the shadow of a partially-float constant it inserts an alloca, a store of the primal and the per-byte zeroing just after the value's clone, walking past any following phis so the stores do not land in the phi region. That walk stopped at a phi with no incoming values.

The PHINode case of this same function creates its shadow phi with CreatePHI(shadowTy, phi->getNumIncomingValues()) and only calls addIncoming after it has recursed into invertPointerM for each incoming value. So while that recursion runs, the shadow phi genuinely has zero incoming values, the walk stops on it, and the stores are inserted above it.

That leaves the block's phis no longer contiguous at its start, and the resulting function is rejected:

  Instruction does not dominate all uses!
  PHI nodes not grouped at top of basic block!
  function failed verification

Both complaints come from the single misplacement: the cache store for the primal phi is subsequently emitted at getFirstNonPHI(), which by then precedes that phi's definition.

The incoming count says nothing about whether a phi is in the phi region, so skip every phi.

fixes: https://github.com/EnzymeAD/Enzyme/issues/3029
closes: https://github.com/EnzymeAD/Enzyme/pull/3126

cc @wsmoses 