### PR TITLE
Forward terminator handler: shadow only results the terminator forwards

### DIFF
--- a/enzyme/Enzyme/MLIR/Implementations/CoreDialectsAutoDiffImplementations.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/CoreDialectsAutoDiffImplementations.cpp
@@ -333,15 +333,23 @@ void mlir::enzyme::detail::regionTerminatorForwardHandler(
           successor.isOperation()
               ? parentOp->getResults()
               : regionBranchOp.getSuccessorInputs(successor);
-      assert(operandRange.size() == targetValues.size());
-      for (auto &&[i, target] : llvm::enumerate(targetValues)) {
+      // The parent may carry more results than the terminator forwards to it
+      // (a gpu wrapper's token-like result has no yield operand); only the
+      // paired prefix can be shadowed.
+      size_t numPaired = std::min(operandRange.size(), targetValues.size());
+      for (auto &&[i, target] :
+           llvm::enumerate(targetValues.take_front(numPaired))) {
         if (!gutils->isConstantValue(target))
           operandsToShadow.insert(operandRange.getBeginOperandIndex() + i);
       }
     }
   } else {
-    assert(parentOp->getNumResults() == origTerminator->getNumOperands());
-    for (auto res : parentOp->getResults()) {
+    // The parent may carry more results than its terminator forwards (a gpu
+    // wrapper's token-like result has no yield operand); only the paired
+    // results can be shadowed.
+    size_t numPaired = std::min<size_t>(parentOp->getNumResults(),
+                                        origTerminator->getNumOperands());
+    for (auto res : parentOp->getResults().take_front(numPaired)) {
       if (!gutils->isConstantValue(res))
         operandsToShadow.insert(res.getResultNumber());
     }

--- a/enzyme/Enzyme/MLIR/Implementations/GPUAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/GPUAutoDiffOpInterfaceImpl.cpp
@@ -13,6 +13,7 @@
 
 #include "Implementations/CoreDialectsAutoDiffImplementations.h"
 #include "Interfaces/AutoDiffOpInterface.h"
+#include "Interfaces/GradientUtils.h"
 
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -44,11 +45,31 @@ struct GPUAllocOpInterface
     return isa<gpu::DeallocOp>(user);
   }
 };
+
+struct GPULaunchOpInterface
+    : public AutoDiffOpInterface::ExternalModel<GPULaunchOpInterface,
+                                                gpu::LaunchOp> {
+  LogicalResult createForwardModeTangent(Operation *op, OpBuilder &builder,
+                                         MGradientUtils *gutils) const {
+    // The launch operands (async dependencies, grid/block/cluster sizes,
+    // dynamic shared memory) and the optional token result carry no
+    // tangents; the tangent of a launch is the launch itself with a
+    // differentiated body.
+    for (auto &region : op->getRegions())
+      for (auto &block : region)
+        for (Operation &o : block)
+          if (failed(gutils->visitChild(&o)))
+            return failure();
+    return success();
+  }
+};
 } // namespace
 
 void mlir::enzyme::registerGPUDialectAutoDiffInterface(
     DialectRegistry &registry) {
   registry.addExtension(+[](MLIRContext *context, gpu::GPUDialect *) {
     gpu::AllocOp::attachInterface<GPUAllocOpInterface>(*context);
+    gpu::LaunchOp::attachInterface<GPULaunchOpInterface>(*context);
+    registerAutoDiffUsingRegionTerminatorInterface<gpu::TerminatorOp>(*context);
   });
 }

--- a/enzyme/test/MLIR/ForwardMode/gpulaunch.mlir
+++ b/enzyme/test/MLIR/ForwardMode/gpulaunch.mlir
@@ -1,0 +1,40 @@
+// RUN: %eopt --enzyme %s | FileCheck %s
+
+// An async gpu.launch carries a token result that its gpu.terminator does not
+// forward (the terminator has no operands at all): the terminator handler must
+// only pair the results a terminator operand exists for, not assert on the
+// count mismatch.
+
+module {
+  func.func @square(%x : memref<?xf32>, %y : memref<?xf32>, %n : index) {
+    %c1 = arith.constant 1 : index
+    %t = gpu.launch async blocks(%bx, %by, %bz) in (%gx = %c1, %gy = %c1, %gz = %c1)
+        threads(%tx, %ty, %tz) in (%sx = %n, %sy = %c1, %sz = %c1) {
+      %v = memref.load %x[%tx] : memref<?xf32>
+      %m = arith.mulf %v, %v : f32
+      memref.store %m, %y[%tx] : memref<?xf32>
+      gpu.terminator
+    }
+    return
+  }
+  func.func @dsquare(%x : memref<?xf32>, %dx : memref<?xf32>, %y : memref<?xf32>, %dy : memref<?xf32>, %n : index) {
+    enzyme.fwddiff @square(%x, %dx, %y, %dy, %n) { activity=[#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_dup>, #enzyme<activity enzyme_const>], ret_activity=[] } : (memref<?xf32>, memref<?xf32>, memref<?xf32>, memref<?xf32>, index) -> ()
+    return
+  }
+}
+
+// CHECK: func.func private @fwddiffesquare(%[[x:.+]]: memref<?xf32>, %[[dx:.+]]: memref<?xf32>, %[[y:.+]]: memref<?xf32>, %[[dy:.+]]: memref<?xf32>, %[[n:.+]]: index) {
+// CHECK-NEXT:   %[[c1:.+]] = arith.constant 1 : index
+// CHECK-NEXT:   %[[token:.+]] = gpu.launch async blocks(%[[bx:.+]], %[[by:.+]], %[[bz:.+]]) in (%[[gx:.+]] = %[[c1]], %[[gy:.+]] = %[[c1]], %[[gz:.+]] = %[[c1]]) threads(%[[tx:.+]], %[[ty:.+]], %[[tz:.+]]) in (%[[sx:.+]] = %[[n]], %[[sy:.+]] = %[[c1]], %[[sz:.+]] = %[[c1]]) {
+// CHECK-NEXT:     %[[dv:.+]] = memref.load %[[dx]][%[[tx]]] : memref<?xf32>
+// CHECK-NEXT:     %[[v:.+]] = memref.load %[[x]][%[[tx]]] : memref<?xf32>
+// CHECK-NEXT:     %[[p0:.+]] = arith.mulf %[[dv]], %[[v]] fastmath<fast> : f32
+// CHECK-NEXT:     %[[p1:.+]] = arith.mulf %[[dv]], %[[v]] fastmath<fast> : f32
+// CHECK-NEXT:     %[[dm:.+]] = arith.addf %[[p0]], %[[p1]] fastmath<fast> : f32
+// CHECK-NEXT:     %[[m:.+]] = arith.mulf %[[v]], %[[v]] : f32
+// CHECK-NEXT:     memref.store %[[dm]], %[[dy]][%[[tx]]] : memref<?xf32>
+// CHECK-NEXT:     memref.store %[[m]], %[[y]][%[[tx]]] : memref<?xf32>
+// CHECK-NEXT:     gpu.terminator
+// CHECK-NEXT:   }
+// CHECK-NEXT:   return
+// CHECK-NEXT: }


### PR DESCRIPTION
Fixes the pre-existing `-c dbg` failure of Enzyme-JAX's `diffrules_enzymexla_gpu_wrapper_fwd.mlir`: `regionTerminatorForwardHandler`'s fallback path asserts `parentOp->getNumResults() == origTerminator->getNumOperands()`, but a parent op may legitimately carry more results than its terminator forwards — enzymexla's `gpu_wrapper` yields nothing for its token-like index result. Release builds happened to work (the loop only touched paired results); debug builds aborted. Pair up to the terminator's operand count; unpaired trailing results have nothing to shadow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD