### PR TITLE
MLIR: forward mode for affine.parallel

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
@@ -67,6 +67,36 @@ affine::AffineIfOp createAffineIfWithShadows(Operation *op, OpBuilder &builder,
       adaptor.getOperands(), !original.getElseRegion().empty());
 }
 
+affine::AffineParallelOp
+createAffineParallelWithShadows(Operation *op, OpBuilder &builder,
+                                MGradientUtils *gutils,
+                                affine::AffineParallelOp original,
+                                ValueRange remappedOperands, TypeRange rettys) {
+  // A result of an affine.parallel is a reduction, and a reduction of the
+  // tangents is the derivative of a sum. Anything else needs its own rule,
+  // which reverse mode does not have either.
+  SmallVector<Attribute> reductions;
+  for (auto &&[reduction, result] :
+       llvm::zip_equal(original.getReductions(), original.getResults())) {
+    reductions.push_back(reduction);
+    if (gutils->isConstantValue(result))
+      continue;
+    auto kind = cast<arith::AtomicRMWKindAttr>(reduction).getValue();
+    if (kind != arith::AtomicRMWKind::addf &&
+        kind != arith::AtomicRMWKind::addi)
+      original.emitError() << "forward mode of an active "
+                           << stringifyEnum(kind)
+                           << " reduction is not yet implemented";
+    reductions.push_back(reduction);
+  }
+  auto reductionsAttr = builder.getArrayAttr(reductions);
+  return affine::AffineParallelOp::create(
+      builder, original->getLoc(), rettys, reductionsAttr,
+      original.getLowerBoundsMapAttr(), original.getLowerBoundsGroupsAttr(),
+      original.getUpperBoundsMapAttr(), original.getUpperBoundsGroupsAttr(),
+      original.getStepsAttr(), remappedOperands);
+}
+
 struct AffineForOpInterfaceReverse
     : public ReverseAutoDiffOpInterface::ExternalModel<
           AffineForOpInterfaceReverse, affine::AffineForOp>,

--- a/enzyme/Enzyme/MLIR/Implementations/AffineDerivatives.td
+++ b/enzyme/Enzyme/MLIR/Implementations/AffineDerivatives.td
@@ -10,6 +10,17 @@ def : ControlFlowOp<"affine", "AffineForOp", [{
   }
 }]>;
 
+def : ControlFlowOp<"affine", "AffineParallelOp", [{
+  Operation *createWithShadows(Operation *op, OpBuilder &builder,
+                               MGradientUtils *gutils, Operation *original,
+                               ValueRange remappedOperands,
+                               TypeRange rettys) const {
+    return createAffineParallelWithShadows(op, builder, gutils,
+                                           cast<affine::AffineParallelOp>(original),
+                                           remappedOperands, rettys);
+  }
+}]>;
+
 def : ControlFlowOp<"affine", "AffineIfOp", [{
     Operation *createWithShadows(Operation *op, OpBuilder &builder,
                                MGradientUtils *gutils, Operation *original,

--- a/enzyme/test/MLIR/ForwardMode/affine_parallel.mlir
+++ b/enzyme/test/MLIR/ForwardMode/affine_parallel.mlir
@@ -1,0 +1,34 @@
+// RUN: %eopt --enzyme %s | FileCheck %s
+
+module {
+  func.func @square(%x : memref<?xf64>, %y : memref<?xf64>, %n : index) {
+    affine.parallel (%i) = (0) to (symbol(%n)) {
+      %v = affine.load %x[%i] : memref<?xf64>
+      %s = arith.mulf %v, %v : f64
+      affine.store %s, %y[%i] : memref<?xf64>
+    }
+    return
+  }
+
+  func.func @dsquare(%x : memref<?xf64>, %dx : memref<?xf64>, %y : memref<?xf64>, %dy : memref<?xf64>, %n : index) {
+    enzyme.fwddiff @square(%x, %dx, %y, %dy, %n) {
+      activity=[#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_dup>, #enzyme<activity enzyme_const>],
+      ret_activity=[]
+    } : (memref<?xf64>, memref<?xf64>, memref<?xf64>, memref<?xf64>, index) -> ()
+    return
+  }
+}
+
+// CHECK:  func.func private @fwddiffesquare(%[[x:.+]]: memref<?xf64>, %[[dx:.+]]: memref<?xf64>, %[[y:.+]]: memref<?xf64>, %[[dy:.+]]: memref<?xf64>, %[[n:.+]]: index) {
+// CHECK-NEXT:    affine.parallel (%[[i:.+]]) = (0) to (symbol(%[[n]])) {
+// CHECK-NEXT:      %[[dv:.+]] = affine.load %[[dx]][%[[i]]] : memref<?xf64>
+// CHECK-NEXT:      %[[v:.+]] = affine.load %[[x]][%[[i]]] : memref<?xf64>
+// CHECK-NEXT:      %[[l:.+]] = arith.mulf %[[dv]], %[[v]] fastmath<fast> : f64
+// CHECK-NEXT:      %[[r:.+]] = arith.mulf %[[dv]], %[[v]] fastmath<fast> : f64
+// CHECK-NEXT:      %[[ds:.+]] = arith.addf %[[l]], %[[r]] fastmath<fast> : f64
+// CHECK-NEXT:      %[[s:.+]] = arith.mulf %[[v]], %[[v]] : f64
+// CHECK-NEXT:      affine.store %[[ds]], %[[dy]][%[[i]]] : memref<?xf64>
+// CHECK-NEXT:      affine.store %[[s]], %[[y]][%[[i]]] : memref<?xf64>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }


### PR DESCRIPTION
`affine.parallel` had a reverse-mode rule and a region-branch interface but no forward-mode one, so `createForwardModeTangent` fell through to "could not compute the adjoint for this operation".

That is the shape every raised CUDA kernel takes: differentiating a function that launches a kernel produces an `affine.parallel` in the host module, so forward mode over any kernel launch failed. It is what blocks the MFEM dFEM CUDA tests today.

Registered through `ControlFlowOp` in `AffineDerivatives.td`, the same way `affine.for`, `affine.if`, `scf.for` and `scf.parallel` are, with the body next to `createAffineForWithShadows`/`createAffineIfWithShadows`. It rebuilds the loop with the same bounds, groups and steps.

One difference from `scf.parallel`: a reduction there is an `scf.reduce` region, which the generic handler differentiates on its own, while here it is an `AtomicRMWKind` attribute that has to be repeated for the shadow result. Repeating the kind is the derivative of a sum and nothing else, so an active reduction of any other kind is reported. It cannot refuse outright -- `createWithShadows` returns an `Operation *` -- and reverse mode rejects reductions on this op wholesale, so nothing reaches it today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD