### PR TITLE
MLIR: forward mode for llvm.extractvalue and llvm.insertvalue

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/LLVMDerivatives.td
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMDerivatives.td
@@ -24,6 +24,8 @@ def : InactiveOp<"LLVM", "UnreachableOp">;
 
 
 def : ReadOnlyIdentityOp<"LLVM", "LoadOp", [0]>;
+def : MemoryIdentityOp<"LLVM", "ExtractValueOp", [0], [0]>;
+def : MemoryIdentityOp<"LLVM", "InsertValueOp", [0, 1], [0, 1]>;
 def : ReadOnlyIdentityOp<"LLVM", "AddrSpaceCastOp", [0]>;
 def : ReadOnlyIdentityOp<"LLVM", "BitcastOp", [0]>;
 def : ReadOnlyIdentityOp<"LLVM", "GEPOp", [0]>;

--- a/enzyme/test/MLIR/ForwardMode/aggregate.mlir
+++ b/enzyme/test/MLIR/ForwardMode/aggregate.mlir
@@ -1,0 +1,41 @@
+// RUN: %eopt --enzyme %s | FileCheck %s
+
+module {
+  func.func @square(%x : !llvm.ptr, %y : !llvm.ptr) {
+    %u = llvm.mlir.poison : !llvm.struct<(ptr, ptr)>
+    %a0 = llvm.insertvalue %x, %u[0] : !llvm.struct<(ptr, ptr)>
+    %a1 = llvm.insertvalue %y, %a0[1] : !llvm.struct<(ptr, ptr)>
+    %px = llvm.extractvalue %a1[0] : !llvm.struct<(ptr, ptr)>
+    %py = llvm.extractvalue %a1[1] : !llvm.struct<(ptr, ptr)>
+    %v = llvm.load %px : !llvm.ptr -> f64
+    %s = arith.mulf %v, %v : f64
+    llvm.store %s, %py : f64, !llvm.ptr
+    return
+  }
+
+  func.func @dsquare(%x : !llvm.ptr, %dx : !llvm.ptr, %y : !llvm.ptr, %dy : !llvm.ptr) {
+    enzyme.fwddiff @square(%x, %dx, %y, %dy) {
+      activity=[#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_dup>],
+      ret_activity=[]
+    } : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    return
+  }
+}
+
+// CHECK:  func.func private @fwddiffesquare(%[[x:.+]]: !llvm.ptr, %[[dx:.+]]: !llvm.ptr, %[[y:.+]]: !llvm.ptr, %[[dy:.+]]: !llvm.ptr) {
+// CHECK:    %[[sa0:.+]] = llvm.insertvalue %[[dx]], %{{.+}}[0] : !llvm.struct<(ptr, ptr)>
+// CHECK:    %[[pa0:.+]] = llvm.insertvalue %[[x]], %{{.+}}[0] : !llvm.struct<(ptr, ptr)>
+// CHECK:    %[[sa1:.+]] = llvm.insertvalue %[[dy]], %[[sa0]][1] : !llvm.struct<(ptr, ptr)>
+// CHECK:    %[[pa1:.+]] = llvm.insertvalue %[[y]], %[[pa0]][1] : !llvm.struct<(ptr, ptr)>
+// CHECK:    %[[spx:.+]] = llvm.extractvalue %[[sa1]][0] : !llvm.struct<(ptr, ptr)>
+// CHECK:    %[[ppx:.+]] = llvm.extractvalue %[[pa1]][0] : !llvm.struct<(ptr, ptr)>
+// CHECK:    %[[spy:.+]] = llvm.extractvalue %[[sa1]][1] : !llvm.struct<(ptr, ptr)>
+// CHECK:    %[[ppy:.+]] = llvm.extractvalue %[[pa1]][1] : !llvm.struct<(ptr, ptr)>
+// CHECK:    %[[dv:.+]] = llvm.load %[[spx]] : !llvm.ptr -> f64
+// CHECK:    %[[v:.+]] = llvm.load %[[ppx]] : !llvm.ptr -> f64
+// CHECK:    %[[l:.+]] = arith.mulf %[[dv]], %[[v]] fastmath<fast> : f64
+// CHECK:    %[[r:.+]] = arith.mulf %[[dv]], %[[v]] fastmath<fast> : f64
+// CHECK:    %[[ds:.+]] = arith.addf %[[l]], %[[r]] fastmath<fast> : f64
+// CHECK:    %[[s:.+]] = arith.mulf %[[v]], %[[v]] : f64
+// CHECK:    llvm.store %[[ds]], %[[spy]] : f64, !llvm.ptr
+// CHECK:    llvm.store %[[s]], %[[ppy]] : f64, !llvm.ptr


### PR DESCRIPTION
`llvm.extractvalue` and `llvm.insertvalue` had `ExtractValueOpInterfaceReverse` and `InsertValueOpInterfaceReverse` and no forward-mode model, so forward mode over a struct of pointers stopped at "could not compute the adjoint for this operation".

That is the shape a by-value capture takes. Every lambda-taking kernel launcher -- MFEM's `forall`, and the `CuWrap` templates under it -- assembles the captured pointers into a struct with `insertvalue` and reads them back inside the kernel with `extractvalue`. Without these, no such launch can be differentiated in forward mode.

Two `MemoryIdentityOp` lines: the shadow of an aggregate holds, field for field, the shadow of what the primal holds, so each op is the same access on the shadow aggregate, which is what `memoryIdentityForwardHandler` already does. Both operands are listed as stored so that a constant one -- the poison an insertvalue chain starts from, or an inactive pointer -- reaches `inactiveStoredValueShadow` instead of being an error.

Worth noting for anyone writing one of these by hand: the operands must reach `invertPointerM`, and only a genuinely constant operand should fall back. A struct of pointers holds no floats of its own, so activity classifies the *aggregate* inactive even when a pointer it carries is active; routing the container through the inactive-value helper unconditionally yields a null-filled struct, which shows up as `insertvalue zero, poison` followed by an `extractvalue` of it and a shadow load from null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD