### PR TITLE
PreserveNVVM: let a pipeline without custom rules drop their linkage

### DIFF
--- a/enzyme/Enzyme/PreserveNVVM.cpp
+++ b/enzyme/Enzyme/PreserveNVVM.cpp
@@ -113,7 +113,8 @@ bool isTargetNVPTX(llvm::Module &M) {
 template <const char *handlername, DerivativeMode Mode, int numargs>
 static void
 handleCustomDerivative(llvm::Module &M, llvm::GlobalVariable &g,
-                       SmallVectorImpl<GlobalVariable *> &globalsToErase) {
+                       SmallVectorImpl<GlobalVariable *> &globalsToErase,
+                       bool PreserveCustomRuleLinkage) {
   if (g.hasInitializer()) {
     if (auto CA = dyn_cast<ConstantAggregate>(g.getInitializer())) {
       if (CA->getNumOperands() < numargs) {
@@ -291,31 +292,36 @@ handleCustomDerivative(llvm::Module &M, llvm::GlobalVariable &g,
               Fs[fn] = NewF;
             }
 
-          preserveLinkage(true, *Fs[1], false);
+          if (PreserveCustomRuleLinkage)
+            preserveLinkage(true, *Fs[1], false);
           Fs[0]->setMetadata(
               "enzyme_augment",
               llvm::MDTuple::get(Fs[0]->getContext(),
                                  {llvm::ValueAsMetadata::get(Fs[1])}));
-          preserveLinkage(true, *Fs[2], false);
+          if (PreserveCustomRuleLinkage)
+            preserveLinkage(true, *Fs[2], false);
           Fs[0]->setMetadata(
               "enzyme_gradient",
               llvm::MDTuple::get(Fs[0]->getContext(),
                                  {llvm::ValueAsMetadata::get(Fs[2])}));
         } else if (Mode == DerivativeMode::ForwardMode) {
           assert(numargs == 2);
-          preserveLinkage(true, *Fs[1], false);
+          if (PreserveCustomRuleLinkage)
+            preserveLinkage(true, *Fs[1], false);
           Fs[0]->setMetadata(
               "enzyme_derivative",
               llvm::MDTuple::get(Fs[0]->getContext(),
                                  {llvm::ValueAsMetadata::get(Fs[1])}));
         } else if (Mode == DerivativeMode::ForwardModeSplit) {
           assert(numargs == 3);
-          preserveLinkage(true, *Fs[1], false);
+          if (PreserveCustomRuleLinkage)
+            preserveLinkage(true, *Fs[1], false);
           Fs[0]->setMetadata(
               "enzyme_augment",
               llvm::MDTuple::get(Fs[0]->getContext(),
                                  {llvm::ValueAsMetadata::get(Fs[1])}));
-          preserveLinkage(true, *Fs[2], false);
+          if (PreserveCustomRuleLinkage)
+            preserveLinkage(true, *Fs[2], false);
           Fs[0]->setMetadata(
               "enzyme_splitderivative",
               llvm::MDTuple::get(Fs[0]->getContext(),
@@ -342,7 +348,8 @@ handleCustomDerivative(llvm::Module &M, llvm::GlobalVariable &g,
   globalsToErase.push_back(&g);
 }
 
-bool preserveNVVM(bool Begin, Module &M) {
+bool preserveNVVM(bool Begin, Module &M,
+                  bool PreserveCustomRuleLinkage = true) {
   bool changed = false;
   constexpr static const char gradient_handler_name[] =
       "__enzyme_register_gradient";
@@ -515,17 +522,18 @@ bool preserveNVVM(bool Begin, Module &M) {
   for (GlobalVariable &g : M.globals()) {
     if (g.getName().contains(gradient_handler_name)) {
       handleCustomDerivative<gradient_handler_name,
-                             DerivativeMode::ReverseModeGradient, 3>(M, g,
-                                                                     toErase);
+                             DerivativeMode::ReverseModeGradient, 3>(
+          M, g, toErase, PreserveCustomRuleLinkage);
       changed = true;
     } else if (g.getName().contains(derivative_handler_name)) {
       handleCustomDerivative<derivative_handler_name,
-                             DerivativeMode::ForwardMode, 2>(M, g, toErase);
+                             DerivativeMode::ForwardMode, 2>(
+          M, g, toErase, PreserveCustomRuleLinkage);
       changed = true;
     } else if (g.getName().contains(splitderivative_handler_name)) {
       handleCustomDerivative<splitderivative_handler_name,
-                             DerivativeMode::ForwardModeSplit, 3>(M, g,
-                                                                  toErase);
+                             DerivativeMode::ForwardModeSplit, 3>(
+          M, g, toErase, PreserveCustomRuleLinkage);
       changed = true;
     }
     if (g.getName().contains("__enzyme_inactive_global")) {
@@ -1066,7 +1074,7 @@ extern "C" void AddPreserveNVVMPass(LLVMPassManagerRef PM, uint8_t Begin) {
 
 PreserveNVVMNewPM::Result
 PreserveNVVMNewPM::run(llvm::Module &M, llvm::ModuleAnalysisManager &MAM) {
-  bool changed = preserveNVVM(Begin, M);
+  bool changed = preserveNVVM(Begin, M, PreserveCustomRuleLinkage);
   return changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }
 llvm::AnalysisKey PreserveNVVMNewPM::Key;

--- a/enzyme/Enzyme/PreserveNVVM.h
+++ b/enzyme/Enzyme/PreserveNVVM.h
@@ -43,11 +43,19 @@ class PreserveNVVMNewPM final : public PassParent<PreserveNVVMNewPM> {
 
 private:
   bool Begin;
+  // Whether a function named as one half of a custom derivative rule is kept
+  // external and uninlined so the rule can still be resolved later. A pipeline
+  // that does not implement custom rules -- the MLIR one -- has nothing to
+  // resolve them with, and holding the rule's functions in place only keeps
+  // dead code, and the kernels it launches, alive. The globals are consumed
+  // either way.
+  bool PreserveCustomRuleLinkage;
   static llvm::AnalysisKey Key;
 
 public:
   using Result = llvm::PreservedAnalyses;
-  PreserveNVVMNewPM(bool Begin) : Begin(Begin) {}
+  PreserveNVVMNewPM(bool Begin, bool PreserveCustomRuleLinkage = true)
+      : Begin(Begin), PreserveCustomRuleLinkage(PreserveCustomRuleLinkage) {}
 
   Result run(llvm::Module &M, llvm::ModuleAnalysisManager &MAM);
 


### PR DESCRIPTION
`__enzyme_register_derivative` and friends name a function and the rule that differentiates it. `handleCustomDerivative` reads the global, records the pairing as metadata on the primal, and holds the rule's own halves external through `preserveLinkage` so they are still there when differentiation gets to them.

A pipeline that does not implement custom rules has nothing to resolve them with. Holding those functions in place then only keeps dead code alive -- and where the rule's derivative launches a kernel, the kernel with it. This adds a `PreserveCustomRuleLinkage` flag, defaulting to the current behaviour, that a pipeline can turn off.

The globals are consumed either way. That part is not optional: left standing they are a definition of the same name in every translation unit that saw the declaration.

### Measured

Compiling one of MFEM's dFEM CUDA unit tests through the MLIR raising pipeline, which has no custom rules and so opts out:

| | before | after |
|---|---|---|
| `FwdCall` references | 20 | 0 |
| `CuWrap1DStruct` functions | 10 | 5 |
| module | 907 KB | 827 KB |

`FwdCall` is MFEM's hand-written forward rule for its CUDA launcher; with nothing to resolve the rule, it and the `FwdLaunch` kernel it launches are dead, and now say so.

### Testing

No test is added: the default path is unchanged and the flag has no CLI surface to toggle from lit -- it is chosen by whoever constructs the pass. The custom-rule tests behave identically with and without the change (`ForwardMode/custom0.ll`, `custom2.ll` pass; `ForwardMode/custom1.ll` and `ReverseMode/custom-gradient.ll` fail on pristine main too, unrelated to this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
