### PR TITLE
MLIR: give the affine atomic an ordering, and lower it to the enzyme one

### DIFF
--- a/enzyme/Enzyme/MLIR/Dialect/EnzymeOps.td
+++ b/enzyme/Enzyme/MLIR/Dialect/EnzymeOps.td
@@ -561,18 +561,16 @@ def AffineAtomicRMWOp : Enzyme_Op<"affine_atomic_rmw", [
 
   let results = (outs AnyType:$result);
 
-  let arguments = (ins
-      AtomicRMWKindAttr:$kind,
+  let arguments = (ins AtomicRMWKindAttr:$kind, AtomicOrdering:$ordering,
       AnyType:$value,
       Arg<AnyMemRef, "the reference to rmw", [MemRead, MemWrite]>:$memref,
-      Variadic<Index>:$indices,
-      AffineMapAttr:$map,
+      Variadic<Index>:$indices, AffineMapAttr:$map,
       OptionalAttr<IntValidAlignment<I64Attr>>:$alignment,
       DefaultValuedAttr<Arith_FastMathAttr,
                         "::mlir::arith::FastMathFlags::none">:$fastmath);
 
   let assemblyFormat = [{
-    $kind $value `,` $memref `,` `(` $map `)` `[` $indices `]`
+    $kind $value `,` $memref `,` `(` $map `)` `[` $indices `]` $ordering
     (`fastmath` `` $fastmath^)? attr-dict `:` `(` type($value) `,`
     type($memref) `)` `->` type($result)
   }];

--- a/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/AffineAutoDiffOpInterfaceImpl.cpp
@@ -908,8 +908,9 @@ struct AffineLoadOpInterfaceReverse
           } else {
             setDerivativeFastMath(enzyme::AffineAtomicRMWOp::create(
                 builder, loadOp.getLoc(), gradient.getType(),
-                arith::AtomicRMWKind::addf, gradient, memrefGradient,
-                retrievedArguments, loadOp.getAffineMap(), alignAttr));
+                arith::AtomicRMWKind::addf, Ordering::monotonic, gradient,
+                memrefGradient, retrievedArguments, loadOp.getAffineMap(),
+                alignAttr));
           }
         }
       }

--- a/enzyme/Enzyme/MLIR/Implementations/EnzymeAutoDiffOpInterfaceImpl.cpp
+++ b/enzyme/Enzyme/MLIR/Implementations/EnzymeAutoDiffOpInterfaceImpl.cpp
@@ -85,10 +85,12 @@ struct AffineAtomicRMWOpInterfaceReverse
     if (!gutils->isConstantValue(rmwOp.getResult())) {
       Value gradient = gutils->diffe(rmwOp.getResult(), builder);
       gutils->zeroDiffe(rmwOp.getResult(), builder);
+      // The adjoint accumulates where the primal did, so it is ordered as
+      // the primal was.
       setDerivativeFastMath(enzyme::AffineAtomicRMWOp::create(
           builder, rmwOp.getLoc(), gradient.getType(),
-          arith::AtomicRMWKind::addf, gradient, memrefGradient,
-          retrievedArguments, rmwOp.getMap(), alignAttr));
+          arith::AtomicRMWKind::addf, rmwOp.getOrdering(), gradient,
+          memrefGradient, retrievedArguments, rmwOp.getMap(), alignAttr));
     }
 
     return success();
@@ -157,8 +159,8 @@ struct AffineAtomicRMWOpForwardInterface
       shadowIndices.push_back(v);
     auto shadowOp = enzyme::AffineAtomicRMWOp::create(
         builder, rmwOp.getLoc(), shadowVal.getType(),
-        arith::AtomicRMWKind::addf, shadowVal, shadowMemref, shadowIndices,
-        rmwOp.getMap(), rmwOp.getAlignmentAttr());
+        arith::AtomicRMWKind::addf, rmwOp.getOrdering(), shadowVal,
+        shadowMemref, shadowIndices, rmwOp.getMap(), rmwOp.getAlignmentAttr());
     shadowOp->setAttr("fastmath", newOp.getFastmathAttr());
     if (!gutils->isConstantValue(rmwOp.getResult()))
       gutils->setDiffe(rmwOp.getResult(), shadowOp.getResult(), builder);

--- a/enzyme/Enzyme/MLIR/Passes/LowerAffineAtomicRmwPass.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/LowerAffineAtomicRmwPass.cpp
@@ -34,11 +34,14 @@ struct LowerAffineAtomicRmwPass
       SmallVector<Value> indices;
       enzyme::computeAffineIndices(builder, rmw.getLoc(), rmw.getMap(),
                                    rmw.getIndices(), indices);
-      rmw.getResult().replaceAllUsesWith(
-          memref::AtomicRMWOp::create(builder, rmw.getLoc(),
-                                      arith::AtomicRMWKind::addf,
-                                      rmw.getValue(), rmw.getMemref(), indices)
-              .getResult());
+      // The enzyme atomic rather than the memref one: it is what carries the
+      // ordering and the alignment this op holds. The kind is the one the op
+      // names, which is not always an accumulation.
+      auto lowered = enzyme::AtomicRMWOp::create(
+          builder, rmw.getLoc(), rmw.getResult().getType(), rmw.getKind(),
+          rmw.getOrdering(), rmw.getValue(), rmw.getMemref(), indices,
+          rmw.getAlignmentAttr(), rmw.getFastmath());
+      rmw.getResult().replaceAllUsesWith(lowered.getResult());
       rmw->erase();
     });
   };

--- a/enzyme/test/MLIR/ForwardMode/affine_atomic_rmw.mlir
+++ b/enzyme/test/MLIR/ForwardMode/affine_atomic_rmw.mlir
@@ -7,7 +7,7 @@ module {
   func.func @f(%a: f64, %m: memref<?xf64>) {
     affine.for %i = 0 to 4 {
       %v = arith.mulf %a, %a : f64
-      %old = "enzyme.affine_atomic_rmw"(%v, %m) <{alignment = 8 : i64, fastmath = #arith.fastmath<fast>, kind = 0 : i64, map = affine_map<() -> (0)>}> : (f64, memref<?xf64>) -> f64
+      %old = "enzyme.affine_atomic_rmw"(%v, %m) <{ordering = 2 : i32, alignment = 8 : i64, fastmath = #arith.fastmath<fast>, kind = 0 : i64, map = affine_map<() -> (0)>}> : (f64, memref<?xf64>) -> f64
     }
     return
   }
@@ -21,5 +21,5 @@ module {
 // CHECK: %[[t1:.+]] = arith.mulf %[[da]], %[[a]] fastmath<fast> : f64
 // CHECK: %[[dv:.+]] = arith.addf %[[t0]], %[[t1]] fastmath<fast> : f64
 // CHECK: %[[v:.+]] = arith.mulf %[[a]], %[[a]] : f64
-// CHECK-DAG: enzyme.affine_atomic_rmw addf %[[dv]], %[[dm]], (#[[$MAP]]) [] fastmath<fast> {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64
-// CHECK-DAG: enzyme.affine_atomic_rmw addf %[[v]], %[[m]], (#[[$MAP]]) [] fastmath<fast> {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64
+// CHECK-DAG: enzyme.affine_atomic_rmw addf %[[dv]], %[[dm]], (#[[$MAP]]) [] monotonic fastmath<fast> {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64
+// CHECK-DAG: enzyme.affine_atomic_rmw addf %[[v]], %[[m]], (#[[$MAP]]) [] monotonic fastmath<fast> {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64

--- a/enzyme/test/MLIR/Passes/atomic_rmw_zero.mlir
+++ b/enzyme/test/MLIR/Passes/atomic_rmw_zero.mlir
@@ -28,7 +28,7 @@ func.func @used(%m: memref<4xf64>, %i: index) -> f64 {
 
 func.func @affine_used(%m: memref<4xf64>, %i: index) -> f64 {
   %z = arith.constant 0.000000e+00 : f64
-  %0 = enzyme.affine_atomic_rmw addf %z, %m, (affine_map<(d0) -> (d0)>)[%i] fastmath<fast> : (f64, memref<4xf64>) -> f64
+  %0 = enzyme.affine_atomic_rmw addf %z, %m, (affine_map<(d0) -> (d0)>)[%i] monotonic fastmath<fast> : (f64, memref<4xf64>) -> f64
   return %0 : f64
 }
 

--- a/enzyme/test/MLIR/Passes/lower_affine_atomic_rmw.mlir
+++ b/enzyme/test/MLIR/Passes/lower_affine_atomic_rmw.mlir
@@ -4,7 +4,7 @@
 module {
   func.func @affine2(%arg0: f32, %arg2: memref<?xf32>) {
     affine.parallel (%arg5) = (0) to (4) {
-      %5 = enzyme.affine_atomic_rmw addf %arg0, %arg2, (#map) [%arg5] : (f32, memref<?xf32>) -> f32
+      %5 = enzyme.affine_atomic_rmw addf %arg0, %arg2, (#map) [%arg5] monotonic : (f32, memref<?xf32>) -> f32
       affine.yield
     }
     return
@@ -17,7 +17,7 @@ module {
 // CHECK-SAME:      %[[ARG1:.*]]: memref<?xf32>) {
 // CHECK:           affine.parallel (%[[VAL_0:.*]]) = (0) to (4) {
 // CHECK:             %[[APPLY_0:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_0]])
-// CHECK:             %[[ATOMIC_RMW_0:.*]] = memref.atomic_rmw addf %[[ARG0]], %[[ARG1]]{{\[}}%[[APPLY_0]]] : (f32, memref<?xf32>) -> f32
+// CHECK:             %[[ATOMIC_RMW_0:.*]] = enzyme.atomic_rmw addf %[[ARG0]], %[[ARG1]]{{\[}}%[[APPLY_0]]] monotonic : (f32, memref<?xf32>) -> f32
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }

--- a/enzyme/test/MLIR/ReverseMode/affine_atomic.mlir
+++ b/enzyme/test/MLIR/ReverseMode/affine_atomic.mlir
@@ -34,7 +34,7 @@ module {
 // CHECK:             affine.store %[[CONSTANT_0]], %[[ARG4]][0] : memref<?xf32>
 // CHECK:             %[[MULF_1:.*]] = arith.mulf %[[LOAD_2]], %[[ARG0]] fastmath<fast> : f32
 // CHECK:             %[[MULF_2:.*]] = arith.mulf %[[LOAD_2]], %[[LOAD_1]] fastmath<fast> : f32
-// CHECK:             %[[AFFINE_ATOMIC_RMW_0:.*]] = enzyme.affine_atomic_rmw addf %[[MULF_1]], %[[ARG2]], (#[[$ATTR_0]]) [] fastmath<fast> : (f32, memref<?xf32>) -> f32
+// CHECK:             %[[AFFINE_ATOMIC_RMW_0:.*]] = enzyme.affine_atomic_rmw addf %[[MULF_1]], %[[ARG2]], (#[[$ATTR_0]]) [] monotonic fastmath<fast> : (f32, memref<?xf32>) -> f32
 // CHECK:             affine.yield %[[MULF_2]] : f32
 // CHECK:           }
 // CHECK:           memref.dealloc %[[ALLOC_0]] : memref<1xf32>

--- a/enzyme/test/MLIR/ReverseMode/affine_atomic_rmw.mlir
+++ b/enzyme/test/MLIR/ReverseMode/affine_atomic_rmw.mlir
@@ -11,7 +11,7 @@ module {
   func.func @f(%a: f64, %m: memref<?xf64>) {
     affine.parallel (%i) = (0) to (4) {
       %v = arith.mulf %a, %a : f64
-      %old = "enzyme.affine_atomic_rmw"(%v, %m) <{alignment = 8 : i64, fastmath = #arith.fastmath<fast>, kind = 0 : i64, map = affine_map<() -> (0)>}> : (f64, memref<?xf64>) -> f64
+      %old = "enzyme.affine_atomic_rmw"(%v, %m) <{ordering = 2 : i32, alignment = 8 : i64, fastmath = #arith.fastmath<fast>, kind = 0 : i64, map = affine_map<() -> (0)>}> : (f64, memref<?xf64>) -> f64
     }
     return
   }
@@ -22,7 +22,7 @@ module {
 // CHECK-SAME: %[[a:.+]]: f64, %[[m:[^ :]+]]: memref<?xf64>, %[[dm:[^ :]+]]: memref<?xf64>) -> f64
 // CHECK: %[[sq:.+]] = arith.mulf %[[a]], %[[a]] : f64
 // CHECK: affine.parallel
-// CHECK: enzyme.affine_atomic_rmw addf %[[sq]], %[[m]], (#[[$MAP]]) [] fastmath<fast> {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64
+// CHECK: enzyme.affine_atomic_rmw addf %[[sq]], %[[m]], (#[[$MAP]]) [] monotonic fastmath<fast> {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64
 // CHECK: %[[red:.+]] = affine.parallel (%{{.+}}) = (0) to (4) reduce ("addf") -> (f64)
 // CHECK: %[[g:.+]] = affine.load %[[dm]][0] {alignment = 8 : i64} : memref<?xf64>
 // CHECK: %[[t0:.+]] = arith.mulf %[[g]], %[[a]] fastmath<fast> : f64


### PR DESCRIPTION
`enzyme.affine_atomic_rmw` named no ordering. An atomic that carried one — `seq_cst`, say — lost it the moment its address became a map, silently, because the op had nowhere to keep it. Give it the same `AtomicOrdering` the non-affine `enzyme.atomic_rmw` already has:

```mlir
%0 = enzyme.affine_atomic_rmw addf %v, %m, (#map) [%i] seq_cst {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64
```

**The lowering dropped it too**, by going to `memref.atomic_rmw`, which has nowhere to put an ordering either. It now lowers to `enzyme.atomic_rmw`, which does, and carries the alignment and fastmath across with it.

**And it lowered every atomic as `addf`.** The kind was hardcoded, so an `addi` or a `maximumf` came out a floating add — a miscompile for any atomic that was not a float accumulation. It now lowers the kind the op names.

Both derivatives of the op are ordered as the primal was: the adjoint accumulates where the primal accumulated, and the forward shadow does what the primal does on the shadow buffer. The gradient accumulations built for *loads* keep `monotonic` — a load has no ordering to carry.

**Downstream:** the attribute is required, matching `enzyme.atomic_rmw`, so Enzyme-JAX's `raiseAtomicRMW` needs a one-line change to pass one — `rmw.getOrdering()` where it converts the enzyme atomic, `monotonic` where it converts the memref one. I have that change ready to go alongside the pin bump.

Verified by building Enzyme-JAX against this branch (`OVERRIDE_ENZYME_PATH`): with it, `seq_cst` survives `affine-cfg`, where before the op came out with no ordering at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
