### PR TITLE
Update LLVM 19 guards for trigonometric functions

### DIFF
--- a/enzyme/Enzyme/InstructionDerivatives.td
+++ b/enzyme/Enzyme/InstructionDerivatives.td
@@ -1032,6 +1032,12 @@ def : IntrPattern<(Op $x),
                   >;
 
 def : IntrPattern<(Op $x),
+                  [["tan", "19", ""]],
+                  [(FMul (DiffeRet), (FAdd (ConstantFP<"1.0"> $x), (FMul(Call<(SameFunc)> $x):$c, $c)))],
+                  (ForwardFromSummedReverse)
+                  >;
+
+def : IntrPattern<(Op $x),
                   [["exp"]],
                   [(FMul (DiffeRet), (Call<(SameFunc)> $x))],
                   (ForwardFromSummedReverse)                  

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -101,8 +101,13 @@ const llvm::StringMap<llvm::Intrinsic::ID> LIBM_FUNCTIONS = {
     {"sincn", Intrinsic::not_intrinsic},
     {"cos", Intrinsic::cos},
     {"sin", Intrinsic::sin},
+#if LLVM_VERSION_MAJOR >= 19
+    {"tan", Intrinsic::tan},
+    {"acos", Intrinsic::acos},
+#else
     {"tan", Intrinsic::not_intrinsic},
     {"acos", Intrinsic::not_intrinsic},
+#endif
     {"__nv_frcp_rd", Intrinsic::not_intrinsic},
     {"__nv_frcp_rn", Intrinsic::not_intrinsic},
     {"__nv_frcp_ru", Intrinsic::not_intrinsic},
@@ -111,9 +116,17 @@ const llvm::StringMap<llvm::Intrinsic::ID> LIBM_FUNCTIONS = {
     {"__nv_drcp_rn", Intrinsic::not_intrinsic},
     {"__nv_drcp_ru", Intrinsic::not_intrinsic},
     {"__nv_drcp_rz", Intrinsic::not_intrinsic},
+#if LLVM_VERSION_MAJOR >= 19
+    {"asin", Intrinsic::asin},
+#else
     {"asin", Intrinsic::not_intrinsic},
+#endif
     {"__nv_asin", Intrinsic::not_intrinsic},
+#if LLVM_VERSION_MAJOR >= 19
+    {"atan", Intrinsic::atan},
+#else
     {"atan", Intrinsic::not_intrinsic},
+#endif
     {"atan2", Intrinsic::not_intrinsic},
     {"__nv_atan2", Intrinsic::not_intrinsic},
 #if LLVM_VERSION_MAJOR >= 19

--- a/enzyme/test/Enzyme/ReverseMode/tan19.ll
+++ b/enzyme/test/Enzyme/ReverseMode/tan19.ll
@@ -1,0 +1,30 @@
+; RUN: if [ %llvmver -ge 19 ]; then %opt < %s %newLoadEnzyme -enzyme-preopt=false -passes="enzyme,function(mem2reg,instsimplify,%simplifycfg)" -S | FileCheck %s; fi
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare double @llvm.tan.f64(double) #14
+
+; Function Attrs: nounwind readnone uwtable
+define double @tester(double %x) {
+entry:
+  %0 = call double @llvm.tan.f64(double %x)
+  ret double %0
+}
+
+define double @test_derivative(double %x) {
+entry:
+  %0 = tail call double (ptr, ...) @__enzyme_autodiff(ptr nonnull @tester, double %x)
+  ret double %0
+}
+
+; Function Attrs: nounwind
+declare double @__enzyme_autodiff(ptr, ...)
+
+; CHECK: define internal { double } @diffetester(double %x, double %differeturn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:  %0 = call fast double @llvm.tan.f64(double %x)
+; CHECK-NEXT:  %1 = fmul fast double %0, %0
+; CHECK-NEXT:  %2 = fadd fast double 1.000000e+00, %1
+; CHECK-NEXT:  %3 = fmul fast double %differeturn, %2
+; CHECK-NEXT:  %4 = insertvalue { double } undef, double %3, 0
+; CHECK-NEXT:  ret { double } %4
+; CHECK-NEXT: }


### PR DESCRIPTION
This marks several trigonometric functions as `Intrinsic` for `LLVM >= 19`

Closes #3101 

I double-checked the list of functions to tag on the [LLVM repo](https://github.com/llvm/llvm-project) as follows:
```console 
git grep -h 'DefaultAttrsIntrinsic' llvmorg-18.1.0 -- llvm/include/llvm/IR/Intrinsics.td | grep llvm_anyfloat_ty > 18.log
git grep -h 'DefaultAttrsIntrinsic' llvmorg-19.1.0 -- llvm/include/llvm/IR/Intrinsics.td | grep llvm_anyfloat_ty > 19.log
diff -b 18.log 19.log

4a5,7
>   def int_asin : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
>   def int_acos : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
>   def int_atan : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
6a10,13
>   def int_tan  : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
>   def int_sinh : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
>   def int_cosh : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
>   def int_tanh : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
49a57,59
>   def int_experimental_constrained_asin  : DefaultAttrsIntrinsic<[ llvm_anyfloat_ty ],
>   def int_experimental_constrained_acos  : DefaultAttrsIntrinsic<[ llvm_anyfloat_ty ],
>   def int_experimental_constrained_atan  : DefaultAttrsIntrinsic<[ llvm_anyfloat_ty ],
51a62,65
>   def int_experimental_constrained_tan  : DefaultAttrsIntrinsic<[ llvm_anyfloat_ty ],
>   def int_experimental_constrained_sinh  : DefaultAttrsIntrinsic<[ llvm_anyfloat_ty ],
>   def int_experimental_constrained_cosh  : DefaultAttrsIntrinsic<[ llvm_anyfloat_ty ],
>   def int_experimental_constrained_tanh  : DefaultAttrsIntrinsic<[ llvm_anyfloat_ty ],
```

cc @pelesh @lukelowry