### PR TITLE
mlir: Allocate the $b$ checkpoints at once in binomial checkpointing

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/LLVMAutoDiffOpInterfaceImpl.cpp
@@ -589,7 +589,7 @@ struct PtrExtent {
   Value ptr;  // pointer the extent was found on; the queried one by default
 };
 
-static Value normalizeSizeToI64(OpBuilder &builder, Location loc, Value size);
+static Value normalizeToI64(OpBuilder &builder, Location loc, Value size);
 
 // An alloca says how much it is: the size of the element type, that many times.
 // Nothing has to have annotated it, and `builder` is only used to say the
@@ -600,8 +600,7 @@ static Value allocaExtent(OpBuilder &builder, LLVM::AllocaOp alloca) {
   auto i64Ty = builder.getIntegerType(64);
   Value bytes = LLVM::ConstantOp::create(builder, alloca.getLoc(), i64Ty,
                                          builder.getI64IntegerAttr(elemBytes));
-  Value count =
-      normalizeSizeToI64(builder, alloca.getLoc(), alloca.getArraySize());
+  Value count = normalizeToI64(builder, alloca.getLoc(), alloca.getArraySize());
   if (!count)
     return nullptr;
   Value size = LLVM::MulOp::create(builder, alloca.getLoc(), bytes, count);
@@ -649,24 +648,23 @@ static Value castLikeSpaceOf(OpBuilder &builder, Value ptr, Value inSpaceOf) {
                                        inSpaceOf.getType(), ptr);
 }
 
-// llvm_ext.ptr_size_hint accepts AnyInteger, but llvm_ext.alloc and
-// llvm_ext.memcpy require an i64 size, so a narrower (or wider) hint has to be
-// converted rather than forwarded -- otherwise we build invalid IR that only
-// fails later, in the verifier. Returns null if the size is not an integer.
-static Value normalizeSizeToI64(OpBuilder &builder, Location loc, Value size) {
-  auto i64Ty = builder.getIntegerType(64);
-  if (size.getType() == i64Ty)
-    return size;
+static Value normalizeToI64(OpBuilder &builder, Location loc, Value val) {
+  auto i64Ty = builder.getI64Type();
+  if (val.getType() == i64Ty)
+    return val;
 
-  auto srcTy = dyn_cast<IntegerType>(size.getType());
+  if (val.getType().isIndex())
+    return arith::IndexCastOp::create(builder, loc, i64Ty, val);
+
+  auto srcTy = dyn_cast<IntegerType>(val.getType());
   if (!srcTy) {
-    llvm::errs() << "ptr size hint is not an integer: " << size << "\n";
+    llvm::errs() << "ptr size hint is not an integer: " << val << "\n";
     return nullptr;
   }
   // Sizes are non-negative, so zero-extend when widening.
   if (srcTy.getWidth() < 64)
-    return LLVM::ZExtOp::create(builder, loc, i64Ty, size);
-  return LLVM::TruncOp::create(builder, loc, i64Ty, size);
+    return LLVM::ZExtOp::create(builder, loc, i64Ty, val);
+  return LLVM::TruncOp::create(builder, loc, i64Ty, val);
 }
 
 struct PointerClonableTypeInterface
@@ -679,7 +677,7 @@ struct PointerClonableTypeInterface
       return nullptr;
     }
 
-    Value size = normalizeSizeToI64(builder, value.getLoc(), extent.size);
+    Value size = normalizeToI64(builder, value.getLoc(), extent.size);
     if (!size)
       return nullptr;
 
@@ -709,7 +707,7 @@ struct PointerClonableTypeInterface
       return;
     }
 
-    Value size = normalizeSizeToI64(builder, src.getLoc(), extent.size);
+    Value size = normalizeToI64(builder, src.getLoc(), extent.size);
     if (!size)
       return;
 
@@ -721,6 +719,44 @@ struct PointerClonableTypeInterface
 
   void freeClonedValue(Type self, OpBuilder &builder, Value value) const {
     llvm_ext::FreeOp::create(builder, value.getLoc(), value);
+  }
+
+  bool implementsBatchAllocation(Type self, Value base,
+                                 OpFoldResult size) const {
+    return true;
+  }
+
+  Value deriveSubElement(Type self, OpBuilder &builder, Location loc,
+                         Value base, Value multiel, Value index) const {
+    PtrExtent extent = findPtrExtent(base);
+    Value size = normalizeToI64(builder, loc, extent.size);
+    index = normalizeToI64(builder, loc, index);
+
+    Value offset = arith::MulIOp::create(builder, loc, size, index);
+    Value gep =
+        LLVM::GEPOp::create(builder, loc, multiel.getType(),
+                            builder.getI8Type(), multiel, ValueRange{offset});
+
+    return gep;
+  }
+
+  Value batchAllocate(Type self, OpBuilder &builder, Location loc, Value base,
+                      OpFoldResult size) const {
+    PtrExtent extent = findPtrExtent(base);
+
+    Value numel = dyn_cast<Value>(size);
+    if (auto attr = dyn_cast<Attribute>(size)) {
+      numel = arith::ConstantOp::materialize(builder, attr,
+                                             builder.getI64Type(), loc);
+    }
+
+    Value baseSize = normalizeToI64(builder, loc, extent.size);
+    Value totalSize = arith::MulIOp::create(builder, loc, numel, baseSize);
+
+    Value ptr = llvm_ext::AllocOp::create(builder, loc, extent.ptr.getType(),
+                                          totalSize);
+
+    return ptr;
   }
 };
 

--- a/enzyme/Enzyme/MLIR/Implementations/LoopCheckpointing.h
+++ b/enzyme/Enzyme/MLIR/Implementations/LoopCheckpointing.h
@@ -541,8 +541,16 @@ template <typename FinalClass, typename OpName> struct LoopCheckpointing {
     return llvm::to_vector(state);
   }
 
-  static Value cloneSlot(OpBuilder &b, Location loc, Value buf, Value slot) {
-    return memref::LoadOp::create(b, loc, buf, ValueRange{slot});
+  static Value cloneSlot(OpBuilder &builder, Location loc, Value base,
+                         Value buf, Value slot, int64_t budget) {
+    auto iface = cast<ClonableTypeInterface>(base.getType());
+    if (iface.implementsBatchAllocation(
+            base, OpFoldResult(builder.getI64IntegerAttr(budget)))) {
+      Value loaded = iface.deriveSubElement(builder, loc, base, buf, slot);
+      return loaded;
+    }
+
+    return memref::LoadOp::create(builder, loc, buf, ValueRange{slot});
   }
 
   // A `budget`-slot buffer of clone *handles* for one mutable ref, with a
@@ -563,34 +571,60 @@ template <typename FinalClass, typename OpName> struct LoopCheckpointing {
   // make all slots alias.
   static Value allocCloneSlots(OpBuilder &b, Location loc, int64_t budget,
                                Value proto, ClonableTypeInterface iface) {
-    SmallVector<Value> clones;
-    for (int64_t j = 0; j < budget; ++j)
-      clones.push_back(iface.cloneValue(b, proto));
+    OpFoldResult size = OpFoldResult(b.getI64IntegerAttr(budget));
+
+    if (iface.implementsBatchAllocation(proto, size)) {
+      Value batchAlloc = iface.batchAllocate(b, loc, proto, size);
+      return batchAlloc;
+    }
 
     Value buf = memref::AllocOp::create(
-        b, loc, MemRefType::get({budget}, clones.front().getType()));
-    for (auto &&[j, clone] : llvm::enumerate(clones)) {
-      Value slot = arith::ConstantIndexOp::create(b, loc, j);
-      memref::StoreOp::create(b, loc, clone, buf, ValueRange{slot});
+        b, loc, MemRefType::get({budget}, proto.getType()));
+
+    Value lb = arith::ConstantIndexOp::create(b, loc, 0);
+    Value ub = arith::ConstantIndexOp::create(b, loc, budget);
+    Value step = arith::ConstantIndexOp::create(b, loc, 1);
+    auto loop = scf::ForOp::create(b, loc, lb, ub, step);
+
+    {
+      OpBuilder::InsertionGuard guard(b);
+      b.setInsertionPoint(loop.getBody()->getTerminator());
+      Value clone = iface.cloneValue(b, proto);
+      memref::StoreOp::create(b, loc, clone, buf,
+                              ValueRange{loop.getInductionVar()});
     }
+
     return buf;
   }
 
   // Free each slot's clone, then the handle buffer itself. A loop is fine
   // here: a free has side effects so it cannot be hoisted, and nothing can
   // alias.
-  static void freeCloneSlots(OpBuilder &b, Location loc, int64_t budget,
-                             Value buf, ClonableTypeInterface iface) {
-    Value lb = arith::ConstantIndexOp::create(b, loc, 0);
-    Value ub = arith::ConstantIndexOp::create(b, loc, budget);
-    Value step = arith::ConstantIndexOp::create(b, loc, 1);
-    auto loop = scf::ForOp::create(b, loc, lb, ub, step);
-    {
-      OpBuilder::InsertionGuard g(b);
-      b.setInsertionPointToStart(loop.getBody());
-      iface.freeClonedValue(b, cloneSlot(b, loc, buf, loop.getInductionVar()));
+  static void freeCloneSlots(OpBuilder &builder, Value ref, Value buf,
+                             int64_t budget) {
+    ClonableTypeInterface iface = cast<ClonableTypeInterface>(ref.getType());
+    OpFoldResult numel = builder.getI64IntegerAttr(budget);
+
+    if (iface.implementsBatchAllocation(ref, numel)) {
+      iface.freeClonedValue(builder, buf);
+      return;
     }
-    memref::DeallocOp::create(b, loc, buf);
+
+    Value lb = arith::ConstantIndexOp::create(builder, ref.getLoc(), 0);
+    Value ub = arith::ConstantIndexOp::create(builder, ref.getLoc(), budget);
+    Value step = arith::ConstantIndexOp::create(builder, ref.getLoc(), 1);
+    auto loop = scf::ForOp::create(builder, ref.getLoc(), lb, ub, step);
+
+    {
+      OpBuilder::InsertionGuard guard(builder);
+      builder.setInsertionPoint(loop.getBody()->getTerminator());
+
+      Value val = memref::LoadOp::create(builder, buf.getLoc(), buf,
+                                         loop.getInductionVar());
+      iface.freeClonedValue(builder, val);
+    }
+
+    memref::DeallocOp::create(builder, buf.getLoc(), buf);
   }
 
   // Forward augmentation for binomial (Revolve) checkpointing. Builds an
@@ -721,7 +755,9 @@ template <typename FinalClass, typename OpName> struct LoopCheckpointing {
     // advance.
     for (auto &&[ref, buf] : llvm::zip_equal(mutableRefs, mutBufs)) {
       auto iface = cast<ClonableTypeInterface>(ref.getType());
-      iface.copyValue(builder, cloneSlot(builder, loc, buf, k),
+      iface.copyValue(builder,
+                      cloneSlot(builder, loc, gutils->getNewFromOriginal(ref),
+                                buf, k, budget),
                       gutils->getNewFromOriginal(ref));
     }
 
@@ -973,10 +1009,12 @@ template <typename FinalClass, typename OpName> struct LoopCheckpointing {
     // Re-prime each working clone from the snapshot paired with slot `capo`,
     // so the replay below starts from the mutable memory as it was at
     // ckptStep.
-    for (auto &&[r, ref] : llvm::enumerate(mutableRefs))
-      cast<ClonableTypeInterface>(ref.getType())
-          .copyValue(builder, workClones[r],
-                     cloneSlot(builder, loc, mutBufs[r], capo));
+    for (auto &&[r, ref] : llvm::enumerate(mutableRefs)) {
+      auto iface = cast<ClonableTypeInterface>(ref.getType());
+      iface.copyValue(builder, workClones[r],
+                      cloneSlot(builder, loc, gutils->getNewFromOriginal(ref),
+                                mutBufs[r], capo, budget));
+    }
 
     // Inner remat loop: reconstruct state at (currentRevStep - 1), carrying
     // (pos, capo, state..., [stores...]).
@@ -1025,10 +1063,14 @@ template <typename FinalClass, typename OpName> struct LoopCheckpointing {
             FinalClass::storeSlot(builder, loc, wStores[i], acapo, val);
       wStores[idxStore] =
           FinalClass::storeSlot(builder, loc, wStores[idxStore], acapo, pos);
-      for (auto &&[r, ref] : llvm::enumerate(mutableRefs))
-        cast<ClonableTypeInterface>(ref.getType())
-            .copyValue(builder, cloneSlot(builder, loc, mutBufs[r], acapo),
-                       workClones[r]);
+
+      for (auto &&[r, ref] : llvm::enumerate(mutableRefs)) {
+        auto iface = cast<ClonableTypeInterface>(ref.getType());
+        iface.copyValue(builder,
+                        cloneSlot(builder, loc, gutils->getNewFromOriginal(ref),
+                                  mutBufs[r], acapo, budget),
+                        workClones[r]);
+      }
 
       Value posPlusSplit = FinalClass::emitAdd(builder, loc, pos, split);
       Value isLast =
@@ -1244,7 +1286,7 @@ template <typename FinalClass, typename OpName> struct LoopCheckpointing {
     for (auto &&[r, ref] : llvm::enumerate(mutableRefs)) {
       auto iface = cast<ClonableTypeInterface>(ref.getType());
       iface.freeClonedValue(builder, workClones[r]);
-      freeCloneSlots(builder, loc, budget, mutBufs[r], iface);
+      freeCloneSlots(builder, ref, mutBufs[r], budget);
     }
 
     return success(valid);

--- a/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
@@ -277,6 +277,76 @@ public:
   void freeClonedValue(mlir::Type self, OpBuilder &builder, Value value) const {
     memref::DeallocOp::create(builder, value.getLoc(), value);
   };
+
+  bool implementsBatchAllocation(Type self, Value base,
+                                 OpFoldResult size) const {
+    return true;
+  }
+
+  Value deriveSubElement(Type self, OpBuilder &builder, Location loc,
+                         Value base, Value multiel, Value index) const {
+    auto MT = cast<MemRefType>(base.getType());
+
+    SmallVector<Value> dynSizes, offsets;
+
+    offsets.push_back(index);
+
+    SmallVector<int64_t> static_offsets(MT.getRank() + 1, 0);
+    static_offsets[0] = ShapedType::kDynamic;
+
+    SmallVector<int64_t> static_sizes;
+    static_sizes.push_back(1);
+    static_sizes.append(MT.getShape().begin(), MT.getShape().end());
+    SmallVector<int64_t> static_strides(MT.getRank() + 1, 1);
+
+    for (auto [i, sz] : llvm::enumerate(MT.getShape())) {
+      if (sz == ShapedType::kDynamic) {
+        Value dimI = arith::ConstantIndexOp::create(builder, loc, i);
+        dynSizes.push_back(memref::DimOp::create(builder, loc, base, i));
+      }
+    }
+
+    auto RT = memref::SubViewOp::inferRankReducedResultType(
+        MT.getShape(), cast<MemRefType>(multiel.getType()), static_offsets,
+        static_sizes, static_strides);
+    auto sv = memref::SubViewOp::create(
+        builder, loc, RT, multiel, offsets, dynSizes, /*strides=*/ValueRange(),
+        /*static_offsets=*/builder.getDenseI64ArrayAttr(static_offsets),
+        /*static_sizes=*/builder.getDenseI64ArrayAttr(static_sizes),
+        /*static_strides=*/builder.getDenseI64ArrayAttr(static_strides));
+
+    return sv;
+  }
+
+  Value batchAllocate(Type self, OpBuilder &builder, Location loc, Value base,
+                      OpFoldResult numel) const {
+    auto MT = cast<MemRefType>(self);
+
+    SmallVector<int64_t> shape;
+    SmallVector<Value> dynSizes;
+
+    if (auto attr = dyn_cast<Attribute>(numel)) {
+      shape.push_back(cast<IntegerAttr>(attr).getValue().getSExtValue());
+    } else {
+      shape.push_back(ShapedType::kDynamic);
+      dynSizes.push_back(cast<Value>(numel));
+    }
+
+    for (auto [i, sz] : llvm::enumerate(MT.getShape())) {
+      shape.push_back(sz);
+
+      if (sz == ShapedType::kDynamic) {
+        dynSizes.push_back(memref::DimOp::create(
+            builder, loc, base,
+            arith::ConstantIndexOp::create(builder, loc, i)));
+      }
+    }
+
+    Value alloc = memref::AllocOp::create(
+        builder, loc, MemRefType::get(shape, MT.getElementType()), dynSizes);
+
+    return alloc;
+  }
 };
 
 class MemRefAutoDiffTypeInterface

--- a/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/MemRefAutoDiffOpInterfaceImpl.cpp
@@ -344,7 +344,6 @@ public:
 
     for (auto [i, sz] : llvm::enumerate(MT.getShape())) {
       if (sz == ShapedType::kDynamic) {
-        Value dimI = arith::ConstantIndexOp::create(builder, loc, i);
         dynSizes.push_back(memref::DimOp::create(builder, loc, base, i));
       }
     }

--- a/enzyme/Enzyme/MLIR/Interfaces/AutoDiffTypeInterface.h
+++ b/enzyme/Enzyme/MLIR/Interfaces/AutoDiffTypeInterface.h
@@ -15,6 +15,7 @@
 #define ENZYME_MLIR_INTERFACES_AUTODIFFTYPEINTERFACE_H
 
 #include "mlir/IR/Attributes.h"
+#include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/Types.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Support/LogicalResult.h"

--- a/enzyme/Enzyme/MLIR/Interfaces/AutoDiffTypeInterface.td
+++ b/enzyme/Enzyme/MLIR/Interfaces/AutoDiffTypeInterface.td
@@ -69,7 +69,7 @@ def AutoDiffTypeInterface : TypeInterface<"AutoDiffTypeInterface"> {
     >,
     InterfaceMethod<
       /*desc=*/[{
-        Check if the mlir Attribute with the given type is 0.       
+        Check if the mlir Attribute with the given type is 0.
       }],
       /*retTy=*/"bool",
       /*methodName=*/"isZeroAttr",
@@ -149,6 +149,48 @@ def ClonableTypeInterface : TypeInterface<"ClonableTypeInterface"> {
     >,
     InterfaceMethod<
       /*desc=*/[{
+        Does the type implement batch allocation and subelement derivation.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"implementsBatchAllocation",
+      /*args=*/(ins "::mlir::Value":$base, "::mlir::OpFoldResult":$numel),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return false;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Tries to allocate multiple values.
+      }],
+      /*retTy=*/"::mlir::Value",
+      /*methodName=*/"batchAllocate",
+      /*args=*/(ins "::mlir::OpBuilder &":$builder, "::mlir::Location":$loc,
+                    "::mlir::Value":$base, "::mlir::OpFoldResult":$numel),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        llvm_unreachable("multiple values allocation not implemented");
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Given the bulk allocation return a subview to the element located at
+        index `index`.
+
+        The type returned by `deriveSubElement` does not have to match self
+        completely but should be usable in place of it.
+      }],
+      /*retTy=*/"::mlir::Value",
+      /*methodName=*/"deriveSubElement",
+      /*args=*/(ins "::mlir::OpBuilder &":$builder, "::mlir::Location":$loc,
+                    "::mlir::Value":$base, "::mlir::Value":$multiel, "::mlir::Value":$index),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        llvm_unreachable("bulk allocation is not implemented for type");
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
         Copy the contents of `src` into the already-allocated `dst`.
 
         Allocates nothing, so one clone can be reused across several
@@ -168,7 +210,7 @@ def ClonableTypeInterface : TypeInterface<"ClonableTypeInterface"> {
     >,
     InterfaceMethod<
       /*desc=*/[{
-        Free the clone.
+        Free the clone or batch allocated value.
       }],
       /*retTy=*/"void",
       /*methodName=*/"freeClonedValue",

--- a/enzyme/test/MLIR/ReverseMode/affine_for_binomial_checkpointing_mutable_memory.mlir
+++ b/enzyme/test/MLIR/ReverseMode/affine_for_binomial_checkpointing_mutable_memory.mlir
@@ -26,21 +26,19 @@ module {
 // at that point ("operand cannot be used as a dimension id"). This is the
 // regression the test guards: LoopCheckpointing's cloneOp hook must expand
 // such ops into memref.load/memref.store (via affine::expandAffineMap)
-// instead of cloning them as-is -- see %11/%30 below, both memref.load, and
-// %arg0/%alloc_6 (their memref operand) both being plain, generically-typed
+// instead of cloning them as-is -- see %10/%28 below, both memref.load, and
+// %arg0/%alloc_2 (their memref operand) both being plain, generically-typed
 // Values rather than valid affine dims/symbols.
 //
 // Otherwise this mirrors scf_for_checkpointing_binomial_mutable_memory.mlir
-// line for line: the mutable outside reference (%arg0) gets one clone per
-// checkpoint slot (%alloc_1 through %alloc_4) and a buffer of handles to them
-// (%alloc_5), all up front so taking a checkpoint is a plain copy into an
-// existing allocation, plus one working clone (%alloc_6) that the reverse
+// line for line: the mutable outside reference (%arg0) is checkpointed into a
+// single allocation one rank higher than itself (%alloc_1 :
+// memref<4x10xf64>), allocated up front so taking a checkpoint is a plain copy
+// into a subview of it, plus one working clone (%alloc_2) that the reverse
 // pass replays into.
 
 // CHECK:  func.func @reduce_sum(%arg0: memref<10xf64>, %arg1: memref<10xf64>, %arg2: f64) {
 // CHECK-NEXT:    %c9 = arith.constant 9 : index
-// CHECK-NEXT:    %c3 = arith.constant 3 : index
-// CHECK-NEXT:    %c2 = arith.constant 2 : index
 // CHECK-NEXT:    %c4 = arith.constant 4 : index
 // CHECK-NEXT:    %c10 = arith.constant 10 : index
 // CHECK-NEXT:    %c1 = arith.constant 1 : index
@@ -48,19 +46,7 @@ module {
 // CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f64
 // CHECK-NEXT:    %alloc = memref.alloc() : memref<4xf64>
 // CHECK-NEXT:    %alloc_0 = memref.alloc() : memref<4xindex>
-// CHECK-NEXT:    %alloc_1 = memref.alloc() : memref<10xf64>
-// CHECK-NEXT:    memref.copy %arg0, %alloc_1 : memref<10xf64> to memref<10xf64>
-// CHECK-NEXT:    %alloc_2 = memref.alloc() : memref<10xf64>
-// CHECK-NEXT:    memref.copy %arg0, %alloc_2 : memref<10xf64> to memref<10xf64>
-// CHECK-NEXT:    %alloc_3 = memref.alloc() : memref<10xf64>
-// CHECK-NEXT:    memref.copy %arg0, %alloc_3 : memref<10xf64> to memref<10xf64>
-// CHECK-NEXT:    %alloc_4 = memref.alloc() : memref<10xf64>
-// CHECK-NEXT:    memref.copy %arg0, %alloc_4 : memref<10xf64> to memref<10xf64>
-// CHECK-NEXT:    %alloc_5 = memref.alloc() : memref<4xmemref<10xf64>>
-// CHECK-NEXT:    memref.store %alloc_1, %alloc_5[%c0] : memref<4xmemref<10xf64>>
-// CHECK-NEXT:    memref.store %alloc_2, %alloc_5[%c1] : memref<4xmemref<10xf64>>
-// CHECK-NEXT:    memref.store %alloc_3, %alloc_5[%c2] : memref<4xmemref<10xf64>>
-// CHECK-NEXT:    memref.store %alloc_4, %alloc_5[%c3] : memref<4xmemref<10xf64>>
+// CHECK-NEXT:    %alloc_1 = memref.alloc() : memref<4x10xf64>
 // CHECK-NEXT:    %0:2 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %c0, %arg5 = %cst) -> (index, f64) {
 // CHECK-NEXT:      memref.store %arg5, %alloc[%arg3] : memref<4xf64>
 // CHECK-NEXT:      memref.store %arg4, %alloc_0[%arg3] : memref<4xindex>
@@ -68,77 +54,73 @@ module {
 // CHECK-NEXT:      %4 = arith.subi %c4, %arg3 : index
 // CHECK-NEXT:      %5 = arith.minui %4, %3 : index
 // CHECK-NEXT:      %6 = enzyme.binomial_progress %3, %5 : index
-// CHECK-NEXT:      %7 = memref.load %alloc_5[%arg3] : memref<4xmemref<10xf64>>
-// CHECK-NEXT:      memref.copy %arg0, %7 : memref<10xf64> to memref<10xf64>
-// CHECK-NEXT:      %8 = scf.for %arg6 = %c0 to %6 step %c1 iter_args(%arg7 = %arg5) -> (f64) {
-// CHECK-NEXT:        %10 = arith.addi %arg4, %arg6 : index
-// CHECK-NEXT:        %11 = memref.load %arg0[%10] : memref<10xf64>
-// CHECK-NEXT:        %12 = arith.addf %arg7, %11 : f64
-// CHECK-NEXT:        memref.store %12, %arg0[%c0] : memref<10xf64>
-// CHECK-NEXT:        scf.yield %12 : f64
+// CHECK-NEXT:      %subview = memref.subview %alloc_1[%arg3, 0] [1, 10] [1, 1] : memref<4x10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:      memref.copy %arg0, %subview : memref<10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:      %7 = scf.for %arg6 = %c0 to %6 step %c1 iter_args(%arg7 = %arg5) -> (f64) {
+// CHECK-NEXT:        %9 = arith.addi %arg4, %arg6 : index
+// CHECK-NEXT:        %10 = memref.load %arg0[%9] : memref<10xf64>
+// CHECK-NEXT:        %11 = arith.addf %arg7, %10 : f64
+// CHECK-NEXT:        memref.store %11, %arg0[%c0] : memref<10xf64>
+// CHECK-NEXT:        scf.yield %11 : f64
 // CHECK-NEXT:      } {enzyme.disable_mincut = true}
-// CHECK-NEXT:      %9 = arith.addi %arg4, %6 : index
-// CHECK-NEXT:      scf.yield %9, %8 : index, f64
+// CHECK-NEXT:      %8 = arith.addi %arg4, %6 : index
+// CHECK-NEXT:      scf.yield %8, %7 : index, f64
 // CHECK-NEXT:    } {enzyme.disable_mincut = true}
 // CHECK-NEXT:    %1 = arith.addf %arg2, %cst fastmath<fast> : f64
-// CHECK-NEXT:    %alloc_6 = memref.alloc() : memref<10xf64>
-// CHECK-NEXT:    memref.copy %arg0, %alloc_6 : memref<10xf64> to memref<10xf64>
+// CHECK-NEXT:    %alloc_2 = memref.alloc() : memref<10xf64>
+// CHECK-NEXT:    memref.copy %arg0, %alloc_2 : memref<10xf64> to memref<10xf64>
 // CHECK-NEXT:    %2:2 = scf.for %arg3 = %c0 to %c10 step %c1 iter_args(%arg4 = %c4, %arg5 = %1) -> (index, f64) {
 // CHECK-NEXT:      %3 = arith.subi %arg4, %c1 : index
 // CHECK-NEXT:      %4 = arith.subi %c10, %arg3 : index
 // CHECK-NEXT:      %5 = memref.load %alloc[%3] : memref<4xf64>
 // CHECK-NEXT:      %6 = memref.load %alloc_0[%3] : memref<4xindex>
-// CHECK-NEXT:      %7 = memref.load %alloc_5[%3] : memref<4xmemref<10xf64>>
-// CHECK-NEXT:      memref.copy %7, %alloc_6 : memref<10xf64> to memref<10xf64>
-// CHECK-NEXT:      %8:3 = scf.while (%arg6 = %6, %arg7 = %3, %arg8 = %5) : (index, index, f64) -> (index, index, f64) {
-// CHECK-NEXT:        %19 = arith.addi %arg6, %c1 : index
-// CHECK-NEXT:        %20 = arith.cmpi slt, %19, %4 : index
-// CHECK-NEXT:        scf.condition(%20) %arg6, %arg7, %arg8 : index, index, f64
+// CHECK-NEXT:      %subview = memref.subview %alloc_1[%3, 0] [1, 10] [1, 1] : memref<4x10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:      memref.copy %subview, %alloc_2 : memref<10xf64, strided<[1], offset: ?>> to memref<10xf64>
+// CHECK-NEXT:      %7:3 = scf.while (%arg6 = %6, %arg7 = %3, %arg8 = %5) : (index, index, f64) -> (index, index, f64) {
+// CHECK-NEXT:        %18 = arith.addi %arg6, %c1 : index
+// CHECK-NEXT:        %19 = arith.cmpi slt, %18, %4 : index
+// CHECK-NEXT:        scf.condition(%19) %arg6, %arg7, %arg8 : index, index, f64
 // CHECK-NEXT:      } do {
 // CHECK-NEXT:      ^bb0(%arg6: index, %arg7: index, %arg8: f64):
-// CHECK-NEXT:        %19 = arith.subi %4, %arg6 : index
-// CHECK-NEXT:        %20 = arith.subi %c4, %arg7 : index
-// CHECK-NEXT:        %21 = arith.minui %20, %19 : index
-// CHECK-NEXT:        %22 = enzyme.binomial_progress %19, %21 : index
+// CHECK-NEXT:        %18 = arith.subi %4, %arg6 : index
+// CHECK-NEXT:        %19 = arith.subi %c4, %arg7 : index
+// CHECK-NEXT:        %20 = arith.minui %19, %18 : index
+// CHECK-NEXT:        %21 = enzyme.binomial_progress %18, %20 : index
 // CHECK-NEXT:        memref.store %arg8, %alloc[%arg7] : memref<4xf64>
 // CHECK-NEXT:        memref.store %arg6, %alloc_0[%arg7] : memref<4xindex>
-// CHECK-NEXT:        %23 = memref.load %alloc_5[%arg7] : memref<4xmemref<10xf64>>
-// CHECK-NEXT:        memref.copy %alloc_6, %23 : memref<10xf64> to memref<10xf64>
-// CHECK-NEXT:        %24 = arith.addi %arg6, %22 : index
-// CHECK-NEXT:        %25 = arith.cmpi eq, %24, %4 : index
-// CHECK-NEXT:        %26 = arith.subi %24, %c1 : index
-// CHECK-NEXT:        %27 = arith.select %25, %26, %24 : index
-// CHECK-NEXT:        %28 = scf.for %arg9 = %arg6 to %27 step %c1 iter_args(%arg10 = %arg8) -> (f64) {
-// CHECK-NEXT:          %30 = memref.load %alloc_6[%arg9] : memref<10xf64>
-// CHECK-NEXT:          %31 = arith.addf %arg10, %30 : f64
-// CHECK-NEXT:          memref.store %31, %alloc_6[%c0] : memref<10xf64>
-// CHECK-NEXT:          scf.yield %31 : f64
+// CHECK-NEXT:        %subview_3 = memref.subview %alloc_1[%arg7, 0] [1, 10] [1, 1] : memref<4x10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:        memref.copy %alloc_2, %subview_3 : memref<10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:        %22 = arith.addi %arg6, %21 : index
+// CHECK-NEXT:        %23 = arith.cmpi eq, %22, %4 : index
+// CHECK-NEXT:        %24 = arith.subi %22, %c1 : index
+// CHECK-NEXT:        %25 = arith.select %23, %24, %22 : index
+// CHECK-NEXT:        %26 = scf.for %arg9 = %arg6 to %25 step %c1 iter_args(%arg10 = %arg8) -> (f64) {
+// CHECK-NEXT:          %28 = memref.load %alloc_2[%arg9] : memref<10xf64>
+// CHECK-NEXT:          %29 = arith.addf %arg10, %28 : f64
+// CHECK-NEXT:          memref.store %29, %alloc_2[%c0] : memref<10xf64>
+// CHECK-NEXT:          scf.yield %29 : f64
 // CHECK-NEXT:        } {enzyme.disable_mincut = true}
-// CHECK-NEXT:        %29 = arith.addi %arg7, %c1 : index
-// CHECK-NEXT:        scf.yield %24, %29, %28 : index, index, f64
+// CHECK-NEXT:        %27 = arith.addi %arg7, %c1 : index
+// CHECK-NEXT:        scf.yield %22, %27, %26 : index, index, f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %9 = arith.subi %c9, %arg3 : index
-// CHECK-NEXT:      %10 = memref.load %alloc_6[%9] : memref<10xf64>
-// CHECK-NEXT:      %11 = arith.addf %8#2, %10 : f64
-// CHECK-NEXT:      memref.store %11, %alloc_6[%c0] : memref<10xf64>
-// CHECK-NEXT:      %12 = arith.addf %arg5, %cst fastmath<fast> : f64
-// CHECK-NEXT:      %13 = affine.load %arg1[0] : memref<10xf64>
-// CHECK-NEXT:      %14 = arith.addf %12, %13 fastmath<fast> : f64
+// CHECK-NEXT:      %8 = arith.subi %c9, %arg3 : index
+// CHECK-NEXT:      %9 = memref.load %alloc_2[%8] : memref<10xf64>
+// CHECK-NEXT:      %10 = arith.addf %7#2, %9 : f64
+// CHECK-NEXT:      memref.store %10, %alloc_2[%c0] : memref<10xf64>
+// CHECK-NEXT:      %11 = arith.addf %arg5, %cst fastmath<fast> : f64
+// CHECK-NEXT:      %12 = affine.load %arg1[0] : memref<10xf64>
+// CHECK-NEXT:      %13 = arith.addf %11, %12 fastmath<fast> : f64
 // CHECK-NEXT:      affine.store %cst, %arg1[0] : memref<10xf64>
-// CHECK-NEXT:      %15 = arith.addf %14, %cst fastmath<fast> : f64
-// CHECK-NEXT:      %16 = arith.addf %14, %cst fastmath<fast> : f64
-// CHECK-NEXT:      %17 = memref.load %arg1[%9] : memref<10xf64>
-// CHECK-NEXT:      %18 = arith.addf %17, %16 fastmath<fast> : f64
-// CHECK-NEXT:      memref.store %18, %arg1[%9] : memref<10xf64>
-// CHECK-NEXT:      scf.yield %8#1, %15 : index, f64
+// CHECK-NEXT:      %14 = arith.addf %13, %cst fastmath<fast> : f64
+// CHECK-NEXT:      %15 = arith.addf %13, %cst fastmath<fast> : f64
+// CHECK-NEXT:      %16 = memref.load %arg1[%8] : memref<10xf64>
+// CHECK-NEXT:      %17 = arith.addf %16, %15 fastmath<fast> : f64
+// CHECK-NEXT:      memref.store %17, %arg1[%8] : memref<10xf64>
+// CHECK-NEXT:      scf.yield %7#1, %14 : index, f64
 // CHECK-NEXT:    } {enzyme.disable_mincut = true}
 // CHECK-NEXT:    memref.dealloc %alloc : memref<4xf64>
 // CHECK-NEXT:    memref.dealloc %alloc_0 : memref<4xindex>
-// CHECK-NEXT:    memref.dealloc %alloc_6 : memref<10xf64>
-// CHECK-NEXT:    scf.for %arg3 = %c0 to %c4 step %c1 {
-// CHECK-NEXT:      %3 = memref.load %alloc_5[%arg3] : memref<4xmemref<10xf64>>
-// CHECK-NEXT:      memref.dealloc %3 : memref<10xf64>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    memref.dealloc %alloc_5 : memref<4xmemref<10xf64>>
+// CHECK-NEXT:    memref.dealloc %alloc_2 : memref<10xf64>
+// CHECK-NEXT:    memref.dealloc %alloc_1 : memref<4x10xf64>
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }

--- a/enzyme/test/MLIR/ReverseMode/scf_for_binomial_checkpointing_budget_exceeds_trip.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_for_binomial_checkpointing_budget_exceeds_trip.mlir
@@ -1,19 +1,5 @@
 // RUN: %eopt %s --enzyme-wrap="infn=main outfn= argTys=enzyme_dup retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops --canonicalize --enzyme-simplify-math | FileCheck %s
 
-// A budget larger than the trip count. The *effective* budget is
-// min(budget, numIters) = 3, so only slots [0, 3) are ever written, but the
-// buffers are still sized by the static budget (8): clone slots are allocated
-// eagerly for all 8 and the teardown loop frees all 8, so slots [3, 8) are
-// allocated and freed without ever holding a snapshot.
-//
-// The clamp is unconditional. Without it the placement loop would run 8 times
-// over 3 steps, and the slots past the end would be recorded at a step beyond
-// the last one -- holding the final state rather than a checkpoint, which the
-// reverse pass then replays from, silently corrupting the gradient.
-//
-// This also pins the eager-allocation choice: a lazily-filled buffer would need
-// a null sentinel per slot, which does not exist for a memref element type.
-
 module {
   func.func @main(%m: memref<f32>) -> f32 {
     %c0 = arith.constant 0 : index
@@ -34,28 +20,16 @@ module {
 }
 
 // CHECK-LABEL: func.func @main(
-// Buffers are sized by the static budget, not the effective one.
-// CHECK-DAG:     memref.alloc() : memref<8xf32>
-// CHECK-DAG:     memref.alloc() : memref<8xindex>
-// CHECK-DAG:     %[[SLOTS:.+]] = memref.alloc() : memref<8xmemref<f32>>
+// CHECK:         memref.alloc() : memref<8xf32>
+// CHECK-NEXT:    memref.alloc() : memref<8xindex>
+// CHECK-NEXT:    %[[SLOTS:.+]] = memref.alloc() : memref<8xf32>
 
-// All 8 slots get a clone, including the ones beyond the effective budget.
-// CHECK-COUNT-8: memref.store %{{.+}}, %[[SLOTS]][%c{{[0-9]+}}] : memref<8xmemref<f32>>
-
-// The forward placement loop is bounded by the effective budget (3), so only
-// slots [0, 3) are ever snapshotted.
 // CHECK:         scf.for %[[K:.+]] = %c0 to %c3 step %c1
-// CHECK:           %[[FWDSLOT:.+]] = memref.load %[[SLOTS]][%[[K]]] : memref<8xmemref<f32>>
+// CHECK:           %[[FWDSLOT:.+]] = memref.subview %[[SLOTS]][%[[K]]] [1] [1] : memref<8xf32> to memref<f32, strided<[], offset: ?>>
 // CHECK-NEXT:      memref.copy %arg0, %[[FWDSLOT]]
 
-// Reverse reads are still indexed by the stack pointer.
 // CHECK:         scf.for %{{.+}} = %c0 to %c3 step %c1 iter_args(%[[SP:.+]] = %c3
 // CHECK-NEXT:      %[[CAPO:.+]] = arith.subi %[[SP]], %c1 : index
-// CHECK:           memref.load %[[SLOTS]][%[[CAPO]]] : memref<8xmemref<f32>>
+// CHECK:           memref.subview %[[SLOTS]][%[[CAPO]]] [1] [1] : memref<8xf32> to memref<f32, strided<[], offset: ?>>
 
-// Teardown covers the whole buffer, so the unused slots are freed too.
-// CHECK:         scf.for %[[J:.+]] = %c0 to %c8 step %c1 {
-// CHECK-NEXT:      %[[FREESLOT:.+]] = memref.load %[[SLOTS]][%[[J]]] : memref<8xmemref<f32>>
-// CHECK-NEXT:      memref.dealloc %[[FREESLOT]] : memref<f32>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    memref.dealloc %[[SLOTS]] : memref<8xmemref<f32>>
+// CHECK:         memref.dealloc %[[SLOTS]] : memref<8xf32>

--- a/enzyme/test/MLIR/ReverseMode/scf_for_binomial_checkpointing_ptr_device.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_for_binomial_checkpointing_ptr_device.mlir
@@ -1,16 +1,6 @@
 // RUN: %eopt %s --raise-llvm-ext --enzyme-wrap="infn=main outfn= argTys=enzyme_dup retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops --canonicalize --enzyme-simplify-math | FileCheck %s
 // RUN: %eopt %s --allow-unregistered-dialect --raise-llvm-ext --enzyme-wrap="infn=main outfn= argTys=enzyme_dup retTys=enzyme_active mode=ReverseModeCombined" --lower-llvm-ext --canonicalize --remove-unnecessary-enzyme-ops --canonicalize --enzyme-simplify-math | FileCheck %s --check-prefix=LOWER
 
-// The shape a CUDA program hits: the checkpointed loop mutates memory reached
-// through a pointer that really lives on the device, but whose C type says
-// nothing about that (cudaMalloc hands back a plain `float *`). The third
-// argument of __enzyme_ptr_size_hint annotates the memory space; raise-llvm-ext
-// turns it into an addrspacecast, and cloning follows the cast, so the
-// snapshots are device allocations rather than host ones.
-//
-// The second RUN line covers lower-llvm-ext; the copies it emits are enzymexla
-// ops, which live outside this repository, hence --allow-unregistered-dialect.
-
 module {
   llvm.func @__enzyme_ptr_size_hint(!llvm.ptr, i64, i64)
 
@@ -36,31 +26,20 @@ module {
     return %0 : f32
   }
 }
-
 // CHECK-LABEL: func.func @main(
-// The annotated space reaches every allocation, copy and free: the handles are
-// device pointers, so the buffer holding them is one of those too.
+// CHECK:         %[[TOTAL:.+]] = arith.constant 160 : i64
 // CHECK:         %[[SZ:.+]] = llvm.mlir.constant(40 : i64) : i64
 // CHECK:         %[[DEV:.+]] = llvm.addrspacecast %arg0 : !llvm.ptr to !llvm.ptr<1>
 // CHECK:         llvm_ext.ptr_size_hint %[[DEV]], %[[SZ]] : !llvm.ptr<1>, i64
-// CHECK:         %[[C0:.+]] = llvm_ext.alloc %[[SZ]] : (i64) -> !llvm.ptr<1>
-// CHECK-NEXT:    llvm_ext.memcpy %[[C0]], %[[DEV]], %[[SZ]] : !llvm.ptr<1>, !llvm.ptr<1>, i64
-// CHECK:         %[[SLOTS:.+]] = memref.alloc() : memref<4x!llvm.ptr<1>>
-// CHECK-NEXT:    memref.store %[[C0]], %[[SLOTS]][%c0] : memref<4x!llvm.ptr<1>>
+// CHECK:         %[[SLOTS:.+]] = llvm_ext.alloc %[[TOTAL]] : (i64) -> !llvm.ptr<1>
 
-// Snapshot into slot %k, and the working clone the reverse pass replays into.
-// CHECK:         %[[FWDSLOT:.+]] = memref.load %[[SLOTS]][%{{.+}}] : memref<4x!llvm.ptr<1>>
+// CHECK:         %[[FWDSLOT:.+]] = llvm.getelementptr %[[SLOTS]][%{{.+}}] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i8
 // CHECK-NEXT:    llvm_ext.memcpy %[[FWDSLOT]], %{{.+}}, %[[SZ]] : !llvm.ptr<1>, !llvm.ptr<1>, i64
 // CHECK:         %[[WORK:.+]] = llvm_ext.alloc %[[SZ]] : (i64) -> !llvm.ptr<1>
 
-// Teardown frees device handles, never host ones.
 // CHECK:         llvm_ext.free %[[WORK]] : !llvm.ptr<1>
-// CHECK:           %[[FREESLOT:.+]] = memref.load %[[SLOTS]][%{{.+}}] : memref<4x!llvm.ptr<1>>
-// CHECK-NEXT:      llvm_ext.free %[[FREESLOT]] : !llvm.ptr<1>
-// CHECK:         memref.dealloc %[[SLOTS]] : memref<4x!llvm.ptr<1>>
+// CHECK-NEXT:    llvm_ext.free %[[SLOTS]] : !llvm.ptr<1>
 
-// lower-llvm-ext routes all of it through the GPU runtime: no malloc/free of
-// what is device memory, which is the bug the annotation exists to avoid.
 // LOWER-LABEL: func.func @main(
 // LOWER-NOT:     llvm.call @malloc
 // LOWER-NOT:     llvm.call @free

--- a/enzyme/test/MLIR/ReverseMode/scf_for_binomial_checkpointing_ptr_mutable.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_for_binomial_checkpointing_ptr_mutable.mlir
@@ -1,14 +1,6 @@
 // RUN: %eopt %s --enzyme-wrap="infn=main outfn= argTys=enzyme_dup retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops --canonicalize --enzyme-simplify-math | FileCheck %s
 // RUN: %eopt %s --allow-unregistered-dialect --enzyme-wrap="infn=main outfn= argTys=enzyme_dup retTys=enzyme_active mode=ReverseModeCombined" --lower-llvm-ext --canonicalize --remove-unnecessary-enzyme-ops --canonicalize --enzyme-simplify-math | FileCheck %s --check-prefix=LOWER
 
-// Binomial checkpointing of a bare !llvm.ptr, the shape a CUDA program hits:
-// the loop mutates memory reached through a pointer whose extent is not in its
-// type, so the size comes from llvm_ext.ptr_size_hint and the clone buffer holds
-// pointer *handles* rather than flattened contents.
-//
-// The second RUN line covers lower-llvm-ext; the copies it emits are enzymexla
-// ops, which live outside this repository, hence --allow-unregistered-dialect.
-
 module {
   func.func @main(%p: !llvm.ptr) -> f32 {
     %c0 = arith.constant 0 : index
@@ -31,66 +23,42 @@ module {
     return %0 : f32
   }
 }
-
 // CHECK-LABEL: func.func @main(
-// One clone per slot allocated up front, then the buffer of handles they are
-// stored in -- which is typed from a clone. The size on every alloc/memcpy is
-// the hinted extent.
+// CHECK:         %[[TOTAL:.+]] = arith.constant 160 : i64
 // CHECK:         %[[SZ:.+]] = llvm.mlir.constant(40 : i64) : i64
-// CHECK:         %[[C0:.+]] = llvm_ext.alloc %[[SZ]] : (i64) -> !llvm.ptr
-// CHECK-NEXT:    llvm_ext.memcpy %[[C0]], %arg0, %[[SZ]]
-// CHECK-NEXT:    %[[C1:.+]] = llvm_ext.alloc %[[SZ]] : (i64) -> !llvm.ptr
-// CHECK-NEXT:    llvm_ext.memcpy %[[C1]], %arg0, %[[SZ]]
-// CHECK-NEXT:    %[[C2:.+]] = llvm_ext.alloc %[[SZ]] : (i64) -> !llvm.ptr
-// CHECK-NEXT:    llvm_ext.memcpy %[[C2]], %arg0, %[[SZ]]
-// CHECK-NEXT:    %[[C3:.+]] = llvm_ext.alloc %[[SZ]] : (i64) -> !llvm.ptr
-// CHECK-NEXT:    llvm_ext.memcpy %[[C3]], %arg0, %[[SZ]]
-// CHECK-NEXT:    %[[SLOTS:.+]] = memref.alloc() : memref<4x!llvm.ptr>
-// CHECK-NEXT:    memref.store %[[C0]], %[[SLOTS]][%c0] : memref<4x!llvm.ptr>
-// CHECK-NEXT:    memref.store %[[C1]], %[[SLOTS]][%c1] : memref<4x!llvm.ptr>
-// CHECK-NEXT:    memref.store %[[C2]], %[[SLOTS]][%c2] : memref<4x!llvm.ptr>
-// CHECK-NEXT:    memref.store %[[C3]], %[[SLOTS]][%c3] : memref<4x!llvm.ptr>
+// CHECK:         %[[SLOTS:.+]] = llvm_ext.alloc %[[TOTAL]] : (i64) -> !llvm.ptr
 
-// Forward: snapshot into slot %k with a copy, no new allocation.
 // CHECK:         scf.for %[[K:.+]] = %c0 to %c4 step %c1
-// CHECK:           %[[FWDSLOT:.+]] = memref.load %[[SLOTS]][%[[K]]] : memref<4x!llvm.ptr>
+// CHECK:           %[[KI:.+]] = arith.index_cast %[[K]] : index to i64
+// CHECK-NEXT:      %[[OFF:.+]] = arith.muli %[[KI]], %[[SZ]] : i64
+// CHECK-NEXT:      %[[FWDSLOT:.+]] = llvm.getelementptr %[[SLOTS]][%[[OFF]]] : (!llvm.ptr, i64) -> !llvm.ptr, i8
 // CHECK-NEXT:      llvm_ext.memcpy %[[FWDSLOT]], %arg0, %[[SZ]]
 
-// The working clone the reverse pass replays into, outside the reverse loop.
 // CHECK:         %[[WORK:.+]] = llvm_ext.alloc %[[SZ]] : (i64) -> !llvm.ptr
 // CHECK-NEXT:    llvm_ext.memcpy %[[WORK]], %arg0, %[[SZ]]
 
-// Reverse: the slot index is the stack-pointer iter arg minus one, never a
-// function of the reverse induction variable.
 // CHECK:         scf.for %{{.+}} = %c0 to %c10 step %c1 iter_args(%[[SP:.+]] = %c4
 // CHECK-NEXT:      %[[CAPO:.+]] = arith.subi %[[SP]], %c1 : index
 // CHECK:           memref.load %{{.+}}[%[[CAPO]]] : memref<4xf32>
 // CHECK:           memref.load %{{.+}}[%[[CAPO]]] : memref<4xindex>
-// CHECK:           %[[REVSLOT:.+]] = memref.load %[[SLOTS]][%[[CAPO]]] : memref<4x!llvm.ptr>
+// CHECK:           %[[CAPOI:.+]] = arith.index_cast %[[CAPO]] : index to i64
+// CHECK-NEXT:      %[[REVOFF:.+]] = arith.muli %[[CAPOI]], %[[SZ]] : i64
+// CHECK-NEXT:      %[[REVSLOT:.+]] = llvm.getelementptr %[[SLOTS]][%[[REVOFF]]] : (!llvm.ptr, i64) -> !llvm.ptr, i8
 // CHECK-NEXT:      llvm_ext.memcpy %[[WORK]], %[[REVSLOT]], %[[SZ]]
 
-// The remat re-places a checkpoint; the pointer snapshot moves with it.
 // CHECK:           scf.while ({{.*}}%[[ACAPO:.+]] = %[[CAPO]]
-// CHECK:             %[[ACSLOT:.+]] = memref.load %[[SLOTS]][%[[ACAPO]]] : memref<4x!llvm.ptr>
+// CHECK:             %[[ACAPOI:.+]] = arith.index_cast %[[ACAPO]] : index to i64
+// CHECK-NEXT:        %[[ACOFF:.+]] = arith.muli %[[ACAPOI]], %[[SZ]] : i64
+// CHECK-NEXT:        %[[ACSLOT:.+]] = llvm.getelementptr %[[SLOTS]][%[[ACOFF]]] : (!llvm.ptr, i64) -> !llvm.ptr, i8
 // CHECK-NEXT:        llvm_ext.memcpy %[[ACSLOT]], %[[WORK]], %[[SZ]]
 
-// Teardown: working clone, then every slot's clone, then the handle buffer.
 // CHECK:         llvm_ext.free %[[WORK]]
-// CHECK-NEXT:    scf.for %[[J:.+]] = %c0 to %c4 step %c1 {
-// CHECK-NEXT:      %[[FREESLOT:.+]] = memref.load %[[SLOTS]][%[[J]]] : memref<4x!llvm.ptr>
-// CHECK-NEXT:      llvm_ext.free %[[FREESLOT]]
-// CHECK-NEXT:    }
-// CHECK-NEXT:    memref.dealloc %[[SLOTS]] : memref<4x!llvm.ptr>
+// CHECK-NEXT:    llvm_ext.free %[[SLOTS]]
 
-// After lower-llvm-ext the host allocator is used throughout, including for the
-// frees of handles loaded back out of the buffer: those handles are typed
-// !llvm.ptr, so the memory space is right there in the type and no tracing back
-// to the allocation is needed to pick the deallocator.
 // LOWER-DAG:   llvm.func @malloc(i64) -> !llvm.ptr
 // LOWER-DAG:   llvm.func @free(!llvm.ptr)
 // LOWER-LABEL: func.func @main(
 // LOWER:         llvm.call @malloc
 // LOWER:         "enzymexla.memcpy"
-// LOWER:         memref.load
 // LOWER:         llvm.call @free
 // LOWER-NOT:     llvm_ext.

--- a/enzyme/test/MLIR/ReverseMode/scf_for_checkpointing_binomial_mutable_memory.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_for_checkpointing_binomial_mutable_memory.mlir
@@ -21,24 +21,8 @@ module {
   }
 }
 
-// The mutable outside reference (%arg0) gets one clone per checkpoint slot
-// (%alloc_1 through %alloc_4) and a buffer of handles to them (%alloc_5), all
-// up front so taking a checkpoint is a plain copy into an existing allocation,
-// plus one working clone (%alloc_6) that the reverse pass replays into. Slot j
-// of %alloc_5 pairs with slot j of the state (%alloc) and step-index (%alloc_0)
-// buffers, so all three are indexed by the checkpoint stack pointer -- `%3 =
-// arith.subi %arg4, %c1` below, where %arg4 is the reverse loop's
-// live-checkpoint iter arg.
-//
-// The index must never be a function of the reverse induction variable. That is
-// the regression this test guards: it used to read the handle buffer at
-// `9 - %arg3`, i.e. out of bounds of the 4-slot buffer for every iteration past
-// the budget, handing the replay a garbage buffer and then freeing it.
-
 // CHECK:  func.func @reduce_sum(%arg0: memref<10xf64>, %arg1: memref<10xf64>, %arg2: f64) {
 // CHECK-NEXT:    %c9 = arith.constant 9 : index
-// CHECK-NEXT:    %c3 = arith.constant 3 : index
-// CHECK-NEXT:    %c2 = arith.constant 2 : index
 // CHECK-NEXT:    %c4 = arith.constant 4 : index
 // CHECK-NEXT:    %c10 = arith.constant 10 : index
 // CHECK-NEXT:    %c1 = arith.constant 1 : index
@@ -46,19 +30,7 @@ module {
 // CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f64
 // CHECK-NEXT:    %alloc = memref.alloc() : memref<4xf64>
 // CHECK-NEXT:    %alloc_0 = memref.alloc() : memref<4xindex>
-// CHECK-NEXT:    %alloc_1 = memref.alloc() : memref<10xf64>
-// CHECK-NEXT:    memref.copy %arg0, %alloc_1 : memref<10xf64> to memref<10xf64>
-// CHECK-NEXT:    %alloc_2 = memref.alloc() : memref<10xf64>
-// CHECK-NEXT:    memref.copy %arg0, %alloc_2 : memref<10xf64> to memref<10xf64>
-// CHECK-NEXT:    %alloc_3 = memref.alloc() : memref<10xf64>
-// CHECK-NEXT:    memref.copy %arg0, %alloc_3 : memref<10xf64> to memref<10xf64>
-// CHECK-NEXT:    %alloc_4 = memref.alloc() : memref<10xf64>
-// CHECK-NEXT:    memref.copy %arg0, %alloc_4 : memref<10xf64> to memref<10xf64>
-// CHECK-NEXT:    %alloc_5 = memref.alloc() : memref<4xmemref<10xf64>>
-// CHECK-NEXT:    memref.store %alloc_1, %alloc_5[%c0] : memref<4xmemref<10xf64>>
-// CHECK-NEXT:    memref.store %alloc_2, %alloc_5[%c1] : memref<4xmemref<10xf64>>
-// CHECK-NEXT:    memref.store %alloc_3, %alloc_5[%c2] : memref<4xmemref<10xf64>>
-// CHECK-NEXT:    memref.store %alloc_4, %alloc_5[%c3] : memref<4xmemref<10xf64>>
+// CHECK-NEXT:    %alloc_1 = memref.alloc() : memref<4x10xf64>
 // CHECK-NEXT:    %0:2 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %c0, %arg5 = %cst) -> (index, f64) {
 // CHECK-NEXT:      memref.store %arg5, %alloc[%arg3] : memref<4xf64>
 // CHECK-NEXT:      memref.store %arg4, %alloc_0[%arg3] : memref<4xindex>
@@ -66,77 +38,73 @@ module {
 // CHECK-NEXT:      %4 = arith.subi %c4, %arg3 : index
 // CHECK-NEXT:      %5 = arith.minui %4, %3 : index
 // CHECK-NEXT:      %6 = enzyme.binomial_progress %3, %5 : index
-// CHECK-NEXT:      %7 = memref.load %alloc_5[%arg3] : memref<4xmemref<10xf64>>
-// CHECK-NEXT:      memref.copy %arg0, %7 : memref<10xf64> to memref<10xf64>
-// CHECK-NEXT:      %8 = scf.for %arg6 = %c0 to %6 step %c1 iter_args(%arg7 = %arg5) -> (f64) {
-// CHECK-NEXT:        %10 = arith.addi %arg4, %arg6 : index
-// CHECK-NEXT:        %11 = memref.load %arg0[%10] : memref<10xf64>
-// CHECK-NEXT:        %12 = arith.addf %arg7, %11 : f64
-// CHECK-NEXT:        memref.store %12, %arg0[%c0] : memref<10xf64>
-// CHECK-NEXT:        scf.yield %12 : f64
+// CHECK-NEXT:      %subview = memref.subview %alloc_1[%arg3, 0] [1, 10] [1, 1] : memref<4x10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:      memref.copy %arg0, %subview : memref<10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:      %7 = scf.for %arg6 = %c0 to %6 step %c1 iter_args(%arg7 = %arg5) -> (f64) {
+// CHECK-NEXT:        %9 = arith.addi %arg4, %arg6 : index
+// CHECK-NEXT:        %10 = memref.load %arg0[%9] : memref<10xf64>
+// CHECK-NEXT:        %11 = arith.addf %arg7, %10 : f64
+// CHECK-NEXT:        memref.store %11, %arg0[%c0] : memref<10xf64>
+// CHECK-NEXT:        scf.yield %11 : f64
 // CHECK-NEXT:      } {enzyme.disable_mincut = true}
-// CHECK-NEXT:      %9 = arith.addi %arg4, %6 : index
-// CHECK-NEXT:      scf.yield %9, %8 : index, f64
+// CHECK-NEXT:      %8 = arith.addi %arg4, %6 : index
+// CHECK-NEXT:      scf.yield %8, %7 : index, f64
 // CHECK-NEXT:    } {enzyme.disable_mincut = true}
 // CHECK-NEXT:    %1 = arith.addf %arg2, %cst fastmath<fast> : f64
-// CHECK-NEXT:    %alloc_6 = memref.alloc() : memref<10xf64>
-// CHECK-NEXT:    memref.copy %arg0, %alloc_6 : memref<10xf64> to memref<10xf64>
+// CHECK-NEXT:    %alloc_2 = memref.alloc() : memref<10xf64>
+// CHECK-NEXT:    memref.copy %arg0, %alloc_2 : memref<10xf64> to memref<10xf64>
 // CHECK-NEXT:    %2:2 = scf.for %arg3 = %c0 to %c10 step %c1 iter_args(%arg4 = %c4, %arg5 = %1) -> (index, f64) {
 // CHECK-NEXT:      %3 = arith.subi %arg4, %c1 : index
 // CHECK-NEXT:      %4 = arith.subi %c10, %arg3 : index
 // CHECK-NEXT:      %5 = memref.load %alloc[%3] : memref<4xf64>
 // CHECK-NEXT:      %6 = memref.load %alloc_0[%3] : memref<4xindex>
-// CHECK-NEXT:      %7 = memref.load %alloc_5[%3] : memref<4xmemref<10xf64>>
-// CHECK-NEXT:      memref.copy %7, %alloc_6 : memref<10xf64> to memref<10xf64>
-// CHECK-NEXT:      %8:3 = scf.while (%arg6 = %6, %arg7 = %3, %arg8 = %5) : (index, index, f64) -> (index, index, f64) {
-// CHECK-NEXT:        %19 = arith.addi %arg6, %c1 : index
-// CHECK-NEXT:        %20 = arith.cmpi slt, %19, %4 : index
-// CHECK-NEXT:        scf.condition(%20) %arg6, %arg7, %arg8 : index, index, f64
+// CHECK-NEXT:      %subview = memref.subview %alloc_1[%3, 0] [1, 10] [1, 1] : memref<4x10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:      memref.copy %subview, %alloc_2 : memref<10xf64, strided<[1], offset: ?>> to memref<10xf64>
+// CHECK-NEXT:      %7:3 = scf.while (%arg6 = %6, %arg7 = %3, %arg8 = %5) : (index, index, f64) -> (index, index, f64) {
+// CHECK-NEXT:        %18 = arith.addi %arg6, %c1 : index
+// CHECK-NEXT:        %19 = arith.cmpi slt, %18, %4 : index
+// CHECK-NEXT:        scf.condition(%19) %arg6, %arg7, %arg8 : index, index, f64
 // CHECK-NEXT:      } do {
 // CHECK-NEXT:      ^bb0(%arg6: index, %arg7: index, %arg8: f64):
-// CHECK-NEXT:        %19 = arith.subi %4, %arg6 : index
-// CHECK-NEXT:        %20 = arith.subi %c4, %arg7 : index
-// CHECK-NEXT:        %21 = arith.minui %20, %19 : index
-// CHECK-NEXT:        %22 = enzyme.binomial_progress %19, %21 : index
+// CHECK-NEXT:        %18 = arith.subi %4, %arg6 : index
+// CHECK-NEXT:        %19 = arith.subi %c4, %arg7 : index
+// CHECK-NEXT:        %20 = arith.minui %19, %18 : index
+// CHECK-NEXT:        %21 = enzyme.binomial_progress %18, %20 : index
 // CHECK-NEXT:        memref.store %arg8, %alloc[%arg7] : memref<4xf64>
 // CHECK-NEXT:        memref.store %arg6, %alloc_0[%arg7] : memref<4xindex>
-// CHECK-NEXT:        %23 = memref.load %alloc_5[%arg7] : memref<4xmemref<10xf64>>
-// CHECK-NEXT:        memref.copy %alloc_6, %23 : memref<10xf64> to memref<10xf64>
-// CHECK-NEXT:        %24 = arith.addi %arg6, %22 : index
-// CHECK-NEXT:        %25 = arith.cmpi eq, %24, %4 : index
-// CHECK-NEXT:        %26 = arith.subi %24, %c1 : index
-// CHECK-NEXT:        %27 = arith.select %25, %26, %24 : index
-// CHECK-NEXT:        %28 = scf.for %arg9 = %arg6 to %27 step %c1 iter_args(%arg10 = %arg8) -> (f64) {
-// CHECK-NEXT:          %30 = memref.load %alloc_6[%arg9] : memref<10xf64>
-// CHECK-NEXT:          %31 = arith.addf %arg10, %30 : f64
-// CHECK-NEXT:          memref.store %31, %alloc_6[%c0] : memref<10xf64>
-// CHECK-NEXT:          scf.yield %31 : f64
+// CHECK-NEXT:        %subview_3 = memref.subview %alloc_1[%arg7, 0] [1, 10] [1, 1] : memref<4x10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:        memref.copy %alloc_2, %subview_3 : memref<10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:        %22 = arith.addi %arg6, %21 : index
+// CHECK-NEXT:        %23 = arith.cmpi eq, %22, %4 : index
+// CHECK-NEXT:        %24 = arith.subi %22, %c1 : index
+// CHECK-NEXT:        %25 = arith.select %23, %24, %22 : index
+// CHECK-NEXT:        %26 = scf.for %arg9 = %arg6 to %25 step %c1 iter_args(%arg10 = %arg8) -> (f64) {
+// CHECK-NEXT:          %28 = memref.load %alloc_2[%arg9] : memref<10xf64>
+// CHECK-NEXT:          %29 = arith.addf %arg10, %28 : f64
+// CHECK-NEXT:          memref.store %29, %alloc_2[%c0] : memref<10xf64>
+// CHECK-NEXT:          scf.yield %29 : f64
 // CHECK-NEXT:        } {enzyme.disable_mincut = true}
-// CHECK-NEXT:        %29 = arith.addi %arg7, %c1 : index
-// CHECK-NEXT:        scf.yield %24, %29, %28 : index, index, f64
+// CHECK-NEXT:        %27 = arith.addi %arg7, %c1 : index
+// CHECK-NEXT:        scf.yield %22, %27, %26 : index, index, f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %9 = arith.subi %c9, %arg3 : index
-// CHECK-NEXT:      %10 = memref.load %alloc_6[%9] : memref<10xf64>
-// CHECK-NEXT:      %11 = arith.addf %8#2, %10 : f64
-// CHECK-NEXT:      memref.store %11, %alloc_6[%c0] : memref<10xf64>
-// CHECK-NEXT:      %12 = arith.addf %arg5, %cst fastmath<fast> : f64
-// CHECK-NEXT:      %13 = memref.load %arg1[%c0] : memref<10xf64>
-// CHECK-NEXT:      %14 = arith.addf %12, %13 fastmath<fast> : f64
+// CHECK-NEXT:      %8 = arith.subi %c9, %arg3 : index
+// CHECK-NEXT:      %9 = memref.load %alloc_2[%8] : memref<10xf64>
+// CHECK-NEXT:      %10 = arith.addf %7#2, %9 : f64
+// CHECK-NEXT:      memref.store %10, %alloc_2[%c0] : memref<10xf64>
+// CHECK-NEXT:      %11 = arith.addf %arg5, %cst fastmath<fast> : f64
+// CHECK-NEXT:      %12 = memref.load %arg1[%c0] : memref<10xf64>
+// CHECK-NEXT:      %13 = arith.addf %11, %12 fastmath<fast> : f64
 // CHECK-NEXT:      memref.store %cst, %arg1[%c0] : memref<10xf64>
-// CHECK-NEXT:      %15 = arith.addf %14, %cst fastmath<fast> : f64
-// CHECK-NEXT:      %16 = arith.addf %14, %cst fastmath<fast> : f64
-// CHECK-NEXT:      %17 = memref.load %arg1[%9] : memref<10xf64>
-// CHECK-NEXT:      %18 = arith.addf %17, %16 fastmath<fast> : f64
-// CHECK-NEXT:      memref.store %18, %arg1[%9] : memref<10xf64>
-// CHECK-NEXT:      scf.yield %8#1, %15 : index, f64
+// CHECK-NEXT:      %14 = arith.addf %13, %cst fastmath<fast> : f64
+// CHECK-NEXT:      %15 = arith.addf %13, %cst fastmath<fast> : f64
+// CHECK-NEXT:      %16 = memref.load %arg1[%8] : memref<10xf64>
+// CHECK-NEXT:      %17 = arith.addf %16, %15 fastmath<fast> : f64
+// CHECK-NEXT:      memref.store %17, %arg1[%8] : memref<10xf64>
+// CHECK-NEXT:      scf.yield %7#1, %14 : index, f64
 // CHECK-NEXT:    } {enzyme.disable_mincut = true}
 // CHECK-NEXT:    memref.dealloc %alloc : memref<4xf64>
 // CHECK-NEXT:    memref.dealloc %alloc_0 : memref<4xindex>
-// CHECK-NEXT:    memref.dealloc %alloc_6 : memref<10xf64>
-// CHECK-NEXT:    scf.for %arg3 = %c0 to %c4 step %c1 {
-// CHECK-NEXT:      %3 = memref.load %alloc_5[%arg3] : memref<4xmemref<10xf64>>
-// CHECK-NEXT:      memref.dealloc %3 : memref<10xf64>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    memref.dealloc %alloc_5 : memref<4xmemref<10xf64>>
+// CHECK-NEXT:    memref.dealloc %alloc_2 : memref<10xf64>
+// CHECK-NEXT:    memref.dealloc %alloc_1 : memref<4x10xf64>
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }

--- a/enzyme/test/MLIR/ReverseMode/scf_for_memref_binomial_checkpointing.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_for_memref_binomial_checkpointing.mlir
@@ -1,14 +1,5 @@
 // RUN: %eopt %s --enzyme-wrap="infn=main outfn= argTys=enzyme_dup retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops --lower-enzyme-binomial-progress --canonicalize --enzyme-simplify-math | FileCheck %s
 
-// Binomial checkpointing with a mutable (memref) value referenced from outside
-// the loop. The reference gets a budget-sized buffer of clone handles, filled up
-// front so a checkpoint is a plain copy into an existing allocation, plus one
-// working clone the reverse pass replays into. Slot j pairs with the state and
-// step-index buffers' slot j, so all three are indexed by the checkpoint stack
-// pointer -- never by the reverse induction variable, which is what regressed
-// here (the reverse read used to be `numIters-1 - iv` into a budget-sized
-// buffer, i.e. out of bounds for every iteration past the budget).
-
 module {
 
   func.func @main(%m: memref<f32>) -> f32 {
@@ -29,59 +20,36 @@ module {
 }
 
 // CHECK-LABEL: func.func @main(
-// CHECK-DAG:     %[[STATE:.+]] = memref.alloc() : memref<3xf32>
-// CHECK-DAG:     %[[IDX:.+]] = memref.alloc() : memref<3xindex>
 
-// One clone per slot, allocated up front, then the handle buffer they are
-// stored into -- which is typed from a clone.
-// CHECK:         %[[C0:.+]] = memref.alloc() : memref<f32>
-// CHECK-NEXT:    memref.copy %arg0, %[[C0]]
-// CHECK-NEXT:    %[[C1:.+]] = memref.alloc() : memref<f32>
-// CHECK-NEXT:    memref.copy %arg0, %[[C1]]
-// CHECK-NEXT:    %[[C2:.+]] = memref.alloc() : memref<f32>
-// CHECK-NEXT:    memref.copy %arg0, %[[C2]]
-// CHECK-NEXT:    %[[SLOTS:.+]] = memref.alloc() : memref<3xmemref<f32>>
-// CHECK-NEXT:    memref.store %[[C0]], %[[SLOTS]][%c0]
-// CHECK-NEXT:    memref.store %[[C1]], %[[SLOTS]][%c1]
-// CHECK-NEXT:    memref.store %[[C2]], %[[SLOTS]][%c2]
+// CHECK:         %[[STATE:.+]] = memref.alloc() : memref<3xf32>
+// CHECK-NEXT:    %[[IDX:.+]] = memref.alloc() : memref<3xindex>
+// CHECK-NEXT:    %[[SLOTS:.+]] = memref.alloc() : memref<3xf32>
 
-// Forward checkpoint-placement loop (budget = 3): slot index is the loop IV.
 // CHECK:         scf.for %[[K:.+]] = %c0 to %c3 step %c1
 // CHECK:           memref.store {{.*}}, %[[STATE]][%[[K]]]
 // CHECK:           memref.store {{.*}}, %[[IDX]][%[[K]]]
-// CHECK:           %[[FWDSLOT:.+]] = memref.load %[[SLOTS]][%[[K]]] : memref<3xmemref<f32>>
-// CHECK-NEXT:      memref.copy %arg0, %[[FWDSLOT]] : memref<f32> to memref<f32>
+// CHECK:           %[[FWDSLOT:.+]] = memref.subview %[[SLOTS]][%[[K]]] [1] [1] : memref<3xf32> to memref<f32, strided<[], offset: ?>>
+// CHECK-NEXT:      memref.copy %arg0, %[[FWDSLOT]] : memref<f32> to memref<f32, strided<[], offset: ?>>
 
-// The working clone the reverse pass replays into, outside the reverse loop.
 // CHECK:         %[[WORK:.+]] = memref.alloc() : memref<f32>
 // CHECK-NEXT:    memref.copy %arg0, %[[WORK]]
 
-// Reverse loop over all 9 steps, carrying the stack pointer as an iter arg.
 // CHECK:         scf.for %{{.+}} = %c0 to %c9 step %c1 iter_args(%[[SP:.+]] = %c3
-// The slot index is the stack pointer minus one -- NOT a function of the
-// reverse induction variable. That is the regression this test guards.
 // CHECK-NEXT:      %[[CAPO:.+]] = arith.subi %[[SP]], %c1 : index
 // CHECK:           memref.load %[[STATE]][%[[CAPO]]]
 // CHECK:           memref.load %[[IDX]][%[[CAPO]]]
-// CHECK:           %[[REVSLOT:.+]] = memref.load %[[SLOTS]][%[[CAPO]]] : memref<3xmemref<f32>>
-// CHECK-NEXT:      memref.copy %[[REVSLOT]], %[[WORK]] : memref<f32> to memref<f32>
+// CHECK:           %[[REVSLOT:.+]] = memref.subview %[[SLOTS]][%[[CAPO]]] [1] [1] : memref<3xf32> to memref<f32, strided<[], offset: ?>>
+// CHECK-NEXT:      memref.copy %[[REVSLOT]], %[[WORK]] : memref<f32, strided<[], offset: ?>> to memref<f32>
 
-// The remat re-places a checkpoint at slot `acapo`; the snapshot moves with it.
 // CHECK:           scf.while ({{.*}}%[[ACAPO:.+]] = %[[CAPO]]
 // CHECK:             memref.store {{.*}}, %[[IDX]][%[[ACAPO]]]
-// CHECK:             %[[ACSLOT:.+]] = memref.load %[[SLOTS]][%[[ACAPO]]] : memref<3xmemref<f32>>
-// CHECK-NEXT:        memref.copy %[[WORK]], %[[ACSLOT]] : memref<f32> to memref<f32>
+// CHECK:             %[[ACSLOT:.+]] = memref.subview %[[SLOTS]][%[[ACAPO]]] [1] [1] : memref<3xf32> to memref<f32, strided<[], offset: ?>>
+// CHECK-NEXT:        memref.copy %[[WORK]], %[[ACSLOT]] : memref<f32> to memref<f32, strided<[], offset: ?>>
 // The replay reads the working clone, never a checkpoint slot.
 // CHECK:             memref.load %[[WORK]][] : memref<f32>
 
-// Everything is freed: the state/index buffers, the working clone, then each
-// slot's clone followed by the handle buffer.
 // CHECK:         memref.dealloc %[[STATE]] : memref<3xf32>
-// CHECK:         memref.dealloc %[[IDX]] : memref<3xindex>
-// CHECK:         memref.dealloc %[[WORK]] : memref<f32>
-// CHECK:         scf.for %[[J:.+]] = %c0 to %c3 step %c1 {
-// CHECK-NEXT:      %[[FREESLOT:.+]] = memref.load %[[SLOTS]][%[[J]]] : memref<3xmemref<f32>>
-// CHECK-NEXT:      memref.dealloc %[[FREESLOT]] : memref<f32>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    memref.dealloc %[[SLOTS]] : memref<3xmemref<f32>>
-// CHECK:         return
+// CHECK-NEXT:    memref.dealloc %[[IDX]] : memref<3xindex>
+// CHECK-NEXT:    memref.dealloc %[[WORK]] : memref<f32>
+// CHECK-NEXT:    memref.dealloc %[[SLOTS]] : memref<3xf32>
+// CHECK-NEXT:    return


### PR DESCRIPTION
the honest summary: the change removes ~30 fixed allocations from b=16, worth ~15 ms — a real 4.9% at nt=50 that fades to under 1% by nt=800, and nothing measurable for b=4. It won't move the long-running checkpointed cases that motivate binomial in the first place.