### PR TITLE
MLIR: one getBaseObject for gradient utils and alias queries

### DIFF
--- a/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/GradientUtils.cpp
@@ -11,6 +11,7 @@
 #include "Interfaces/AutoDiffOpInterface.h"
 #include "Interfaces/AutoDiffTypeInterface.h"
 #include "Interfaces/CloneFunction.h"
+#include "Interfaces/Utils.h"
 
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/SymbolTable.h"
@@ -349,26 +350,7 @@ LogicalResult MGradientUtils::visitChild(Operation *op) {
 }
 
 Value MGradientUtils::getBaseObject(Value v) {
-  while (Operation *def = v.getDefiningOp()) {
-    if (auto view = dyn_cast<ViewLikeOpInterface>(def)) {
-      v = view.getViewSource();
-      continue;
-    }
-    if (auto gep = dyn_cast<LLVM::GEPOp>(def)) {
-      v = gep.getBase();
-      continue;
-    }
-    if (auto bc = dyn_cast<LLVM::BitcastOp>(def)) {
-      v = bc.getArg();
-      continue;
-    }
-    if (auto asc = dyn_cast<LLVM::AddrSpaceCastOp>(def)) {
-      v = asc.getArg();
-      continue;
-    }
-    break;
-  }
-  return v;
+  return mlir::enzyme::oputils::getBaseObject(v);
 }
 
 DIFFE_TYPE MGradientUtils::getDiffeTypeOfBase(Value ptr) {

--- a/enzyme/Enzyme/MLIR/Interfaces/Utils.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/Utils.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 #include <optional>
 
 using namespace mlir;
@@ -104,22 +105,22 @@ static bool isCaptured(Value v, Operation *potentialUser = nullptr,
   return false;
 }
 
-static Value getBase(Value v) {
-  while (true) {
-    if (auto s = v.getDefiningOp<LLVM::GEPOp>()) {
-      v = s.getBase();
+Value getBaseObject(Value v) {
+  while (Operation *def = v.getDefiningOp()) {
+    if (auto view = dyn_cast<ViewLikeOpInterface>(def)) {
+      v = view.getViewSource();
       continue;
     }
-    if (auto s = v.getDefiningOp<LLVM::BitcastOp>()) {
-      v = s.getArg();
+    if (auto gep = dyn_cast<LLVM::GEPOp>(def)) {
+      v = gep.getBase();
       continue;
     }
-    if (auto s = v.getDefiningOp<LLVM::AddrSpaceCastOp>()) {
-      v = s.getArg();
+    if (auto bc = dyn_cast<LLVM::BitcastOp>(def)) {
+      v = bc.getArg();
       continue;
     }
-    if (auto s = v.getDefiningOp<memref::CastOp>()) {
-      v = s.getSource();
+    if (auto asc = dyn_cast<LLVM::AddrSpaceCastOp>(def)) {
+      v = asc.getArg();
       continue;
     }
     break;
@@ -134,8 +135,8 @@ static bool isStackAlloca(Value v) {
 }
 
 bool mayAlias(Value v1, Value v2) {
-  v1 = getBase(v1);
-  v2 = getBase(v2);
+  v1 = getBaseObject(v1);
+  v2 = getBaseObject(v2);
   if (v1 == v2)
     return true;
 

--- a/enzyme/Enzyme/MLIR/Interfaces/Utils.h
+++ b/enzyme/Enzyme/MLIR/Interfaces/Utils.h
@@ -25,6 +25,11 @@ bool isReadOnly(Operation *op);
 
 bool isReadNone(Operation *op);
 
+// Walks a pointer-like value to the object it is derived from, looking
+// through view-like ops (memref.cast, memref.memory_space_cast, subviews),
+// llvm.getelementptr, llvm.bitcast, and llvm.addrspacecast.
+Value getBaseObject(Value v);
+
 // Checks if 2 values v1 and v2 may alias with each other locally
 bool mayAlias(Value v1, Value v2);
 


### PR DESCRIPTION
The alias utility's local `getBase` knew `memref.cast` but not the other view-like ops (subviews, `memory_space_cast`) that `MGradientUtils::getBaseObject` sees through — which matters now that the raising pipeline emits `memory_space_cast` for shared-memory promotions (EnzymeAD/Enzyme-JAX#2836). Move the walk into `oputils::getBaseObject` and use it for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD