### PR TITLE
MLIR: derivatives for enzyme.affine_atomic_rmw

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/EnzymeAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/EnzymeAutoDiffOpInterfaceImpl.cpp
@@ -20,6 +20,7 @@
 
 #include "Dialect/Dialect.h"
 #include "Dialect/Ops.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/IR/TypeSupport.h"
 
 using namespace mlir;
@@ -27,11 +28,153 @@ using namespace mlir::enzyme;
 
 namespace {
 #include "Implementations/EnzymeDerivatives.inc"
+
+// The primal op atomically performs old = m[i]; m[i] = old + v and yields
+// old. Backward, the location's adjoint serves both reads: the added value
+// takes it (d_v += dm[i]), and it keeps flowing to whatever wrote m[i]
+// before -- the atomic changed the value, not which value the location
+// stands for. A used result read the pre-add value, so its adjoint joins
+// the location's, atomically for the same reason the primal add was atomic.
+// The load of the location's adjoint is plain: the reverse sweep mirrors
+// the forward structure, so the barriers that ordered the primal's atomics
+// against this thread's reads order the shadow's atomics against this load.
+struct AffineAtomicRMWOpInterfaceReverse
+    : public ReverseAutoDiffOpInterface::ExternalModel<
+          AffineAtomicRMWOpInterfaceReverse, enzyme::AffineAtomicRMWOp> {
+  LogicalResult createReverseModeAdjoint(Operation *op, OpBuilder &builder,
+                                         MGradientUtilsReverse *gutils,
+                                         SmallVector<Value> caches) const {
+    auto rmwOp = cast<enzyme::AffineAtomicRMWOp>(op);
+    Value memref = rmwOp.getMemref();
+    Value val = rmwOp.getValue();
+
+    if (gutils->isConstantValue(memref)) {
+      // Inactive memory: the value folds into it and the result read from it
+      // carries nothing out.
+      if (!gutils->isConstantValue(rmwOp.getResult()))
+        gutils->zeroDiffe(rmwOp.getResult(), builder);
+      return success();
+    }
+
+    if (rmwOp.getKind() != arith::AtomicRMWKind::addf)
+      return op->emitError()
+             << "could not compute the adjoint of a non-add atomic rmw " << *op;
+
+    auto iface = dyn_cast<AutoDiffTypeInterface>(val.getType());
+    if (!iface)
+      return op->emitError()
+             << "could not compute the adjoint of an atomic rmw on a type "
+                "without autodiff semantics "
+             << *op;
+
+    Value memrefGradient = gutils->popCache(caches.front(), builder);
+    SmallVector<Value> retrievedArguments;
+    for (Value cache : ValueRange(caches).drop_front(1))
+      retrievedArguments.push_back(gutils->popCache(cache, builder));
+
+    auto alignAttr = rmwOp.getAlignmentAttr();
+    if (!gutils->isConstantValue(val)) {
+      auto loadedGradient = affine::AffineLoadOp::create(
+          builder, rmwOp.getLoc(), memrefGradient, rmwOp.getMap(),
+          ArrayRef<Value>(retrievedArguments));
+      if (alignAttr)
+        loadedGradient->setAttr("alignment", alignAttr);
+      gutils->addToDiffe(val, loadedGradient, builder);
+    }
+
+    if (!gutils->isConstantValue(rmwOp.getResult())) {
+      Value gradient = gutils->diffe(rmwOp.getResult(), builder);
+      gutils->zeroDiffe(rmwOp.getResult(), builder);
+      setDerivativeFastMath(enzyme::AffineAtomicRMWOp::create(
+          builder, rmwOp.getLoc(), gradient.getType(),
+          arith::AtomicRMWKind::addf, gradient, memrefGradient,
+          retrievedArguments, rmwOp.getMap(), alignAttr));
+    }
+
+    return success();
+  }
+
+  SmallVector<Value> cacheValues(Operation *op,
+                                 MGradientUtilsReverse *gutils) const {
+    auto rmwOp = cast<enzyme::AffineAtomicRMWOp>(op);
+    if (gutils->isConstantValue(rmwOp.getMemref()))
+      return {};
+    OpBuilder cacheBuilder(gutils->getNewFromOriginal(op));
+    SmallVector<Value> caches;
+    caches.push_back(gutils->initAndPushCache(
+        gutils->invertPointerM(rmwOp.getMemref(), cacheBuilder), cacheBuilder));
+    for (Value v : rmwOp.getIndices())
+      caches.push_back(gutils->initAndPushCache(gutils->getNewFromOriginal(v),
+                                                cacheBuilder));
+    return caches;
+  }
+
+  void createShadowValues(Operation *op, OpBuilder &builder,
+                          MGradientUtilsReverse *gutils) const {}
+};
+
+// Forward mode mirrors the primal on the shadows: the tangent of the value
+// joins the location's tangent through the same atomic add, and what the
+// primal read out (the pre-add value) has as its tangent what the shadow
+// location held before the shadow's add -- exactly what the mirrored atomic
+// returns.
+struct AffineAtomicRMWOpForwardInterface
+    : public AutoDiffOpInterface::ExternalModel<
+          AffineAtomicRMWOpForwardInterface, enzyme::AffineAtomicRMWOp> {
+  LogicalResult createForwardModeTangent(Operation *op, OpBuilder &builder,
+                                         MGradientUtils *gutils) const {
+    auto rmwOp = cast<enzyme::AffineAtomicRMWOp>(op);
+    auto iface = dyn_cast<AutoDiffTypeInterface>(rmwOp.getValue().getType());
+    if (!iface)
+      return op->emitError()
+             << "could not compute the tangent of an atomic rmw on a type "
+                "without autodiff semantics "
+             << *op;
+
+    if (gutils->isConstantValue(rmwOp.getMemref())) {
+      // Inactive memory: the value's tangent folds into it and the result
+      // read from it carries a zero tangent out.
+      if (!gutils->isConstantValue(rmwOp.getResult()))
+        gutils->setDiffe(rmwOp.getResult(),
+                         iface.createNullValue(builder, op->getLoc()), builder);
+      return success();
+    }
+
+    if (rmwOp.getKind() != arith::AtomicRMWKind::addf)
+      return op->emitError()
+             << "could not compute the tangent of a non-add atomic rmw " << *op;
+
+    Value shadowMemref = gutils->invertPointerM(rmwOp.getMemref(), builder);
+    Value shadowVal = gutils->isConstantValue(rmwOp.getValue())
+                          ? iface.createNullValue(builder, op->getLoc())
+                          : gutils->invertPointerM(rmwOp.getValue(), builder);
+    auto newOp =
+        cast<enzyme::AffineAtomicRMWOp>(gutils->getNewFromOriginal(op));
+    SmallVector<Value> shadowIndices;
+    for (Value v : newOp.getIndices())
+      shadowIndices.push_back(v);
+    auto shadowOp = enzyme::AffineAtomicRMWOp::create(
+        builder, rmwOp.getLoc(), shadowVal.getType(),
+        arith::AtomicRMWKind::addf, shadowVal, shadowMemref, shadowIndices,
+        rmwOp.getMap(), rmwOp.getAlignmentAttr());
+    shadowOp->setAttr("fastmath", newOp.getFastmathAttr());
+    if (!gutils->isConstantValue(rmwOp.getResult()))
+      gutils->setDiffe(rmwOp.getResult(), shadowOp.getResult(), builder);
+    return success();
+  }
+};
+
 } // namespace
 
 void mlir::enzyme::registerEnzymeDialectAutoDiffInterface(
     DialectRegistry &registry) {
   registry.addExtension(+[](MLIRContext *context, enzyme::EnzymeDialect *) {
     registerInterfaces(context);
+    // The rules build affine loads and atomic adds over affine maps.
+    context->getOrLoadDialect<affine::AffineDialect>();
+    enzyme::AffineAtomicRMWOp::attachInterface<
+        AffineAtomicRMWOpInterfaceReverse>(*context);
+    enzyme::AffineAtomicRMWOp::attachInterface<
+        AffineAtomicRMWOpForwardInterface>(*context);
   });
 }

--- a/enzyme/test/MLIR/ForwardMode/affine_atomic_rmw.mlir
+++ b/enzyme/test/MLIR/ForwardMode/affine_atomic_rmw.mlir
@@ -1,0 +1,25 @@
+// RUN: %eopt %s --enzyme-wrap="infn=f outfn= argTys=enzyme_dup,enzyme_dup retTys= mode=ForwardMode" --canonicalize | FileCheck %s
+
+// Forward mode mirrors the primal on the shadows: the tangent of the added
+// value joins the shadow location through the same atomic add.
+
+module {
+  func.func @f(%a: f64, %m: memref<?xf64>) {
+    affine.for %i = 0 to 4 {
+      %v = arith.mulf %a, %a : f64
+      %old = "enzyme.affine_atomic_rmw"(%v, %m) <{alignment = 8 : i64, fastmath = #arith.fastmath<fast>, kind = 0 : i64, map = affine_map<() -> (0)>}> : (f64, memref<?xf64>) -> f64
+    }
+    return
+  }
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<() -> (0)>
+// CHECK-LABEL: func.func @f(
+// CHECK-SAME: %[[a:.+]]: f64, %[[da:.+]]: f64, %[[m:[^ :]+]]: memref<?xf64>, %[[dm:[^ :]+]]: memref<?xf64>)
+// CHECK: affine.for
+// CHECK: %[[t0:.+]] = arith.mulf %[[da]], %[[a]] fastmath<fast> : f64
+// CHECK: %[[t1:.+]] = arith.mulf %[[da]], %[[a]] fastmath<fast> : f64
+// CHECK: %[[dv:.+]] = arith.addf %[[t0]], %[[t1]] fastmath<fast> : f64
+// CHECK: %[[v:.+]] = arith.mulf %[[a]], %[[a]] : f64
+// CHECK-DAG: enzyme.affine_atomic_rmw addf %[[dv]], %[[dm]], (#[[$MAP]]) [] fastmath<fast> {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64
+// CHECK-DAG: enzyme.affine_atomic_rmw addf %[[v]], %[[m]], (#[[$MAP]]) [] fastmath<fast> {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64

--- a/enzyme/test/MLIR/ReverseMode/affine_atomic_rmw.mlir
+++ b/enzyme/test/MLIR/ReverseMode/affine_atomic_rmw.mlir
@@ -1,0 +1,32 @@
+// RUN: %eopt %s --enzyme-wrap="infn=f outfn= argTys=enzyme_active,enzyme_dup retTys= mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops --enzyme-simplify-math | FileCheck %s
+
+// The primal op atomically adds into the location and yields the pre-add
+// value; here the result is unused, so backward the location's adjoint
+// simply flows to the added value: d_v += dm[i], read off the shadow at the
+// same affine position. The load is plain -- the reverse sweep mirrors the
+// forward structure, so whatever ordered the primal's atomics against this
+// thread's reads orders the shadow's atomics against this load.
+
+module {
+  func.func @f(%a: f64, %m: memref<?xf64>) {
+    affine.parallel (%i) = (0) to (4) {
+      %v = arith.mulf %a, %a : f64
+      %old = "enzyme.affine_atomic_rmw"(%v, %m) <{alignment = 8 : i64, fastmath = #arith.fastmath<fast>, kind = 0 : i64, map = affine_map<() -> (0)>}> : (f64, memref<?xf64>) -> f64
+    }
+    return
+  }
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<() -> (0)>
+// CHECK-LABEL: func.func @f(
+// CHECK-SAME: %[[a:.+]]: f64, %[[m:[^ :]+]]: memref<?xf64>, %[[dm:[^ :]+]]: memref<?xf64>) -> f64
+// CHECK: %[[sq:.+]] = arith.mulf %[[a]], %[[a]] : f64
+// CHECK: affine.parallel
+// CHECK: enzyme.affine_atomic_rmw addf %[[sq]], %[[m]], (#[[$MAP]]) [] fastmath<fast> {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64
+// CHECK: %[[red:.+]] = affine.parallel (%{{.+}}) = (0) to (4) reduce ("addf") -> (f64)
+// CHECK: %[[g:.+]] = affine.load %[[dm]][0] {alignment = 8 : i64} : memref<?xf64>
+// CHECK: %[[t0:.+]] = arith.mulf %[[g]], %[[a]] fastmath<fast> : f64
+// CHECK: %[[t1:.+]] = arith.mulf %[[g]], %[[a]] fastmath<fast> : f64
+// CHECK: %[[t2:.+]] = arith.addf %[[t0]], %[[t1]] fastmath<fast> : f64
+// CHECK: affine.yield %[[t2]] : f64
+// CHECK: return %[[red]] : f64


### PR DESCRIPTION
The op is emitted as the derivative of affine loads under atomic-add
accumulation, but appearing in a primal -- a kernel that itself
accumulates with atomics, as MFEM's dfem hyperelasticity tests do --
neither mode had a rule for it and differentiation stopped.

Reverse: the location's adjoint serves both reads. The added value takes
it (d_v += dm[i], a plain load: the reverse sweep mirrors the forward
structure, so the barriers that ordered the primal's atomics order the
shadow's), and it keeps flowing to whatever wrote the location before.
A used result read the pre-add value, so its adjoint joins the
location's, atomically for the same reason the primal add was atomic.

Forward: the tangent of the added value joins the shadow location
through the same atomic add, whose result carries the tangent of the
value the primal read out.

Non-add kinds still refuse, now saying why.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD