### PR TITLE
MLIR: never merge identical blocks in the region-inlining sweeps

### DIFF
--- a/enzyme/Enzyme/MLIR/Passes/InlineEnzymeRegions.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/InlineEnzymeRegions.cpp
@@ -424,11 +424,6 @@ struct InlineEnzymeIntoRegion
         &getContext());
 
     GreedyRewriteConfig config;
-    // The default aggressive region simplification merges structurally
-    // identical blocks module-wide -- including a host function's cold
-    // error tails that differ only in constants. LLVM cannot split such
-    // shared tails back apart, and its machine passes then hoist the
-    // merged tail's setup into the hot path.
     config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
     (void)applyPatternsGreedily(getOperation(), std::move(patterns), config);
   }

--- a/enzyme/Enzyme/MLIR/Passes/InlineEnzymeRegions.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/InlineEnzymeRegions.cpp
@@ -424,6 +424,12 @@ struct InlineEnzymeIntoRegion
         &getContext());
 
     GreedyRewriteConfig config;
+    // The default aggressive region simplification merges structurally
+    // identical blocks module-wide -- including a host function's cold
+    // error tails that differ only in constants. LLVM cannot split such
+    // shared tails back apart, and its machine passes then hoist the
+    // merged tail's setup into the hot path.
+    config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
     (void)applyPatternsGreedily(getOperation(), std::move(patterns), config);
   }
 };

--- a/enzyme/Enzyme/MLIR/Passes/RemoveUnusedEnzymeOps.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/RemoveUnusedEnzymeOps.cpp
@@ -378,6 +378,8 @@ static void applyPatterns(Operation *op) {
       op->getContext());
 
   GreedyRewriteConfig config;
+  config.setRegionSimplificationLevel(
+      GreedySimplifyRegionLevel::Normal);
   config.enableFolding();
   (void)applyPatternsGreedily(op, std::move(patterns), config);
 }
@@ -400,6 +402,8 @@ static void applyPatternsToEnzymeOps(Operation *op,
                   SetSimplify, InitSimplify>(op->getContext());
 
   GreedyRewriteConfig config;
+  config.setRegionSimplificationLevel(
+      GreedySimplifyRegionLevel::Normal);
   config.enableFolding();
   if (listener)
     config.setListener(listener);

--- a/enzyme/Enzyme/MLIR/Passes/RemoveUnusedEnzymeOps.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/RemoveUnusedEnzymeOps.cpp
@@ -378,8 +378,7 @@ static void applyPatterns(Operation *op) {
       op->getContext());
 
   GreedyRewriteConfig config;
-  config.setRegionSimplificationLevel(
-      GreedySimplifyRegionLevel::Normal);
+  config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
   config.enableFolding();
   (void)applyPatternsGreedily(op, std::move(patterns), config);
 }
@@ -402,8 +401,7 @@ static void applyPatternsToEnzymeOps(Operation *op,
                   SetSimplify, InitSimplify>(op->getContext());
 
   GreedyRewriteConfig config;
-  config.setRegionSimplificationLevel(
-      GreedySimplifyRegionLevel::Normal);
+  config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
   config.enableFolding();
   if (listener)
     config.setListener(listener);

--- a/enzyme/Enzyme/MLIR/Passes/SimplifyMath.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/SimplifyMath.cpp
@@ -55,8 +55,7 @@ struct MathematicSimplification
     patterns.insert<ApplySimplificationPattern>(&getContext());
 
     GreedyRewriteConfig config;
-    config.setRegionSimplificationLevel(
-        GreedySimplifyRegionLevel::Normal);
+    config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
     config.enableFolding();
     (void)applyPatternsGreedily(getOperation(), std::move(patterns), config);
   };

--- a/enzyme/Enzyme/MLIR/Passes/SimplifyMath.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/SimplifyMath.cpp
@@ -55,6 +55,8 @@ struct MathematicSimplification
     patterns.insert<ApplySimplificationPattern>(&getContext());
 
     GreedyRewriteConfig config;
+    config.setRegionSimplificationLevel(
+        GreedySimplifyRegionLevel::Normal);
     config.enableFolding();
     (void)applyPatternsGreedily(getOperation(), std::move(patterns), config);
   };

--- a/enzyme/Enzyme/MLIR/Passes/SplitMultiResults.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/SplitMultiResults.cpp
@@ -109,6 +109,8 @@ struct SplitMultiResultsPass
     patterns.insert<SplitMultiIf>(&getContext());
 
     GreedyRewriteConfig config;
+    config.setRegionSimplificationLevel(
+        GreedySimplifyRegionLevel::Normal);
     (void)applyPatternsGreedily(getOperation(), std::move(patterns), config);
   }
 };

--- a/enzyme/Enzyme/MLIR/Passes/SplitMultiResults.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/SplitMultiResults.cpp
@@ -109,8 +109,7 @@ struct SplitMultiResultsPass
     patterns.insert<SplitMultiIf>(&getContext());
 
     GreedyRewriteConfig config;
-    config.setRegionSimplificationLevel(
-        GreedySimplifyRegionLevel::Normal);
+    config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
     (void)applyPatternsGreedily(getOperation(), std::move(patterns), config);
   }
 };

--- a/enzyme/test/MLIR/Passes/inline_regions_no_block_merge.mlir
+++ b/enzyme/test/MLIR/Passes/inline_regions_no_block_merge.mlir
@@ -1,0 +1,29 @@
+// RUN: %eopt --inline-enzyme-regions %s | FileCheck %s
+
+// A function with no enzyme regions must pass through untouched: the
+// driver's region simplification must not merge structurally identical
+// blocks that differ only in constants -- LLVM cannot split such shared
+// tails apart again, and its backend hoists the merged tail's setup into
+// the hot path.
+
+llvm.func @use(i64)
+llvm.func @twin_tails(%c: i1) {
+  llvm.cond_br %c, ^bb1, ^bb2
+^bb1:
+  %a = llvm.mlir.constant(27 : i64) : i64
+  llvm.call @use(%a) : (i64) -> ()
+  llvm.br ^bb3
+^bb2:
+  %b = llvm.mlir.constant(20 : i64) : i64
+  llvm.call @use(%b) : (i64) -> ()
+  llvm.br ^bb3
+^bb3:
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @twin_tails
+// CHECK: ^bb1:
+// CHECK-NEXT: llvm.call @use
+// CHECK: ^bb2:
+// CHECK-NEXT: llvm.call @use
+// CHECK: ^bb3:

--- a/enzyme/test/MLIR/ReverseMode/inactive_arg.mlir
+++ b/enzyme/test/MLIR/ReverseMode/inactive_arg.mlir
@@ -19,11 +19,14 @@ module {
 // CHECK-NEXT:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-NEXT:    %[[CACHE:.+]] = "enzyme.init"() : () -> !enzyme.Cache<i32>
 //      CHECK:    %[[COND:.+]] = arith.cmpf ogt, %[[X]], %[[ZERO]] : f32
-//      CHECK:    cf.cond_br %[[COND]], ^bb1(%[[CST0]] : i32), ^bb1(%[[CST1]] : i32)
-//      CHECK:  ^bb1(%[[BLOCKARG:.+]]: i32): // 2 preds: ^bb0, ^bb0
-// CHECK-NEXT:    "enzyme.push"(%[[CACHE]], %[[BLOCKARG]]) : (!enzyme.Cache<i32>, i32) -> ()
-// CHECK-NEXT:    cf.br ^bb2
-//      CHECK:  ^bb2: // pred: ^bb1
+//      CHECK:    cf.cond_br %[[COND]], ^bb1, ^bb2
+//      CHECK:  ^bb1: // pred: ^bb0
+// CHECK-NEXT:    "enzyme.push"(%[[CACHE]], %[[CST0]]) : (!enzyme.Cache<i32>, i32) -> ()
+// CHECK-NEXT:    cf.br ^bb3
+//      CHECK:  ^bb2: // pred: ^bb0
+// CHECK-NEXT:    "enzyme.push"(%[[CACHE]], %[[CST1]]) : (!enzyme.Cache<i32>, i32) -> ()
+// CHECK-NEXT:    cf.br ^bb3
+//      CHECK:  ^bb3: // 2 preds: ^bb1, ^bb2
 //      CHECK:    %[[INCOMING:.+]] = "enzyme.pop"(%[[CACHE]]) : (!enzyme.Cache<i32>) -> i32
 // CHECK-NEXT:    %[[COND2:.+]] = arith.cmpi eq, %[[INCOMING]], %[[CST1]] : i32
 // CHECK-NEXT:    %[[GRAD:.+]] = arith.select %[[COND2]], %[[DIFFE]], %[[ZERO]] : f32


### PR DESCRIPTION
The greedy driver's default aggressive region simplification merges structurally identical blocks module-wide — including a **host** function's cold error tails that differ only in constants (the shape `MFEM_VERIFY`-style macros produce everywhere). `inline-enzyme-regions` was the first merger in the raising pipeline's masking chain (fixing it exposed the same defect in three Enzyme-JAX passes, fixed in EnzymeAD/Enzyme-JAX#2926); the postpass drivers (`SplitMultiResults`, `RemoveUnusedEnzymeOps`, `SimplifyMath`) get the same treatment since they sweep whole AD modules. Same rationale as the canonicalize-parallel precedent, where aggressive merging was already a correctness bug (invoke successor operands).

## Why merging identical blocks loses performance

The merge converts *conditionally-executed* cold code into *unconditionally-paid* hot-path cost:

1. **PHI-of-constants pushes cold setup into hot predecessors.** Merging tails that differ only in constants turns the constants into block arguments — PHIs at LLVM level — whose incoming values must be materialized *in the predecessors*: the hot-path blocks ending in the "did the check fail?" branch. The error-message address, message-length constants, and stream-buffer addresses then execute on the hot path before a branch that is essentially never taken.

2. **Live-across-hot-region values defeat shrink-wrapping.** The hoisted values must survive across the hot region's calls, forcing extra callee-saved registers (three extra pushes measured) and a doubled stack frame; every call pays the fat prologue/epilogue. Cachegrind: +13 instructions per call, +19% total, with branch counts and mispredictions byte-identical — pure extra executed work, not prediction effects.

3. **It is a one-way door.** Undoing the merge is tail duplication, and neither IR-level SimplifyCFG nor machine tail-dup will duplicate blocks containing calls; the PHI-of-constants shape also blocks jump-threading. Clang never merges these in the first place: its heuristics are frequency-aware, while `mergeIdenticalBlocks` is unconditional structural CSE with no frequency model.

Measured end to end on an MFEM-style reproducer: ~10% hot-path tax removed, restoring parity with vanilla clang (frame byte-identical). The merged form is statically smaller but dynamically slower — a code-size transform firing in a performance context the backend cannot undo.

## Validation

MLIR lit test included; bazel lit 1189/1189 on the companion; full MFEM CUDA suite 74/74 with correct numerics on a complete rebuild through the fixed pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD