### PR TITLE
Fix Bazel workflow file at OS definition

### DIFF
--- a/.github/workflows/enzyme-bazel.yml
+++ b/.github/workflows/enzyme-bazel.yml
@@ -40,6 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os:
           - linux-x86-n2-32
         build:
           - Release

--- a/enzyme/Enzyme/InstructionDerivatives.td
+++ b/enzyme/Enzyme/InstructionDerivatives.td
@@ -1032,6 +1032,12 @@ def : IntrPattern<(Op $x),
                   >;
 
 def : IntrPattern<(Op $x),
+                  [["tan", "19", ""]],
+                  [(FMul (DiffeRet), (Intrinsic<"tan"> $x))],
+                  (ForwardFromSummedReverse)
+                  >;
+
+def : IntrPattern<(Op $x),
                   [["exp"]],
                   [(FMul (DiffeRet), (Call<(SameFunc)> $x))],
                   (ForwardFromSummedReverse)                  

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -101,8 +101,13 @@ const llvm::StringMap<llvm::Intrinsic::ID> LIBM_FUNCTIONS = {
     {"sincn", Intrinsic::not_intrinsic},
     {"cos", Intrinsic::cos},
     {"sin", Intrinsic::sin},
+#if LLVM_VERSION_MAJOR >= 19
+    {"tan", Intrinsic::tan},
+    {"acos", Intrinsic::acos},
+#else
     {"tan", Intrinsic::not_intrinsic},
     {"acos", Intrinsic::not_intrinsic},
+#endif
     {"__nv_frcp_rd", Intrinsic::not_intrinsic},
     {"__nv_frcp_rn", Intrinsic::not_intrinsic},
     {"__nv_frcp_ru", Intrinsic::not_intrinsic},
@@ -111,9 +116,17 @@ const llvm::StringMap<llvm::Intrinsic::ID> LIBM_FUNCTIONS = {
     {"__nv_drcp_rn", Intrinsic::not_intrinsic},
     {"__nv_drcp_ru", Intrinsic::not_intrinsic},
     {"__nv_drcp_rz", Intrinsic::not_intrinsic},
+#if LLVM_VERSION_MAJOR >= 19
+    {"asin", Intrinsic::asin},
+#else
     {"asin", Intrinsic::not_intrinsic},
+#endif
     {"__nv_asin", Intrinsic::not_intrinsic},
+#if LLVM_VERSION_MAJOR >= 19
+    {"atan", Intrinsic::atan},
+#else
     {"atan", Intrinsic::not_intrinsic},
+#endif
     {"atan2", Intrinsic::not_intrinsic},
     {"__nv_atan2", Intrinsic::not_intrinsic},
 #if LLVM_VERSION_MAJOR >= 19


### PR DESCRIPTION
I noticed in #3153 that the Bazel workflow did not run. See https://github.com/EnzymeAD/Enzyme/actions/runs/31821292498/workflow. This fixes the definition of the OS in the workflow file. 

Draft to see if this breaks anything else.