### PR TITLE
Add workflow for Fortran linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,3 +32,19 @@ jobs:
     - name: Check for direct LLVM API calls that Utils.h wraps
       run: |
         python3 enzyme/scripts/check_llvm_api.py --github enzyme/Enzyme
+
+  fortran-lint:
+    name: Linting for Fortran source
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Fortitude
+      run: |
+        python3 -m venv enzyme_venv
+        . enzyme_venv/bin/activate
+        pip install fortitude-lint
+    - name: Run Fortitude check
+      run: |
+        . enzyme_venv/bin/activate
+        fortitude check

--- a/enzyme/Fortran/enzyme.f90
+++ b/enzyme/Fortran/enzyme.f90
@@ -21,7 +21,7 @@
 !
 ! ===----------------------------------------------------------------------=== !
 module enzyme
-  use iso_c_binding, only: c_int
+  use, intrinsic :: iso_c_binding, only: c_int
   use enzyme_function_hooks, only: enzyme_autodiff => f__enzyme_autodiff, &
                                    enzyme_fwddiff  => f__enzyme_fwddiff
   implicit none

--- a/enzyme/test/Fortran/BatchMode/square_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/BatchMode/square_with_explicit_interface.f90
@@ -12,11 +12,15 @@
 !       handle the different signature for __enzyme_batch used by ifx.
 
 module squareBatch
+  implicit none
+  public
   interface
     subroutine square__enzyme_batch(sr, width_desc, width, &
                                     vec_desc, x1, x2, x3, x4, y1, y2, y3, y4)
+      implicit none
       interface
         subroutine sr_decal(xx, yy)
+          implicit none
           real, intent(in)  :: xx
           real, intent(out) :: yy
         end subroutine sr_decal

--- a/enzyme/test/Fortran/BatchMode/square_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/BatchMode/square_with_explicit_interface.f90
@@ -36,8 +36,8 @@ contains
     real, intent(in)  :: x
     real, intent(out) :: y
     y = x ** 2
-  end subroutine
-end module
+  end subroutine square
+end module squareBatch
 
 program main
   use enzyme, only: enzyme_vector, enzyme_width
@@ -59,7 +59,7 @@ program main
   write(*,"(f0.4)") y2
   write(*,"(f0.4)") y3
   write(*,"(f0.4)") y4
-end program
+end program main
 
 ! CHECK: 533.6100
 ! CHECK-NEXT: 100.0000

--- a/enzyme/test/Fortran/ForwardMode/allocatable_with_bindings_O0.f90
+++ b/enzyme/test/Fortran/ForwardMode/allocatable_with_bindings_O0.f90
@@ -42,9 +42,9 @@ contains
         real, intent(in) :: x(n)
         real, intent(inout) :: y
         y = x(1)
-    end subroutine
+    end subroutine selectFirst
 
-end program
+end program main
 
 ! CHECK: 2
 ! CHECK-NEXT: 1

--- a/enzyme/test/Fortran/ReverseMode/allocatable_with_bindings_O0.f90
+++ b/enzyme/test/Fortran/ReverseMode/allocatable_with_bindings_O0.f90
@@ -42,9 +42,9 @@ contains
     real, intent(in) :: x(n)
     real, intent(inout) :: y
     y = x(1)
-  end subroutine
+  end subroutine selectFirst
 
-end program
+end program main
 
 ! CHECK: 2
 ! CHECK-NEXT: 1

--- a/enzyme/test/Fortran/ReverseMode/dot_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/ReverseMode/dot_with_bindings_opt.f90
@@ -68,9 +68,9 @@ contains
     real, dimension(n), intent(in) :: b
     real, intent(in) :: c
     dot = dot_product(a, b) + c
-  end function
+  end function dot
 
-end program
+end program main
 
 ! CHECK: 20.0
 ! CHECK-NEXT: 20.0

--- a/enzyme/test/Fortran/ReverseMode/norm_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/ReverseMode/norm_with_bindings_opt.f90
@@ -36,9 +36,9 @@ contains
     real, dimension(n), intent(in) :: x
     real, dimension(n), intent(out) :: y
     y(:) = x / sum(x)
-  end subroutine
+  end subroutine norm
 
-end program
+end program main
 
 ! CHECK: 1.0000
 ! CHECK-NEXT: 0.0000

--- a/enzyme/test/Fortran/ReverseMode/square_with_bindings_O0.f90
+++ b/enzyme/test/Fortran/ReverseMode/square_with_bindings_O0.f90
@@ -30,7 +30,7 @@ contains
   real function square(x)
     real, intent(in) :: x
     square = x**2
-  end function
+  end function square
 
 end program main
 

--- a/fortitude.toml
+++ b/fortitude.toml
@@ -1,0 +1,6 @@
+[check]
+# Ignored Rules and justification:
+#   S001: line too long - the default line length of 100 is easily exceeded by some of the lit run commands
+#   C003: 'implicit none' missing 'external' - this is a Fortran 2013 feature and we support older standards
+#   C091: external procedure - this is crucial to the way the Fortran bindings are set up
+ignore = ["S001", "C003", "C091"]

--- a/fortitude.toml
+++ b/fortitude.toml
@@ -1,6 +1,6 @@
 [check]
 # Ignored Rules and justification:
-#   S001: line too long - the default line length of 100 is easily exceeded by some of the lit run commands
+#   S001: line too long - most reasonable maximum line lengths are exceeded by some of the lit run commands
 #   C003: 'implicit none' missing 'external' - this is a Fortran 2013 feature and we support older standards
 #   C091: external procedure - this is crucial to the way the Fortran bindings are set up
 ignore = ["S001", "C003", "C091"]


### PR DESCRIPTION
This PR adds a workflow step for Fortran linting using the [Fortitude](https://fortitude.readthedocs.io/en/stable/) linter.

I included a `fortitude.toml` file that configures ignores and included three that are relevant to the way things are currently set up. I fixed all other recommendations to get the linter passing.