### PR TITLE
Preserve types on reverse cache reloads

### DIFF
--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -7922,6 +7922,17 @@ Value *GradientUtils::lookupM(Value *val, IRBuilder<> &BuilderM,
   Value *result =
       lookupValueFromCache(inst->getType(), /*isForwardPass*/ false, BuilderM,
                            found->second, found->first, isi1, available);
+  if (auto *resultInst = dyn_cast<Instruction>(result)) {
+    auto *origInst = isOriginal(inst);
+    if (!origInst)
+      origInst = isOriginal(prelcssaInst);
+    if (origInst) {
+      TypeTree TT = TR.query(origInst);
+      if (TT.isKnown())
+        resultInst->setMetadata("enzyme_type",
+                                TT.toMD(resultInst->getContext()));
+    }
+  }
   if (auto LI2 = dyn_cast<LoadInst>(result))
     if (auto LI1 = dyn_cast<LoadInst>(inst)) {
       llvm::SmallVector<unsigned int, 9> ToCopy2(MD_ToCopy);

--- a/enzyme/test/Enzyme/ReverseMode/bsearch2.ll
+++ b/enzyme/test/Enzyme/ReverseMode/bsearch2.ll
@@ -101,10 +101,13 @@ attributes #1 = { noinline nounwind uwtable }
 ; CHECK: invertend:                                        ; preds = %end, %incinvertloop
 ; CHECK-NEXT:   %"iv'ac.0" = phi i64 [ %3, %incinvertloop ], [ 9, %end ]
 ; CHECK-NEXT:   %6 = getelementptr inbounds i64, i64* %"idx!manual_lcssa_malloccache", i64 %"iv'ac.0"
-; CHECK-NEXT:   %7 = load i64, i64* %6, align 8, !invariant.group ![[ig0]]
+; CHECK-NEXT:   %7 = load i64, i64* %6, align 8, !invariant.group ![[ig0]], !enzyme_type ![[INTTYPE:[0-9]+]]
 ; CHECK-NEXT:   %"gep2'ipg_unwrap" = getelementptr inbounds double, double* %"x'", i64 %7
 ; CHECK-NEXT:   %8 = load double, double* %"gep2'ipg_unwrap", align 8
 ; CHECK-NEXT:   %9 = fadd fast double %8, %differeturn
 ; CHECK-NEXT:   store double %9, double* %"gep2'ipg_unwrap", align 8
 ; CHECK-NEXT:   br label %invertbody
 ; CHECK-NEXT: }
+
+; CHECK-DAG: ![[INTTYPE]] = !{!"Unknown", i32 -1, ![[INTEGER:[0-9]+]]}
+; CHECK-DAG: ![[INTEGER]] = !{!"Integer"}

--- a/enzyme/test/Enzyme/ReverseMode/combined_rt.ll
+++ b/enzyme/test/Enzyme/ReverseMode/combined_rt.ll
@@ -851,7 +851,7 @@ attributes #21 = { willreturn }
 ; CHECK-NEXT:  br i1 [[icmp_active]], label %invertbb13_active, label %invertbb13_amerge
 
 ; CHECK:invertbb13_active:{{.*}}
-; CHECK-NEXT:  store double 0.000000e+00, double addrspace(13)* %"i39'ipc_unwrap", align 8, !tbaa !58, !alias.scope !140, !noalias !141
+; CHECK-NEXT:  store double 0.000000e+00, double addrspace(13)* %"i39'ipc_unwrap", align 8, !tbaa !58, !alias.scope ![[ACTIVE_SCOPE:[0-9]+]], !noalias ![[ACTIVE_NOALIAS:[0-9]+]]
 ; CHECK-NEXT:  br label %invertbb13_amerge
 
 ; CHECK:invertbb13_amerge:{{.*}}
@@ -861,7 +861,7 @@ attributes #21 = { willreturn }
 ; CHECK-NEXT:  br i1 [[icmp_amerge]], label %invertbb13_amerge_active, label %invertbb13_amerge_amerge
 
 ; CHECK:invertbb13_amerge_active:                         ; preds = %invertbb13_amerge
-; CHECK-NEXT:  store double 0.000000e+00, double addrspace(13)* %"i37'ipc_unwrap", align 8, !tbaa !58, !alias.scope !140, !noalias !141
+; CHECK-NEXT:  store double 0.000000e+00, double addrspace(13)* %"i37'ipc_unwrap", align 8, !tbaa !58, !alias.scope ![[ACTIVE_SCOPE]], !noalias ![[ACTIVE_NOALIAS]]
 ; CHECK-NEXT:  br label %invertbb13_amerge_amerge
 
 ; CHECK:invertbb13_amerge_amerge:                         ; preds = %invertbb13_amerge_active, %invertbb13_amerge


### PR DESCRIPTION
Reverse cache reloads created by `lookupM` dropped the original TypeTree. Preserve it as `enzyme_type` metadata so nested differentiation can classify cached integer loop indices.

Adds a focused check to `bsearch2.ll`. Tracks EnzymeAD/Enzyme.jl#3472.