### PR TITLE
Use GlobalVariable::getAlign, which replaced getAlignment

### DIFF
--- a/enzyme/Enzyme/FunctionUtils.cpp
+++ b/enzyme/Enzyme/FunctionUtils.cpp
@@ -2614,8 +2614,8 @@ Function *PreProcessCache::preprocessForClone(Function *F,
               g.getValueType(), g.getType()->getPointerAddressSpace(), nullptr,
               g.getName() + "_local");
 
-          if (g.getAlignment()) {
-            antialloca->setAlignment(Align(g.getAlignment()));
+          if (g.getAlign()) {
+            antialloca->setAlignment(*g.getAlign());
           }
 
           std::map<Constant *, Value *> remap;
@@ -2674,13 +2674,11 @@ Function *PreProcessCache::preprocessForClone(Function *F,
           {
 
             auto cal = bb.CreateCall(intr, args);
-            if (g.getAlignment()) {
-              cal->addParamAttr(
-                  0, Attribute::getWithAlignment(g.getContext(),
-                                                 Align(g.getAlignment())));
-              cal->addParamAttr(
-                  1, Attribute::getWithAlignment(g.getContext(),
-                                                 Align(g.getAlignment())));
+            if (g.getAlign()) {
+              cal->addParamAttr(0, Attribute::getWithAlignment(g.getContext(),
+                                                               *g.getAlign()));
+              cal->addParamAttr(1, Attribute::getWithAlignment(g.getContext(),
+                                                               *g.getAlign()));
             }
           }
 
@@ -2689,13 +2687,11 @@ Function *PreProcessCache::preprocessForClone(Function *F,
           for (ReturnInst *RI : Returns) {
             IRBuilder<> IB(RI);
             auto cal = IB.CreateCall(intr, args);
-            if (g.getAlignment()) {
-              cal->addParamAttr(
-                  0, Attribute::getWithAlignment(g.getContext(),
-                                                 Align(g.getAlignment())));
-              cal->addParamAttr(
-                  1, Attribute::getWithAlignment(g.getContext(),
-                                                 Align(g.getAlignment())));
+            if (g.getAlign()) {
+              cal->addParamAttr(0, Attribute::getWithAlignment(g.getContext(),
+                                                               *g.getAlign()));
+              cal->addParamAttr(1, Attribute::getWithAlignment(g.getContext(),
+                                                               *g.getAlign()));
             }
           }
         }

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -5731,8 +5731,8 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
               AllocaInst *antialloca = bb.CreateAlloca(
                   allocaTy, arg->getType()->getPointerAddressSpace(), nullptr,
                   arg->getName() + "'ipa");
-              if (arg->getAlignment()) {
-                antialloca->setAlignment(Align(arg->getAlignment()));
+              if (arg->getAlign()) {
+                antialloca->setAlignment(*arg->getAlign());
               }
               return antialloca;
             };
@@ -5758,10 +5758,10 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
               Type *tys[] = {dst_arg->getType(), len_arg->getType()};
               auto memset = cast<CallInst>(bb.CreateCall(
                   getIntrinsicDeclaration(M, Intrinsic::memset, tys), args));
-              if (arg->getAlignment()) {
+              if (arg->getAlign()) {
                 memset->addParamAttr(
                     0, Attribute::getWithAlignment(arg->getContext(),
-                                                   Align(arg->getAlignment())));
+                                                   *arg->getAlign()));
               }
               memset->addParamAttr(0, Attribute::NonNull);
               assert((width > 1 && antialloca->getType() ==


### PR DESCRIPTION
LLVM removed `GlobalObject::getAlignment()`, so `FunctionUtils.cpp` and `GradientUtils.cpp` no longer compile against current LLVM:

```
Enzyme/FunctionUtils.cpp:2617:17: error: no member named 'getAlignment' in 'llvm::GlobalVariable'; did you mean 'getAlign'?
```

Its replacement, `getAlign()`, returns a `MaybeAlign`, which is already what these sites want: the guards keep testing for a specified alignment, and the uses take the `Align` out of the optional rather than rebuilding one from an unsigned. Behavior is unchanged.

Found while building Enzyme-JAX against the LLVM that the current XLA pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AyMHG2YuT1uZgr3DY2aeQ