### PR TITLE
PreserveNVVM: the primal of a custom rule is pinned in two places

### DIFF
--- a/enzyme/Enzyme/PreserveNVVM.cpp
+++ b/enzyme/Enzyme/PreserveNVVM.cpp
@@ -492,10 +492,12 @@ bool preserveNVVM(bool Begin, Module &M,
     }
 
   for (GlobalVariable &g : M.globals()) {
-    if (g.getName().contains(gradient_handler_name) ||
-        g.getName().contains(derivative_handler_name) ||
-        g.getName().contains(splitderivative_handler_name) ||
-        g.getName().contains("__enzyme_nofree") ||
+    bool customRule = g.getName().contains(gradient_handler_name) ||
+                      g.getName().contains(derivative_handler_name) ||
+                      g.getName().contains(splitderivative_handler_name);
+    if (customRule && !PreserveCustomRuleLinkage)
+      continue;
+    if (customRule || g.getName().contains("__enzyme_nofree") ||
         g.getName().contains("__enzyme_inactivefn") ||
         g.getName().contains("__enzyme_sparse_accumulate") ||
         g.getName().contains("__enzyme_function_like") ||


### PR DESCRIPTION
A registration global is walked twice. `handleCustomDerivative` records the pairing on the primal and holds the rule's own halves in place; a second loop then pins the first function of every enzyme global it recognises, and for `__enzyme_register_derivative` that first function is the primal.

#3148 only reached the first of those. A pipeline that opted out of preserving custom-rule linkage still had the primal pinned -- `alwaysinline` taken off it and `noinline` put on -- which is the opposite of what opting out asks for. A caller that cannot resolve a rule wants neither half held.

### Measured

MFEM registers `CuWrap1DStruct::Call` as the primal of a rule whose derivative is `FwdCall`, and marks the wrapper `always_inline` (mfem/mfem#5450) so a pipeline without custom rules can see through it to the body's closure. Compiling one of its dFEM CUDA unit tests through the MLIR raising pipeline, which opts out:

| | before | after |
|---|---|---|
| `CuWrap1DStruct` functions surviving | 5 | 0 |
| calls to them | 5 | 0 |
| `noinline` on them | 5 | 0 |

The attribute was being stripped before any inliner saw it; the give-away is that the function ends up carrying both `noinline` and `"prev_always_inline"`, PreserveNVVM's own note that it had removed an `alwaysinline`.

With the wrapper inlined the closure lands in the caller's frame, mem2reg promotes it, each captured pointer carries its own activity, and MFEM's Enzyme GPU tests go from 7 failing with a zero tangent to **all 8 passing, 1141 assertions**.

### Testing

The custom-rule tests behave identically with and without this change (`ForwardMode/custom0.ll`, `custom2.ll` pass; `ForwardMode/custom1.ll` and `ReverseMode/custom-gradient.ll` fail on pristine main too). As with #3148 the flag has no CLI surface for lit to toggle, so the new behaviour is covered by the MFEM result above rather than by a test here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
