### PR TITLE
Partial update of unit tests to use newer regex

### DIFF
--- a/enzyme/test/Enzyme/ForwardMode/atomicfadd.ll
+++ b/enzyme/test/Enzyme/ForwardMode/atomicfadd.ll
@@ -22,9 +22,9 @@ attributes #0 = { norecurse nounwind readonly uwtable }
 attributes #1 = { nounwind uwtable }
 attributes #2 = { nounwind }
 
-; CHECK: define internal double @fwddiffesum(double* nocapture %n, double* nocapture %"n'", double %x, double %"x'") 
+; CHECK: define internal double @fwddiffesum({{ptr|double\*}} {{captures\(none\)|nocapture}} %n, {{ptr|double\*}} {{captures\(none\)|nocapture}} %"n'", double %x, double %"x'") 
 ; CHECK-NEXT: entry:
-; CHECK-NEXT:   %res = atomicrmw fadd double* %n, double %x monotonic
-; CHECK-NEXT:   %0 = atomicrmw fadd double* %"n'", double %"x'" monotonic
+; CHECK-NEXT:   %res = atomicrmw fadd {{ptr|double\*}} %n, double %x monotonic
+; CHECK-NEXT:   %0 = atomicrmw fadd {{ptr|double\*}} %"n'", double %"x'" monotonic
 ; CHECK-NEXT:   ret double %0
 ; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ForwardMode/erfi.ll
+++ b/enzyme/test/Enzyme/ForwardMode/erfi.ll
@@ -22,7 +22,7 @@ declare double @__enzyme_fwddiff(double (double)*, ...)
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT:    %0 = fmul fast double %x, %x
 ; CHECK-NEXT:    %1 = call fast double @llvm.exp.f64(double %0)
-; CHECK-NEXT:    %2 = fmul fast double 0x3FF20DD750429B6D, %1
+; CHECK-NEXT:    %2 = fmul fast double {{f?}}0x3FF20DD750429B6D, %1
 ; CHECK-NEXT:    %3 = fmul fast double %"x'", %2
 ; CHECK-NEXT:    ret double %3
 ; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ForwardMode/square2.ll
+++ b/enzyme/test/Enzyme/ForwardMode/square2.ll
@@ -64,24 +64,24 @@ attributes #4 = { nounwind }
 ; CHECK: define internal double @fwddiffesquare(double %x, double %"x'")
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT:   %"x.addr'ipa" = alloca double, align 8
-; CHECK-NEXT:   store double 0.000000e+00, double* %"x.addr'ipa", align 8
+; CHECK-NEXT:   store double 0.000000e+00, {{ptr|double\*}} %"x.addr'ipa", align 8
 ; CHECK-NEXT:   %x.addr = alloca double, align 8
 ; CHECK-NEXT:   %"y'ipa" = alloca double, align 8
-; CHECK-NEXT:   store double 0.000000e+00, double* %"y'ipa", align 8
-; CHECK-NEXT:   store double %"x'", double* %"x.addr'ipa", align 8
-; CHECK-NEXT:   store double %x, double* %x.addr, align 8
-; CHECK-NEXT:   call void @fwddiffesquare_(double* %x.addr, double* %"x.addr'ipa", double* {{(undef|poison)}}, double* %"y'ipa")
-; CHECK-NEXT:   %[[i0:.+]] = load double, double* %"y'ipa", align 8
+; CHECK-NEXT:   store double 0.000000e+00, {{ptr|double\*}} %"y'ipa", align 8
+; CHECK-NEXT:   store double %"x'", {{ptr|double\*}} %"x.addr'ipa", align 8
+; CHECK-NEXT:   store double %x, {{ptr|double\*}} %x.addr, align 8
+; CHECK-NEXT:   call void @fwddiffesquare_({{ptr|double\*}} %x.addr, {{ptr|double\*}} %"x.addr'ipa", {{ptr|double\*}} {{(undef|poison)}}, {{ptr|double\*}} %"y'ipa")
+; CHECK-NEXT:   %[[i0:.+]] = load double, {{ptr|double\*}} %"y'ipa", align 8
 ; CHECK-NEXT:   ret double %[[i0]]
 ; CHECK-NEXT: }
 
-; CHECK: define internal void @fwddiffesquare_(double* nocapture readonly %src, double* nocapture %"src'", double* nocapture writeonly %dest, double* nocapture %"dest'")
+; CHECK: define internal void @fwddiffesquare_({{ptr|double\*}} {{readonly captures\(none\)|nocapture readonly}} %src, {{ptr|double\*}} {{captures\(none\)|nocapture}} %"src'", {{ptr|double\*}} {{writeonly captures\(none\)|nocapture writeonly}} %dest, {{ptr|double\*}} {{captures\(none\)|nocapture}} %"dest'")
 ; CHECK-NEXT: entry:
-; CHECK-NEXT:   %[[i1:.+]] = load double, double* %"src'", align 8
-; CHECK-NEXT:   %0 = load double, double* %src, align 8
+; CHECK-NEXT:   %[[i1:.+]] = load double, {{ptr|double\*}} %"src'", align 8
+; CHECK-NEXT:   %0 = load double, {{ptr|double\*}} %src, align 8
 ; CHECK-NEXT:   %[[i2:.+]] = fmul fast double %[[i1]], %0
 ; CHECK-NEXT:   %[[i3:.+]] = fmul fast double %[[i1]], %0
 ; CHECK-NEXT:   %[[i4:.+]] = fadd fast double %[[i2]], %[[i3]]
-; CHECK-NEXT:   store double %[[i4]], double* %"dest'", align 8
+; CHECK-NEXT:   store double %[[i4]], {{ptr|double\*}} %"dest'", align 8
 ; CHECK-NEXT:   ret void
 ; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ForwardMode/square3.ll
+++ b/enzyme/test/Enzyme/ForwardMode/square3.ll
@@ -65,31 +65,31 @@ attributes #4 = { nounwind }
 ; CHECK: define internal double @fwddiffesquare(double %x, double %"x'")
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT:   %"x.addr'ipa" = alloca double, align 8
-; CHECK-NEXT:   store double 0.000000e+00, double* %"x.addr'ipa", align 8
+; CHECK-NEXT:   store double 0.000000e+00, {{ptr|double\*}} %"x.addr'ipa", align 8
 ; CHECK-NEXT:   %x.addr = alloca double, align 8
 ; CHECK-NEXT:   %"y'ipa" = alloca double, align 8
-; CHECK-NEXT:   store double 0.000000e+00, double* %"y'ipa", align 8
+; CHECK-NEXT:   store double 0.000000e+00, {{ptr|double\*}} %"y'ipa", align 8
 ; CHECK-NEXT:   %y = alloca double, align 8
-; CHECK-NEXT:   store double %"x'", double* %"x.addr'ipa", align 8
-; CHECK-NEXT:   store double %x, double* %x.addr, align 8
-; CHECK-NEXT:   call void @fwddiffesquare_(double* %x.addr, double* %"x.addr'ipa", double* %y, double* %"y'ipa")
-; CHECK-NEXT:   %[[ipl:.+]] = load double, double* %"y'ipa", align 8
-; CHECK-NEXT:   %[[i0:.+]] = load double, double* %y
+; CHECK-NEXT:   store double %"x'", {{ptr|double\*}} %"x.addr'ipa", align 8
+; CHECK-NEXT:   store double %x, {{ptr|double\*}} %x.addr, align 8
+; CHECK-NEXT:   call void @fwddiffesquare_({{ptr|double\*}} %x.addr, {{ptr|double\*}} %"x.addr'ipa", {{ptr|double\*}} %y, {{ptr|double\*}} %"y'ipa")
+; CHECK-NEXT:   %[[ipl:.+]] = load double, {{ptr|double\*}} %"y'ipa", align 8
+; CHECK-NEXT:   %[[i0:.+]] = load double, {{ptr|double\*}} %y
 ; CHECK-NEXT:   %[[i1:.+]] = fmul fast double %[[ipl]], %[[i0]]
 ; CHECK-NEXT:   %[[i2:.+]] = fmul fast double %[[ipl]], %[[i0]]
 ; CHECK-NEXT:   %[[i3:.+]] = fadd fast double %[[i1]], %[[i2]]
 ; CHECK-NEXT:   ret double %[[i3]]
 ; CHECK-NEXT: }
 
-; CHECK: define internal void @fwddiffesquare_(double* nocapture readonly %src, double* nocapture %"src'", double* nocapture writeonly %dest, double* nocapture %"dest'")
+; CHECK: define internal void @fwddiffesquare_({{ptr|double\*}} {{readonly captures\(none\)|nocapture readonly}} %src, {{ptr|double\*}} {{captures\(none\)|nocapture}} %"src'", {{ptr|double\*}} {{writeonly captures\(none\)|nocapture writeonly}} %dest, {{ptr|double\*}} {{captures\(none\)|nocapture}} %"dest'")
 ; CHECK-NEXT: entry:
-; CHECK-NEXT:   %[[i1:.+]] = load double, double* %"src'", align 8
-; CHECK-NEXT:   %0 = load double, double* %src, align 8
+; CHECK-NEXT:   %[[i1:.+]] = load double, {{ptr|double\*}} %"src'", align 8
+; CHECK-NEXT:   %0 = load double, {{ptr|double\*}} %src, align 8
 ; CHECK-NEXT:   %mul = fmul double %0, %0
 ; CHECK-NEXT:   %[[i2:.+]] = fmul fast double %[[i1]], %0
 ; CHECK-NEXT:   %[[i3:.+]] = fmul fast double %[[i1]], %0
 ; CHECK-NEXT:   %[[i4:.+]] = fadd fast double %[[i2]], %[[i3]]
-; CHECK-NEXT:   store double %[[i4]], double* %"dest'", align 8
-; CHECK-NEXT:   store double %mul, double* %dest
+; CHECK-NEXT:   store double %[[i4]], {{ptr|double\*}} %"dest'", align 8
+; CHECK-NEXT:   store double %mul, {{ptr|double\*}} %dest
 ; CHECK-NEXT:   ret void
 ; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ForwardMode/sret12.ll
+++ b/enzyme/test/Enzyme/ForwardMode/sret12.ll
@@ -1,5 +1,6 @@
-; RUN: if [ %llvmver -ge 12 ] && [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -mem2reg -simplifycfg -early-cse -S | FileCheck %s ; fi
-; RUN: if [ %llvmver -ge 12 ]; then %opt < %s %newLoadEnzyme -passes="enzyme,function(mem2reg,%simplifycfg,early-cse)" -enzyme-preopt=false -S | FileCheck %s ; fi
+; RUN: if [ %llvmver -ge 12 ] && [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -mem2reg -simplifycfg -early-cse -S | FileCheck %s -check-prefixes LL16,CHECK; fi
+; RUN: if [ %llvmver -ge 12 ] && [ %llvmver -le 16 ]; then %opt < %s %newLoadEnzyme -passes="enzyme,function(mem2reg,%simplifycfg,early-cse)" -enzyme-preopt=false -S | FileCheck %s -check-prefixes LL16,CHECK; fi
+; RUN: if [ %llvmver -ge 17 ]; then %opt < %s %newLoadEnzyme -passes="enzyme,function(mem2reg,%simplifycfg,early-cse)" -enzyme-preopt=false -S | FileCheck %s -check-prefixes LL24,CHECK; fi
 
 ; #include <stdio.h>
 ; #include <array>
@@ -73,27 +74,28 @@ attributes #5 = { argmemonly nofree nosync nounwind willreturn }
 attributes #6 = { nounwind }
 
 
-; CHECK: define dso_local void @_Z7dsquared(%"struct.std::array"* noalias sret(%"struct.std::array") align 8 %agg.result, double %x)
+; CHECK: define dso_local void @_Z7dsquared({{ptr|%"struct\.std::array"\*}} noalias sret(%"struct.std::array") align 8 %agg.result, double %x)
 ; CHECK-NEXT: entry:  
 ; CHECK-NEXT:   %0 = alloca %"struct.std::array"
-; CHECK-NEXT:   call void @fwddiffe_Z6squared(%"struct.std::array"* %0, %"struct.std::array"* %agg.result, double %x, double 1.000000e+00)
+; CHECK-NEXT:   call void @fwddiffe_Z6squared({{ptr|%"struct\.std::array"\*}} %0, {{ptr|%"struct\.std::array"\*}} %agg.result, double %x, double 1.000000e+00)
 ; CHECK-NEXT:   ret void
 ; CHECK-NEXT: }
 
 
-; CHECK: define internal void @fwddiffe_Z6squared(%"struct.std::array"* noalias nocapture writeonly align 8 "enzyme_sret"="{{[0-9]+}}" %agg.result, %"struct.std::array"* nocapture align 8 "enzyme_sret"="{{[0-9]+}}" %"agg.result'", double %x, double %"x'") 
+; CHECK: define internal void @fwddiffe_Z6squared({{ptr|%"struct\.std::array"\*}} noalias{{( nocapture)?}} writeonly align 8{{( captures\(none\))?}} "enzyme_sret"="{{[0-9]+}}" %agg.result, {{ptr|%"struct\.std::array"\*}}{{( nocapture)?}} align 8{{( captures\(none\))?}} "enzyme_sret"="{{[0-9]+}}" %"agg.result'", double %x, double %"x'") 
 ; CHECK-NEXT: entry:  
-; CHECK-NEXT:   %"arrayinit.begin'ipg" = getelementptr inbounds %"struct.std::array", %"struct.std::array"* %"agg.result'", i64 0, i32 0, i64 0
+; LL16-NEXT:    %"arrayinit.begin'ipg" = getelementptr inbounds %"struct.std::array", %"struct.std::array"* %"agg.result'", i64 0, i32 0, i64 0
 ; CHECK-NEXT:   %mul = fmul double %x, %x
 ; CHECK-NEXT:   %0 = fmul fast double %"x'", %x
 ; CHECK-NEXT:   %1 = fadd fast double %0, %0
-; CHECK-NEXT:   store double %1, double* %"arrayinit.begin'ipg", align 8
-; CHECK-NEXT:   %"arrayinit.element'ipg" = getelementptr inbounds %"struct.std::array", %"struct.std::array"* %"agg.result'", i64 0, i32 0, i64 1
+; LL16-NEXT:    store double %1, double* %"arrayinit.begin'ipg", align 8
+; LL24-NEXT:    store double %1, ptr %"agg.result'", align 8{{.*}}
+; CHECK-NEXT:   %"arrayinit.element'ipg" = getelementptr inbounds %"struct.std::array", {{ptr|%"struct\.std::array"\*}} %"agg.result'", i64 0, i32 0, i64 1
 ; CHECK-NEXT:   %2 = fmul fast double %1, %x
 ; CHECK-NEXT:   %3 = fmul fast double %"x'", %mul
 ; CHECK-NEXT:   %4 = fadd fast double %2, %3
-; CHECK-NEXT:   store double %4, double* %"arrayinit.element'ipg", align 8
-; CHECK-NEXT:   %"arrayinit.element3'ipg" = getelementptr inbounds %"struct.std::array", %"struct.std::array"* %"agg.result'", i64 0, i32 0, i64 2
-; CHECK-NEXT:   store double %"x'", double* %"arrayinit.element3'ipg", align 8
+; CHECK-NEXT:   store double %4, {{ptr|double\*}} %"arrayinit.element'ipg", align 8{{.*}}
+; CHECK-NEXT:   %"arrayinit.element3'ipg" = getelementptr inbounds %"struct.std::array", {{ptr|%"struct\.std::array"\*}} %"agg.result'", i64 0, i32 0, i64 2
+; CHECK-NEXT:   store double %"x'", {{ptr|double\*}} %"arrayinit.element3'ipg", align 8
 ; CHECK-NEXT:  ret void
 ; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ForwardMode/store3.ll
+++ b/enzyme/test/Enzyme/ForwardMode/store3.ll
@@ -22,12 +22,12 @@ declare dso_local double @__enzyme_fwddiff(i8*, double*, double*, double, double
 attributes #0 = { noinline norecurse nounwind uwtable }
 attributes #1 = { noinline nounwind uwtable }
 
-; CHECK: define internal double @fwddiffef(double* noalias nocapture %out, double* nocapture %"out'", double %x, double %"x'")
+; CHECK: define internal double @fwddiffef({{ptr|double\*}} noalias {{captures\(none\)|nocapture}} %out, {{ptr|double\*}} {{captures\(none\)|nocapture}} %"out'", double %x, double %"x'")
 ; CHECK-NEXT: entry:
-; CHECK-NEXT:   store double %"x'", double* %"out'", align 8
-; CHECK-NEXT:   store double %x, double* %out, align 8
-; CHECK-NEXT:   store double 0.000000e+00, double* %"out'", align 8
-; CHECK-NEXT:   store double 0.000000e+00, double* %out, align 8
-; CHECK-NEXT:   %"res'ipl" = load double, double* %"out'"
+; CHECK-NEXT:   store double %"x'", {{ptr|double\*}} %"out'", align 8
+; CHECK-NEXT:   store double %x, {{ptr|double\*}} %out, align 8
+; CHECK-NEXT:   store double 0.000000e+00, {{ptr|double\*}} %"out'", align 8
+; CHECK-NEXT:   store double 0.000000e+00, {{ptr|double\*}} %out, align 8
+; CHECK-NEXT:   %"res'ipl" = load double, {{ptr|double\*}} %"out'"
 ; CHECK-NEXT:   ret double %"res'ipl"
 ; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ForwardMode/storeconstexpr.ll
+++ b/enzyme/test/Enzyme/ForwardMode/storeconstexpr.ll
@@ -19,9 +19,9 @@ entry:
 ; Function Attrs: alwaysinline
 declare double @__enzyme_fwddiff(i8*, ...)
 
-; CHECK: define internal void @fwddiffecallee(i64* %from, i64* %"from'", i64* %to, i64* %"to'")
+; CHECK: define internal void @fwddiffecallee({{ptr|i64\*}} %from, {{ptr|i64\*}} %"from'", {{ptr|i64\*}} %to, {{ptr|i64\*}} %"to'")
 ; CHECK-NEXT: entry:
-; CHECK-NEXT:   store i64 ptrtoint ([18 x i8]* @.str to i64), i64* %"to'", align 4
-; CHECK-NEXT:   store i64 ptrtoint ([18 x i8]* @.str to i64), i64* %to, align 4
+; CHECK-NEXT:   store i64 ptrtoint ({{ptr|\[18 x i8\]\*}} @.str to i64), {{ptr|i64\*}} %"to'", align 4
+; CHECK-NEXT:   store i64 ptrtoint ({{ptr|\[18 x i8\]\*}} @.str to i64), {{ptr|i64\*}} %to, align 4
 ; CHECK-NEXT:   ret void
 ; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ForwardMode/sumnlist.ll
+++ b/enzyme/test/Enzyme/ForwardMode/sumnlist.ll
@@ -92,9 +92,9 @@ attributes #4 = { nounwind }
 !10 = !{!4, !4, i64 0}
 
 
-; CHECK: define internal double @fwddiffesum_list(%struct.n* noalias readonly %node, %struct.n* %"node'", i64 %times)
+; CHECK: define internal double @fwddiffesum_list({{ptr|%struct.n\*}} noalias readonly %node, {{ptr|%struct.n\*}} %"node'", i64 %times)
 ; CHECK-NEXT: entry:
-; CHECK-NEXT:   %cmp18 = icmp eq %struct.n* %node, null
+; CHECK-NEXT:   %cmp18 = icmp eq {{ptr|%struct.n\*}} %node, null
 ; CHECK-NEXT:   br i1 %cmp18, label %for.cond.cleanup, label %for.cond1.preheader.preheader
 
 ; CHECK: for.cond1.preheader.preheader:                    ; preds = %entry
@@ -102,10 +102,10 @@ attributes #4 = { nounwind }
 
 ; CHECK: for.cond1.preheader:  
 ; CHECK-NEXT:   %[[sum019:.+]] = phi {{(fast )?}}double [ %[[i3:.+]], %for.cond.cleanup4 ], [ 0.000000e+00, %for.cond1.preheader.preheader ]
-; CHECK-NEXT:   %[[dval:.+]] = phi %struct.n* [ %[[ipl4:.+]], %for.cond.cleanup4 ], [ %"node'", %for.cond1.preheader.preheader ]
-; CHECK-NEXT:   %val.020 = phi %struct.n* [ %[[i1:.+]], %for.cond.cleanup4 ], [ %node, %for.cond1.preheader.preheader ]
-; CHECK-NEXT:   %"values'ipg" = getelementptr inbounds %struct.n, %struct.n* %[[dval]], i64 0, i32 0
-; CHECK-NEXT:   %"'ipl" = load double*, double** %"values'ipg", align 8
+; CHECK-NEXT:   %[[dval:.+]] = phi {{ptr|%struct.n\*}} [ %[[ipl4:.+]], %for.cond.cleanup4 ], [ %"node'", %for.cond1.preheader.preheader ]
+; CHECK-NEXT:   %val.020 = phi {{ptr|%struct.n\*}} [ %[[i1:.+]], %for.cond.cleanup4 ], [ %node, %for.cond1.preheader.preheader ]
+; CHECK-NEXT:   %"values'ipg" = getelementptr inbounds %struct.n, {{ptr|%struct.n\*}} %[[dval]], i64 0, i32 0
+; CHECK-NEXT:   %"'ipl" = load {{ptr|double\*}}, {{ptr|double\*\*}} %"values'ipg", align 8
 ; CHECK-NEXT:   br label %for.body5
 
 ; CHECK: for.cond.cleanup.loopexit:                        ; preds = %for.cond.cleanup4
@@ -116,19 +116,19 @@ attributes #4 = { nounwind }
 ; CHECK-NEXT:   ret double %[[sum0]]
 
 ; CHECK: for.cond.cleanup4:                                ; preds = %for.body5
-; CHECK-NEXT:   %"next'ipg" = getelementptr inbounds %struct.n, %struct.n* %[[dval]], i64 0, i32 1
-; CHECK-NEXT:   %next = getelementptr inbounds %struct.n, %struct.n* %val.020, i64 0, i32 1
-; CHECK-NEXT:   %[[ipl4]] = load %struct.n*, %struct.n** %"next'ipg", align 8
-; CHECK-NEXT:   %[[i1]] = load %struct.n*, %struct.n** %next, align 8, !tbaa !7
-; CHECK-NEXT:   %cmp = icmp eq %struct.n* %[[i1]], null
+; CHECK-NEXT:   %"next'ipg" = getelementptr inbounds %struct.n, {{ptr|%struct.n\*}} %[[dval]], i64 0, i32 1
+; CHECK-NEXT:   %next = getelementptr inbounds %struct.n, {{ptr|%struct.n\*}} %val.020, i64 0, i32 1
+; CHECK-NEXT:   %[[ipl4]] = load {{ptr|%struct.n\*}}, {{ptr|%struct.n\*\*}} %"next'ipg", align 8
+; CHECK-NEXT:   %[[i1]] = load {{ptr|%struct.n\*}}, {{ptr|%struct.n\*\*}} %next, align 8, !tbaa !7
+; CHECK-NEXT:   %cmp = icmp eq {{ptr|%struct.n\*}} %[[i1]], null
 ; CHECK-NEXT:   br i1 %cmp, label %for.cond.cleanup.loopexit, label %for.cond1.preheader
 
 ; CHECK: for.body5:                                        ; preds = %for.body5, %for.cond1.preheader
 ; CHECK-NEXT:   %[[sum116:.+]] = phi {{(fast )?}}double [ %[[sum019]], %for.cond1.preheader ], [ %[[i3]], %for.body5 ]
 ; CHECK-NEXT:   %iv1 = phi i64 [ %iv.next2, %for.body5 ], [ 0, %for.cond1.preheader ]
 ; CHECK-NEXT:   %iv.next2 = add nuw nsw i64 %iv1, 1
-; CHECK-NEXT:   %"arrayidx'ipg" = getelementptr inbounds double, double* %"'ipl", i64 %iv1
-; CHECK-NEXT:   %[[i2:.+]] = load double, double* %"arrayidx'ipg", align 8
+; CHECK-NEXT:   %"arrayidx'ipg" = getelementptr inbounds double, {{ptr|double\*}} %"'ipl", i64 %iv1
+; CHECK-NEXT:   %[[i2:.+]] = load double, {{ptr|double\*}} %"arrayidx'ipg", align 8
 ; CHECK-NEXT:   %[[i3]] = fadd fast double %[[i2]], %[[sum116]]
 ; CHECK-NEXT:   %exitcond = icmp eq i64 %iv1, %times
 ; CHECK-NEXT:   br i1 %exitcond, label %for.cond.cleanup4, label %for.body5

--- a/enzyme/test/Enzyme/ForwardMode/sumsimple.ll
+++ b/enzyme/test/Enzyme/ForwardMode/sumsimple.ll
@@ -38,7 +38,7 @@ declare dso_local double @__enzyme_fwddiff(i8*, double*, double*, double**, doub
 attributes #0 = { noinline nounwind uwtable }
 
 
-; CHECK: define internal void @fwddiffef(double* %x, double* %"x'", double** %y, double** %"y'", i64 %n)
+; CHECK: define internal void @fwddiffef({{ptr|double\*}} %x, {{ptr|double\*}} %"x'", {{ptr|double\*\*}} %y, {{ptr|double\*\*}} %"y'", i64 %n)
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT:   %0 = add {{(nuw )?}}i64 %n, 1
 ; CHECK-NEXT:   br label %for.cond
@@ -50,16 +50,16 @@ attributes #0 = { noinline nounwind uwtable }
 ; CHECK-NEXT:   br i1 %cmp, label %for.body, label %for.end
 
 ; CHECK: for.body:                                         ; preds = %for.cond
-; CHECK-NEXT:   %[[i2:.+]] = load double, double* %"x'"
-; CHECK-NEXT:   %[[i1:.+]] = load double, double* %x
-; CHECK-NEXT:   %[[ipl:.+]] = load double*, double** %"y'"
-; CHECK-NEXT:   %[[i3:.+]] = load double*, double** %y
-; CHECK-NEXT:   %[[i5:.+]] = load double, double* %[[ipl]]
-; CHECK-NEXT:   %[[i4:.+]] = load double, double* %[[i3]]
+; CHECK-NEXT:   %[[i2:.+]] = load double, {{ptr|double\*}} %"x'"
+; CHECK-NEXT:   %[[i1:.+]] = load double, {{ptr|double\*}} %x
+; CHECK-NEXT:   %[[ipl:.+]] = load {{ptr|double\*}}, {{ptr|double\*\*}} %"y'"
+; CHECK-NEXT:   %[[i3:.+]] = load {{ptr|double\*}}, {{ptr|double\*\*}} %y
+; CHECK-NEXT:   %[[i5:.+]] = load double, {{ptr|double\*}} %[[ipl]]
+; CHECK-NEXT:   %[[i4:.+]] = load double, {{ptr|double\*}} %[[i3]]
 ; CHECK-NEXT:   %[[add:.+]] = fadd fast double %[[i4]], %[[i1]]
 ; CHECK-NEXT:   %[[i6:.+]] = fadd fast double %[[i5]], %[[i2]]
-; CHECK-NEXT:   store double %[[i6]], double* %[[ipl]]
-; CHECK-NEXT:   store double %[[add]], double* %[[i3]]
+; CHECK-NEXT:   store double %[[i6]], {{ptr|double\*}} %[[ipl]]
+; CHECK-NEXT:   store double %[[add]], {{ptr|double\*}} %[[i3]]
 ; CHECK-NEXT:   br label %for.cond
 
 ; CHECK: for.end:                                          ; preds = %for.cond

--- a/enzyme/test/Enzyme/ForwardMode/sumsimpleoptnone.ll
+++ b/enzyme/test/Enzyme/ForwardMode/sumsimpleoptnone.ll
@@ -38,7 +38,7 @@ declare dso_local double @__enzyme_fwddiff(i8*, double*, double*, double**, doub
 attributes #0 = { noinline nounwind uwtable optnone }
 
 
-; CHECK: define internal void @fwddiffef(double* %x, double* %"x'", double** %y, double** %"y'", i64 %n)
+; CHECK: define internal void @fwddiffef({{ptr|double\*}} %x, {{ptr|double\*}} %"x'", {{ptr|double\*\*}} %y, {{ptr|double\*\*}} %"y'", i64 %n)
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT:   %0 = add {{(nuw )?}}i64 %n, 1
 ; CHECK-NEXT:   br label %for.cond
@@ -50,16 +50,16 @@ attributes #0 = { noinline nounwind uwtable optnone }
 ; CHECK-NEXT:   br i1 %cmp, label %for.body, label %for.end
 
 ; CHECK: for.body:                                         ; preds = %for.cond
-; CHECK-NEXT:   %[[i2:.+]] = load double, double* %"x'"
-; CHECK-NEXT:   %[[i1:.+]] = load double, double* %x
-; CHECK-NEXT:   %[[ipl:.+]] = load double*, double** %"y'"
-; CHECK-NEXT:   %[[i3:.+]] = load double*, double** %y
-; CHECK-NEXT:   %[[i5:.+]] = load double, double* %[[ipl]]
-; CHECK-NEXT:   %[[i4:.+]] = load double, double* %[[i3]]
+; CHECK-NEXT:   %[[i2:.+]] = load double, {{ptr|double\*}} %"x'"
+; CHECK-NEXT:   %[[i1:.+]] = load double, {{ptr|double\*}} %x
+; CHECK-NEXT:   %[[ipl:.+]] = load {{ptr|double\*}}, {{ptr|double\*\*}} %"y'"
+; CHECK-NEXT:   %[[i3:.+]] = load {{ptr|double\*}}, {{ptr|double\*\*}} %y
+; CHECK-NEXT:   %[[i5:.+]] = load double, {{ptr|double\*}} %[[ipl]]
+; CHECK-NEXT:   %[[i4:.+]] = load double, {{ptr|double\*}} %[[i3]]
 ; CHECK-NEXT:   %[[add:.+]] = fadd fast double %[[i4]], %[[i1]]
 ; CHECK-NEXT:   %[[i6:.+]] = fadd fast double %[[i5]], %[[i2]]
-; CHECK-NEXT:   store double %[[i6]], double* %[[ipl]]
-; CHECK-NEXT:   store double %[[add]], double* %[[i3]]
+; CHECK-NEXT:   store double %[[i6]], {{ptr|double\*}} %[[ipl]]
+; CHECK-NEXT:   store double %[[add]], {{ptr|double\*}} %[[i3]]
 ; CHECK-NEXT:   br label %for.cond
 
 ; CHECK: for.end:                                          ; preds = %for.cond

--- a/enzyme/test/Enzyme/ForwardMode/sumsquare.ll
+++ b/enzyme/test/Enzyme/ForwardMode/sumsquare.ll
@@ -36,7 +36,7 @@ attributes #1 = { nounwind uwtable }
 attributes #2 = { nounwind }
 
 
-; CHECK: define internal double @fwddiffesumsquare(double* nocapture readonly %x, double* nocapture %"x'", i64 %n)
+; CHECK: define internal double @fwddiffesumsquare({{ptr|double\*}} {{readonly captures\(none\)|nocapture readonly}} %x, {{ptr|double\*}} {{captures\(none\)|nocapture}} %"x'", i64 %n)
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT:   br label %for.body
 
@@ -47,10 +47,10 @@ attributes #2 = { nounwind }
 ; CHECK-DAG:   %iv = phi i64 [ %iv.next, %for.body ], [ 0, %entry ]
 ; CHECK-DAG:   %[[total011:.+]] = phi{{( fast)?}} double [ 0.000000e+00, %entry ], [ %[[i4:.+]], %for.body ]
 ; CHECK-NEXT:   %iv.next = add nuw nsw i64 %iv, 1
-; CHECK-NEXT:   %"arrayidx'ipg" = getelementptr inbounds double, double* %"x'", i64 %iv
-; CHECK-NEXT:   %arrayidx = getelementptr inbounds double, double* %x, i64 %iv
-; CHECK-NEXT:   %[[i1:.+]] = load double, double* %"arrayidx'ipg"
-; CHECK-NEXT:   %[[i0:.+]] = load double, double* %arrayidx, align 8
+; CHECK-NEXT:   %"arrayidx'ipg" = getelementptr inbounds double, {{ptr|double\*}} %"x'", i64 %iv
+; CHECK-NEXT:   %arrayidx = getelementptr inbounds double, {{ptr|double\*}} %x, i64 %iv
+; CHECK-NEXT:   %[[i1:.+]] = load double, {{ptr|double\*}} %"arrayidx'ipg"
+; CHECK-NEXT:   %[[i0:.+]] = load double, {{ptr|double\*}} %arrayidx, align 8
 ; CHECK-NEXT:   %[[i2:.+]] = fmul fast double %[[i1:.+]], %[[i0:.+]]
 ; CHECK-NEXT:   %[[i3:.+]] = fadd fast double %[[i2:.+]], %[[i2:.+]]
 ; CHECK-NEXT:   %[[i4]] = fadd fast double %[[i3:.+]], %[[total011]]

--- a/enzyme/test/Enzyme/ForwardMode/sumwithbreak.ll
+++ b/enzyme/test/Enzyme/ForwardMode/sumwithbreak.ll
@@ -44,7 +44,7 @@ declare dso_local double @__enzyme_fwddiff(i8*, double*, double*, i64)
 attributes #0 = { noinline nounwind uwtable }
 
 
-; CHECK: define internal double @fwddiffef(double* nocapture readonly %x, double* nocapture %"x'", i64 %n)
+; CHECK: define internal double @fwddiffef({{ptr|double\*}} {{readonly captures\(none\)|nocapture readonly}} %x, {{ptr|double\*}} {{captures\(none\)|nocapture}} %"x'", i64 %n)
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT:   br label %for.body
 
@@ -57,16 +57,16 @@ attributes #0 = { noinline nounwind uwtable }
 ; CHECK-NEXT:   br i1 %cmp2, label %if.then, label %if.end
 
 ; CHECK: if.then:                                          ; preds = %for.body
-; CHECK-NEXT:   %"arrayidx'ipg" = getelementptr inbounds double, double* %"x'", i64 %n
-; CHECK-NEXT:   %[[i0:.+]] = load double, double* %"arrayidx'ipg", align 8
+; CHECK-NEXT:   %"arrayidx'ipg" = getelementptr inbounds double, {{ptr|double\*}} %"x'", i64 %n
+; CHECK-NEXT:   %[[i0:.+]] = load double, {{ptr|double\*}} %"arrayidx'ipg", align 8
 ; CHECK-NEXT:   %[[i1:.+]] = fadd fast double %[[i0]], %[[data016]]
 ; CHECK-NEXT:   br label %cleanup
 
 ; CHECK: if.end:                                           ; preds = %for.body
-; CHECK-NEXT:   %"arrayidx4'ipg" = getelementptr inbounds double, double* %"x'", i64 %iv
-; CHECK-NEXT:   %arrayidx4 = getelementptr inbounds double, double* %x, i64 %iv
-; CHECK-NEXT:   %[[i3:.+]] = load double, double* %"arrayidx4'ipg", align 8
-; CHECK-NEXT:   %[[i2:.+]] = load double, double* %arrayidx4, align 8
+; CHECK-NEXT:   %"arrayidx4'ipg" = getelementptr inbounds double, {{ptr|double\*}} %"x'", i64 %iv
+; CHECK-NEXT:   %arrayidx4 = getelementptr inbounds double, {{ptr|double\*}} %x, i64 %iv
+; CHECK-NEXT:   %[[i3:.+]] = load double, {{ptr|double\*}} %"arrayidx4'ipg", align 8
+; CHECK-NEXT:   %[[i2:.+]] = load double, {{ptr|double\*}} %arrayidx4, align 8
 ; CHECK-NEXT:   %add5 = fadd fast double %[[i2]], %data.016
 ; CHECK-NEXT:   %[[i4]] = fadd fast double %[[i3]], %[[data016]]
 ; CHECK-NEXT:   %cmp = icmp ult i64 %iv, %n

--- a/enzyme/test/Enzyme/ForwardMode/unmalloc.ll
+++ b/enzyme/test/Enzyme/ForwardMode/unmalloc.ll
@@ -1,5 +1,6 @@
-; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme -instsimplify -enzyme-preopt=false -enzyme-detect-readthrow=0 -S | FileCheck %s; fi
-; RUN: %opt < %s %newLoadEnzyme -passes="enzyme,function(instsimplify)" -enzyme-preopt=false -enzyme-detect-readthrow=0 -S | FileCheck %s
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme -instsimplify -enzyme-preopt=false -enzyme-detect-readthrow=0 -S | FileCheck %s -check-prefixes LL16,CHECK; fi
+; RUN: if [ %llvmver -le 16 ]; then %opt < %s %newLoadEnzyme -passes="enzyme,function(instsimplify)" -enzyme-preopt=false -enzyme-detect-readthrow=0 -S | FileCheck %s -check-prefixes LL16,CHECK; fi
+; RUN: if [ %llvmver -ge 17 ]; then %opt < %s %newLoadEnzyme -passes="enzyme,function(instsimplify)" -enzyme-preopt=false -enzyme-detect-readthrow=0 -S | FileCheck %s -check-prefixes LL24,CHECK; fi
 
 declare void @__enzyme_fwddiff(...)
 
@@ -22,12 +23,14 @@ declare void @free(i8*)
 
 declare i8* @malloc(i64)
 
-; CHECK: define internal void @fwddiffejulia_gradient_deferred__5305(double %i95, double %"i95'", double* %i346, double* %"i346'")
-; CHECK-NEXT:   %[[i1:.+]] = call noalias nonnull i8* @malloc(i64 100)
-; CHECK-NEXT:   %"i74'ipc" = bitcast i8* %[[i1]] to double*
-; CHECK-NEXT:   store double %"i95'", double* %"i74'ipc", align 8
-; CHECK-NEXT:   %"i257'ipl" = load double, double* %"i74'ipc", align 8
-; CHECK-NEXT:   store double %"i257'ipl", double* %"i346'"
-; CHECK-NEXT:   call void @free(i8* nonnull %[[i1]])
+; CHECK: define internal void @fwddiffejulia_gradient_deferred__5305(double %i95, double %"i95'", {{ptr|double\*}} %i346, {{ptr|double\*}} %"i346'")
+; CHECK-NEXT:   %[[i1:.+]] = call noalias nonnull {{ptr|i8\*}} @malloc(i64 100)
+; LL16-NEXT:    %"i74'ipc" = bitcast i8* %[[i1]] to double*
+; LL16-NEXT:    store double %"i95'", double* %"i74'ipc", align 8{{.*}}
+; LL16-NEXT:    %"i257'ipl" = load double, double* %"i74'ipc", align 8{{.*}}
+; LL24-NEXT:    store double %"i95'", ptr %[[i1]], align 8{{.*}}
+; LL24-NEXT:    %"i257'ipl" = load double, ptr %[[i1]], align 8{{.*}}
+; CHECK-NEXT:   store double %"i257'ipl", {{ptr|double\*}} %"i346'"
+; CHECK-NEXT:   call void @free({{ptr|i8\*}} nonnull %[[i1]])
 ; CHECK-NEXT:   ret void
 ; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ForwardMode/vecsquare.ll
+++ b/enzyme/test/Enzyme/ForwardMode/vecsquare.ll
@@ -27,12 +27,12 @@ entry:
 
 ; CHECK: define internal { float, float, float } @fwddiffesquare(<4 x float> %x, <4 x float> %"x'")
 ; CHECK-NEXT: entry:
-; CHECK-NEXT:    %sq = fmul <4 x float> %x, %x
-; CHECK-NEXT:    %0 = fmul fast <4 x float> %"x'", %x
-; CHECK-NEXT:    %1 = fadd fast <4 x float> %0, %0
-; CHECK-NEXT:    %2 = fmul fast <4 x float> %1, %x
-; CHECK-NEXT:    %3 = fmul fast <4 x float> %sq, %"x'"
-; CHECK-NEXT:    %4 = fadd fast <4 x float> %2, %3
+; CHECK-NEXT:    %sq = fmul{{( nnan)?( ninf)?}} <4 x float> %x, %x
+; CHECK-NEXT:    %[[i0:.+]] = fmul fast <4 x float> %"x'", %x
+; CHECK-NEXT:    %[[i1:.+]] = fadd fast <4 x float> %[[i0]], %[[i0]]
+; CHECK-NEXT:    %[[i2:.+]] = fmul fast <4 x float> %[[i1]], %x
+; CHECK-NEXT:    %[[i3:.+]] = fmul fast <4 x float> {{%sq, %"x'"|%"x'", %sq}}
+; CHECK-NEXT:    %[[i4:.+]] = fadd fast <4 x float> %[[i2]], %[[i3]]
 ; CHECK-NEXT:    %[[i5:.+]] = extractelement <4 x float> %1, {{(i32|i64)}} 1
 ; CHECK-NEXT:    %[[i6:.+]] = extractelement <4 x float> %4, {{(i32|i64)}} 0
 ; CHECK-NEXT:    %[[i7:.+]] = extractelement <4 x float> %4, {{(i32|i64)}} 1


### PR DESCRIPTION
Many of the Enzyme unit tests seem to fail with the latest version of LLVM on Mac (target triple: arm64-apple-darwin25.5.0). This updates some of the regex for a few of the ForwardMode tests. Most changes are allowing for opaque pointers.

For some of the tests, I added LL16 and LL24 FileCheck prefixes to handle the different IR you get between LLVM pre-version 16 and mainline (v 24). I'm open to suggestions if there are different ways we want this to be handled or if we don't want to support LLVM mainline in the unit tests yet