### PR TITLE
Fix handling of `-O2` and `-O3` for Fortran+OpenMP

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -4553,6 +4553,38 @@ public:
             available[&*subarg] = pre_args[i];
             subarg++;
           }
+          // At optimization levels ≥O2 the compiler may outline the OMP
+          // parallel region in a way that produces intermediate instructions
+          // (loads, GEPs, casts, ...) as tape-store operands rather than bare
+          // captured arguments.  `unwrapM`/`lookupM` require every instruction
+          // it encounters to belong to `gutils->newFunc`, so we pre-populate
+          // `available` with caller-context clones of any such cross-function
+          // instructions before calling `unwrapM`.
+          SmallPtrSet<Value *, 8> remapVisited;
+          std::function<Value *(Value *)> remapFromOutlined;
+          remapFromOutlined = [&](Value *v) -> Value * {
+            if (auto found = available.find(v); found != available.end())
+              return found->second;
+            if (isa<Constant>(v) || isa<BasicBlock>(v) || isa<Function>(v) ||
+                isa<MetadataAsValue>(v) || isa<InlineAsm>(v) ||
+                isa<Argument>(v))
+              return v;
+            auto inst = cast<Instruction>(v);
+            if (inst->getParent()->getParent() == gutils->newFunc)
+              return v;
+            // Guard against cycles (shouldn't occur in SSA, but be safe).
+            if (!remapVisited.insert(v).second)
+              return v;
+            auto newInst = inst->clone();
+            newInst->setName(inst->getName() + ".omprem");
+            for (unsigned i = 0; i < newInst->getNumOperands(); ++i)
+              newInst->setOperand(i, remapFromOutlined(inst->getOperand(i)));
+            BuilderZ.Insert(newInst);
+            available[inst] = newInst;
+            return newInst;
+          };
+          for (auto &gpair : geps)
+            remapFromOutlined(gpair.second);
           for (auto pair : geps) {
             Value *op = pair.second;
             Value *alloc = op;

--- a/enzyme/test/Fortran/OpenMP/square_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/OpenMP/square_with_bindings_opt.f90
@@ -1,9 +1,9 @@
 ! REQUIRES: fortran
 ! RUN: %fc -flto -O1 -fopenmp -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 -fopenmp %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -fopenmp -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O2 -fopenmp %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -fopenmp -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O3 -fopenmp %t.ll -o %t1 && %t1 | FileCheck %s
 ! RUN: %if flangenzyme %{ %fc -O1 -fopenmp %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
-
-! FIXME: O2 and O3 are omitted: Enzyme crashes in AdjointGenerator::visitOMPCall
-!        at those optimization levels.
+! RUN: %if flangenzyme %{ %fc -O2 -fopenmp %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
 
 program main
   use enzyme, only: enzyme_const, enzyme_dup, enzyme_autodiff

--- a/enzyme/test/Fortran/OpenMP/square_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/OpenMP/square_with_explicit_interface.f90
@@ -1,10 +1,10 @@
 ! REQUIRES: fortran
 ! RUN: %fc -flto -O0 -fopenmp -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 -fopenmp %t.ll -o %t1 && %t1 | FileCheck %s
 ! RUN: %fc -flto -O1 -fopenmp -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 -fopenmp %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -fopenmp -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O2 -fopenmp %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -fopenmp -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O3 -fopenmp %t.ll -o %t1 && %t1 | FileCheck %s
 ! RUN: %if flangenzyme %{ %fc -O0 -fopenmp %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
-
-! FIXME: O2 and O3 are omitted: Enzyme crashes in AdjointGenerator::visitOMPCall
-!        at those optimization levels.
+! RUN: %if flangenzyme %{ %fc -O2 -fopenmp %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
 
 module squareOMP
   implicit none


### PR DESCRIPTION
Closes #3161

I admit that this PR is purely AI-generated and that I don't follow all of the logic.

## AI summary:

<details>

### Root cause

In `visitOMPCall` (around line 4548), after cloning the augmented OMP outlined function (`newcalled = CloneFunction(...)`), an `available` map is built that only covers `newcalled`'s **arguments** → caller-context values. At `-O0`/`-O1` the tape store operands happen to be those arguments directly, so `unwrapM` works fine. At `-O2`/`-O3` the optimiser inlines intermediate computations (loads, GEPs, casts over captured arguments) into the outlined function body, so the tape store operands are **instructions inside `newcalled`**. When `unwrapM` recurses through them and eventually calls `lookupM`, that function asserts `inst->getParent()->getParent() == newFunc` — but `inst` is in `newcalled`, not the caller.

### Fix (`AdjointGenerator.h`)

After building `available`, a `remapFromOutlined` lambda recursively walks each tape-store operand's def–use tree. For any instruction that lives in `newcalled` (not in `gutils->newFunc`), it clones the instruction with remapped operands into `BuilderZ`'s context and adds the mapping to `available`. By the time `unwrapM` is called, `available` already contains caller-context versions of all cross-function values, so `lookupM`'s early-exit path (`available.find(val)`) fires before the assertion.

</details>