### PR TITLE
mlir: Use the checkpoint period for the outer trip count

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
@@ -225,40 +225,41 @@ struct AffineForOpInterfaceReverse
     return affine::AffineForOp::create(builder, loc, lb, ub, step, inits);
   }
 
-  // Unlike scf.for (a plain sequential reverse-iteration counter), the reverse
-  // outer loop steps by nInner, matching the forward one exactly -- see
-  // computeReverseSegmentBound for what that buys.
+  // Both outer loops count segments: one iteration per checkpoint, so the trip
+  // count is the stated period. Every bound and index below is an affine
+  // expression in that segment index.
   static affine::AffineForOp
   createForwardOuterLoop(OpBuilder &builder, Location loc,
                          const PeriodicSchedule &sched, ValueRange inits) {
-    return createConstantScaffoldLoop(builder, loc, 0,
-                                      sched.nInner * sched.numSegments(),
-                                      sched.nInner, inits);
+    return createConstantScaffoldLoop(builder, loc, 0, sched.numSegments(), 1,
+                                      inits);
   }
 
   static affine::AffineForOp
   createReverseOuterLoop(OpBuilder &builder, Location loc,
                          const PeriodicSchedule &sched, ValueRange inits) {
-    return createConstantScaffoldLoop(builder, loc, 0,
-                                      sched.nInner * sched.numSegments(),
-                                      sched.nInner, inits);
+    return createConstantScaffoldLoop(builder, loc, 0, sched.numSegments(), 1,
+                                      inits);
   }
 
-  // Nothing to precompute: the bound below is a compile-time AffineMap
-  // attached directly to the loop op, not a separately-emitted runtime
-  // Value, so there is nothing to hoist relative to the mutable-ref cloning
-  // loop the way scf.for's cmpi+select needs to be.
+  static void materializeSegmentValues(OpBuilder &, Location,
+                                       PeriodicSchedule &sched) {
+    assert(!sched.isDynamic() &&
+           "affine.for has no dynamic periodic path -- see "
+           "supportsDynamicPeriodic");
+  }
+
   static SmallVector<Value>
   computeForwardSegmentHint(OpBuilder &, Location, Value,
                             const PeriodicSchedule &) {
     return {};
   }
 
-  // Bound = min(nInner, numIters - outerIV): the standard affine-tiling idiom
-  // for a boundary tile, expressed as a multi-result upper-bound map (the
-  // "min" keyword documented on affine.for). Provably equivalent to
-  // scf.for's cmpi+select formula in every case: the two only disagree where
-  // neither formula's boundary case is active.
+  // Bound = min(nInner, numIters - nInner * j), for segment index j: the
+  // standard affine-tiling idiom for a boundary tile, expressed as a
+  // multi-result upper-bound map (the "min" keyword documented on affine.for).
+  // Equivalent to scf.for's cmpi+select formula in every case: the two only
+  // disagree where neither formula's boundary case is active.
   static affine::AffineForOp
   createForwardSegmentLoop(OpBuilder &builder, Location loc, Value outerIV,
                            ArrayRef<Value> /*fwdHint*/,
@@ -267,9 +268,10 @@ struct AffineForOpInterfaceReverse
             trailingIters = sched.trailingIters;
     int64_t numIters = nInner * nOuter + trailingIters;
     MLIRContext *ctx = builder.getContext();
-    AffineExpr d0 = builder.getAffineDimExpr(0);
+    AffineExpr j = builder.getAffineDimExpr(0);
     AffineExpr nInnerExpr = builder.getAffineConstantExpr(nInner);
-    AffineExpr remainingExpr = builder.getAffineConstantExpr(numIters) - d0;
+    AffineExpr remainingExpr =
+        builder.getAffineConstantExpr(numIters) - nInnerExpr * j;
     AffineMap ubMap = AffineMap::get(1, 0, {nInnerExpr, remainingExpr}, ctx);
     return affine::AffineForOp::create(
         builder, loc, /*lbOperands=*/ValueRange{},
@@ -277,18 +279,16 @@ struct AffineForOpInterfaceReverse
         /*step=*/1, inits);
   }
 
-  // Reverse counterpart. `outerIV` (call it j') is the *reverse* outer
-  // loop's own induction variable; per createReverseOuterLoop, that
-  // loop steps by nInner, so j' = j * nInner where j = 0 (last forward
-  // segment), 1, 2, .... The forward segment index being replayed is
-  // k = (nOuter + hasTrailing - 1) - j, so its base is
-  // segmentBase = k * nInner = (nOuter + hasTrailing - 1) * nInner - j' (no
-  // division needed, since j' is already j * nInner), and the bound is
-  // min(nInner, numIters - segmentBase), expanded into one affine map of j'.
-  // (scf.for's analogous formula uses k = nOuter - j instead, which omits
-  // the "+ hasTrailing - 1" term -- a pre-existing defect, not reproduced
-  // here since this is new code with no existing behavior to preserve; see
-  // the LoopCheckpointing.h doc comment.)
+  // Reverse counterpart. `outerIV` (call it j) is the reverse outer loop's own
+  // segment counter, so the forward segment being replayed is
+  // k = (numSegments - 1) - j, its base is segmentBase = k * nInner, and the
+  // bound is min(nInner, numIters - segmentBase), expanded into one affine map
+  // of j.
+  //
+  // A min bound cannot express a trailing segment longer than nInner -- it
+  // would clamp it to nInner and leave the tail of the loop unreplayed -- which
+  // is why getStaticPeriodicSchedule keeps the remainder the shorter part of
+  // the split.
   static affine::AffineForOp
   createReverseSegmentLoop(OpBuilder &builder, Location loc, Value outerIV,
                            ArrayRef<Value> /*revHint*/,
@@ -297,13 +297,14 @@ struct AffineForOpInterfaceReverse
             trailingIters = sched.trailingIters;
     int64_t numIters = nInner * nOuter + trailingIters;
     int64_t s = nOuter + (trailingIters > 0 ? 1 : 0);
-    // numIters - segmentBase, segmentBase = (s-1)*nInner - j'
-    //   = numIters - (s-1)*nInner + j' = constOffset + j'
+    // numIters - segmentBase, segmentBase = ((s-1) - j) * nInner
+    //   = numIters - (s-1)*nInner + nInner*j = constOffset + nInner*j
     int64_t constOffset = numIters - (s - 1) * nInner;
     MLIRContext *ctx = builder.getContext();
-    AffineExpr d0 = builder.getAffineDimExpr(0);
+    AffineExpr j = builder.getAffineDimExpr(0);
     AffineExpr nInnerExpr = builder.getAffineConstantExpr(nInner);
-    AffineExpr remainingExpr = builder.getAffineConstantExpr(constOffset) + d0;
+    AffineExpr remainingExpr =
+        builder.getAffineConstantExpr(constOffset) + nInnerExpr * j;
     AffineMap ubMap = AffineMap::get(1, 0, {nInnerExpr, remainingExpr}, ctx);
     return affine::AffineForOp::create(
         builder, loc, /*lbOperands=*/ValueRange{},
@@ -320,30 +321,29 @@ struct AffineForOpInterfaceReverse
         templateLoop.getUpperBoundMap(), templateLoop.getStepAsInt(), inits);
   }
 
-  // (outerIV + localIV) * step + start, as one affine.apply -- the whole
+  // (nInner * j + localIV) * step + start, as one affine.apply -- the whole
   // chain must be built as a single affine expression (not the generic
   // arith ops scf.for's implementation uses) so the result is itself a valid
   // affine dimension, usable as an index by any affine.load/affine.store
   // cloned with it substituted in for forOp's own induction variable.
   static Value computeForwardSegmentIV(OpBuilder &builder, Location loc,
                                        affine::AffineForOp forOp, Value outerIV,
-                                       Value localIV, const PeriodicSchedule &,
+                                       Value localIV,
+                                       const PeriodicSchedule &sched,
                                        ArrayRef<Value> /*fwdHint*/) {
     int64_t step = getConstantStep(forOp);
     int64_t start = getConstantStart(forOp);
     MLIRContext *ctx = builder.getContext();
-    AffineExpr d0 = builder.getAffineDimExpr(0),
-               d1 = builder.getAffineDimExpr(1);
-    AffineExpr expr = (d0 + d1) * step + start;
+    AffineExpr j = builder.getAffineDimExpr(0),
+               localIdx = builder.getAffineDimExpr(1);
+    AffineExpr expr = (j * sched.nInner + localIdx) * step + start;
     AffineMap map = AffineMap::get(2, 0, {expr}, ctx);
     return affine::AffineApplyOp::create(builder, loc, map,
                                          ValueRange{outerIV, localIV});
   }
 
-  // (segmentBase + localIV) * step + start, segmentBase = (nOuter +
-  // hasTrailing - 1) * nInner - outerIV -- see createReverseSegmentLoop for
-  // why this differs from scf.for's formula, and for why `outerIV` (j' =
-  // j * nInner) needs no division here to recover segmentBase = k * nInner.
+  // (segmentBase + localIV) * step + start, with segmentBase = nInner *
+  // ((numSegments - 1) - j) -- see createReverseSegmentLoop.
   static SmallVector<Value>
   computeReverseSegmentHint(OpBuilder &builder, Location loc, Value outerIV,
                             const PeriodicSchedule &) {
@@ -361,9 +361,9 @@ struct AffineForOpInterfaceReverse
     int64_t step = getConstantStep(forOp);
     int64_t start = getConstantStart(forOp);
     MLIRContext *ctx = builder.getContext();
-    AffineExpr jPrime = builder.getAffineDimExpr(0),
+    AffineExpr j = builder.getAffineDimExpr(0),
                localIdx = builder.getAffineDimExpr(1);
-    AffineExpr segmentBase = lastSegmentBase - jPrime;
+    AffineExpr segmentBase = lastSegmentBase - j * nInner;
     AffineExpr flatIV = segmentBase + localIdx;
     AffineExpr expr = flatIV * step + start;
     AffineMap map = AffineMap::get(2, 0, {expr}, ctx);
@@ -1177,18 +1177,34 @@ public:
            forOp.getStepAsInt();
   }
 
+  // A bound map with several results is a min (upper bound) or a max (lower
+  // bound) -- affine.for's own reading of one, and the shape the periodic
+  // checkpointing scaffold gives a segment that may be short:
+  // `min(nInner, remaining)`. affine.apply cannot express it, since it requires
+  // a single-result map, so materialize it with the op that can.
+  static Value materializeBound(OpBuilder &builder, Location loc, AffineMap map,
+                                ValueRange operands, bool isUpper) {
+    if (map.getNumResults() == 1)
+      return AffineApplyOp::create(builder, loc, map, operands);
+    if (isUpper)
+      return affine::AffineMinOp::create(builder, loc, map, operands);
+    return affine::AffineMaxOp::create(builder, loc, map, operands);
+  }
+
   static SmallVector<IntOrValue, 1>
   getDimensionBounds(OpBuilder &builder, affine::AffineForOp forOp) {
     auto iters = getConstantNumberOfIterations(forOp);
     if (iters) {
       return {IntOrValue(*iters)};
     } else {
-      auto lb = AffineApplyOp::create(builder, forOp.getLoc(),
-                                      forOp.getLowerBoundMap(),
-                                      forOp.getLowerBoundOperands());
-      auto ub = AffineApplyOp::create(builder, forOp.getLoc(),
-                                      forOp.getUpperBoundMap(),
-                                      forOp.getUpperBoundOperands());
+      Value lb =
+          materializeBound(builder, forOp.getLoc(), forOp.getLowerBoundMap(),
+                           forOp.getLowerBoundOperands(),
+                           /*isUpper=*/false);
+      Value ub =
+          materializeBound(builder, forOp.getLoc(), forOp.getUpperBoundMap(),
+                           forOp.getUpperBoundOperands(),
+                           /*isUpper=*/true);
 
       Value diff = arith::SubIOp::create(builder, forOp->getLoc(), ub, lb);
       if (forOp.getStepAsInt() != 1) {
@@ -1209,9 +1225,10 @@ public:
                                                 affine::AffineForOp forOp) {
     Value val = forOp.getBody()->getArgument(0);
     if (!forOp.hasConstantLowerBound() || forOp.getConstantLowerBound() != 0) {
-      auto lb = AffineApplyOp::create(builder, forOp.getLoc(),
-                                      forOp.getLowerBoundMap(),
-                                      forOp.getLowerBoundOperands());
+      Value lb =
+          materializeBound(builder, forOp.getLoc(), forOp.getLowerBoundMap(),
+                           forOp.getLowerBoundOperands(),
+                           /*isUpper=*/false);
       val = arith::SubIOp::create(builder, forOp->getLoc(), val, lb);
     }
 

--- a/enzyme/Enzyme/MLIR/Implementations/LoopCheckpointing.h
+++ b/enzyme/Enzyme/MLIR/Implementations/LoopCheckpointing.h
@@ -37,27 +37,41 @@ namespace enzyme {
 template <typename FinalClass, typename OpName> struct LoopCheckpointing {
   // How the trip count is decomposed for periodic checkpointing: `nOuter`
   // segments of `nInner` iterations, plus a shorter trailing segment of
-  // `trailingIters`. When the trip count is only known at runtime the same
-  // decomposition is described by `numItersV` / `nOuterV` instead, and the
-  // static segment count is -1 to mark that nothing beyond the period is known
-  // at compile time.
+  // `trailingIters`.
+  //
+  // A stated period budgets the *outer* half of that: it is the number of
+  // segments, hence of checkpoints, hence both the trip count of the scaffold's
+  // outer loops and the size of the one allocation that outlives the forward
+  // pass. The segment length is what is derived from it, as
+  // ceil(numIters / nOuter). Reading the period as the segment length instead
+  // would leave the checkpoint storage growing with the trip count --
+  // ceil(numIters / period) live checkpoints -- which is the opposite of what
+  // stating a budget is for.
+  //
+  // Every dialect's outer loops therefore count segments, one iteration per
+  // checkpoint, and derive the segment's base iteration as nInner * index.
   struct PeriodicSchedule {
+    // Iterations per full segment, or -1 when only `nInnerV` knows it.
     int64_t nInner = 0;
+    // Number of full segments. Always known at compile time.
     int64_t nOuter = -1;
+    // Iterations in the short trailing segment, 0 when the full segments
+    // divide the trip count evenly -- and always 0 for a dynamic trip count,
+    // where every segment is instead clamped against the trip count at
+    // runtime. That clamp covers both the short segment and the empty ones
+    // that a rounded-up segment length can leave at the end.
     int64_t trailingIters = 0;
 
     // Non-null exactly when the trip count is dynamic. numIters/start/step are
     // materialized before the scaffold (and cached for the reverse pass);
-    // nOuterV is ceil(numIters / nInner), i.e. the total segment count.
-    Value numItersV, nOuterV, startV, stepV;
+    // nOuterV is the segment count as a value, which only the dynamic schedule
+    // needs (a static one has numSegments() for that).
+    Value numItersV, nOuterV, nInnerV, startV, stepV;
 
     bool isDynamic() const { return numItersV != nullptr; }
     bool hasTrailing() const { return trailingIters > 0; }
     // Total number of segments, the trailing one included.
-    int64_t numSegments() const {
-      assert(!isDynamic() && "segment count is only known at runtime");
-      return nOuter + hasTrailing();
-    }
+    int64_t numSegments() const { return nOuter + hasTrailing(); }
   };
 
   // Names of the attributes the checkpointing directives are read from. A
@@ -72,6 +86,9 @@ template <typename FinalClass, typename OpName> struct LoopCheckpointing {
     return "enzyme.binomial_checkpointing";
   }
 
+  // Both schemes read the period as a budget on the number of live
+  // checkpoints: the size of the binomial checkpoint table, or the number of
+  // segments a periodic decomposition is cut into. See PeriodicSchedule.
   static StringRef checkpointPeriodAttrName() {
     return "enzyme.checkpoint_period";
   }
@@ -113,9 +130,12 @@ template <typename FinalClass, typename OpName> struct LoopCheckpointing {
     if (FinalClass::getConstantNumberOfIterations(forOp).has_value())
       return true;
     // A dynamic trip count has no compile-time N to take the square root of,
-    // so the period cannot be defaulted: it has to be stated.
-    return FinalClass::supportsDynamicPeriodic() &&
-           FinalClass::getCheckpointBudget(forOp).has_value();
+    // so the period cannot be defaulted: it has to be stated, and (being the
+    // segment count, which the scaffold divides by) it has to be positive.
+    if (!FinalClass::supportsDynamicPeriodic())
+      return false;
+    auto period = FinalClass::getCheckpointBudget(forOp);
+    return period.has_value() && *period > 0;
   }
 
   static bool needsBinomialCheckpointing(OpName forOp) {
@@ -1253,30 +1273,54 @@ template <typename FinalClass, typename OpName> struct LoopCheckpointing {
   //===--------------------------------------------------------------------===//
   // Periodic (sqrt-decomposition) checkpointing: decompose the N-iteration
   // loop into ~sqrt(N) outer segments, each holding down ~sqrt(N) primal
-  // steps in a checkpoint; the reverse pass replays one segment at a time.
+  // steps in a checkpoint; the reverse pass replays one segment at a time. A
+  // stated period replaces the sqrt(N) segment count with one the caller
+  // budgets for, and the segment length grows to match.
   //===--------------------------------------------------------------------===//
 
-  // The compile-time half of the decomposition. An explicit period is honoured
-  // as `nInner`; without one the classic sqrt(N) split is used, which -- unlike
-  // N/period -- deliberately keeps nOuter == nInner and lets the remainder
-  // spill into a trailing segment that may be as long as nInner itself.
+  // The compile-time half of the decomposition. A stated period is a budget on
+  // the *segment* count -- see PeriodicSchedule -- so it is the segment length
+  // that is derived from it, as ceil(numIters / period). Without one the
+  // classic sqrt(N) split is used, which deliberately keeps nOuter == nInner
+  // and lets the remainder spill into a trailing segment that may be as long as
+  // nInner itself.
   static PeriodicSchedule getStaticPeriodicSchedule(OpName forOp) {
     PeriodicSchedule sched;
     auto period = FinalClass::getCheckpointBudget(forOp);
     auto numIters = FinalClass::getConstantNumberOfIterations(forOp);
     if (!numIters) {
-      // FinalClass::needsCheckpointing() only admits a dynamic trip count with
-      // a period.
-      sched.nInner = *period;
+      // Same reading of the period, with the division left to the runtime:
+      // nInnerV ends up holding ceil(numIters / nOuter).
+      // needsCheckpointing() only admits a dynamic trip count with a positive
+      // period.
+      sched.nInner = -1;
+      sched.nOuter = *period;
+      return sched;
+    }
+    if (*numIters <= 0) {
+      // Nothing to segment. Spelled out because both splits below divide by a
+      // quantity derived from the trip count, and because a zero-length segment
+      // would give the scaffold loop a zero step.
+      sched.nInner = 1;
+      sched.nOuter = 0;
       return sched;
     }
     if (period && *period > 0) {
-      sched.nInner = *period;
-      sched.nOuter = *numIters / sched.nInner;
+      // Rounding the length up is what holds the segment count to the budget:
+      // numSegments() then lands at or below `period`, never above.
+      sched.nInner = (*numIters + *period - 1) / *period;
     } else {
-      sched.nInner = sched.nOuter = (int64_t)std::sqrt(*numIters);
+      sched.nInner = (int64_t)std::sqrt(*numIters);
     }
-    sched.trailingIters = *numIters - sched.nInner * sched.nOuter;
+    // Whole segments, plus a remainder shorter than one of them. The remainder
+    // has to be the shorter part: a dialect whose segment bound is
+    // min(nInner, remaining) -- affine.for's boundary-tile map, stablehlo's
+    // runtime clamp -- silently truncates a trailing segment longer than
+    // nInner, and the tail of the loop is then never replayed at all. Splitting
+    // sqrt(N) as nOuter == nInner and letting the remainder run on up to
+    // 2*sqrt(N), which is what this did, is what made that reachable.
+    sched.nOuter = *numIters / sched.nInner;
+    sched.trailingIters = *numIters % sched.nInner;
     return sched;
   }
 
@@ -1359,16 +1403,64 @@ template <typename FinalClass, typename OpName> struct LoopCheckpointing {
     }
   }
 
-  // ceil(numIters / nInner), the segment count in the dynamic case. Split out
-  // because the reverse pass recomputes it from the popped trip count rather
-  // than transporting the forward pass's own value.
-  static void computeDynamicSegmentCount(OpBuilder &builder, Location loc,
-                                         PeriodicSchedule &sched) {
-    Value nInnerV = FinalClass::emitConst(builder, loc, sched.nInner);
+  // The segment length as a value, which every segment bound and replayed
+  // induction variable is derived from. Split out (rather than transported from
+  // the forward pass) because the reverse pass recomputes it from the popped
+  // trip count, by the very same formula: it is a pure function of the
+  // schedule.
+  static void materializeSegmentValues(OpBuilder &builder, Location loc,
+                                       PeriodicSchedule &sched) {
+    if (!sched.isDynamic()) {
+      sched.nInnerV = FinalClass::emitConst(builder, loc, sched.nInner);
+      return;
+    }
+    // nInner = ceil(numIters / nOuter). Rounding *up* is what keeps the
+    // statically-many segments covering the whole trip count; it is also what
+    // lets the last segments start past the end of the loop, so each segment's
+    // length has to be clamped against the trip count where it is built.
+    sched.nOuterV = FinalClass::emitConst(builder, loc, sched.nOuter);
     Value roundUp = FinalClass::emitAdd(
         builder, loc, sched.numItersV,
-        FinalClass::emitConst(builder, loc, sched.nInner - 1));
-    sched.nOuterV = FinalClass::emitDivU(builder, loc, roundUp, nInnerV);
+        FinalClass::emitConst(builder, loc, sched.nOuter - 1));
+    sched.nInnerV = FinalClass::emitDivU(builder, loc, roundUp, sched.nOuterV);
+  }
+
+  // How many iterations the segment based at `base` covers: nInner, except for
+  // the trailing one. Which segment that is, and how short, is the one thing
+  // the two trip counts disagree on, so it is decided here rather than in each
+  // direction's hook -- both directions ask this the same question, about a
+  // base they derived the same way.
+  static Value segmentLength(OpBuilder &builder, Location loc,
+                             const PeriodicSchedule &sched, Value base) {
+    if (!sched.isDynamic()) {
+      if (!sched.hasTrailing())
+        return sched.nInnerV;
+      // The trailing segment is the one based just past the last full one.
+      Value isTrailing = FinalClass::emitCmpEQ(
+          builder, loc, base,
+          FinalClass::emitConst(builder, loc, sched.nInner * sched.nOuter));
+      return FinalClass::emitSelect(
+          builder, loc, isTrailing,
+          FinalClass::emitConst(builder, loc, sched.trailingIters),
+          sched.nInnerV);
+    }
+
+    // A runtime trip count cannot say which segment is short, so every one of
+    // them is clamped: min(nInner, numIters - base). The subtraction saturates
+    // rather than wrapping, which is the other half of rounding the segment
+    // length up -- the last segments can then start at or past the end of the
+    // loop, and an unsigned wrap there would turn an empty segment into a full
+    // one running off the end.
+    Value inBounds = FinalClass::emitMin(builder, loc, base, sched.numItersV);
+    return FinalClass::emitMin(
+        builder, loc, sched.nInnerV,
+        FinalClass::emitSub(builder, loc, sched.numItersV, inBounds));
+  }
+
+  // The base iteration of segment `index`, counted from the start of the loop.
+  static Value segmentBase(OpBuilder &builder, Location loc,
+                           const PeriodicSchedule &sched, Value index) {
+    return FinalClass::emitMul(builder, loc, index, sched.nInnerV);
   }
 
   // Materialize trip count / lower bound / step for a dynamic trip count, at
@@ -1385,7 +1477,7 @@ template <typename FinalClass, typename OpName> struct LoopCheckpointing {
         builder, loc,
         FinalClass::getNumIterationsValue(builder, loc, forOp, gutils),
         FinalClass::getIndexLikeType(builder));
-    computeDynamicSegmentCount(builder, loc, sched);
+    FinalClass::materializeSegmentValues(builder, loc, sched);
   }
 
   static SmallVector<Value> cachePeriodic(OpName forOp, Operation *op,
@@ -1397,6 +1489,8 @@ template <typename FinalClass, typename OpName> struct LoopCheckpointing {
     PeriodicSchedule sched = FinalClass::getStaticPeriodicSchedule(forOp);
     if (!FinalClass::getConstantNumberOfIterations(forOp).has_value())
       materializeDynamicSchedule(cacheBuilder, loc, forOp, gutils, sched);
+    else
+      FinalClass::materializeSegmentValues(cacheBuilder, loc, sched);
 
     SmallVector<Value> immutableRefs, mutableRefs;
     FinalClass::splitOutsideRefs(forOp, mutableRefs, immutableRefs);
@@ -1410,9 +1504,14 @@ template <typename FinalClass, typename OpName> struct LoopCheckpointing {
                                                        newForOpInits);
     FinalClass::preserveAttributesButCheckpointing(outerFwd, forOp);
 
-    Value outerFwdIV = FinalClass::getInductionVar(outerFwd);
     Block *outerFwdBody = FinalClass::getBodyBlock(outerFwd);
     cacheBuilder.setInsertionPointToStart(outerFwdBody);
+
+    // A segment index, in every dialect and whether or not the trip count is
+    // known: the outer loops run one iteration per checkpoint. Recovering the
+    // segment's base iteration from it (nInner * index) is left to the hooks,
+    // which is what `fwdHint` carries.
+    Value outerFwdIV = FinalClass::getInductionVar(outerFwd);
 
     IRMapping mapping;
 
@@ -1537,8 +1636,8 @@ template <typename FinalClass, typename OpName> struct LoopCheckpointing {
       sched.numItersV = gutils->popCache(caches[base], builder);
       sched.startV = gutils->popCache(caches[base + 1], builder);
       sched.stepV = gutils->popCache(caches[base + 2], builder);
-      computeDynamicSegmentCount(builder, loc, sched);
     }
+    FinalClass::materializeSegmentValues(builder, loc, sched);
 
     auto revOuter = FinalClass::createReverseOuterLoop(builder, loc, sched,
                                                        incomingGradients);
@@ -1546,6 +1645,9 @@ template <typename FinalClass, typename OpName> struct LoopCheckpointing {
 
     OpBuilder::InsertionGuard guard(builder);
     Block *revOuterBody = FinalClass::getBodyBlock(revOuter);
+    // The same segment index as the forward direction, counted from the end:
+    // segment numSegments() - 1 is replayed first. `revHint` carries whatever
+    // the hooks derive from it.
     Value revOuterIV = FinalClass::getInductionVar(revOuter);
     FinalClass::setInsertionPointToBodyEnd(builder, revOuterBody);
 

--- a/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/SCFAutoDiffOpInterfaceImpl.cpp
@@ -207,111 +207,86 @@ struct ForOpInterfaceReverse
   static scf::ForOp createConstantScaffoldLoop(OpBuilder &builder, Location loc,
                                                int64_t lb, int64_t ub,
                                                int64_t step, ValueRange inits) {
-    // Creation order (step, then ub, then lb) matches the original
-    // outerFwd construction exactly: canonicalize's constant placement is
-    // sensitive to it (constants aren't freely reordered), so this order
-    // must be preserved for scf.for's output to stay byte-identical.
+    // Creation order (step, then ub, then lb): canonicalize's constant
+    // placement is sensitive to it, since constants aren't freely reordered,
+    // so keeping one order here is what keeps the two scaffolds' constants
+    // laid out the same way.
     Value stepV = arith::ConstantIndexOp::create(builder, loc, step);
     Value ubV = arith::ConstantIndexOp::create(builder, loc, ub);
     Value lbV = arith::ConstantIndexOp::create(builder, loc, lb);
     return scf::ForOp::create(builder, loc, lbV, ubV, stepV, inits);
   }
 
-  // The forward outer loop steps *by* nInner, so its induction variable is the
-  // segment's base iteration directly. With a dynamic trip count the bound is
-  // the trip count rounded up to a whole number of segments.
+  // Both outer loops count segments: one iteration per checkpoint, so the trip
+  // count is the stated period. It stays a compile-time constant even when the
+  // trip count of the loop being differentiated is not -- that is what reading
+  // the period as a segment count buys -- which is what lets the checkpoint
+  // storage these loops push one entry to per iteration be sized statically.
   static scf::ForOp createForwardOuterLoop(OpBuilder &builder, Location loc,
                                            const PeriodicSchedule &sched,
                                            ValueRange inits) {
-    if (!sched.isDynamic())
-      return createConstantScaffoldLoop(builder, loc, 0,
-                                        sched.nInner * sched.numSegments(),
-                                        sched.nInner, inits);
-
-    Value stepV = arith::ConstantIndexOp::create(builder, loc, sched.nInner);
-    Value ubV = arith::MulIOp::create(builder, loc, sched.nOuterV, stepV);
-    Value lbV = arith::ConstantIndexOp::create(builder, loc, 0);
-    return scf::ForOp::create(builder, loc, lbV, ubV, stepV, inits);
+    return createConstantScaffoldLoop(builder, loc, 0, sched.numSegments(), 1,
+                                      inits);
   }
 
-  // Unchanged shape: a plain sequential reverse-iteration counter.
   static scf::ForOp createReverseOuterLoop(OpBuilder &builder, Location loc,
                                            const PeriodicSchedule &sched,
                                            ValueRange inits) {
-    if (!sched.isDynamic())
-      return createConstantScaffoldLoop(builder, loc, 0, sched.numSegments(), 1,
-                                        inits);
-
-    Value stepV = arith::ConstantIndexOp::create(builder, loc, 1);
-    Value lbV = arith::ConstantIndexOp::create(builder, loc, 0);
-    return scf::ForOp::create(builder, loc, lbV, sched.nOuterV, stepV, inits);
+    return createConstantScaffoldLoop(builder, loc, 0, sched.numSegments(), 1,
+                                      inits);
   }
 
+  // {segment base, segment length}, for the segment `outerIV` indexes. Both are
+  // emitted once here, at the top of the outer body, and handed back to the
+  // hooks that need them -- which is also what keeps the base from being
+  // computed twice, once for the segment loop's bound and once for the
+  // induction variable derived from it.
   static SmallVector<Value>
   computeForwardSegmentHint(OpBuilder &builder, Location loc, Value outerIV,
                             const PeriodicSchedule &sched) {
-    Value nInnerCst =
-        arith::ConstantIndexOp::create(builder, loc, sched.nInner);
-    // The last segment is short whenever the trip count is not a whole
-    // multiple of the period, which for a dynamic trip count is not something
-    // that can be decided here: clamp unconditionally.
-    if (sched.isDynamic())
-      return {arith::MinUIOp::create(
-          builder, loc, nInnerCst,
-          arith::SubIOp::create(builder, loc, sched.numItersV, outerIV))};
+    Value base = segmentBase(builder, loc, sched, outerIV);
+    return {base, segmentLength(builder, loc, sched, base)};
+  }
 
-    Value nInnerUB = nInnerCst;
-    if (sched.hasTrailing()) {
-      // if this is the last iteration, then the inner loop will only make
-      // trailingIters iterations
-      Value trailingCst =
-          arith::ConstantIndexOp::create(builder, loc, sched.trailingIters);
-      Value lastOuterIter = arith::ConstantIndexOp::create(
-          builder, loc, sched.nInner * sched.nOuter);
-      Value isLastFwdIter = arith::CmpIOp::create(
-          builder, loc, arith::CmpIPredicate::eq, outerIV, lastOuterIter);
-      nInnerUB = arith::SelectOp::create(builder, loc, isLastFwdIter,
-                                         trailingCst, nInnerCst);
-    }
-    return {nInnerUB};
+  // The reverse replays the segments back to front, so its own counter names
+  // segment numSegments() - 1 - i. Same two values as the forward direction,
+  // from there on.
+  //
+  // numSegments() - 1, not nOuter: the two coincide only when there *is* a
+  // trailing segment. Without one (a period that divides the trip count, or a
+  // perfect-square sqrt split) nOuter - i names a segment one past the end, and
+  // the replayed segment's induction variable comes out shifted by a whole
+  // period -- silently, since the value is dead whenever the loop body does not
+  // read its induction variable, which is why no test caught it.
+  static SmallVector<Value>
+  computeReverseSegmentHint(OpBuilder &builder, Location loc, Value outerIV,
+                            const PeriodicSchedule &sched) {
+    Value lastSegment =
+        arith::ConstantIndexOp::create(builder, loc, sched.numSegments() - 1);
+    Value index = arith::SubIOp::create(builder, loc, lastSegment, outerIV);
+    Value base = segmentBase(builder, loc, sched, index);
+    return {base, segmentLength(builder, loc, sched, base)};
+  }
+
+  static scf::ForOp createSegmentLoop(OpBuilder &builder, Location loc,
+                                      ArrayRef<Value> hint, ValueRange inits) {
+    Value one = arith::ConstantIndexOp::create(builder, loc, 1);
+    Value zero = arith::ConstantIndexOp::create(builder, loc, 0);
+    return scf::ForOp::create(builder, loc, zero, hint[1], one, inits);
   }
 
   static scf::ForOp createForwardSegmentLoop(OpBuilder &builder, Location loc,
                                              Value, ArrayRef<Value> fwdHint,
                                              const PeriodicSchedule &,
                                              ValueRange inits) {
-    Value one = arith::ConstantIndexOp::create(builder, loc, 1);
-    Value zero = arith::ConstantIndexOp::create(builder, loc, 0);
-    return scf::ForOp::create(builder, loc, zero, fwdHint[0], one, inits);
+    return createSegmentLoop(builder, loc, fwdHint, inits);
   }
 
   static scf::ForOp createReverseSegmentLoop(OpBuilder &builder, Location loc,
-                                             Value outerIV,
-                                             ArrayRef<Value> revHint,
-                                             const PeriodicSchedule &sched,
+                                             Value, ArrayRef<Value> revHint,
+                                             const PeriodicSchedule &,
                                              ValueRange inits) {
-    Value zero = arith::ConstantIndexOp::create(builder, loc, 0);
-    Value one = arith::ConstantIndexOp::create(builder, loc, 1);
-    Value nInnerCst =
-        arith::ConstantIndexOp::create(builder, loc, sched.nInner);
-    Value nInnerUB = nInnerCst;
-    if (sched.isDynamic()) {
-      // Same clamp as the forward direction, against this segment's own base.
-      // `precomputedBound` is the segment index counted from the end.
-      Value base = arith::MulIOp::create(builder, loc, revHint[0], nInnerCst);
-      nInnerUB = arith::MinUIOp::create(
-          builder, loc, nInnerCst,
-          arith::SubIOp::create(builder, loc, sched.numItersV, base));
-    } else if (sched.hasTrailing()) {
-      // this is the first reverse iteration
-      Value trailingCst =
-          arith::ConstantIndexOp::create(builder, loc, sched.trailingIters);
-      Value isFirstRevIter = arith::CmpIOp::create(
-          builder, loc, arith::CmpIPredicate::eq, outerIV, zero);
-      nInnerUB = arith::SelectOp::create(builder, loc, isFirstRevIter,
-                                         trailingCst, nInnerCst);
-    }
-    return scf::ForOp::create(builder, loc, zero, nInnerUB, one, inits);
+    return createSegmentLoop(builder, loc, revHint, inits);
   }
 
   static scf::ForOp createLoopWithSameBounds(OpBuilder &builder, Location loc,
@@ -322,56 +297,13 @@ struct ForOpInterfaceReverse
                               templateLoop.getStep(), inits);
   }
 
-  static Value computeForwardSegmentIV(OpBuilder &builder, Location loc,
-                                       scf::ForOp forOp, Value outerIV,
-                                       Value localIV,
-                                       const PeriodicSchedule &sched,
-                                       ArrayRef<Value> /*fwdHint*/) {
-    Value flatIV = arith::AddIOp::create(builder, loc, outerIV, localIV);
-    if (sched.isDynamic()) {
-      flatIV = castToType(builder, loc, flatIV, sched.stepV.getType());
-      return arith::AddIOp::create(
-          builder, loc, sched.startV,
-          arith::MulIOp::create(builder, loc, sched.stepV, flatIV));
-    }
-    Value stepCst =
-        arith::ConstantIndexOp::create(builder, loc, getConstantStep(forOp));
-    return arith::MulIOp::create(builder, loc, flatIV, stepCst);
-  }
-
-  // The index of the segment being replayed, counted from the end.
-  static SmallVector<Value>
-  computeReverseSegmentHint(OpBuilder &builder, Location loc, Value outerIV,
-                            const PeriodicSchedule &sched) {
-    if (sched.isDynamic()) {
-      Value last = arith::SubIOp::create(
-          builder, loc, sched.nOuterV,
-          arith::ConstantIndexOp::create(builder, loc, 1));
-      return {arith::SubIOp::create(builder, loc, last, outerIV)};
-    }
-    // numSegments() - 1, not nOuter: the two coincide only when there *is* a
-    // trailing segment. Without one (a period that divides the trip count, or a
-    // perfect-square sqrt split) nOuter - j names a segment one past the end,
-    // and the replayed segment's induction variable comes out shifted by a
-    // whole period -- silently, since the value is dead whenever the loop body
-    // does not read its induction variable, which is why no test caught it.
-    Value lastSegment =
-        arith::ConstantIndexOp::create(builder, loc, sched.numSegments() - 1);
-    return {arith::SubIOp::create(builder, loc, lastSegment, outerIV)};
-  }
-
-  static Value computeReverseSegmentIV(OpBuilder &builder, Location loc,
-                                       scf::ForOp forOp, Value outerIV,
-                                       Value localIV,
-                                       const PeriodicSchedule &sched,
-                                       ArrayRef<Value> revHint) {
-    Value currentOuterStep = revHint[0];
-    Value nInnerCst =
-        arith::ConstantIndexOp::create(builder, loc, sched.nInner);
-    Value flatIV = arith::AddIOp::create(
-        builder, loc,
-        arith::MulIOp::create(builder, loc, currentOuterStep, nInnerCst),
-        localIV);
+  // start + step * (segment base + localIV): the original loop's own induction
+  // variable at the iteration this replay step stands for. Both directions
+  // count iterations from the same place, so both ask for it the same way.
+  static Value segmentIV(OpBuilder &builder, Location loc, scf::ForOp forOp,
+                         const PeriodicSchedule &sched, ArrayRef<Value> hint,
+                         Value localIV) {
+    Value flatIV = arith::AddIOp::create(builder, loc, hint[0], localIV);
     if (sched.isDynamic()) {
       flatIV = castToType(builder, loc, flatIV, sched.stepV.getType());
       return arith::AddIOp::create(
@@ -385,6 +317,22 @@ struct ForOpInterfaceReverse
     return arith::AddIOp::create(
         builder, loc, arith::MulIOp::create(builder, loc, flatIV, stepCst),
         startCst);
+  }
+
+  static Value computeForwardSegmentIV(OpBuilder &builder, Location loc,
+                                       scf::ForOp forOp, Value /*outerIV*/,
+                                       Value localIV,
+                                       const PeriodicSchedule &sched,
+                                       ArrayRef<Value> fwdHint) {
+    return segmentIV(builder, loc, forOp, sched, fwdHint, localIV);
+  }
+
+  static Value computeReverseSegmentIV(OpBuilder &builder, Location loc,
+                                       scf::ForOp forOp, Value /*outerIV*/,
+                                       Value localIV,
+                                       const PeriodicSchedule &sched,
+                                       ArrayRef<Value> revHint) {
+    return segmentIV(builder, loc, forOp, sched, revHint, localIV);
   }
 
   static void createScaffoldYield(OpBuilder &builder, Location loc,

--- a/enzyme/test/MLIR/ReverseMode/affine_for_checkpointing.mlir
+++ b/enzyme/test/MLIR/ReverseMode/affine_for_checkpointing.mlir
@@ -17,60 +17,57 @@ module {
   }
 }
 
-// CHECK: #[[MAP:.+]] = affine_map<(d0, d1) -> (d0 + d1)>
-// CHECK: #[[MAP1:.+]] = affine_map<(d0, d1) -> (-d0 + d1 + 6)>
+// CHECK: #[[MAP:.+]] = affine_map<(d0, d1) -> (d0 * 3 + d1)>
+// CHECK: #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0 * -3 + d1 + 6)>
 // CHECK:  func.func @main(%arg0: f32, %arg1: f32) -> f32 {
 // CHECK-NEXT:    %c2 = arith.constant 2 : index
-// CHECK-NEXT:    %c3 = arith.constant 3 : index
 // CHECK-NEXT:    %alloc = memref.alloc() : memref<3xf32>
-// CHECK-NEXT:    %[[v0:.+]] = affine.for %arg2 = 0 to 9 step 3 iter_args(%arg3 = %arg0) -> (f32) {
-// CHECK-NEXT:      %[[idx:.+]] = arith.divui %arg2, %c3 : index
-// CHECK-NEXT:      memref.store %arg3, %alloc[%[[idx]]] : memref<3xf32>
-// CHECK-NEXT:      %[[v3:.+]] = affine.for %arg4 = 0 to 3 iter_args(%arg5 = %arg3) -> (f32) {
-// CHECK-NEXT:        %[[v4:.+]] = affine.apply #[[MAP]](%arg2, %arg4)
-// CHECK-NEXT:        %[[v5:.+]] = arith.mulf %arg5, %arg5 : f32
-// CHECK-NEXT:        %[[v6:.+]] = math.cos %[[v5]] : f32
-// CHECK-NEXT:        %[[v7:.+]] = arith.index_cast %[[v4]] : index to i64
-// CHECK-NEXT:        %[[v8:.+]] = arith.uitofp %[[v7]] : i64 to f32
-// CHECK-NEXT:        %[[v9:.+]] = arith.mulf %[[v6]], %[[v8]] : f32
-// CHECK-NEXT:        affine.yield %[[v9]] : f32
+// CHECK-NEXT:    %0 = affine.for %arg2 = 0 to 3 iter_args(%arg3 = %arg0) -> (f32) {
+// CHECK-NEXT:      memref.store %arg3, %alloc[%arg2] : memref<3xf32>
+// CHECK-NEXT:      %2 = affine.for %arg4 = 0 to 3 iter_args(%arg5 = %arg3) -> (f32) {
+// CHECK-NEXT:        %3 = affine.apply #[[MAP]](%arg2, %arg4)
+// CHECK-NEXT:        %4 = arith.mulf %arg5, %arg5 : f32
+// CHECK-NEXT:        %5 = math.cos %4 : f32
+// CHECK-NEXT:        %6 = arith.index_cast %3 : index to i64
+// CHECK-NEXT:        %7 = arith.uitofp %6 : i64 to f32
+// CHECK-NEXT:        %8 = arith.mulf %5, %7 : f32
+// CHECK-NEXT:        affine.yield %8 : f32
 // CHECK-NEXT:      }
-// CHECK-NEXT:      affine.yield %[[v3]] : f32
+// CHECK-NEXT:      affine.yield %2 : f32
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %[[v1:.+]] = affine.for %arg2 = 0 to 9 step 3 iter_args(%arg3 = %arg1) -> (f32) {
-// CHECK-NEXT:      %[[idx2:.+]] = arith.divui %arg2, %c3 : index
-// CHECK-NEXT:      %[[ridx:.+]] = arith.subi %c2, %[[idx2]] : index
-// CHECK-NEXT:      %[[v4:.+]] = memref.load %alloc[%[[ridx]]] : memref<3xf32>
+// CHECK-NEXT:    %1 = affine.for %arg2 = 0 to 3 iter_args(%arg3 = %arg1) -> (f32) {
+// CHECK-NEXT:      %2 = arith.subi %c2, %arg2 : index
+// CHECK-NEXT:      %3 = memref.load %alloc[%2] : memref<3xf32>
 // CHECK-NEXT:      %alloc_0 = memref.alloc() : memref<3xf32>
-// CHECK-NEXT:      %[[v5:.+]] = affine.for %arg4 = 0 to 3 iter_args(%arg5 = %[[v4]]) -> (f32) {
+// CHECK-NEXT:      %4 = affine.for %arg4 = 0 to 3 iter_args(%arg5 = %3) -> (f32) {
 // CHECK-NEXT:        memref.store %arg5, %alloc_0[%arg4] : memref<3xf32>
-// CHECK-NEXT:        %[[v7:.+]] = affine.apply #[[MAP1]](%arg2, %arg4)
-// CHECK-NEXT:        %[[v8:.+]] = arith.mulf %arg5, %arg5 : f32
-// CHECK-NEXT:        %[[v9:.+]] = math.cos %[[v8]] : f32
-// CHECK-NEXT:        %[[v10:.+]] = arith.index_cast %[[v7]] : index to i64
-// CHECK-NEXT:        %[[v11:.+]] = arith.uitofp %[[v10]] : i64 to f32
-// CHECK-NEXT:        %[[v12:.+]] = arith.mulf %[[v9]], %[[v11]] : f32
-// CHECK-NEXT:        affine.yield %[[v12]] : f32
+// CHECK-NEXT:        %6 = affine.apply #[[MAP1]](%arg2, %arg4)
+// CHECK-NEXT:        %7 = arith.mulf %arg5, %arg5 : f32
+// CHECK-NEXT:        %8 = math.cos %7 : f32
+// CHECK-NEXT:        %9 = arith.index_cast %6 : index to i64
+// CHECK-NEXT:        %10 = arith.uitofp %9 : i64 to f32
+// CHECK-NEXT:        %11 = arith.mulf %8, %10 : f32
+// CHECK-NEXT:        affine.yield %11 : f32
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[v6:.+]] = affine.for %arg4 = 0 to 3 iter_args(%arg5 = %arg3) -> (f32) {
-// CHECK-NEXT:        %[[r7:.+]] = arith.subi %c2, %arg4 : index
-// CHECK-NEXT:        %[[v8:.+]] = memref.load %alloc_0[%[[r7]]] : memref<3xf32>
-// CHECK-NEXT:        %[[v9:.+]] = affine.apply #[[MAP1]](%arg2, %[[r7]])
-// CHECK-NEXT:        %[[v10:.+]] = arith.mulf %[[v8]], %[[v8]] : f32
-// CHECK-NEXT:        %[[v11:.+]] = arith.index_cast %[[v9]] : index to i64
-// CHECK-NEXT:        %[[v12:.+]] = arith.uitofp %[[v11]] : i64 to f32
-// CHECK-NEXT:        %[[v13:.+]] = arith.mulf %arg5, %[[v12]] fastmath<fast> : f32
-// CHECK-NEXT:        %[[v14:.+]] = math.sin %[[v10]] fastmath<fast> : f32
-// CHECK-NEXT:        %[[v15:.+]] = arith.negf %[[v14]] fastmath<fast> : f32
-// CHECK-NEXT:        %[[v16:.+]] = arith.mulf %[[v13]], %[[v15]] fastmath<fast> : f32
-// CHECK-NEXT:        %[[v17:.+]] = arith.mulf %[[v16]], %[[v8]] fastmath<fast> : f32
-// CHECK-NEXT:        %[[v18:.+]] = arith.mulf %[[v16]], %[[v8]] fastmath<fast> : f32
-// CHECK-NEXT:        %[[v19:.+]] = arith.addf %[[v17]], %[[v18]] fastmath<fast> : f32
-// CHECK-NEXT:        affine.yield %[[v19]] : f32
+// CHECK-NEXT:      %5 = affine.for %arg4 = 0 to 3 iter_args(%arg5 = %arg3) -> (f32) {
+// CHECK-NEXT:        %6 = arith.subi %c2, %arg4 : index
+// CHECK-NEXT:        %7 = memref.load %alloc_0[%6] : memref<3xf32>
+// CHECK-NEXT:        %8 = affine.apply #[[MAP1]](%arg2, %6)
+// CHECK-NEXT:        %9 = arith.mulf %7, %7 : f32
+// CHECK-NEXT:        %10 = arith.index_cast %8 : index to i64
+// CHECK-NEXT:        %11 = arith.uitofp %10 : i64 to f32
+// CHECK-NEXT:        %12 = arith.mulf %arg5, %11 fastmath<fast> : f32
+// CHECK-NEXT:        %13 = math.sin %9 fastmath<fast> : f32
+// CHECK-NEXT:        %14 = arith.negf %13 fastmath<fast> : f32
+// CHECK-NEXT:        %15 = arith.mulf %12, %14 fastmath<fast> : f32
+// CHECK-NEXT:        %16 = arith.mulf %15, %7 fastmath<fast> : f32
+// CHECK-NEXT:        %17 = arith.mulf %15, %7 fastmath<fast> : f32
+// CHECK-NEXT:        %18 = arith.addf %16, %17 fastmath<fast> : f32
+// CHECK-NEXT:        affine.yield %18 : f32
 // CHECK-NEXT:      }
 // CHECK-NEXT:      memref.dealloc %alloc_0 : memref<3xf32>
-// CHECK-NEXT:      affine.yield %[[v6]] : f32
+// CHECK-NEXT:      affine.yield %5 : f32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    memref.dealloc %alloc : memref<3xf32>
-// CHECK-NEXT:    return %[[v1]] : f32
+// CHECK-NEXT:    return %1 : f32
 // CHECK-NEXT:  }

--- a/enzyme/test/MLIR/ReverseMode/scf_for_checkpointing.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_for_checkpointing.mlir
@@ -21,12 +21,10 @@ module {
 // CHECK-NEXT:    %c2 = arith.constant 2 : index
 // CHECK-NEXT:    %c3 = arith.constant 3 : index
 // CHECK-NEXT:    %c1 = arith.constant 1 : index
-// CHECK-NEXT:    %c9 = arith.constant 9 : index
 // CHECK-NEXT:    %c0 = arith.constant 0 : index
 // CHECK-NEXT:    %[[v0:.+]] = tensor.empty() : tensor<3xf32>
-// CHECK-NEXT:    %[[v1:.+]]:2 = scf.for %arg2 = %c0 to %c9 step %c3 iter_args(%arg3 = %arg0, %[[arg5:.+]] = %[[v0]]) -> (f32, tensor<3xf32>) {
-// CHECK-NEXT:      %[[idx:.+]] = arith.divui %arg2, %c3 : index
-// CHECK-NEXT:      %inserted = tensor.insert %arg3 into %[[arg5]][%[[idx]]] : tensor<3xf32>
+// CHECK-NEXT:    %[[v1:.+]]:2 = scf.for %arg2 = %c0 to %c3 step %c1 iter_args(%arg3 = %arg0, %[[arg5:.+]] = %[[v0]]) -> (f32, tensor<3xf32>) {
+// CHECK-NEXT:      %inserted = tensor.insert %arg3 into %[[arg5]][%arg2] : tensor<3xf32>
 // CHECK-NEXT:      %[[v3:.+]] = scf.for %[[arg6:.+]] = %c0 to %c3 step %c1 iter_args(%[[arg7:.+]] = %arg3) -> (f32) {
 // CHECK-NEXT:        %[[v5:.+]] = arith.mulf %[[arg7]], %[[arg7]] : f32
 // CHECK-NEXT:        %[[v6:.+]] = math.cos %[[v5]] : f32

--- a/enzyme/test/MLIR/ReverseMode/scf_for_checkpointing_dynamic.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_for_checkpointing_dynamic.mlir
@@ -1,11 +1,5 @@
 // RUN: %eopt %s --enzyme-wrap="infn=main outfn= argTys=enzyme_active,enzyme_const retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops --canonicalize --enzyme-simplify-math --canonicalize | FileCheck %s
 
-// Periodic checkpointing with a dynamic (runtime) upper bound. The period has to
-// be stated -- there is no compile-time trip count to take the square root of --
-// and the segment count is then ceil(numIters / period), computed at runtime.
-// Each segment's length is clamped to min(period, numIters - segmentBase), since
-// whether the last one is short cannot be decided here.
-
 module {
   func.func @main(%arg0: f32, %ub: index) -> (f32) {
     %lb = arith.constant 0 : index
@@ -19,23 +13,72 @@ module {
   }
 }
 
-// CHECK-LABEL: func.func @main(
+// CHECK:  func.func @main(%arg0: f32, %arg1: index, %arg2: f32) -> f32 {
+// CHECK-NEXT:    %c3 = arith.constant 3 : index
+// CHECK-NEXT:    %c4 = arith.constant 4 : index
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %c0 = arith.constant 0 : index
 
-// Trip count and segment count are computed at runtime, not folded.
-// CHECK:         %[[NITERS:.+]] = arith.divui
-// CHECK:         arith.divui
+// The segment length, ceil(numIters / 4), is the only runtime half of the
+// decomposition; the checkpoint buffer is sized by the period.
+// CHECK-NEXT:    %[[fwdRound:.+]] = arith.addi %arg1, %c3 : index
+// CHECK-NEXT:    %[[fwdInner:.+]] = arith.divui %[[fwdRound]], %c4 : index
+// CHECK-NEXT:    %[[buf:.+]] = memref.alloc() : memref<4xf32>
 
-// Forward: one outer segment loop stepping by the period, with the inner
-// recompute loop bounded by the runtime clamp.
-// CHECK:         scf.for
-// CHECK:           arith.minui
-// CHECK:           scf.for
+// Forward: exactly 4 segments, one checkpoint each, the recompute loop bounded
+// by the saturating clamp.
+// CHECK-NEXT:    %[[fwd:.+]] = scf.for %[[j:.+]] = %c0 to %c4 step %c1 iter_args(%[[st:.+]] = %arg0) -> (f32) {
+// CHECK-NEXT:      memref.store %[[st]], %[[buf]][%[[j]]] : memref<4xf32>
+// CHECK-NEXT:      %[[fbase:.+]] = arith.muli %[[j]], %[[fwdInner]] : index
+// CHECK-NEXT:      %[[fbaseC:.+]] = arith.minui %[[fbase]], %arg1 : index
+// CHECK-NEXT:      %[[fleft:.+]] = arith.subi %arg1, %[[fbaseC]] : index
+// CHECK-NEXT:      %[[flen:.+]] = arith.minui %[[fwdInner]], %[[fleft]] : index
+// CHECK-NEXT:      %[[fseg:.+]] = scf.for %{{.+}} = %c0 to %[[flen]] step %c1 iter_args(%[[fs:.+]] = %[[st]]) -> (f32) {
+// CHECK-NEXT:        %[[fsq:.+]] = arith.mulf %[[fs]], %[[fs]] : f32
+// CHECK-NEXT:        %[[fcos:.+]] = math.cos %[[fsq]] : f32
+// CHECK-NEXT:        scf.yield %[[fcos]] : f32
+// CHECK-NEXT:      }
+// CHECK-NEXT:      scf.yield %[[fseg]] : f32
+// CHECK-NEXT:    }
 
-// Reverse: the segments are replayed back to front, again with the clamp, and
-// the body's adjoint (sin) shows up inside.
-// CHECK:         scf.for
-// CHECK:           arith.minui
-// CHECK:           scf.for
-// CHECK:           scf.for
-// CHECK:             math.sin
-// CHECK:         return
+// The reverse pass recomputes the segment length from the cached trip count
+// rather than transporting the forward pass's own value.
+// CHECK-NEXT:    %[[revRound:.+]] = arith.addi %arg1, %c3 : index
+// CHECK-NEXT:    %[[revInner:.+]] = arith.divui %[[revRound]], %c4 : index
+
+// Reverse: the same 4 segments, replayed back to front (segment 3 - j), each
+// re-clamped against its own base.
+// CHECK-NEXT:    %[[rev:.+]] = scf.for %[[i:.+]] = %c0 to %c4 step %c1 iter_args(%[[d:.+]] = %arg2) -> (f32) {
+// CHECK-NEXT:      %[[slot:.+]] = arith.subi %c3, %[[i]] : index
+// CHECK-NEXT:      %[[ckpt:.+]] = memref.load %[[buf]][%[[slot]]] : memref<4xf32>
+// CHECK-NEXT:      %[[k:.+]] = arith.subi %c3, %[[i]] : index
+// CHECK-NEXT:      %[[rbase:.+]] = arith.muli %[[k]], %[[revInner]] : index
+// CHECK-NEXT:      %[[rbaseC:.+]] = arith.minui %[[rbase]], %arg1 : index
+// CHECK-NEXT:      %[[rleft:.+]] = arith.subi %arg1, %[[rbaseC]] : index
+// CHECK-NEXT:      %[[rlen:.+]] = arith.minui %[[revInner]], %[[rleft]] : index
+// CHECK-NEXT:      %[[tape:.+]] = memref.alloc(%[[rlen]]) : memref<?xf32>
+// CHECK-NEXT:      %[[replay:.+]] = scf.for %[[l:.+]] = %c0 to %[[rlen]] step %c1 iter_args(%[[rs:.+]] = %[[ckpt]]) -> (f32) {
+// CHECK-NEXT:        enzyme.store %[[rs]], %[[tape]][%[[l]]] ([%[[rlen]]]) : memref<?xf32>
+// CHECK-NEXT:        %[[rsq:.+]] = arith.mulf %[[rs]], %[[rs]] : f32
+// CHECK-NEXT:        %[[rcos:.+]] = math.cos %[[rsq]] : f32
+// CHECK-NEXT:        scf.yield %[[rcos]] : f32
+// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[adj:.+]] = scf.for %[[m:.+]] = %c0 to %[[rlen]] step %c1 iter_args(%[[ad:.+]] = %[[d]]) -> (f32) {
+// CHECK-NEXT:        %[[last:.+]] = arith.subi %[[rlen]], %c1 : index
+// CHECK-NEXT:        %[[ridx:.+]] = arith.subi %[[last]], %[[m]] : index
+// CHECK-NEXT:        %[[v:.+]] = enzyme.load %[[tape]][%[[ridx]]] ([%[[rlen]]]) : memref<?xf32>
+// CHECK-NEXT:        %[[vsq:.+]] = arith.mulf %[[v]], %[[v]] : f32
+// CHECK-NEXT:        %[[sin:.+]] = math.sin %[[vsq]] fastmath<fast> : f32
+// CHECK-NEXT:        %[[neg:.+]] = arith.negf %[[sin]] fastmath<fast> : f32
+// CHECK-NEXT:        %[[dsq:.+]] = arith.mulf %[[ad]], %[[neg]] fastmath<fast> : f32
+// CHECK-NEXT:        %[[dl:.+]] = arith.mulf %[[dsq]], %[[v]] fastmath<fast> : f32
+// CHECK-NEXT:        %[[dr:.+]] = arith.mulf %[[dsq]], %[[v]] fastmath<fast> : f32
+// CHECK-NEXT:        %[[ds:.+]] = arith.addf %[[dl]], %[[dr]] fastmath<fast> : f32
+// CHECK-NEXT:        scf.yield %[[ds]] : f32
+// CHECK-NEXT:      }
+// CHECK-NEXT:      memref.dealloc %[[tape]] : memref<?xf32>
+// CHECK-NEXT:      scf.yield %[[adj]] : f32
+// CHECK-NEXT:    }
+// CHECK-NEXT:    memref.dealloc %[[buf]] : memref<4xf32>
+// CHECK-NEXT:    return %[[rev]] : f32
+// CHECK-NEXT:  }

--- a/enzyme/test/MLIR/ReverseMode/scf_for_checkpointing_mutable_memory.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_for_checkpointing_mutable_memory.mlir
@@ -1,5 +1,10 @@
 // RUN: %eopt %s --enzyme-wrap="infn=reduce_sum outfn= argTys=enzyme_dup retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --enzyme-simplify-math --remove-unnecessary-enzyme-ops | FileCheck %s
 
+// The period is a budget on the number of checkpoints, so 10 iterations with a
+// period of 4 are cut into 4 segments of ceil(10/4) = 3 (the last one short, at
+// 1) rather than into ceil(10/4) = 3 segments of 4. Both the checkpoint buffer
+// and the clone buffer beside it are therefore memref<4x...>.
+
 func.func @reduce_sum(%buf: memref<10xf64>) -> f64 {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -19,46 +24,44 @@ func.func @reduce_sum(%buf: memref<10xf64>) -> f64 {
 }
 
 // CHECK:  func.func @reduce_sum(%arg0: memref<10xf64>, %arg1: memref<10xf64>, %arg2: f64) {
-// CHECK-NEXT:    %c3 = arith.constant 3 : index
-// CHECK-NEXT:    %c8 = arith.constant 8 : index
-// CHECK-NEXT:    %c2 = arith.constant 2 : index
-// CHECK-NEXT:    %c12 = arith.constant 12 : index
+// CHECK-NEXT:    %c9 = arith.constant 9 : index
 // CHECK-NEXT:    %c4 = arith.constant 4 : index
+// CHECK-NEXT:    %c3 = arith.constant 3 : index
 // CHECK-NEXT:    %c1 = arith.constant 1 : index
 // CHECK-NEXT:    %c0 = arith.constant 0 : index
 // CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f64
-// CHECK-NEXT:    %alloc = memref.alloc() : memref<3x10xf64>
-// CHECK-NEXT:    %alloc_0 = memref.alloc() : memref<3xf64>
-// CHECK-NEXT:    %0 = scf.for %arg3 = %c0 to %c12 step %c4 iter_args(%arg4 = %cst) -> (f64) {
-// CHECK-NEXT:      %3 = arith.divui %arg3, %c4 : index
-// CHECK-NEXT:      %4 = arith.cmpi eq, %arg3, %c8 : index
-// CHECK-NEXT:      %5 = arith.select %4, %c2, %c4 : index
-// CHECK-NEXT:      %subview = memref.subview %alloc[%3, 0] [1, 10] [1, 1] : memref<3x10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:    %alloc = memref.alloc() : memref<4x10xf64>
+// CHECK-NEXT:    %alloc_0 = memref.alloc() : memref<4xf64>
+// CHECK-NEXT:    %0 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %cst) -> (f64) {
+// CHECK-NEXT:      %3 = arith.muli %arg3, %c3 : index
+// CHECK-NEXT:      %4 = arith.cmpi eq, %3, %c9 : index
+// CHECK-NEXT:      %5 = arith.select %4, %c1, %c3 : index
+// CHECK-NEXT:      %subview = memref.subview %alloc[%arg3, 0] [1, 10] [1, 1] : memref<4x10xf64> to memref<10xf64, strided<[1], offset: ?>>
 // CHECK-NEXT:      memref.copy %arg0, %subview : memref<10xf64> to memref<10xf64, strided<[1], offset: ?>>
 // CHECK-NEXT:      %6 = scf.for %arg5 = %c0 to %5 step %c1 iter_args(%arg6 = %arg4) -> (f64) {
-// CHECK-NEXT:        %7 = arith.addi %arg3, %arg5 : index
+// CHECK-NEXT:        %7 = arith.addi %3, %arg5 : index
 // CHECK-NEXT:        %8 = memref.load %arg0[%7] : memref<10xf64>
 // CHECK-NEXT:        %9 = arith.addf %arg6, %8 : f64
 // CHECK-NEXT:        memref.store %9, %arg0[%c0] : memref<10xf64>
 // CHECK-NEXT:        scf.yield %9 : f64
 // CHECK-NEXT:      } {enzyme.disable_mincut = true}
-// CHECK-NEXT:      memref.store %arg4, %alloc_0[%3] : memref<3xf64>
+// CHECK-NEXT:      memref.store %arg4, %alloc_0[%arg3] : memref<4xf64>
 // CHECK-NEXT:      scf.yield %6 : f64
 // CHECK-NEXT:    } {enzyme.disable_mincut = true}
 // CHECK-NEXT:    %1 = arith.addf %arg2, %cst fastmath<fast> : f64
-// CHECK-NEXT:    %2 = scf.for %arg3 = %c0 to %c3 step %c1 iter_args(%arg4 = %1) -> (f64) {
-// CHECK-NEXT:      %3 = arith.subi %c2, %arg3 : index
-// CHECK-NEXT:      %subview = memref.subview %alloc[%3, 0] [1, 10] [1, 1] : memref<3x10xf64> to memref<10xf64, strided<[1], offset: ?>>
-// CHECK-NEXT:      %4 = arith.subi %c2, %arg3 : index
-// CHECK-NEXT:      %5 = memref.load %alloc_0[%3] : memref<3xf64>
-// CHECK-NEXT:      %6 = arith.cmpi eq, %arg3, %c0 : index
-// CHECK-NEXT:      %7 = arith.select %6, %c2, %c4 : index
-// CHECK-NEXT:      %8 = arith.muli %4, %c4 : index
+// CHECK-NEXT:    %2 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %1) -> (f64) {
+// CHECK-NEXT:      %3 = arith.subi %c3, %arg3 : index
+// CHECK-NEXT:      %subview = memref.subview %alloc[%3, 0] [1, 10] [1, 1] : memref<4x10xf64> to memref<10xf64, strided<[1], offset: ?>>
+// CHECK-NEXT:      %4 = arith.subi %c3, %arg3 : index
+// CHECK-NEXT:      %5 = arith.muli %4, %c3 : index
+// CHECK-NEXT:      %6 = arith.cmpi eq, %5, %c9 : index
+// CHECK-NEXT:      %7 = arith.select %6, %c1, %c3 : index
+// CHECK-NEXT:      %8 = memref.load %alloc_0[%3] : memref<4xf64>
 // CHECK-NEXT:      %alloc_1 = memref.alloc(%7) : memref<?xmemref<10xf64>>
 // CHECK-NEXT:      %alloc_2 = memref.alloc(%7) : memref<?xindex>
 // CHECK-NEXT:      %alloc_3 = memref.alloc(%7) : memref<?xindex>
-// CHECK-NEXT:      %9 = scf.for %arg5 = %c0 to %7 step %c1 iter_args(%arg6 = %5) -> (f64) {
-// CHECK-NEXT:        %11 = arith.addi %8, %arg5 : index
+// CHECK-NEXT:      %9 = scf.for %arg5 = %c0 to %7 step %c1 iter_args(%arg6 = %8) -> (f64) {
+// CHECK-NEXT:        %11 = arith.addi %5, %arg5 : index
 // CHECK-NEXT:        enzyme.store %11, %alloc_2[%arg5] ([%7]) : memref<?xindex>
 // CHECK-NEXT:        %12 = memref.load %subview[%11] : memref<10xf64, strided<[1], offset: ?>>
 // CHECK-NEXT:        %13 = arith.addf %arg6, %12 : f64
@@ -89,7 +92,7 @@ func.func @reduce_sum(%buf: memref<10xf64>) -> f64 {
 // CHECK-NEXT:      memref.dealloc %alloc_1 : memref<?xmemref<10xf64>>
 // CHECK-NEXT:      scf.yield %10 : f64
 // CHECK-NEXT:    } {enzyme.disable_mincut = true}
-// CHECK-NEXT:    memref.dealloc %alloc_0 : memref<3xf64>
-// CHECK-NEXT:    memref.dealloc %alloc : memref<3x10xf64>
+// CHECK-NEXT:    memref.dealloc %alloc_0 : memref<4xf64>
+// CHECK-NEXT:    memref.dealloc %alloc : memref<4x10xf64>
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }

--- a/enzyme/test/MLIR/ReverseMode/scf_for_memref_checkpointing.mlir
+++ b/enzyme/test/MLIR/ReverseMode/scf_for_memref_checkpointing.mlir
@@ -23,22 +23,20 @@ module {
 // CHECK-NEXT:    %c2 = arith.constant 2 : index
 // CHECK-NEXT:    %c3 = arith.constant 3 : index
 // CHECK-NEXT:    %c1 = arith.constant 1 : index
-// CHECK-NEXT:    %c9 = arith.constant 9 : index
 // CHECK-NEXT:    %c0 = arith.constant 0 : index
 // CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f32
 // CHECK-NEXT:    %alloc = memref.alloc() : memref<3xf32>
 // CHECK-NEXT:    %alloc_0 = memref.alloc() : memref<3xf32>
-// CHECK-NEXT:    %0 = scf.for %arg3 = %c0 to %c9 step %c3 iter_args(%arg4 = %cst) -> (f32) {
-// CHECK-NEXT:      %2 = arith.divui %arg3, %c3 : index
-// CHECK-NEXT:      memref.store %arg4, %alloc_0[%2] : memref<3xf32>
-// CHECK-NEXT:      %subview = memref.subview %alloc[%2] [1] [1] : memref<3xf32> to memref<f32, strided<[], offset: ?>>
+// CHECK-NEXT:    %0 = scf.for %arg3 = %c0 to %c3 step %c1 iter_args(%arg4 = %cst) -> (f32) {
+// CHECK-NEXT:      memref.store %arg4, %alloc_0[%arg3] : memref<3xf32>
+// CHECK-NEXT:      %subview = memref.subview %alloc[%arg3] [1] [1] : memref<3xf32> to memref<f32, strided<[], offset: ?>>
 // CHECK-NEXT:      memref.copy %arg0, %subview : memref<f32> to memref<f32, strided<[], offset: ?>>
-// CHECK-NEXT:      %3 = scf.for %arg5 = %c0 to %c3 step %c1 iter_args(%arg6 = %arg4) -> (f32) {
-// CHECK-NEXT:        %4 = memref.load %arg0[] : memref<f32>
-// CHECK-NEXT:        %5 = arith.mulf %4, %arg6 : f32
-// CHECK-NEXT:        scf.yield %5 : f32
+// CHECK-NEXT:      %2 = scf.for %arg5 = %c0 to %c3 step %c1 iter_args(%arg6 = %arg4) -> (f32) {
+// CHECK-NEXT:        %3 = memref.load %arg0[] : memref<f32>
+// CHECK-NEXT:        %4 = arith.mulf %3, %arg6 : f32
+// CHECK-NEXT:        scf.yield %4 : f32
 // CHECK-NEXT:      }
-// CHECK-NEXT:      scf.yield %3 : f32
+// CHECK-NEXT:      scf.yield %2 : f32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %1 = scf.for %arg3 = %c0 to %c3 step %c1 iter_args(%arg4 = %arg2) -> (f32) {
 // CHECK-NEXT:      %2 = arith.subi %c2, %arg3 : index


### PR DESCRIPTION
https://github.com/EnzymeAD/Enzyme/pull/3092 wrongly used the checkpoint period as the inner trip count. This is unoptimal since then the outer caches will be of size ceil(N / p) instead of p.