### PR TITLE
MLIR: shadow stores of pointers in reverse mode

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
@@ -1042,12 +1042,24 @@ struct AffineStoreOpInterfaceReverse
     return SmallVector<Value>();
   }
 
+  // Same structural story as memref.store: a stored mutable value's shadow
+  // must land at the same affine position in the shadow memref.
   void createShadowValues(Operation *op, OpBuilder &builder,
                           MGradientUtilsReverse *gutils) const {
-    // auto storeOp = cast<memref::StoreOp>(op);
-    // Value memref = storeOp.getMemref();
-    // Value shadow = gutils->getShadowValue(memref);
-    // Do nothing yet. In the future support memref<memref<...>>
+    auto storeOp = cast<affine::AffineStoreOp>(op);
+    Value val = storeOp.getValue();
+    Value memref = storeOp.getMemref();
+    auto iface = dyn_cast<AutoDiffTypeInterface>(val.getType());
+    if (!iface || !iface.isMutable() || gutils->isConstantValue(memref))
+      return;
+    Value memrefShadow = gutils->invertPointerM(memref, builder);
+    Value valShadow = gutils->isConstantValue(val)
+                          ? gutils->getNewFromOriginal(val)
+                          : gutils->invertPointerM(val, builder);
+    auto newOp = cast<affine::AffineStoreOp>(gutils->getNewFromOriginal(op));
+    auto shadowOp = cast<affine::AffineStoreOp>(builder.clone(*newOp));
+    shadowOp.getValueMutable().assign(valShadow);
+    shadowOp.getMemrefMutable().assign(memrefShadow);
   }
 };
 

--- a/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
@@ -482,8 +482,29 @@ struct StoreOpInterfaceReverse
                                      cacheBuilder)};
   }
 
+  // A store of a mutable value -- a pointer -- has no float adjoint to
+  // accumulate; its derivative story is structural, like llvm.getelementptr
+  // above: the shadow memory must hold the shadow pointer at the same spot,
+  // so shadow loads traverse shadow structures. A pointer nothing
+  // differentiates is its own shadow, keeping inactive fields readable
+  // through the shadow object.
   void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {}
+                          MGradientUtilsReverse *gutils) const {
+    auto storeOp = cast<LLVM::StoreOp>(op);
+    Value val = storeOp.getValue();
+    Value addr = storeOp.getAddr();
+    auto iface = cast<AutoDiffTypeInterface>(val.getType());
+    if (!iface.isMutable() || gutils->isConstantValue(addr))
+      return;
+    Value addrShadow = gutils->invertPointerM(addr, builder);
+    Value valShadow = gutils->isConstantValue(val)
+                          ? gutils->getNewFromOriginal(val)
+                          : gutils->invertPointerM(val, builder);
+    auto newOp = cast<LLVM::StoreOp>(gutils->getNewFromOriginal(op));
+    auto shadowOp = cast<LLVM::StoreOp>(builder.clone(*newOp));
+    shadowOp.getValueMutable().assign(valShadow);
+    shadowOp.getAddrMutable().assign(addrShadow);
+  }
 };
 
 struct ExtractValueOpInterfaceReverse

--- a/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
@@ -200,12 +200,27 @@ struct StoreOpInterfaceReverse
     return SmallVector<Value>();
   }
 
+  // A store of a mutable value -- a pointer, an inner memref -- has no float
+  // adjoint to accumulate; its derivative story is structural: the shadow
+  // memory must hold the shadow value at the same spot, so shadow loads
+  // traverse shadow structures. A value nothing differentiates is its own
+  // shadow, keeping inactive fields readable through the shadow object.
   void createShadowValues(Operation *op, OpBuilder &builder,
                           MGradientUtilsReverse *gutils) const {
-    // auto storeOp = cast<memref::StoreOp>(op);
-    // Value memref = storeOp.getMemref();
-    // Value shadow = gutils->getShadowValue(memref);
-    // Do nothing yet. In the future support memref<memref<...>>
+    auto storeOp = cast<memref::StoreOp>(op);
+    Value val = storeOp.getValue();
+    Value memref = storeOp.getMemref();
+    auto iface = dyn_cast<AutoDiffTypeInterface>(val.getType());
+    if (!iface || !iface.isMutable() || gutils->isConstantValue(memref))
+      return;
+    Value memrefShadow = gutils->invertPointerM(memref, builder);
+    Value valShadow = gutils->isConstantValue(val)
+                          ? gutils->getNewFromOriginal(val)
+                          : gutils->invertPointerM(val, builder);
+    auto newOp = cast<memref::StoreOp>(gutils->getNewFromOriginal(op));
+    auto shadowOp = cast<memref::StoreOp>(builder.clone(*newOp));
+    shadowOp.getValueMutable().assign(valShadow);
+    shadowOp.getMemrefMutable().assign(memrefShadow);
   }
 };
 

--- a/enzyme/test/MLIR/ReverseMode/store_ptr_shadow.mlir
+++ b/enzyme/test/MLIR/ReverseMode/store_ptr_shadow.mlir
@@ -1,0 +1,39 @@
+// RUN: %eopt %s --enzyme --canonicalize --remove-unnecessary-enzyme-ops --enzyme-simplify-math | FileCheck %s
+
+// Storing an active pointer into memory has no float adjoint; its derivative
+// story is structural: the shadow slot must hold the shadow pointer, so the
+// later shadow load traverses to the shadow data, where the actual adjoint
+// accumulates. Previously nothing wrote the shadow slot and the shadow load
+// read back a null data pointer.
+
+module {
+  llvm.func @f(%p: !llvm.ptr) -> f64 {
+    %c1 = llvm.mlir.constant(1 : i32) : i32
+    %a = llvm.alloca %c1 x !llvm.struct<(ptr)> : (i32) -> !llvm.ptr
+    llvm.store %p, %a : !llvm.ptr, !llvm.ptr
+    %q = llvm.load %a : !llvm.ptr -> !llvm.ptr
+    %v = llvm.load %q : !llvm.ptr -> f64
+    %s = arith.mulf %v, %v : f64
+    llvm.return %s : f64
+  }
+
+  func.func @df(%p: !llvm.ptr, %dp: !llvm.ptr, %dr: f64) {
+    enzyme.autodiff @f(%p, %dp, %dr) { activity=[#enzyme<activity enzyme_dup>], ret_activity=[#enzyme<activity enzyme_activenoneed>] } : (!llvm.ptr, !llvm.ptr, f64) -> ()
+    return
+  }
+}
+
+// CHECK: llvm.func @diffef(%[[p:.+]]: !llvm.ptr, %[[dp:.+]]: !llvm.ptr, %[[dr:.+]]: f64)
+// The shadow pointer takes the same path through the shadow struct as the
+// primal pointer does through the primal struct.
+// CHECK: llvm.store %[[dp]], %[[sa:.+]] : !llvm.ptr, !llvm.ptr
+// CHECK: llvm.store %[[p]], %[[a:.+]] : !llvm.ptr, !llvm.ptr
+// CHECK: %[[sq:.+]] = llvm.load %[[sa]] : !llvm.ptr -> !llvm.ptr
+// CHECK: %[[q:.+]] = llvm.load %[[a]] : !llvm.ptr -> !llvm.ptr
+// CHECK: %[[v:.+]] = llvm.load %[[q]] : !llvm.ptr -> f64
+// CHECK: %[[t0:.+]] = arith.mulf %[[dr]], %[[v]] fastmath<fast> : f64
+// CHECK: %[[t1:.+]] = arith.mulf %[[dr]], %[[v]] fastmath<fast> : f64
+// CHECK: %[[t2:.+]] = arith.addf %[[t0]], %[[t1]] fastmath<fast> : f64
+// CHECK: %[[prev:.+]] = llvm.load %[[sq]] : !llvm.ptr -> f64
+// CHECK: %[[acc:.+]] = arith.addf %[[prev]], %[[t2]] fastmath<fast> : f64
+// CHECK: llvm.store %[[acc]], %[[sq]] : f64, !llvm.ptr

--- a/enzyme/test/MLIR/ReverseMode/store_ptr_shadow_affine.mlir
+++ b/enzyme/test/MLIR/ReverseMode/store_ptr_shadow_affine.mlir
@@ -1,0 +1,30 @@
+// RUN: %eopt %s --enzyme --canonicalize --remove-unnecessary-enzyme-ops --enzyme-simplify-math | FileCheck %s
+
+// Same structural story as the llvm.store of a pointer: the shadow slot must
+// hold the shadow pointer at the same affine position.
+
+module {
+  llvm.func @f(%p: !llvm.ptr) -> f64 {
+    %a = memref.alloca() : memref<1x!llvm.ptr>
+    affine.store %p, %a[0] : memref<1x!llvm.ptr>
+    %q = affine.load %a[0] : memref<1x!llvm.ptr>
+    %v = llvm.load %q : !llvm.ptr -> f64
+    %s = arith.mulf %v, %v : f64
+    llvm.return %s : f64
+  }
+
+  func.func @df(%p: !llvm.ptr, %dp: !llvm.ptr, %dr: f64) {
+    enzyme.autodiff @f(%p, %dp, %dr) { activity=[#enzyme<activity enzyme_dup>], ret_activity=[#enzyme<activity enzyme_activenoneed>] } : (!llvm.ptr, !llvm.ptr, f64) -> ()
+    return
+  }
+}
+
+// CHECK: llvm.func @diffef(%[[p:.+]]: !llvm.ptr, %[[dp:.+]]: !llvm.ptr, %[[dr:.+]]: f64)
+// CHECK: affine.store %[[dp]], %[[sa:.+]][0] : memref<1x!llvm.ptr>
+// CHECK: affine.store %[[p]], %[[a:.+]][0] : memref<1x!llvm.ptr>
+// CHECK: %[[sq:.+]] = affine.load %[[sa]][0] : memref<1x!llvm.ptr>
+// CHECK: %[[q:.+]] = affine.load %[[a]][0] : memref<1x!llvm.ptr>
+// CHECK: %[[v:.+]] = llvm.load %[[q]] : !llvm.ptr -> f64
+// CHECK: %[[prev:.+]] = llvm.load %[[sq]] : !llvm.ptr -> f64
+// CHECK: %[[acc:.+]] = arith.addf %[[prev]], %{{.+}} fastmath<fast> : f64
+// CHECK: llvm.store %[[acc]], %[[sq]] : f64, !llvm.ptr

--- a/enzyme/test/MLIR/ReverseMode/store_ptr_shadow_memref.mlir
+++ b/enzyme/test/MLIR/ReverseMode/store_ptr_shadow_memref.mlir
@@ -1,0 +1,31 @@
+// RUN: %eopt %s --enzyme --canonicalize --remove-unnecessary-enzyme-ops --enzyme-simplify-math | FileCheck %s
+
+// Same structural story as the llvm.store of a pointer: the shadow slot must
+// hold the shadow pointer, so the shadow load traverses to the shadow data.
+
+module {
+  llvm.func @f(%p: !llvm.ptr) -> f64 {
+    %c0 = arith.constant 0 : index
+    %a = memref.alloca() : memref<1x!llvm.ptr>
+    memref.store %p, %a[%c0] : memref<1x!llvm.ptr>
+    %q = memref.load %a[%c0] : memref<1x!llvm.ptr>
+    %v = llvm.load %q : !llvm.ptr -> f64
+    %s = arith.mulf %v, %v : f64
+    llvm.return %s : f64
+  }
+
+  func.func @df(%p: !llvm.ptr, %dp: !llvm.ptr, %dr: f64) {
+    enzyme.autodiff @f(%p, %dp, %dr) { activity=[#enzyme<activity enzyme_dup>], ret_activity=[#enzyme<activity enzyme_activenoneed>] } : (!llvm.ptr, !llvm.ptr, f64) -> ()
+    return
+  }
+}
+
+// CHECK: llvm.func @diffef(%[[p:.+]]: !llvm.ptr, %[[dp:.+]]: !llvm.ptr, %[[dr:.+]]: f64)
+// CHECK: memref.store %[[dp]], %[[sa:.+]][%{{.+}}] : memref<1x!llvm.ptr>
+// CHECK: memref.store %[[p]], %[[a:.+]][%{{.+}}] : memref<1x!llvm.ptr>
+// CHECK: %[[sq:.+]] = memref.load %[[sa]][%{{.+}}] : memref<1x!llvm.ptr>
+// CHECK: %[[q:.+]] = memref.load %[[a]][%{{.+}}] : memref<1x!llvm.ptr>
+// CHECK: %[[v:.+]] = llvm.load %[[q]] : !llvm.ptr -> f64
+// CHECK: %[[prev:.+]] = llvm.load %[[sq]] : !llvm.ptr -> f64
+// CHECK: %[[acc:.+]] = arith.addf %[[prev]], %{{.+}} fastmath<fast> : f64
+// CHECK: llvm.store %[[acc]], %[[sq]] : f64, !llvm.ptr


### PR DESCRIPTION
Storing an active pointer into memory has no float adjoint to
accumulate; its derivative story is structural, like llvm.getelementptr:
the shadow memory must hold the shadow pointer at the same spot, so
shadow loads traverse shadow structures. Previously nothing wrote the
shadow slot, and reverse-differentiating code that round-trips a data
pointer through a struct -- the capture struct a CUDA kernel launch
packs its arguments into -- read back a null shadow data pointer. A
pointer nothing differentiates is its own shadow, keeping inactive
fields readable through the shadow object.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD

Split out of #3132 per review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD