### PR TITLE
MLIR: an inactive pointer stored into shadow memory is its own shadow

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
@@ -16,6 +16,7 @@
 #include "Implementations/LoopCheckpointing.h"
 #include "Interfaces/AutoDiffOpInterface.h"
 #include "Interfaces/GradientUtilsReverse.h"
+#include "Interfaces/Utils.h"
 #include "Passes/RemovalUtils.h"
 #include "Passes/Utils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -520,8 +521,10 @@ struct AffineForOpInterfaceReverse
     return caches;
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {}
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
+    return success();
+  }
 };
 
 struct AffineParallelOpInterfaceReverse
@@ -597,8 +600,10 @@ struct AffineParallelOpInterfaceReverse
     return caches;
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {}
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
+    return success();
+  }
 };
 
 struct AffineParallelOpEnzymeOpsRemover
@@ -904,8 +909,8 @@ struct AffineLoadOpInterfaceReverse
     return SmallVector<Value>();
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
     auto loadOp = cast<affine::AffineLoadOp>(op);
     Value memref = loadOp.getMemref();
     auto iface = dyn_cast<AutoDiffTypeInterface>(loadOp.getType());
@@ -913,15 +918,29 @@ struct AffineLoadOpInterfaceReverse
     // so what stands for it is the handle held at the same place in the shadow:
     // the same load, off the shadow memref. Reading it out is the whole of the
     // derivative -- see the adjoint above, which leaves it alone.
-    if (!iface || !iface.isMutable())
-      return;
-    if (gutils->isConstantValue(loadOp) || gutils->isConstantValue(memref))
-      return;
+    if (!iface)
+      return op->emitError()
+             << "could not compute the shadow of a load of a type without "
+                "autodiff semantics "
+             << *op;
+    // An immutable load's derivative is the adjoint's to accumulate.
+    if (!iface.isMutable())
+      return success();
+    if (gutils->isConstantValue(loadOp))
+      return success();
+    // Cannot load a non-constant value out of a constant memref: there is no
+    // shadow to read the handle from, so the claimed activity cannot be
+    // honored.
+    if (gutils->isConstantValue(memref))
+      return op->emitError()
+             << "cannot load a non-constant value out of a constant memref "
+             << *op;
     Value memrefShadow = gutils->invertPointerM(memref, builder);
     auto newLoad = cast<affine::AffineLoadOp>(gutils->getNewFromOriginal(op));
     auto shadowLoad = cast<affine::AffineLoadOp>(builder.clone(*newLoad));
     shadowLoad.getMemrefMutable().assign(memrefShadow);
     gutils->setInvertedPointer(loadOp.getResult(), shadowLoad.getResult());
+    return success();
   }
 };
 
@@ -1044,22 +1063,34 @@ struct AffineStoreOpInterfaceReverse
 
   // Same structural story as memref.store: a stored mutable value's shadow
   // must land at the same affine position in the shadow memref.
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
     auto storeOp = cast<affine::AffineStoreOp>(op);
     Value val = storeOp.getValue();
     Value memref = storeOp.getMemref();
     auto iface = dyn_cast<AutoDiffTypeInterface>(val.getType());
-    if (!iface || !iface.isMutable() || gutils->isConstantValue(memref))
-      return;
+    if (!iface)
+      return op->emitError()
+             << "could not compute the shadow of a store of a type without "
+                "autodiff semantics "
+             << *op;
+    if (gutils->isConstantValue(memref))
+      return success();
+    // Immutable values' shadows live in the reverse sweep's adjoint, which
+    // accumulates and zeroes the slot; only mutable values need the forward
+    // sweep to place their shadow.
+    if (!iface.isMutable())
+      return success();
     Value memrefShadow = gutils->invertPointerM(memref, builder);
-    Value valShadow = gutils->isConstantValue(val)
-                          ? gutils->getNewFromOriginal(val)
-                          : gutils->invertPointerM(val, builder);
+    Value valShadow =
+        gutils->isConstantValue(val)
+            ? oputils::inactiveStoredValueShadow(op, *gutils, val, builder)
+            : gutils->invertPointerM(val, builder);
     auto newOp = cast<affine::AffineStoreOp>(gutils->getNewFromOriginal(op));
     auto shadowOp = cast<affine::AffineStoreOp>(builder.clone(*newOp));
     shadowOp.getValueMutable().assign(valShadow);
     shadowOp.getMemrefMutable().assign(memrefShadow);
+    return success();
   }
 };
 

--- a/enzyme/Enzyme/MLIR/Implementations/ArithAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/ArithAutoDiffOpInterfaceImpl.cpp
@@ -201,11 +201,11 @@ struct SelectOpInterfaceReverse
     }
     return caches;
   }
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
     auto selectOp = cast<arith::SelectOp>(op);
     if (gutils->isConstantValue(selectOp.getResult()))
-      return;
+      return success();
 
     auto iface =
         dyn_cast<AutoDiffTypeInterface>(selectOp.getResult().getType());
@@ -217,6 +217,7 @@ struct SelectOpInterfaceReverse
           gutils->invertPointerM(selectOp.getFalseValue(), builder));
       gutils->setInvertedPointer(selectOp.getResult(), shadowOp.getResult());
     }
+    return success();
   }
 };
 

--- a/enzyme/Enzyme/MLIR/Implementations/CoreDialectsAutoDiffImplementations.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/CoreDialectsAutoDiffImplementations.cpp
@@ -16,6 +16,7 @@
 #include "Interfaces/AutoDiffTypeInterface.h"
 #include "Interfaces/GradientUtils.h"
 #include "Interfaces/GradientUtilsReverse.h"
+#include "Interfaces/Utils.h"
 #include "Passes/Utils.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -195,15 +196,12 @@ LogicalResult mlir::enzyme::detail::memoryIdentityForwardHandler(
 
         if (contains(storedVals, operand.getOperandNumber()) ||
             contains(storedVals, -1)) {
-          if (auto iface =
-                  dyn_cast<AutoDiffTypeInterface>(operand.get().getType())) {
-            if (!iface.isMutable()) {
-              Type retTy = iface.getShadowType(gutils->width);
-              auto toret = cast<AutoDiffTypeInterface>(retTy).createNullValue(
-                  builder, operand.get().getLoc());
-              newOperands.push_back(toret);
-              continue;
-            }
+          if (isa<AutoDiffTypeInterface>(operand.get().getType())) {
+            // Zero for an immutable value; for a mutable value -- an
+            // inactive pointer -- the primal is its own shadow.
+            newOperands.push_back(oputils::inactiveStoredValueShadow(
+                orig, *gutils, operand.get(), builder));
+            continue;
           }
         }
         orig->emitError()

--- a/enzyme/Enzyme/MLIR/Implementations/CoreDialectsAutoDiffImplementations.h
+++ b/enzyme/Enzyme/MLIR/Implementations/CoreDialectsAutoDiffImplementations.h
@@ -125,8 +125,10 @@ public:
     return SmallVector<Value>();
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {}
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
+    return success();
+  }
 };
 
 template <typename OpTy>
@@ -146,8 +148,10 @@ public:
     return SmallVector<Value>();
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {}
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
+    return success();
+  }
 };
 
 // Implements the forward autodiff interface for operations which are
@@ -196,10 +200,11 @@ public:
     return SmallVector<Value>();
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
     (void)allocationForwardHandler(op, builder, (MGradientUtils *)gutils,
                                    /*zero*/ true);
+    return success();
   }
 };
 
@@ -246,8 +251,10 @@ public:
     return detail::callCacheValues(orig, gutils);
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {}
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
+    return success();
+  }
 };
 
 // Registers the generic call handlers for the given op; the tablegen-emitted

--- a/enzyme/Enzyme/MLIR/Implementations/EnzymeAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/EnzymeAutoDiffOpInterfaceImpl.cpp
@@ -109,8 +109,10 @@ struct AffineAtomicRMWOpInterfaceReverse
     return caches;
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {}
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
+    return success();
+  }
 };
 
 // Forward mode mirrors the primal on the shadows: the tangent of the value

--- a/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
@@ -252,8 +252,10 @@ struct NoAdjointReverseInterface
     return SmallVector<Value>();
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {}
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
+    return success();
+  }
 };
 
 // After a memset the memory holds a fixed byte pattern, which depends on no
@@ -313,8 +315,8 @@ struct GEPOpInterfaceReverse
     return {};
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
     auto gep = cast<LLVM::GEPOp>(op);
     auto newGep = cast<LLVM::GEPOp>(gutils->getNewFromOriginal(op));
     auto base = gep.getBase();
@@ -324,6 +326,7 @@ struct GEPOpInterfaceReverse
       shadowGep.getBaseMutable().assign(baseShadow);
       gutils->setInvertedPointer(gep.getRes(), shadowGep->getResult(0));
     }
+    return success();
   }
 };
 
@@ -346,17 +349,18 @@ struct AddrSpaceCastOpInterfaceReverse
     return {};
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
     auto asCast = cast<LLVM::AddrSpaceCastOp>(op);
     auto arg = asCast.getArg();
     if (gutils->isConstantValue(arg))
-      return;
+      return success();
 
     auto newCast = cast<LLVM::AddrSpaceCastOp>(gutils->getNewFromOriginal(op));
     auto shadowCast = cast<LLVM::AddrSpaceCastOp>(builder.clone(*newCast));
     shadowCast.getArgMutable().assign(gutils->invertPointerM(arg, builder));
     gutils->setInvertedPointer(asCast.getRes(), shadowCast.getRes());
+    return success();
   }
 };
 
@@ -411,8 +415,8 @@ struct LoadOpInterfaceReverse
                                      cacheBuilder)};
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
     auto loadOp = cast<LLVM::LoadOp>(op);
     Value addr = loadOp.getAddr();
     auto iface = dyn_cast<AutoDiffTypeInterface>(loadOp.getType());
@@ -420,15 +424,29 @@ struct LoadOpInterfaceReverse
     // so what stands for it is the handle held at the same place in the shadow:
     // the same load, off the shadow address. Reading it out is the whole of the
     // derivative -- see the adjoint above, which leaves it alone.
-    if (!iface || !iface.isMutable())
-      return;
-    if (gutils->isConstantValue(loadOp) || gutils->isConstantValue(addr))
-      return;
+    if (!iface)
+      return op->emitError()
+             << "could not compute the shadow of a load of a type without "
+                "autodiff semantics "
+             << *op;
+    // An immutable load's derivative is the adjoint's to accumulate.
+    if (!iface.isMutable())
+      return success();
+    if (gutils->isConstantValue(loadOp))
+      return success();
+    // Cannot load a non-constant value out of a constant address: there is no
+    // shadow to read the handle from, so the claimed activity cannot be
+    // honored.
+    if (gutils->isConstantValue(addr))
+      return op->emitError()
+             << "cannot load a non-constant value out of a constant address "
+             << *op;
     Value addrShadow = gutils->invertPointerM(addr, builder);
     auto newLoad = cast<LLVM::LoadOp>(gutils->getNewFromOriginal(op));
     auto shadowLoad = cast<LLVM::LoadOp>(builder.clone(*newLoad));
     shadowLoad.getAddrMutable().assign(addrShadow);
     gutils->setInvertedPointer(loadOp.getResult(), shadowLoad.getResult());
+    return success();
   }
 };
 
@@ -505,7 +523,8 @@ struct MemcpyForwardInterface
       // pointers) must read as the primal's.
     }
     Value srcShadow = gutils->isConstantValue(memcpy.getSrc())
-                          ? gutils->getNewFromOriginal(memcpy.getSrc())
+                          ? oputils::inactiveStoredValueShadow(
+                                op, *gutils, memcpy.getSrc(), builder)
                           : gutils->invertPointerM(memcpy.getSrc(), builder);
     auto shadowOp = cast<LLVM::MemcpyOp>(builder.clone(*newOp));
     shadowOp.getDstMutable().assign(dstShadow);
@@ -576,22 +595,34 @@ struct StoreOpInterfaceReverse
   // so shadow loads traverse shadow structures. A pointer nothing
   // differentiates is its own shadow, keeping inactive fields readable
   // through the shadow object.
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
     auto storeOp = cast<LLVM::StoreOp>(op);
     Value val = storeOp.getValue();
     Value addr = storeOp.getAddr();
-    auto iface = cast<AutoDiffTypeInterface>(val.getType());
-    if (!iface.isMutable() || gutils->isConstantValue(addr))
-      return;
+    auto iface = dyn_cast<AutoDiffTypeInterface>(val.getType());
+    if (!iface)
+      return op->emitError()
+             << "could not compute the shadow of a store of a type without "
+                "autodiff semantics "
+             << *op;
+    if (gutils->isConstantValue(addr))
+      return success();
+    // Immutable values' shadows live in the reverse sweep's adjoint, which
+    // accumulates and zeroes the slot; only mutable values need the forward
+    // sweep to place their shadow.
+    if (!iface.isMutable())
+      return success();
     Value addrShadow = gutils->invertPointerM(addr, builder);
-    Value valShadow = gutils->isConstantValue(val)
-                          ? gutils->getNewFromOriginal(val)
-                          : gutils->invertPointerM(val, builder);
+    Value valShadow =
+        gutils->isConstantValue(val)
+            ? oputils::inactiveStoredValueShadow(op, *gutils, val, builder)
+            : gutils->invertPointerM(val, builder);
     auto newOp = cast<LLVM::StoreOp>(gutils->getNewFromOriginal(op));
     auto shadowOp = cast<LLVM::StoreOp>(builder.clone(*newOp));
     shadowOp.getValueMutable().assign(valShadow);
     shadowOp.getAddrMutable().assign(addrShadow);
+    return success();
   }
 };
 
@@ -629,8 +660,10 @@ struct ExtractValueOpInterfaceReverse
     return {};
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {}
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
+    return success();
+  }
 };
 
 struct InsertValueOpInterfaceReverse
@@ -681,8 +714,10 @@ struct InsertValueOpInterfaceReverse
     return {};
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {}
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
+    return success();
+  }
 };
 
 // What is recorded about the allocation a pointer names: how many bytes are

--- a/enzyme/Enzyme/MLIR/Implementations/LinalgAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LinalgAutoDiffOpInterfaceImpl.cpp
@@ -269,8 +269,10 @@ struct GenericOpInterfaceReverse
     return SmallVector<Value>();
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {}
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
+    return success();
+  }
 };
 
 class GenericFwd

--- a/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
@@ -16,6 +16,7 @@
 #include "Interfaces/AutoDiffTypeInterface.h"
 #include "Interfaces/GradientUtils.h"
 #include "Interfaces/GradientUtilsReverse.h"
+#include "Interfaces/Utils.h"
 
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/DialectRegistry.h"
@@ -107,8 +108,8 @@ struct LoadOpInterfaceReverse
     return SmallVector<Value>();
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
     auto loadOp = cast<memref::LoadOp>(op);
     Value memref = loadOp.getMemref();
     auto iface = dyn_cast<AutoDiffTypeInterface>(loadOp.getType());
@@ -116,15 +117,29 @@ struct LoadOpInterfaceReverse
     // so what stands for it is the handle held at the same place in the shadow:
     // the same load, off the shadow memref. Reading it out is the whole of the
     // derivative -- see the adjoint above, which leaves it alone.
-    if (!iface || !iface.isMutable())
-      return;
-    if (gutils->isConstantValue(loadOp) || gutils->isConstantValue(memref))
-      return;
+    if (!iface)
+      return op->emitError()
+             << "could not compute the shadow of a load of a type without "
+                "autodiff semantics "
+             << *op;
+    // An immutable load's derivative is the adjoint's to accumulate.
+    if (!iface.isMutable())
+      return success();
+    if (gutils->isConstantValue(loadOp))
+      return success();
+    // Cannot load a non-constant value out of a constant memref: there is no
+    // shadow to read the handle from, so the claimed activity cannot be
+    // honored.
+    if (gutils->isConstantValue(memref))
+      return op->emitError()
+             << "cannot load a non-constant value out of a constant memref "
+             << *op;
     Value memrefShadow = gutils->invertPointerM(memref, builder);
     auto newLoad = cast<memref::LoadOp>(gutils->getNewFromOriginal(op));
     auto shadowLoad = cast<memref::LoadOp>(builder.clone(*newLoad));
     shadowLoad.getMemrefMutable().assign(memrefShadow);
     gutils->setInvertedPointer(loadOp.getResult(), shadowLoad.getResult());
+    return success();
   }
 };
 
@@ -205,22 +220,34 @@ struct StoreOpInterfaceReverse
   // memory must hold the shadow value at the same spot, so shadow loads
   // traverse shadow structures. A value nothing differentiates is its own
   // shadow, keeping inactive fields readable through the shadow object.
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
     auto storeOp = cast<memref::StoreOp>(op);
     Value val = storeOp.getValue();
     Value memref = storeOp.getMemref();
     auto iface = dyn_cast<AutoDiffTypeInterface>(val.getType());
-    if (!iface || !iface.isMutable() || gutils->isConstantValue(memref))
-      return;
+    if (!iface)
+      return op->emitError()
+             << "could not compute the shadow of a store of a type without "
+                "autodiff semantics "
+             << *op;
+    if (gutils->isConstantValue(memref))
+      return success();
+    // Immutable values' shadows live in the reverse sweep's adjoint, which
+    // accumulates and zeroes the slot; only mutable values need the forward
+    // sweep to place their shadow.
+    if (!iface.isMutable())
+      return success();
     Value memrefShadow = gutils->invertPointerM(memref, builder);
-    Value valShadow = gutils->isConstantValue(val)
-                          ? gutils->getNewFromOriginal(val)
-                          : gutils->invertPointerM(val, builder);
+    Value valShadow =
+        gutils->isConstantValue(val)
+            ? oputils::inactiveStoredValueShadow(op, *gutils, val, builder)
+            : gutils->invertPointerM(val, builder);
     auto newOp = cast<memref::StoreOp>(gutils->getNewFromOriginal(op));
     auto shadowOp = cast<memref::StoreOp>(builder.clone(*newOp));
     shadowOp.getValueMutable().assign(valShadow);
     shadowOp.getMemrefMutable().assign(memrefShadow);
+    return success();
   }
 };
 
@@ -238,8 +265,8 @@ struct SubViewOpInterfaceReverse
     return SmallVector<Value>();
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
     auto subviewOp = cast<memref::SubViewOp>(op);
     auto newSubviewOp = cast<memref::SubViewOp>(gutils->getNewFromOriginal(op));
     if (!gutils->isConstantValue(subviewOp.getSource())) {
@@ -250,6 +277,7 @@ struct SubViewOpInterfaceReverse
           newSubviewOp.getMixedStrides());
       gutils->setInvertedPointer(subviewOp, shadow);
     }
+    return success();
   }
 };
 

--- a/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
@@ -542,9 +542,10 @@ public:
     return caches;
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
     // auto forOp = cast<scf::ForOp>(op);
+    return success();
   }
 };
 
@@ -760,8 +761,10 @@ struct ParallelOpInterfaceReverse
     return caches;
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {}
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
+    return success();
+  }
 };
 
 struct IfOpEnzymeOpsRemover
@@ -900,12 +903,12 @@ struct IfOpInterfaceReverse
     return SmallVector<Value>{cacheCond};
   }
 
-  void createShadowValues(Operation *op, OpBuilder &builder,
-                          MGradientUtilsReverse *gutils) const {
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
     // TODO: consider making this generic for RegionBranchOpInterface
     auto ifOp = cast<scf::IfOp>(op);
     if (ifOp.getNumResults() == 0)
-      return;
+      return success();
 
     auto newIf = cast<scf::IfOp>(gutils->getNewFromOriginal(ifOp));
     SmallVector<Type> newResultTypes;
@@ -965,6 +968,7 @@ struct IfOpInterfaceReverse
     }
     newIf.replaceAllUsesWith(augmentedResults);
     newIf.erase();
+    return success();
   }
 };
 

--- a/enzyme/Enzyme/MLIR/Interfaces/AutoDiffOpInterface.td
+++ b/enzyme/Enzyme/MLIR/Interfaces/AutoDiffOpInterface.td
@@ -110,7 +110,7 @@ def ReverseAutoDiffOpInterface : OpInterface<"ReverseAutoDiffOpInterface"> {
     /*desc=*/[{
       Creates or alters shadow values.
     }],
-    /*retTy=*/"void",
+    /*retTy=*/"::mlir::LogicalResult",
     /*methodName=*/"createShadowValues",
     /*args=*/(ins "::mlir::OpBuilder &":$builder, "::mlir::enzyme::MGradientUtilsReverse *":$gutils)
     >,

--- a/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogicReverse.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogicReverse.cpp
@@ -59,7 +59,8 @@ LogicalResult MEnzymeLogic::visitChild(Operation *op, OpBuilder &builder,
   if (auto ifaceOp = dyn_cast<ReverseAutoDiffOpInterface>(op)) {
     SmallVector<Value> caches = ifaceOp.cacheValues(gutils);
     OpBuilder augmentBuilder(gutils->getNewFromOriginal(op));
-    ifaceOp.createShadowValues(augmentBuilder, gutils);
+    if (failed(ifaceOp.createShadowValues(augmentBuilder, gutils)))
+      return failure();
     return ifaceOp.createReverseModeAdjoint(builder, gutils, caches);
   }
   op->emitError() << "could not compute the adjoint for this operation " << *op;

--- a/enzyme/Enzyme/MLIR/Interfaces/Utils.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/Utils.cpp
@@ -10,6 +10,8 @@
 #include "Interfaces/Utils.h"
 #include "Dialect/Ops.h"
 #include "Interfaces/AutoDiffTypeInterface.h"
+#include "Interfaces/GradientUtils.h"
+#include "Passes/Utils.h"
 #include "mlir/Analysis/AliasAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -103,6 +105,25 @@ static bool isCaptured(Value v, Operation *potentialUser = nullptr,
   }
 
   return false;
+}
+
+Value inactiveStoredValueShadow(Operation *orig, MGradientUtils &gutils,
+                                Value stored, OpBuilder &builder) {
+  auto iface = cast<AutoDiffTypeInterface>(stored.getType());
+  // An immutable value carries no aliasing structure into the shadow; its
+  // tangent is simply zero.
+  if (!iface.isMutable())
+    return cast<AutoDiffTypeInterface>(gutils.getShadowType(stored.getType()))
+        .createNullValue(builder, orig->getLoc());
+  orig->emitWarning()
+      << "storing an inactive value into differentiated memory; the shadow "
+         "holds the primal value, which runtime activity would be needed to "
+         "check";
+  Value primal = gutils.getNewFromOriginal(stored);
+  if (gutils.width == 1)
+    return primal;
+  SmallVector<Value> batched(gutils.width, primal);
+  return getConcatValue(builder, orig->getLoc(), batched);
 }
 
 Value getBaseObject(Value v) {

--- a/enzyme/Enzyme/MLIR/Interfaces/Utils.h
+++ b/enzyme/Enzyme/MLIR/Interfaces/Utils.h
@@ -8,12 +8,14 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 namespace mlir {
 namespace enzyme {
+class MGradientUtils;
 namespace oputils {
 
 const std::set<std::string> &getNonCapturingFunctions();
@@ -24,6 +26,15 @@ const std::set<std::string> &getNonCapturingFunctions();
 bool isReadOnly(Operation *op);
 
 bool isReadNone(Operation *op);
+
+// The shadow of a stored value nothing differentiates is the primal value
+// itself: the shadow memory's structural fields must read as the primal's.
+// If the activity given was wrong about the value, only runtime activity
+// could catch it; every site says so through here, so a future runtime
+// activity implementation has a single seam to take over (as EnzymeLLVM's
+// does).
+Value inactiveStoredValueShadow(Operation *orig, MGradientUtils &gutils,
+                                Value stored, OpBuilder &builder);
 
 // Walks a pointer-like value to the object it is derived from, looking
 // through view-like ops (memref.cast, memref.memory_space_cast, subviews),

--- a/enzyme/test/MLIR/ForwardMode/store_inactive_ptr.mlir
+++ b/enzyme/test/MLIR/ForwardMode/store_inactive_ptr.mlir
@@ -1,0 +1,18 @@
+// RUN: %eopt %s --enzyme-wrap="infn=f outfn= argTys=enzyme_dup,enzyme_const retTys= mode=ForwardMode" --canonicalize | FileCheck %s
+
+// Storing an inactive pointer into differentiated memory: a mutable value
+// nothing differentiates is its own shadow, so the shadow slot holds the
+// primal pointer and structural fields read the same through the shadow
+// object.
+
+module {
+  func.func @f(%m: memref<?x!llvm.ptr>, %p: !llvm.ptr) {
+    affine.store %p, %m[0] : memref<?x!llvm.ptr>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @f(
+// CHECK-SAME: %[[m:[^ :]+]]: memref<?x!llvm.ptr>, %[[dm:[^ :]+]]: memref<?x!llvm.ptr>, %[[p:.+]]: !llvm.ptr)
+// CHECK-DAG: affine.store %[[p]], %[[dm]][0] : memref<?x!llvm.ptr>
+// CHECK-DAG: affine.store %[[p]], %[[m]][0] : memref<?x!llvm.ptr>

--- a/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
+++ b/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
@@ -1744,9 +1744,10 @@ static void emitMLIRReverse(raw_ostream &os, const Record *pattern,
   os << "          return toret;\n";
   os << "       }\n";
   os << "\n";
-  os << "  void createShadowValues(Operation *op, OpBuilder &builder,\n";
+  os << "  LogicalResult createShadowValues(Operation *op, OpBuilder "
+        "&builder,\n";
   os << "                          MGradientUtilsReverse *gutils) const "
-        "{}\n";
+        "{ return success(); }\n";
 
   os << "     LogicalResult createReverseModeAdjoint(Operation *op0, OpBuilder "
         "&builder,\n";


### PR DESCRIPTION
The memory identity forward handler refused a stored constant of mutable
type outright. The same structural story as the reverse-mode shadow
stores applies: a mutable value nothing differentiates is its own
shadow, so the shadow slot takes the primal pointer and structural
fields read the same through the shadow object. MFEM's enzyme
compatibility test stores an inactive data pointer into differentiated
memory and hit the refusal.

If the given activity was wrong about the pointer, only runtime
activity could catch it; a warning says so until that exists.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD