### PR TITLE
Add Fortran OpenMP tests

### DIFF
--- a/.github/workflows/fortran.yml
+++ b/.github/workflows/fortran.yml
@@ -54,7 +54,7 @@ jobs:
         set -eo pipefail
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
         sudo apt-add-repository "deb http://apt.llvm.org/`lsb_release -c | cut -f2`/ llvm-toolchain-`lsb_release -c | cut -f2`-${{ matrix.llvm }} main"
-        sudo apt-get update && sudo apt-get install -y cmake gcc g++ llvm-${{ matrix.llvm }}-dev ninja-build pip clang-${{ matrix.llvm }} flang-${{ matrix.llvm }}
+        sudo apt-get update && sudo apt-get install -y cmake gcc g++ llvm-${{ matrix.llvm }}-dev libomp-${{ matrix.llvm }}-dev ninja-build pip clang-${{ matrix.llvm }} flang-${{ matrix.llvm }}
         sudo python3 -m pip install --upgrade pip lit
     - uses: actions/checkout@v4
     - name: generate build system

--- a/enzyme/test/Fortran/CMakeLists.txt
+++ b/enzyme/test/Fortran/CMakeLists.txt
@@ -1,6 +1,7 @@
 message("Building Fortran tests")
 
 add_subdirectory(ForwardMode)
+add_subdirectory(OpenMP)
 add_subdirectory(ReverseMode)
 
 # Run regression and unit tests

--- a/enzyme/test/Fortran/CMakeLists.txt
+++ b/enzyme/test/Fortran/CMakeLists.txt
@@ -1,5 +1,6 @@
 message("Building Fortran tests")
 
+add_subdirectory(BatchMode)
 add_subdirectory(ForwardMode)
 add_subdirectory(OpenMP)
 add_subdirectory(ReverseMode)

--- a/enzyme/test/Fortran/OpenMP/CMakeLists.txt
+++ b/enzyme/test/Fortran/OpenMP/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Run regression and unit tests
+add_lit_testsuite(check-enzyme-fortran-openmp "Running enzyme OpenMP fortran integration tests"
+    ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${ENZYME_TEST_DEPS} LLVMEnzyme-${LLVM_VERSION_MAJOR}
+    ARGS -v
+)
+
+set_target_properties(check-enzyme-fortran-openmp PROPERTIES FOLDER "Tests")

--- a/enzyme/test/Fortran/OpenMP/square_with_bindings_O0.f90
+++ b/enzyme/test/Fortran/OpenMP/square_with_bindings_O0.f90
@@ -1,0 +1,54 @@
+! REQUIRES: fortran
+! UNSUPPORTED: ifx
+! RUN: %fc -flto -O0 -fopenmp -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 -fopenmp %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 -fopenmp %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
+
+! NOTE: This test is only configured to run with the flang compiler at -O0.
+!       For it to work with the ifx compiler we will need to figure out how to
+!       handle the indirection involved in the enzyme_autodiff binding.
+
+program main
+  use enzyme, only: enzyme_const, enzyme_dup, enzyme_autodiff
+  implicit none
+
+  integer, parameter :: n = 4
+  real :: x(n), dx(n)
+  real :: y(n), dy(n)
+  integer :: i
+
+  x(1) = 23.1
+  x(2) = 10.0
+  x(3) = 100.0
+  x(4) = 3.14
+
+  dx(:) = 0.0
+  dy(:) = 1.0
+  call enzyme_autodiff(square, enzyme_const, n, &
+                       enzyme_dup, x, dx, &
+                       enzyme_dup, y, dy)
+
+  write(*,"(f0.2)") dx(1)
+  write(*,"(f0.2)") dx(2)
+  write(*,"(f0.2)") dx(3)
+  write(*,"(f0.2)") dx(4)
+
+contains
+
+  subroutine square(n, x, y)
+    integer, intent(in) :: n
+    real, dimension(n), intent(in) :: x
+    real, dimension(n), intent(out) :: y
+    integer :: i
+    !$omp parallel do
+    do i = 1, n
+      y(i) = x(i)**2
+    end do
+    !$omp end parallel do
+  end subroutine square
+
+end program main
+
+! CHECK: 46.20
+! CHECK-NEXT: 20.00
+! CHECK-NEXT: 200.00
+! CHECK-NEXT: 6.28

--- a/enzyme/test/Fortran/OpenMP/square_with_bindings_O0.f90
+++ b/enzyme/test/Fortran/OpenMP/square_with_bindings_O0.f90
@@ -9,12 +9,17 @@
 
 program main
   use enzyme, only: enzyme_const, enzyme_dup, enzyme_autodiff
+  use omp_lib, only: omp_get_max_threads
   implicit none
 
   integer, parameter :: n = 4
   real :: x(n), dx(n)
   real :: y(n), dy(n)
   integer :: i
+
+  if (omp_get_max_threads() < 2) then
+    error stop "This test requires OMP_NUM_THREADS >= 2"
+  end if
 
   x(1) = 23.1
   x(2) = 10.0

--- a/enzyme/test/Fortran/OpenMP/square_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/OpenMP/square_with_bindings_opt.f90
@@ -1,9 +1,9 @@
 ! REQUIRES: fortran
-! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
-! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
+! RUN: %fc -flto -O1 -fopenmp -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 -fopenmp %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O1 -fopenmp %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
+
+! FIXME: O2 and O3 are omitted: Enzyme crashes in AdjointGenerator::visitOMPCall
+!        at those optimization levels.
 
 program main
   use enzyme, only: enzyme_const, enzyme_dup, enzyme_autodiff

--- a/enzyme/test/Fortran/OpenMP/square_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/OpenMP/square_with_bindings_opt.f90
@@ -7,12 +7,17 @@
 
 program main
   use enzyme, only: enzyme_const, enzyme_dup, enzyme_autodiff
+  use omp_lib, only: omp_get_max_threads
   implicit none
 
   integer, parameter :: n = 4
   real :: x(n), dx(n)
   real :: y(n), dy(n)
   integer :: i
+
+  if (omp_get_max_threads() < 2) then
+    error stop "This test requires OMP_NUM_THREADS >= 2"
+  end if
 
   x(1) = 23.1
   x(2) = 10.0

--- a/enzyme/test/Fortran/OpenMP/square_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/OpenMP/square_with_bindings_opt.f90
@@ -1,0 +1,52 @@
+! REQUIRES: fortran
+! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
+! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
+
+program main
+  use enzyme, only: enzyme_const, enzyme_dup, enzyme_autodiff
+  implicit none
+
+  integer, parameter :: n = 4
+  real :: x(n), dx(n)
+  real :: y(n), dy(n)
+  integer :: i
+
+  x(1) = 23.1
+  x(2) = 10.0
+  x(3) = 100.0
+  x(4) = 3.14
+
+  dx(:) = 0.0
+  dy(:) = 1.0
+  call enzyme_autodiff(square, enzyme_const, n, &
+                       enzyme_dup, x, dx, &
+                       enzyme_dup, y, dy)
+
+  write(*,"(f0.2)") dx(1)
+  write(*,"(f0.2)") dx(2)
+  write(*,"(f0.2)") dx(3)
+  write(*,"(f0.2)") dx(4)
+
+contains
+
+  subroutine square(n, x, y)
+    integer, intent(in) :: n
+    real, dimension(n), intent(in) :: x
+    real, dimension(n), intent(out) :: y
+    integer :: i
+    !$omp parallel do
+    do i = 1, n
+      y(i) = x(i)**2
+    end do
+    !$omp end parallel do
+  end subroutine square
+
+end program main
+
+! CHECK: 46.20
+! CHECK-NEXT: 20.00
+! CHECK-NEXT: 200.00
+! CHECK-NEXT: 6.28

--- a/enzyme/test/Fortran/OpenMP/square_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/OpenMP/square_with_explicit_interface.f90
@@ -1,10 +1,10 @@
 ! REQUIRES: fortran
-! RUN: %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
-! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
-! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
+! RUN: %fc -flto -O0 -fopenmp -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 -fopenmp %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O1 -fopenmp -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 -fopenmp %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 -fopenmp %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
+
+! FIXME: O2 and O3 are omitted: Enzyme crashes in AdjointGenerator::visitOMPCall
+!        at those optimization levels.
 
 module squareOMP
   implicit none

--- a/enzyme/test/Fortran/OpenMP/square_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/OpenMP/square_with_explicit_interface.f90
@@ -1,0 +1,71 @@
+! REQUIRES: fortran
+! RUN: %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
+! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
+
+module squareOMP
+  implicit none
+  public
+  interface
+    subroutine square__enzyme_autodiff(sr, n, x, dx, y, dy)
+      implicit none
+      interface
+        subroutine sr_decal(n, a, b)
+          implicit none
+          integer, value, intent(in) :: n
+          real, intent(in) :: a(n)
+          real, intent(out) :: b(n)
+        end subroutine sr_decal
+      end interface
+      procedure(sr_decal) :: sr
+      integer, value, intent(in) :: n
+      real, intent(in) :: x(n)
+      real, intent(inout) :: dx(n)
+      real, intent(out) :: y(n)
+      real, intent(inout) :: dy(n)
+    end subroutine square__enzyme_autodiff
+  end interface
+contains
+  subroutine square(n, x, y)
+    integer, value, intent(in) :: n
+    real, intent(in) :: x(n)
+    real, intent(out) :: y(n)
+    integer :: i
+    !$omp parallel do
+    do i = 1, n
+      y(i) = x(i)**2
+    end do
+  end subroutine square
+end module squareOMP
+
+program main
+  use squareOMP, only: square, square__enzyme_autodiff
+  implicit none
+
+  integer, parameter :: n = 4
+  real :: x(n), dx(n)
+  real :: y(n), dy(n)
+  integer :: i
+
+  x(1) = 23.1
+  x(2) = 10.0
+  x(3) = 100.0
+  x(4) = 3.14
+
+  dx(:) = 0.0
+  dy(:) = 1.0
+  call square__enzyme_autodiff(square, n, x, dx, y, dy)
+
+  write(*,"(f0.2)") dx(1)
+  write(*,"(f0.2)") dx(2)
+  write(*,"(f0.2)") dx(3)
+  write(*,"(f0.2)") dx(4)
+end program main
+
+! CHECK: 46.20
+! CHECK-NEXT: 20.00
+! CHECK-NEXT: 200.00
+! CHECK-NEXT: 6.28

--- a/enzyme/test/Fortran/OpenMP/square_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/OpenMP/square_with_explicit_interface.f90
@@ -43,12 +43,17 @@ end module squareOMP
 
 program main
   use squareOMP, only: square, square__enzyme_autodiff
+  use omp_lib, only: omp_get_max_threads
   implicit none
 
   integer, parameter :: n = 4
   real :: x(n), dx(n)
   real :: y(n), dy(n)
   integer :: i
+
+  if (omp_get_max_threads() < 2) then
+    error stop "This test requires OMP_NUM_THREADS >= 2"
+  end if
 
   x(1) = 23.1
   x(2) = 10.0

--- a/enzyme/test/Fortran/OpenMP/square_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/OpenMP/square_with_explicit_interface.f90
@@ -10,27 +10,32 @@ module squareOMP
   implicit none
   public
   interface
-    subroutine square__enzyme_autodiff(sr, n, x, dx, y, dy)
+    subroutine square__enzyme_autodiff(sr, n_desc, n, &
+                                       x_desc, x, dx, &
+                                       y_desc, y, dy)
       implicit none
       interface
         subroutine sr_decal(n, a, b)
           implicit none
-          integer, value, intent(in) :: n
+          integer, intent(in) :: n
           real, intent(in) :: a(n)
           real, intent(out) :: b(n)
         end subroutine sr_decal
       end interface
       procedure(sr_decal) :: sr
-      integer, value, intent(in) :: n
+      integer, intent(in) :: n_desc
+      integer, intent(in) :: n
+      integer, intent(in) :: x_desc
       real, intent(in) :: x(n)
       real, intent(inout) :: dx(n)
+      integer, intent(in) :: y_desc
       real, intent(out) :: y(n)
       real, intent(inout) :: dy(n)
     end subroutine square__enzyme_autodiff
   end interface
 contains
   subroutine square(n, x, y)
-    integer, value, intent(in) :: n
+    integer, intent(in) :: n
     real, intent(in) :: x(n)
     real, intent(out) :: y(n)
     integer :: i
@@ -43,6 +48,7 @@ end module squareOMP
 
 program main
   use squareOMP, only: square, square__enzyme_autodiff
+  use enzyme, only: enzyme_const, enzyme_dup
   use omp_lib, only: omp_get_max_threads
   implicit none
 
@@ -62,7 +68,9 @@ program main
 
   dx(:) = 0.0
   dy(:) = 1.0
-  call square__enzyme_autodiff(square, n, x, dx, y, dy)
+  call square__enzyme_autodiff(square, enzyme_const, n, &
+                               enzyme_dup, x, dx, &
+                               enzyme_dup, y, dy)
 
   write(*,"(f0.2)") dx(1)
   write(*,"(f0.2)") dx(2)

--- a/enzyme/test/lit.cfg.py
+++ b/enzyme/test/lit.cfg.py
@@ -46,6 +46,17 @@ path = os.path.pathsep.join((config.llvm_libs_dir,
                               config.environment.get('LD_LIBRARY_PATH','')))
 config.environment['LD_LIBRARY_PATH'] = path
 
+# libomp.so is often installed in an arch-specific subdirectory of the LLVM
+# libs dir (e.g. lib/x86_64-unknown-linux-gnu/).  Add any such subdirectory
+# that contains libomp.so to LD_LIBRARY_PATH so that OpenMP executables built
+# during tests can find the runtime library.
+import glob as _glob
+for _omp_so in _glob.glob(os.path.join(config.llvm_libs_dir, '*/libomp.so')):
+    _omp_dir = os.path.dirname(_omp_so)
+    config.environment['LD_LIBRARY_PATH'] = \
+        _omp_dir + os.pathsep + config.environment['LD_LIBRARY_PATH']
+    break
+
 #tools = ['opt', 'lli', 'clang', 'clang++']
 #llvm_config.add_tool_substitutions(tools, config.llvm_tools_dir)
 


### PR DESCRIPTION
Closes #3065

This PR adds a variant of the `square` example for Fortran+OpenMP.

It loops over the same batch of values in the `BatchMode` test, dispatching to OpenMP, and computes the corresponding derivatives via reverse mode.

Currently, this seems to work fine at `-O0` and `-O1`, but not at `-O2` and `-O3`.

Note that I also enabled the Fortran `BatchMode` tests as I noticed they weren't hooked up in `enzyme/test/Fortran/CMakeLists.txt`.