### PR TITLE
BLAS: add rules for cblas_?dotc_sub and cblas_?dotu_sub

### DIFF
--- a/enzyme/Enzyme/BlasDerivatives.td
+++ b/enzyme/Enzyme/BlasDerivatives.td
@@ -12,6 +12,9 @@ def len   : BLASType<1, 0>; // num of elements
 def hbw   : BLASType<1, 0>; // half matrix-bandwith}
 def bw    : BLASType<1, 0>; // matrix-bandwith}
 def fp    : BLASType<1, 1>;  // floating point
+// pointer through which a scalar fp result is returned, taking the place of
+// the return value (e.g. the last arg of cblas_zdotc_sub)
+def fpret : BLASType<1, 1>;
 
 // packed array of size ( n * (n  + 1) / 2 )
 class ap<list<string> _args> : BLASType<1, 1> {
@@ -48,6 +51,8 @@ class CallBlasPattern<dag patternToMatch, list<string> mutables, list<BLASType> 
   list<dag> ArgDerivatives = resultOps;
   list<string> mutable = mutables;
   dag ArgDuals = forwardOps;
+  // Whether the reverse-mode rules are valid for complex (c, z) inputs.
+  bit supportsComplex = 0;
 }
 
 
@@ -56,6 +61,7 @@ def Rows : MagicInst; // given a transpose, normal rows, normal cols get the tru
 def Concat : MagicInst;
 
 def ShadowNoInc : MagicInst;
+def BConj : MagicInst; // complex conjugate of an fp scalar (identity for reals)
 
 class Binop<string _s, list<string> _tys> {
   string s = _s;
@@ -244,6 +250,38 @@ def dot : CallBlasPattern<(Op $n, $x, $incx, $y, $incy),
                   ],
                   (FAdd<""> (BlasCall<"dot"> $n, (Shadow $x), $y), (BlasCall<"dot"> $n, $x, (Shadow $y)))
                   >;
+
+// res = x^H * y = sum(conj(x_i) * y_i), written through the res pointer
+// (the cblas `_sub` calling convention used for the complex dot products).
+// REV: dx += conj(dres) * y ; dy += dres * x
+// FWD: dres = dotc(dx, y) + dotc(x, dy)
+def dotc_sub : CallBlasPattern<(Op $n, $x, $incx, $y, $incy, $res),
+                  ["res"],[len, vinc<["n"]>, vinc<["n"]>, fpret],
+                  [
+                  (BlasCall<"axpy"> $n, (BConj DiffeRet), $y, (Shadow $x)),
+                  (BlasCall<"axpy"> $n, DiffeRet, $x, (Shadow $y)),
+                  (InactiveArg) // res is overwritten; its shadow is consumed as DiffeRet
+                  ],
+                  (FAdd<""> (BlasCall<"dotc_sub"> $n, (Shadow $x), $y), (BlasCall<"dotc_sub"> $n, $x, (Shadow $y)))
+                  > {
+  let supportsComplex = 1;
+}
+
+// res = x^T * y = sum(x_i * y_i), written through the res pointer
+// (unconjugated complex dot product, cblas `_sub` calling convention).
+// REV: dx += dres * y ; dy += dres * x
+// FWD: dres = dotu(dx, y) + dotu(x, dy)
+def dotu_sub : CallBlasPattern<(Op $n, $x, $incx, $y, $incy, $res),
+                  ["res"],[len, vinc<["n"]>, vinc<["n"]>, fpret],
+                  [
+                  (BlasCall<"axpy"> $n, DiffeRet, $y, (Shadow $x)),
+                  (BlasCall<"axpy"> $n, DiffeRet, $x, (Shadow $y)),
+                  (InactiveArg) // res is overwritten; its shadow is consumed as DiffeRet
+                  ],
+                  (FAdd<""> (BlasCall<"dotu_sub"> $n, (Shadow $x), $y), (BlasCall<"dotu_sub"> $n, $x, (Shadow $y)))
+                  > {
+  let supportsComplex = 1;
+}
 
 def nrm2 : CallBlasPattern<(Op $n, $x, $incx),
                   [],[len, vinc<["n"]>],

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -3695,9 +3695,10 @@ llvm::Optional<BlasInfo> extractBLAS(llvm::StringRef in)
 #endif
 {
   const char *extractable[] = {
-      "dot",   "scal",  "axpy",  "gemv",  "gemm",  "spmv", "syrk",  "nrm2",
-      "trmm",  "trmv",  "symm",  "potrf", "potrs", "copy", "spmv",  "syr2k",
-      "potrs", "getrf", "getrs", "trtrs", "getri", "symv", "lacpy", "trsv",
+      "dot",  "scal",  "axpy",  "gemv",     "gemm",  "spmv",  "syrk",
+      "nrm2", "trmm",  "trmv",  "symm",     "potrf", "potrs", "copy",
+      "spmv", "syr2k", "potrs", "getrf",    "getrs", "trtrs", "getri",
+      "symv", "lacpy", "trsv",  "dotc_sub", "dotu_sub",
   };
   const char *floatType[] = {"s", "d", "c", "z"};
   const char *prefixes[] = {"" /*Fortran*/, "cblas_"};
@@ -4215,6 +4216,42 @@ llvm::Value *load_if_ref(llvm::IRBuilder<> &B, llvm::Type *intType,
         V, getPointerType(intType,
                           cast<PointerType>(V->getType())->getAddressSpace()));
   return B.CreateLoad(intType, V);
+}
+
+llvm::Value *complex_conjugate(llvm::IRBuilder<> &B, llvm::Value *V) {
+  auto VT = dyn_cast<VectorType>(V->getType());
+  if (!VT)
+    return V;
+  assert(VT->getElementCount().getKnownMinValue() == 2 &&
+         "complex blas scalars are 2-element vectors");
+  Value *im = B.CreateExtractElement(V, (uint64_t)1);
+  return B.CreateInsertElement(V, B.CreateFNeg(im), (uint64_t)1);
+}
+
+static llvm::Value *blas_scalar_ptr(llvm::IRBuilder<> &B, llvm::Type *fpType,
+                                    llvm::Value *ptr) {
+  if (ptr->getType()->isIntegerTy())
+    return B.CreateIntToPtr(ptr, getUnqual(fpType));
+  return B.CreatePointerCast(
+      ptr, getPointerType(
+               fpType, cast<PointerType>(ptr->getType())->getAddressSpace()));
+}
+
+static llvm::Align blas_scalar_align(llvm::IRBuilder<> &B, llvm::Type *fpType) {
+  auto &DL = B.GetInsertBlock()->getModule()->getDataLayout();
+  return DL.getABITypeAlign(fpType->getScalarType());
+}
+
+llvm::Value *load_blas_scalar(llvm::IRBuilder<> &B, llvm::Type *fpType,
+                              llvm::Value *ptr) {
+  return B.CreateAlignedLoad(fpType, blas_scalar_ptr(B, fpType, ptr),
+                             blas_scalar_align(B, fpType));
+}
+
+void store_blas_scalar(llvm::IRBuilder<> &B, llvm::Type *fpType,
+                       llvm::Value *ptr, llvm::Value *val) {
+  B.CreateAlignedStore(val, blas_scalar_ptr(B, fpType, ptr),
+                       blas_scalar_align(B, fpType));
 }
 
 SmallVector<llvm::Value *, 1> get_blas_row(llvm::IRBuilder<> &B,

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -2323,6 +2323,19 @@ void addValueToCache(llvm::Value *arg, bool cache_arg, llvm::Type *ty,
 llvm::Value *load_if_ref(llvm::IRBuilder<> &B, llvm::Type *intType,
                          llvm::Value *V, bool byRef);
 
+/// Complex conjugate of a blas scalar: complex values are represented as
+/// 2-element fp vectors, real values are returned unchanged.
+llvm::Value *complex_conjugate(llvm::IRBuilder<> &B, llvm::Value *V);
+
+/// Load/store a blas scalar of type fpType through a pointer argument, which
+/// may be passed as an integer (julia) or as a pointer to another element
+/// type. Complex scalars are only assumed to be aligned to their component
+/// type, like the C/Fortran complex types they represent.
+llvm::Value *load_blas_scalar(llvm::IRBuilder<> &B, llvm::Type *fpType,
+                              llvm::Value *ptr);
+void store_blas_scalar(llvm::IRBuilder<> &B, llvm::Type *fpType,
+                       llvm::Value *ptr, llvm::Value *val);
+
 void copy_lower_to_upper(llvm::IRBuilder<> &B, llvm::Type *fpType,
                          BlasInfo blas, bool byRef, llvm::Value *layout,
                          llvm::Value *uplo, llvm::Value *A, llvm::Value *lda,

--- a/enzyme/test/Enzyme/ForwardMode/blas/cblas_zdotc_sub64_.ll
+++ b/enzyme/test/Enzyme/ForwardMode/blas/cblas_zdotc_sub64_.ll
@@ -1,0 +1,87 @@
+; RUN: %opt < %s %newLoadEnzyme -passes="enzyme,function(mem2reg,instsimplify,%simplifycfg)" -enzyme-preopt=false -enzyme-detect-readthrow=0 -S | FileCheck %s
+
+; Complex conjugated dot product, result returned through the last pointer arg.
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare dso_local <2 x double> @__enzyme_fwddiff(...)
+
+declare void @cblas_zdotc_sub64_(i64, <2 x double>*, i64, <2 x double>*, i64, <2 x double>*)
+
+define <2 x double> @active(i64 %len, <2 x double>* noalias %m, <2 x double>* %dm, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn) {
+entry:
+  %r = call <2 x double> (...) @__enzyme_fwddiff(<2 x double> (i64, <2 x double>*, i64, <2 x double>*, i64)* @f, i64 %len, <2 x double>* noalias %m, <2 x double>* %dm, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn)
+  ret <2 x double> %r
+}
+
+define <2 x double> @inactiveFirst(i64 %len, <2 x double>* noalias %m, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn) {
+entry:
+  %r = call <2 x double> (...) @__enzyme_fwddiff(<2 x double> (i64, <2 x double>*, i64, <2 x double>*, i64)* @f, i64 %len, metadata !"enzyme_const", <2 x double>* noalias %m, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn)
+  ret <2 x double> %r
+}
+
+define <2 x double> @inactiveSecond(i64 %len, <2 x double>* noalias %m, <2 x double>* noalias %dm, i64 %incm, <2 x double>* noalias %n, i64 %incn) {
+entry:
+  %r = call <2 x double> (...) @__enzyme_fwddiff(<2 x double> (i64, <2 x double>*, i64, <2 x double>*, i64)* @f, i64 %len, <2 x double>* noalias %m, <2 x double>* noalias %dm, i64 %incm, metadata !"enzyme_const", <2 x double>* noalias %n, i64 %incn)
+  ret <2 x double> %r
+}
+
+define <2 x double> @f(i64 %len, <2 x double>* noalias %m, i64 %incm, <2 x double>* noalias %n, i64 %incn) {
+entry:
+  %res = alloca <2 x double>, align 8
+  call void @cblas_zdotc_sub64_(i64 %len, <2 x double>* %m, i64 %incm, <2 x double>* %n, i64 %incn, <2 x double>* %res)
+  %r = load <2 x double>, <2 x double>* %res, align 8
+  ret <2 x double> %r
+}
+
+; COM: Pointer types and capture attributes are matched loosely since their
+; COM: spelling depends on the llvm version.
+; CHECK: declare void @cblas_zdotc_sub64_(i64 "enzyme_inactive", [[PTR:(<2 x double>\*|ptr)]] {{(nocapture readonly|readonly captures\(none\))}}, i64 "enzyme_inactive", [[PTR]] {{(nocapture readonly|readonly captures\(none\))}}, i64 "enzyme_inactive", [[PTR]] {{(nocapture|captures\(none\))}})
+
+; CHECK: define <2 x double> @active
+; CHECK-NEXT: entry
+; CHECK-NEXT: call fast <2 x double> @[[active:[^(]+]](
+
+; CHECK: define <2 x double> @inactiveFirst
+; CHECK-NEXT: entry
+; CHECK-NEXT: call fast <2 x double> @[[inactiveFirst:[^(]+]](
+
+; CHECK: define <2 x double> @inactiveSecond
+; CHECK-NEXT: entry
+; CHECK-NEXT: call fast <2 x double> @[[inactiveSecond:[^(]+]](
+
+; COM: dres = dotc(dx, y) + dotc(x, dy), written to the shadow of res (promoted by mem2reg)
+; CHECK: define internal <2 x double> @[[active]](i64 %len, [[PTR]] noalias %m, [[PTR]] %"m'", i64 %incm, [[PTR]] noalias %n, [[PTR]] %"n'", i64 %incn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %dotc_sub.ret = alloca <2 x double>, align 16
+; CHECK-NEXT:   %dotc_sub.ret1 = alloca <2 x double>, align 16
+; CHECK-NEXT:   %res = alloca <2 x double>, align 8
+; CHECK-NEXT:   call void @cblas_zdotc_sub64_(i64 %len, [[PTR]] %"m'", i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %dotc_sub.ret)
+; CHECK-NEXT:   %0 = load <2 x double>, [[PTR]] %dotc_sub.ret, align 16
+; CHECK-NEXT:   call void @cblas_zdotc_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %"n'", i64 %incn, [[PTR]] %dotc_sub.ret1)
+; CHECK-NEXT:   %1 = load <2 x double>, [[PTR]] %dotc_sub.ret1, align 16
+; CHECK-NEXT:   %2 = fadd fast <2 x double> %0, %1
+; CHECK-NEXT:   call void @cblas_zdotc_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %res)
+; CHECK-NEXT:   ret <2 x double> %2
+; CHECK-NEXT: }
+
+; CHECK: define internal <2 x double> @[[inactiveFirst]](i64 %len, [[PTR]] noalias %m, i64 %incm, [[PTR]] noalias %n, [[PTR]] %"n'", i64 %incn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %dotc_sub.ret = alloca <2 x double>, align 16
+; CHECK-NEXT:   %res = alloca <2 x double>, align 8
+; CHECK-NEXT:   call void @cblas_zdotc_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %"n'", i64 %incn, [[PTR]] %dotc_sub.ret)
+; CHECK-NEXT:   %0 = load <2 x double>, [[PTR]] %dotc_sub.ret, align 16
+; CHECK-NEXT:   call void @cblas_zdotc_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %res)
+; CHECK-NEXT:   ret <2 x double> %0
+; CHECK-NEXT: }
+
+; CHECK: define internal <2 x double> @[[inactiveSecond]](i64 %len, [[PTR]] noalias %m, [[PTR]] %"m'", i64 %incm, [[PTR]] noalias %n, i64 %incn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %dotc_sub.ret = alloca <2 x double>, align 16
+; CHECK-NEXT:   %res = alloca <2 x double>, align 8
+; CHECK-NEXT:   call void @cblas_zdotc_sub64_(i64 %len, [[PTR]] %"m'", i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %dotc_sub.ret)
+; CHECK-NEXT:   %0 = load <2 x double>, [[PTR]] %dotc_sub.ret, align 16
+; CHECK-NEXT:   call void @cblas_zdotc_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %res)
+; CHECK-NEXT:   ret <2 x double> %0
+; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ForwardMode/blas/cblas_zdotu_sub64_.ll
+++ b/enzyme/test/Enzyme/ForwardMode/blas/cblas_zdotu_sub64_.ll
@@ -1,0 +1,87 @@
+; RUN: %opt < %s %newLoadEnzyme -passes="enzyme,function(mem2reg,instsimplify,%simplifycfg)" -enzyme-preopt=false -enzyme-detect-readthrow=0 -S | FileCheck %s
+
+; Complex unconjugated dot product, result returned through the last pointer arg.
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare dso_local <2 x double> @__enzyme_fwddiff(...)
+
+declare void @cblas_zdotu_sub64_(i64, <2 x double>*, i64, <2 x double>*, i64, <2 x double>*)
+
+define <2 x double> @active(i64 %len, <2 x double>* noalias %m, <2 x double>* %dm, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn) {
+entry:
+  %r = call <2 x double> (...) @__enzyme_fwddiff(<2 x double> (i64, <2 x double>*, i64, <2 x double>*, i64)* @f, i64 %len, <2 x double>* noalias %m, <2 x double>* %dm, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn)
+  ret <2 x double> %r
+}
+
+define <2 x double> @inactiveFirst(i64 %len, <2 x double>* noalias %m, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn) {
+entry:
+  %r = call <2 x double> (...) @__enzyme_fwddiff(<2 x double> (i64, <2 x double>*, i64, <2 x double>*, i64)* @f, i64 %len, metadata !"enzyme_const", <2 x double>* noalias %m, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn)
+  ret <2 x double> %r
+}
+
+define <2 x double> @inactiveSecond(i64 %len, <2 x double>* noalias %m, <2 x double>* noalias %dm, i64 %incm, <2 x double>* noalias %n, i64 %incn) {
+entry:
+  %r = call <2 x double> (...) @__enzyme_fwddiff(<2 x double> (i64, <2 x double>*, i64, <2 x double>*, i64)* @f, i64 %len, <2 x double>* noalias %m, <2 x double>* noalias %dm, i64 %incm, metadata !"enzyme_const", <2 x double>* noalias %n, i64 %incn)
+  ret <2 x double> %r
+}
+
+define <2 x double> @f(i64 %len, <2 x double>* noalias %m, i64 %incm, <2 x double>* noalias %n, i64 %incn) {
+entry:
+  %res = alloca <2 x double>, align 8
+  call void @cblas_zdotu_sub64_(i64 %len, <2 x double>* %m, i64 %incm, <2 x double>* %n, i64 %incn, <2 x double>* %res)
+  %r = load <2 x double>, <2 x double>* %res, align 8
+  ret <2 x double> %r
+}
+
+; COM: Pointer types and capture attributes are matched loosely since their
+; COM: spelling depends on the llvm version.
+; CHECK: declare void @cblas_zdotu_sub64_(i64 "enzyme_inactive", [[PTR:(<2 x double>\*|ptr)]] {{(nocapture readonly|readonly captures\(none\))}}, i64 "enzyme_inactive", [[PTR]] {{(nocapture readonly|readonly captures\(none\))}}, i64 "enzyme_inactive", [[PTR]] {{(nocapture|captures\(none\))}})
+
+; CHECK: define <2 x double> @active
+; CHECK-NEXT: entry
+; CHECK-NEXT: call fast <2 x double> @[[active:[^(]+]](
+
+; CHECK: define <2 x double> @inactiveFirst
+; CHECK-NEXT: entry
+; CHECK-NEXT: call fast <2 x double> @[[inactiveFirst:[^(]+]](
+
+; CHECK: define <2 x double> @inactiveSecond
+; CHECK-NEXT: entry
+; CHECK-NEXT: call fast <2 x double> @[[inactiveSecond:[^(]+]](
+
+; COM: dres = dotu(dx, y) + dotu(x, dy), written to the shadow of res (promoted by mem2reg)
+; CHECK: define internal <2 x double> @[[active]](i64 %len, [[PTR]] noalias %m, [[PTR]] %"m'", i64 %incm, [[PTR]] noalias %n, [[PTR]] %"n'", i64 %incn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %dotu_sub.ret = alloca <2 x double>, align 16
+; CHECK-NEXT:   %dotu_sub.ret1 = alloca <2 x double>, align 16
+; CHECK-NEXT:   %res = alloca <2 x double>, align 8
+; CHECK-NEXT:   call void @cblas_zdotu_sub64_(i64 %len, [[PTR]] %"m'", i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %dotu_sub.ret)
+; CHECK-NEXT:   %0 = load <2 x double>, [[PTR]] %dotu_sub.ret, align 16
+; CHECK-NEXT:   call void @cblas_zdotu_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %"n'", i64 %incn, [[PTR]] %dotu_sub.ret1)
+; CHECK-NEXT:   %1 = load <2 x double>, [[PTR]] %dotu_sub.ret1, align 16
+; CHECK-NEXT:   %2 = fadd fast <2 x double> %0, %1
+; CHECK-NEXT:   call void @cblas_zdotu_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %res)
+; CHECK-NEXT:   ret <2 x double> %2
+; CHECK-NEXT: }
+
+; CHECK: define internal <2 x double> @[[inactiveFirst]](i64 %len, [[PTR]] noalias %m, i64 %incm, [[PTR]] noalias %n, [[PTR]] %"n'", i64 %incn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %dotu_sub.ret = alloca <2 x double>, align 16
+; CHECK-NEXT:   %res = alloca <2 x double>, align 8
+; CHECK-NEXT:   call void @cblas_zdotu_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %"n'", i64 %incn, [[PTR]] %dotu_sub.ret)
+; CHECK-NEXT:   %0 = load <2 x double>, [[PTR]] %dotu_sub.ret, align 16
+; CHECK-NEXT:   call void @cblas_zdotu_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %res)
+; CHECK-NEXT:   ret <2 x double> %0
+; CHECK-NEXT: }
+
+; CHECK: define internal <2 x double> @[[inactiveSecond]](i64 %len, [[PTR]] noalias %m, [[PTR]] %"m'", i64 %incm, [[PTR]] noalias %n, i64 %incn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %dotu_sub.ret = alloca <2 x double>, align 16
+; CHECK-NEXT:   %res = alloca <2 x double>, align 8
+; CHECK-NEXT:   call void @cblas_zdotu_sub64_(i64 %len, [[PTR]] %"m'", i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %dotu_sub.ret)
+; CHECK-NEXT:   %0 = load <2 x double>, [[PTR]] %dotu_sub.ret, align 16
+; CHECK-NEXT:   call void @cblas_zdotu_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %res)
+; CHECK-NEXT:   ret <2 x double> %0
+; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ReverseMode/blas/cblas_zdotc_sub64_.ll
+++ b/enzyme/test/Enzyme/ReverseMode/blas/cblas_zdotc_sub64_.ll
@@ -1,0 +1,160 @@
+;RUN: %opt < %s %newLoadEnzyme -passes="enzyme,function(mem2reg,instsimplify,%simplifycfg)" -S -enzyme-detect-readthrow=0 | FileCheck %s
+
+; Complex conjugated dot product, result returned through the last pointer arg.
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare dso_local void @__enzyme_autodiff(...)
+
+declare void @cblas_zdotc_sub64_(i64, <2 x double>*, i64, <2 x double>*, i64, <2 x double>*)
+
+define void @active(i64 %len, <2 x double>* noalias %m, <2 x double>* %dm, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn) {
+entry:
+  call void (...) @__enzyme_autodiff(<2 x double> (i64, <2 x double>*, i64, <2 x double>*, i64)* @f, i64 %len, <2 x double>* noalias %m, <2 x double>* %dm, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn)
+  ret void
+}
+
+define void @inactiveFirst(i64 %len, <2 x double>* noalias %m, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn) {
+entry:
+  call void (...) @__enzyme_autodiff(<2 x double> (i64, <2 x double>*, i64, <2 x double>*, i64)* @f, i64 %len, metadata !"enzyme_const", <2 x double>* noalias %m, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn)
+  ret void
+}
+
+define void @inactiveSecond(i64 %len, <2 x double>* noalias %m, <2 x double>* noalias %dm, i64 %incm, <2 x double>* noalias %n, i64 %incn) {
+entry:
+  call void (...) @__enzyme_autodiff(<2 x double> (i64, <2 x double>*, i64, <2 x double>*, i64)* @f, i64 %len, <2 x double>* noalias %m, <2 x double>* noalias %dm, i64 %incm, metadata !"enzyme_const", <2 x double>* noalias %n, i64 %incn)
+  ret void
+}
+
+define void @activeMod(i64 %len, <2 x double>* noalias %m, <2 x double>* %dm, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn) {
+entry:
+  call void (...) @__enzyme_autodiff(<2 x double> (i64, <2 x double>*, i64, <2 x double>*, i64)* @modf, i64 %len, <2 x double>* noalias %m, <2 x double>* %dm, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn)
+  ret void
+}
+
+define <2 x double> @f(i64 %len, <2 x double>* noalias %m, i64 %incm, <2 x double>* noalias %n, i64 %incn) {
+entry:
+  %res = alloca <2 x double>, align 8
+  call void @cblas_zdotc_sub64_(i64 %len, <2 x double>* %m, i64 %incm, <2 x double>* %n, i64 %incn, <2 x double>* %res)
+  %r = load <2 x double>, <2 x double>* %res, align 8
+  ret <2 x double> %r
+}
+
+define <2 x double> @modf(i64 %len, <2 x double>* noalias %m, i64 %incm, <2 x double>* noalias %n, i64 %incn) {
+entry:
+  %call = call <2 x double> @f(i64 %len, <2 x double>* %m, i64 %incm, <2 x double>* %n, i64 %incn)
+  store <2 x double> zeroinitializer, <2 x double>* %m
+  store <2 x double> zeroinitializer, <2 x double>* %n
+  ret <2 x double> %call
+}
+
+; COM: Pointer types and capture attributes are matched loosely since their
+; COM: spelling depends on the llvm version.
+; CHECK: declare void @cblas_zdotc_sub64_(i64 "enzyme_inactive", [[PTR:(<2 x double>\*|ptr)]] [[RO:(nocapture readonly|readonly captures\(none\))]], i64 "enzyme_inactive", [[PTR]] [[RO]], i64 "enzyme_inactive", [[PTR]] [[NC:(nocapture|captures\(none\))]])
+
+; CHECK: define void @active
+; CHECK-NEXT: entry
+; CHECK-NEXT: call void @[[active:[^(]+]](
+
+; CHECK: define void @inactiveFirst
+; CHECK-NEXT: entry
+; CHECK-NEXT: call void @[[inactiveFirst:[^(]+]](
+
+; CHECK: define void @inactiveSecond
+; CHECK-NEXT: entry
+; CHECK-NEXT: call void @[[inactiveSecond:[^(]+]](
+
+; CHECK: define void @activeMod
+; CHECK-NEXT: entry
+; CHECK-NEXT: call void @[[activeMod:[^(]+]](
+
+; COM: dx += conj(dres) * y ; dy += dres * x, with dres taken from (and reset in) the shadow of res.
+; CHECK: define internal void @[[active]](i64 %len, [[PTR]] noalias %m, [[PTR]] %"m'", i64 %incm, [[PTR]] noalias %n, [[PTR]] %"n'", i64 %incn, <2 x double> %differeturn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %ret = alloca <2 x double>, align 16
+; CHECK-NEXT:   %byref.conj = alloca <2 x double>, align 16
+; CHECK-NEXT:   %res = alloca <2 x double>, align 8
+; CHECK-NEXT:   call void @cblas_zdotc_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %res)
+; CHECK-NEXT:   store <2 x double> %differeturn, [[PTR]] %ret, align 16
+; CHECK-NEXT:   %0 = load <2 x double>, [[PTR]] %ret, align 16
+; CHECK-NEXT:   %1 = extractelement <2 x double> %0, i64 1
+; CHECK-NEXT:   %2 = fneg fast double %1
+; CHECK-NEXT:   %3 = insertelement <2 x double> %0, double %2, i64 1
+; CHECK-NEXT:   store <2 x double> %3, [[PTR]] %byref.conj, align 16
+; CHECK-NEXT:   call void @cblas_zaxpy64_(i64 %len, [[PTR]] %byref.conj, [[PTR]] %n, i64 %incn, [[PTR]] %"m'", i64 %incm)
+; CHECK-NEXT:   call void @cblas_zaxpy64_(i64 %len, [[PTR]] %ret, [[PTR]] %m, i64 %incm, [[PTR]] %"n'", i64 %incn)
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }
+
+; COM: complex alpha is passed by pointer under the cblas abi
+; CHECK: declare void @cblas_zaxpy64_(i64 "enzyme_inactive", [[PTR]] [[RO]], [[PTR]] [[RO]], i64 "enzyme_inactive", [[PTR]] [[NC]], i64 "enzyme_inactive")
+
+; CHECK: define internal void @[[inactiveFirst]](i64 %len, [[PTR]] noalias %m, i64 %incm, [[PTR]] noalias %n, [[PTR]] %"n'", i64 %incn, <2 x double> %differeturn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %ret = alloca <2 x double>, align 16
+; CHECK-NEXT:   %res = alloca <2 x double>, align 8
+; CHECK-NEXT:   call void @cblas_zdotc_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %res)
+; CHECK-NEXT:   store <2 x double> %differeturn, [[PTR]] %ret, align 16
+; CHECK-NEXT:   call void @cblas_zaxpy64_(i64 %len, [[PTR]] %ret, [[PTR]] %m, i64 %incm, [[PTR]] %"n'", i64 %incn)
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }
+
+; CHECK: define internal void @[[inactiveSecond]](i64 %len, [[PTR]] noalias %m, [[PTR]] %"m'", i64 %incm, [[PTR]] noalias %n, i64 %incn, <2 x double> %differeturn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %byref.conj = alloca <2 x double>, align 16
+; CHECK-NEXT:   %res = alloca <2 x double>, align 8
+; CHECK-NEXT:   call void @cblas_zdotc_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %res)
+; CHECK-NEXT:   %0 = extractelement <2 x double> %differeturn, i64 1
+; CHECK-NEXT:   %1 = fneg fast double %0
+; CHECK-NEXT:   %2 = insertelement <2 x double> %differeturn, double %1, i64 1
+; CHECK-NEXT:   store <2 x double> %2, [[PTR]] %byref.conj, align 16
+; CHECK-NEXT:   call void @cblas_zaxpy64_(i64 %len, [[PTR]] %byref.conj, [[PTR]] %n, i64 %incn, [[PTR]] %"m'", i64 %incm)
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }
+
+; CHECK: define internal void @[[activeMod]](i64 %len, [[PTR]] noalias %m, [[PTR]] %"m'", i64 %incm, [[PTR]] noalias %n, [[PTR]] %"n'", i64 %incn, <2 x double> %differeturn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %call_augmented = call { [[PTR]], [[PTR]] } @[[augMod:[^(]+]](i64 %len, [[PTR]] %m, [[PTR]] %"m'", i64 %incm, [[PTR]] %n, [[PTR]] %"n'", i64 %incn)
+; CHECK:        call void @[[revMod:[^(]+]](i64 %len, [[PTR]] %m, [[PTR]] %"m'", i64 %incm, [[PTR]] %n, [[PTR]] %"n'", i64 %incn, <2 x double> %differeturn, { [[PTR]], [[PTR]] } %call_augmented)
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }
+
+; COM: x and y are overwritten later and must be cached (16 bytes per complex element)
+; CHECK: define internal { [[PTR]], [[PTR]] } @[[augMod]](i64 %len, [[PTR]] noalias %m, [[PTR]] %"m'", i64 %incm, [[PTR]] noalias %n, [[PTR]] %"n'", i64 %incn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %res = alloca <2 x double>, i64 1, align 8
+; CHECK-NEXT:   %mallocsize = mul nuw nsw i64 %len, 16
+; CHECK:        @malloc(i64 %mallocsize)
+; CHECK:        call void @cblas_zcopy64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %cache.x, i64 1)
+; CHECK-NEXT:   %mallocsize1 = mul nuw nsw i64 %len, 16
+; CHECK:        @malloc(i64 %mallocsize1)
+; CHECK:        call void @cblas_zcopy64_(i64 %len, [[PTR]] %n, i64 %incn, [[PTR]] %cache.y, i64 1)
+; CHECK:        call void @cblas_zdotc_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %res)
+; CHECK-NEXT:   ret { [[PTR]], [[PTR]] }
+; CHECK-NEXT: }
+
+; CHECK: define internal void @[[revMod]](i64 %len, [[PTR]] noalias %m, [[PTR]] %"m'", i64 %incm, [[PTR]] noalias %n, [[PTR]] %"n'", i64 %incn, <2 x double> %differeturn, { [[PTR]], [[PTR]] }
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %ret = alloca <2 x double>, align 16
+; CHECK-NEXT:   %byref.conj = alloca <2 x double>, align 16
+; CHECK-NEXT:   %"res'mi" = alloca <2 x double>, i64 1, align 8
+; CHECK:        %1 = load <2 x double>, [[PTR]] %"res'mi", align 8
+; CHECK-NEXT:   %2 = fadd fast <2 x double> %1, %differeturn
+; CHECK-NEXT:   store <2 x double> %2, [[PTR]] %"res'mi", align 8
+; CHECK-NEXT:   %tape.ext.x = extractvalue { [[PTR]], [[PTR]] } %0, 0
+; CHECK-NEXT:   %tape.ext.y = extractvalue { [[PTR]], [[PTR]] } %0, 1
+; CHECK-NEXT:   %3 = load <2 x double>, [[PTR]] %"res'mi", align 8
+; CHECK-NEXT:   store <2 x double> zeroinitializer, [[PTR]] %"res'mi", align 8
+; CHECK-NEXT:   store <2 x double> %3, [[PTR]] %ret, align 16
+; CHECK-NEXT:   %4 = load <2 x double>, [[PTR]] %ret, align 16
+; CHECK-NEXT:   %5 = extractelement <2 x double> %4, i64 1
+; CHECK-NEXT:   %6 = fneg fast double %5
+; CHECK-NEXT:   %7 = insertelement <2 x double> %4, double %6, i64 1
+; CHECK-NEXT:   store <2 x double> %7, [[PTR]] %byref.conj, align 16
+; CHECK-NEXT:   call void @cblas_zaxpy64_(i64 %len, [[PTR]] %byref.conj, [[PTR]] %tape.ext.y, i64 1, [[PTR]] %"m'", i64 %incm)
+; CHECK-NEXT:   call void @cblas_zaxpy64_(i64 %len, [[PTR]] %ret, [[PTR]] %tape.ext.x, i64 1, [[PTR]] %"n'", i64 %incn)
+; CHECK:        @free(
+; CHECK:        @free(
+; CHECK:        ret void
+; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ReverseMode/blas/cblas_zdotu_sub64_.ll
+++ b/enzyme/test/Enzyme/ReverseMode/blas/cblas_zdotu_sub64_.ll
@@ -1,0 +1,145 @@
+;RUN: %opt < %s %newLoadEnzyme -passes="enzyme,function(mem2reg,instsimplify,%simplifycfg)" -S -enzyme-detect-readthrow=0 | FileCheck %s
+
+; Complex unconjugated dot product, result returned through the last pointer arg.
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare dso_local void @__enzyme_autodiff(...)
+
+declare void @cblas_zdotu_sub64_(i64, <2 x double>*, i64, <2 x double>*, i64, <2 x double>*)
+
+define void @active(i64 %len, <2 x double>* noalias %m, <2 x double>* %dm, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn) {
+entry:
+  call void (...) @__enzyme_autodiff(<2 x double> (i64, <2 x double>*, i64, <2 x double>*, i64)* @f, i64 %len, <2 x double>* noalias %m, <2 x double>* %dm, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn)
+  ret void
+}
+
+define void @inactiveFirst(i64 %len, <2 x double>* noalias %m, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn) {
+entry:
+  call void (...) @__enzyme_autodiff(<2 x double> (i64, <2 x double>*, i64, <2 x double>*, i64)* @f, i64 %len, metadata !"enzyme_const", <2 x double>* noalias %m, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn)
+  ret void
+}
+
+define void @inactiveSecond(i64 %len, <2 x double>* noalias %m, <2 x double>* noalias %dm, i64 %incm, <2 x double>* noalias %n, i64 %incn) {
+entry:
+  call void (...) @__enzyme_autodiff(<2 x double> (i64, <2 x double>*, i64, <2 x double>*, i64)* @f, i64 %len, <2 x double>* noalias %m, <2 x double>* noalias %dm, i64 %incm, metadata !"enzyme_const", <2 x double>* noalias %n, i64 %incn)
+  ret void
+}
+
+define void @activeMod(i64 %len, <2 x double>* noalias %m, <2 x double>* %dm, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn) {
+entry:
+  call void (...) @__enzyme_autodiff(<2 x double> (i64, <2 x double>*, i64, <2 x double>*, i64)* @modf, i64 %len, <2 x double>* noalias %m, <2 x double>* %dm, i64 %incm, <2 x double>* noalias %n, <2 x double>* %dn, i64 %incn)
+  ret void
+}
+
+define <2 x double> @f(i64 %len, <2 x double>* noalias %m, i64 %incm, <2 x double>* noalias %n, i64 %incn) {
+entry:
+  %res = alloca <2 x double>, align 8
+  call void @cblas_zdotu_sub64_(i64 %len, <2 x double>* %m, i64 %incm, <2 x double>* %n, i64 %incn, <2 x double>* %res)
+  %r = load <2 x double>, <2 x double>* %res, align 8
+  ret <2 x double> %r
+}
+
+define <2 x double> @modf(i64 %len, <2 x double>* noalias %m, i64 %incm, <2 x double>* noalias %n, i64 %incn) {
+entry:
+  %call = call <2 x double> @f(i64 %len, <2 x double>* %m, i64 %incm, <2 x double>* %n, i64 %incn)
+  store <2 x double> zeroinitializer, <2 x double>* %m
+  store <2 x double> zeroinitializer, <2 x double>* %n
+  ret <2 x double> %call
+}
+
+; COM: Pointer types and capture attributes are matched loosely since their
+; COM: spelling depends on the llvm version.
+; CHECK: declare void @cblas_zdotu_sub64_(i64 "enzyme_inactive", [[PTR:(<2 x double>\*|ptr)]] [[RO:(nocapture readonly|readonly captures\(none\))]], i64 "enzyme_inactive", [[PTR]] [[RO]], i64 "enzyme_inactive", [[PTR]] [[NC:(nocapture|captures\(none\))]])
+
+; CHECK: define void @active
+; CHECK-NEXT: entry
+; CHECK-NEXT: call void @[[active:[^(]+]](
+
+; CHECK: define void @inactiveFirst
+; CHECK-NEXT: entry
+; CHECK-NEXT: call void @[[inactiveFirst:[^(]+]](
+
+; CHECK: define void @inactiveSecond
+; CHECK-NEXT: entry
+; CHECK-NEXT: call void @[[inactiveSecond:[^(]+]](
+
+; CHECK: define void @activeMod
+; CHECK-NEXT: entry
+; CHECK-NEXT: call void @[[activeMod:[^(]+]](
+
+; COM: dx += dres * y ; dy += dres * x, with dres taken from (and reset in) the shadow of res.
+; CHECK: define internal void @[[active]](i64 %len, [[PTR]] noalias %m, [[PTR]] %"m'", i64 %incm, [[PTR]] noalias %n, [[PTR]] %"n'", i64 %incn, <2 x double> %differeturn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %ret = alloca <2 x double>, align 16
+; CHECK-NEXT:   %res = alloca <2 x double>, align 8
+; CHECK-NEXT:   call void @cblas_zdotu_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %res)
+; CHECK-NEXT:   store <2 x double> %differeturn, [[PTR]] %ret, align 16
+; CHECK-NEXT:   call void @cblas_zaxpy64_(i64 %len, [[PTR]] %ret, [[PTR]] %n, i64 %incn, [[PTR]] %"m'", i64 %incm)
+; CHECK-NEXT:   call void @cblas_zaxpy64_(i64 %len, [[PTR]] %ret, [[PTR]] %m, i64 %incm, [[PTR]] %"n'", i64 %incn)
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }
+
+; COM: complex alpha is passed by pointer under the cblas abi
+; CHECK: declare void @cblas_zaxpy64_(i64 "enzyme_inactive", [[PTR]] [[RO]], [[PTR]] [[RO]], i64 "enzyme_inactive", [[PTR]] [[NC]], i64 "enzyme_inactive")
+
+; CHECK: define internal void @[[inactiveFirst]](i64 %len, [[PTR]] noalias %m, i64 %incm, [[PTR]] noalias %n, [[PTR]] %"n'", i64 %incn, <2 x double> %differeturn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %ret = alloca <2 x double>, align 16
+; CHECK-NEXT:   %res = alloca <2 x double>, align 8
+; CHECK-NEXT:   call void @cblas_zdotu_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %res)
+; CHECK-NEXT:   store <2 x double> %differeturn, [[PTR]] %ret, align 16
+; CHECK-NEXT:   call void @cblas_zaxpy64_(i64 %len, [[PTR]] %ret, [[PTR]] %m, i64 %incm, [[PTR]] %"n'", i64 %incn)
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }
+
+; CHECK: define internal void @[[inactiveSecond]](i64 %len, [[PTR]] noalias %m, [[PTR]] %"m'", i64 %incm, [[PTR]] noalias %n, i64 %incn, <2 x double> %differeturn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %ret = alloca <2 x double>, align 16
+; CHECK-NEXT:   %res = alloca <2 x double>, align 8
+; CHECK-NEXT:   call void @cblas_zdotu_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %res)
+; CHECK-NEXT:   store <2 x double> %differeturn, [[PTR]] %ret, align 16
+; CHECK-NEXT:   call void @cblas_zaxpy64_(i64 %len, [[PTR]] %ret, [[PTR]] %n, i64 %incn, [[PTR]] %"m'", i64 %incm)
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }
+
+; CHECK: define internal void @[[activeMod]](i64 %len, [[PTR]] noalias %m, [[PTR]] %"m'", i64 %incm, [[PTR]] noalias %n, [[PTR]] %"n'", i64 %incn, <2 x double> %differeturn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %call_augmented = call { [[PTR]], [[PTR]] } @[[augMod:[^(]+]](i64 %len, [[PTR]] %m, [[PTR]] %"m'", i64 %incm, [[PTR]] %n, [[PTR]] %"n'", i64 %incn)
+; CHECK:        call void @[[revMod:[^(]+]](i64 %len, [[PTR]] %m, [[PTR]] %"m'", i64 %incm, [[PTR]] %n, [[PTR]] %"n'", i64 %incn, <2 x double> %differeturn, { [[PTR]], [[PTR]] } %call_augmented)
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }
+
+; COM: x and y are overwritten later and must be cached (16 bytes per complex element)
+; CHECK: define internal { [[PTR]], [[PTR]] } @[[augMod]](i64 %len, [[PTR]] noalias %m, [[PTR]] %"m'", i64 %incm, [[PTR]] noalias %n, [[PTR]] %"n'", i64 %incn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %res = alloca <2 x double>, i64 1, align 8
+; CHECK-NEXT:   %mallocsize = mul nuw nsw i64 %len, 16
+; CHECK:        @malloc(i64 %mallocsize)
+; CHECK:        call void @cblas_zcopy64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %cache.x, i64 1)
+; CHECK-NEXT:   %mallocsize1 = mul nuw nsw i64 %len, 16
+; CHECK:        @malloc(i64 %mallocsize1)
+; CHECK:        call void @cblas_zcopy64_(i64 %len, [[PTR]] %n, i64 %incn, [[PTR]] %cache.y, i64 1)
+; CHECK:        call void @cblas_zdotu_sub64_(i64 %len, [[PTR]] %m, i64 %incm, [[PTR]] %n, i64 %incn, [[PTR]] %res)
+; CHECK-NEXT:   ret { [[PTR]], [[PTR]] }
+; CHECK-NEXT: }
+
+; CHECK: define internal void @[[revMod]](i64 %len, [[PTR]] noalias %m, [[PTR]] %"m'", i64 %incm, [[PTR]] noalias %n, [[PTR]] %"n'", i64 %incn, <2 x double> %differeturn, { [[PTR]], [[PTR]] }
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %ret = alloca <2 x double>, align 16
+; CHECK-NEXT:   %"res'mi" = alloca <2 x double>, i64 1, align 8
+; CHECK:        %1 = load <2 x double>, [[PTR]] %"res'mi", align 8
+; CHECK-NEXT:   %2 = fadd fast <2 x double> %1, %differeturn
+; CHECK-NEXT:   store <2 x double> %2, [[PTR]] %"res'mi", align 8
+; CHECK-NEXT:   %tape.ext.x = extractvalue { [[PTR]], [[PTR]] } %0, 0
+; CHECK-NEXT:   %tape.ext.y = extractvalue { [[PTR]], [[PTR]] } %0, 1
+; CHECK-NEXT:   %3 = load <2 x double>, [[PTR]] %"res'mi", align 8
+; CHECK-NEXT:   store <2 x double> zeroinitializer, [[PTR]] %"res'mi", align 8
+; CHECK-NEXT:   store <2 x double> %3, [[PTR]] %ret, align 16
+; CHECK-NEXT:   call void @cblas_zaxpy64_(i64 %len, [[PTR]] %ret, [[PTR]] %tape.ext.y, i64 1, [[PTR]] %"m'", i64 %incm)
+; CHECK-NEXT:   call void @cblas_zaxpy64_(i64 %len, [[PTR]] %ret, [[PTR]] %tape.ext.x, i64 1, [[PTR]] %"n'", i64 %incn)
+; CHECK:        @free(
+; CHECK:        @free(
+; CHECK:        ret void
+; CHECK-NEXT: }

--- a/enzyme/tools/enzyme-tblgen/blas-tblgen.cpp
+++ b/enzyme/tools/enzyme-tblgen/blas-tblgen.cpp
@@ -291,13 +291,7 @@ void emit_helper(const TGPattern &pattern, raw_ostream &os) {
   bool lv23 = pattern.isBLASLevel2or3();
   const auto mutArgSet = pattern.getMutableArgs();
 
-  os << "  const bool byRef = blas.prefix == \"\" || blas.prefix == "
-        "\"cublas_\";\n";
-  os << "const bool byRefFloat = byRef || blas.prefix == \"cublas\";\n";
-  os << "(void)byRefFloat;\n";
-  os << "  const bool cblas = blas.prefix == \"cblas_\";\n";
-  os << "  const bool cublas = blas.prefix == \"cublas_\" || blas.prefix == "
-        "\"cublas\";\n";
+  emit_blas_abi_flags(os);
   os << "const bool cublasv2 = blas.prefix == "
         "\"cublas\" && StringRef(blas.suffix).contains(\"v2\");\n";
   os << "  Value *cacheval = nullptr;\n\n";
@@ -1018,6 +1012,26 @@ void rev_call_arg(bool forward, const DagInit *ruleDag,
               "allocationBuilder, \"isnonunit\")}";
         return;
       }
+      if (Def->getName() == "BConj") {
+        // complex conjugate of an fp scalar (identity for real types)
+        if (Dag->getNumArgs() != 1)
+          PrintFatalError(pattern.getLoc(),
+                          "only 1-arg Conj operands supported");
+        os << "({";
+        os << "SmallVector<Value*, 1> carg;\n";
+        os << " for (auto tmp : ";
+        rev_call_arg(forward, Dag, pattern, 0, os, vars);
+        os << " ) carg.push_back(tmp);\n";
+        os << "SmallVector<Value*, 1> vals;\n";
+        os << "for (auto cv : carg) {\n";
+        os << "  Value *cval = load_if_ref(Builder2, fpType, cv, "
+              "byRefFloat);\n";
+        os << "  cval = complex_conjugate(Builder2, cval);\n";
+        os << "  vals.push_back(to_blas_fp_callconv(Builder2, cval, "
+              "byRefFloat, blasFPType, allocationBuilder, \"conj\"));\n";
+        os << "}\n vals; })";
+        return;
+      }
     } else if (Def->getName() == "Shadow" || Def->isSubClassOf("Shadow")) {
       if (Dag->getNumArgs() != 1)
         PrintFatalError(pattern.getLoc(), "only single op shadow supported");
@@ -1192,7 +1206,10 @@ void rev_call_arg(bool forward, const DagInit *ruleDag,
       os << "    SmallVector<Type*, 1> tys; for (auto arg : marg) "
             "tys.push_back(arg->getType());\n";
 
-      std::string dfnc_ret_ty = get_blas_ret_ty(dfnc_name);
+      std::string dfnc_ret_ty =
+          returns_via_ptr(dfnc_name)
+              ? std::string("Type::getVoidTy(fpType->getContext())")
+              : get_blas_ret_ty(dfnc_name);
       os << "    llvm::FunctionType *FT" << dfnc_name << " = FunctionType::get("
          << "cublasv2 ? Type::getVoidTy(fpType->getContext()) : " << dfnc_ret_ty
          << ", tys, false);\n";
@@ -1219,9 +1236,12 @@ void rev_call_arg(bool forward, const DagInit *ruleDag,
          << "    }\n\n";
       os << "    auto cubcall = cast<CallInst>(Builder2.CreateCall(derivcall_"
          << dfnc_name << ", marg, Defs));\n";
-      os << "         SmallVector<Value*, 1> resvec(1, cublasv2 ? "
-         << " (Value*)Builder2.CreateLoad(fpType, marg[marg.size()-1]) : "
-            "(Value*)cubcall);\n"
+      os << "         Value *blasres = cubcall;\n"
+         << "         if (cublasv2) blasres = Builder2.CreateLoad(fpType, "
+            "marg[marg.size()-1]);\n"
+         << "         if (marg_retptr) blasres = Builder2.CreateLoad(fpType, "
+            "marg_retptr);\n"
+         << "         SmallVector<Value*, 1> resvec(1, blasres);\n"
          << "         resvec[0] = to_blas_fp_callconv(Builder2, resvec[0], "
             "byRefFloat, blasFPType, allocationBuilder, \"blascall\");\n"
          << "         resvec;\n";
@@ -1529,8 +1549,21 @@ void rev_call_args(bool forward, Twine argName, const TGPattern &pattern,
   }
   os << "        }\n";
   if (ty == ArgType::fp) {
+    os << "        Value *" << argName << "_retptr = nullptr;\n";
     os << "           if (cublasv2) " << argName
        << ".push_back(Builder2.CreateAlloca(fpType));\n";
+    if (returns_via_ptr(func)) {
+      // The result is written through a pointer passed as the last argument.
+      os << "        " << argName
+         << "_retptr = allocationBuilder.CreateAlloca(fpType, nullptr, \""
+         << func << ".ret\");\n";
+      os << "        " << argName
+         << ".push_back(type_vec_like->isIntegerTy() ? "
+            "(Value*)Builder2.CreatePtrToInt("
+         << argName << "_retptr, type_vec_like) : "
+         << "(Value*)Builder2.CreatePointerCast(" << argName
+         << "_retptr, type_vec_like));\n";
+    }
   }
 }
 
@@ -1783,7 +1816,10 @@ void emit_dag(bool forward, Twine resultVarName, const DagInit *ruleDag,
        << ") "
           "tys.push_back(arg->getType());\n";
 
-    std::string dfnc_ret_ty = get_blas_ret_ty(dfnc_name);
+    std::string dfnc_ret_ty =
+        returns_via_ptr(dfnc_name)
+            ? std::string("Type::getVoidTy(fpType->getContext())")
+            : get_blas_ret_ty(dfnc_name);
     os << "    llvm::FunctionType *FT" << dfnc_name << " = FunctionType::get("
        << "cublasv2 ? Type::getVoidTy(fpType->getContext()) : " << dfnc_ret_ty
        << ", tys, false);\n";
@@ -1815,6 +1851,8 @@ void emit_dag(bool forward, Twine resultVarName, const DagInit *ruleDag,
       os << "         if (cublasv2) " << resultVarName
          << " = Builder2.CreateLoad(fpType, " << argPrefix << "[" << argPrefix
          << ".size()-1]);\n";
+      os << "         if (" << argPrefix << "_retptr) " << resultVarName
+         << " = Builder2.CreateLoad(fpType, " << argPrefix << "_retptr);\n";
     }
 
     if (!forward && !runtimeChecked)
@@ -2186,7 +2224,7 @@ void emit_fwd_rewrite_rules(const TGPattern &pattern, raw_ostream &os) {
   const auto activeArgs = pattern.getActiveArgs();
   for (auto inputType : inputTypes) {
     auto ty = inputType.second;
-    if (isVecLikeArg(ty)) {
+    if (isVecLikeArg(ty) || ty == ArgType::fpret) {
       const auto name = nameVec[inputType.first];
       os << "    Value *d_" << name << " = active_" << name << "\n"
          << "     ? gutils->invertPointerM(orig_" << name << ", Builder2)\n"
@@ -2231,6 +2269,18 @@ void emit_fwd_rewrite_rules(const TGPattern &pattern, raw_ostream &os) {
   emit_dag(/*forward*/ true, "dres", duals, "args", os, "",
            /*actArg*/ -1, pattern, /*runtimeChecked*/ false, vars);
 
+  const ssize_t retPtrIdx = pattern.getRetPtrArgIdx();
+  if (retPtrIdx >= 0) {
+    // The result is returned through a pointer argument: write the derivative
+    // of the result into its shadow instead of returning it.
+    const auto retName = nameVec[retPtrIdx];
+    os << "      if (d_" << retName << ") {\n"
+       << "        if (!dres) dres = Constant::getNullValue(fpType);\n"
+       << "        store_blas_scalar(Builder2, fpType, d_" << retName
+       << ", dres);\n"
+       << "      }\n"
+       << "      dres = nullptr;\n";
+  }
   os << "      if (!dres && !call.getType()->isVoidTy()) dres = "
         "Constant::getNullValue(call.getType());\n";
   os << "      return dres;\n"
@@ -2259,6 +2309,9 @@ void emit_rev_rewrite_rules(const StringMap<TGPattern> &patternMap,
   const auto rules = pattern.getRules();
   const auto activeArgs = pattern.getActiveArgs();
   const bool lv23 = pattern.isBLASLevel2or3();
+  // If >= 0, the result is returned through this (pointer) argument and its
+  // shadow takes the role of the derivative of the return value.
+  const ssize_t retPtrIdx = pattern.getRetPtrArgIdx();
 
   // If any of the rule uses DiffeRet, the primary function has a ret val
   // and we should emit the code for handling it.
@@ -2271,24 +2324,26 @@ void emit_rev_rewrite_rules(const StringMap<TGPattern> &patternMap,
      << "  if (Mode == DerivativeMode::ReverseModeCombined ||\n"
      << "      Mode == DerivativeMode::ReverseModeGradient) {\n";
 
-  os << "    if (blas.floatType == \"c\" || blas.floatType == \"C\" || "
-        "blas.floatType == \"z\" || blas.floatType == \"Z\") {\n"
-     << "      std::string s;\n"
-     << "      llvm::raw_string_ostream ss(s);\n"
-     << "      ss << \"" << pattern.getName() << "\" << \"\\n\";\n"
-     << "      ss << \"Complex inputs not yet supported in reverse mode for "
-        "BLAS calls\" << "
-        "\"\\n\";\n"
-     << "      EmitNoDerivativeError(ss.str(), call, gutils, Builder2);\n"
-     << "    }\n";
+  if (!pattern.supportsComplex()) {
+    os << "    if (blas.floatType == \"c\" || blas.floatType == \"C\" || "
+          "blas.floatType == \"z\" || blas.floatType == \"Z\") {\n"
+       << "      std::string s;\n"
+       << "      llvm::raw_string_ostream ss(s);\n"
+       << "      ss << \"" << pattern.getName() << "\" << \"\\n\";\n"
+       << "      ss << \"Complex inputs not yet supported in reverse mode for "
+          "BLAS calls\" << "
+          "\"\\n\";\n"
+       << "      EmitNoDerivativeError(ss.str(), call, gutils, Builder2);\n"
+       << "    }\n";
+  }
 
   os << "    Value *alloc = nullptr;\n"
-     << "    if (byRef && !cublas) {\n"
+     << "    if (byRefFloat && !cublas) {\n"
      << "      alloc = allocationBuilder.CreateAlloca(fpType, nullptr, "
         "\"ret\");\n"
      << "    }\n\n";
 
-  if (hasDiffeRetVal) {
+  if (hasDiffeRetVal && retPtrIdx < 0) {
     os << "    Value *dif = cublasv2 ? "
           "gutils->invertPointerM(call.getArgOperand("
        << typeMap.size() << " + offset), Builder2) : diffe(&call, Builder2);\n";
@@ -2304,7 +2359,7 @@ void emit_rev_rewrite_rules(const StringMap<TGPattern> &patternMap,
   for (size_t i = 0; i < nameVec.size(); i++) {
     const auto name = nameVec[i];
     const auto ty = typeMap.lookup(i);
-    if (isVecLikeArg(ty)) {
+    if (isVecLikeArg(ty) || ty == ArgType::fpret) {
       os << "    Value *d_" << name << " = active_" << name << "\n"
          << "     ? lookup(gutils->invertPointerM(orig_" << name
          << ", Builder2), Builder2)\n"
@@ -2367,11 +2422,28 @@ void emit_rev_rewrite_rules(const StringMap<TGPattern> &patternMap,
     first = false;
   }
 
-  if (hasDiffeRetVal) {
+  if (hasDiffeRetVal && retPtrIdx < 0) {
     os << ((first) ? "" : ", ") << "Value *dif) {\n"
-       << "        if (byRef && !cublasv2) {\n"
+       << "        if (byRefFloat && !cublas) {\n"
        << "          Builder2.CreateStore(dif, alloc);\n"
        << "          dif = alloc;\n"
+       << "        }\n";
+  } else if (hasDiffeRetVal) {
+    // The result was written through a pointer argument, whose shadow holds
+    // the derivative of the result. Consume it and reset it, as the primal
+    // call overwrote the result.
+    const auto retName = nameVec[retPtrIdx];
+    os << ") {\n"
+       << "        Value *dif = nullptr;\n"
+       << "        if (d_" << retName << ") {\n"
+       << "          dif = load_blas_scalar(Builder2, fpType, d_" << retName
+       << ");\n"
+       << "          store_blas_scalar(Builder2, fpType, d_" << retName
+       << ", Constant::getNullValue(fpType));\n"
+       << "          if (byRefFloat && !cublas) {\n"
+       << "            Builder2.CreateStore(dif, alloc);\n"
+       << "            dif = alloc;\n"
+       << "          }\n"
        << "        }\n";
   } else {
     os << ") {\n";
@@ -2387,7 +2459,7 @@ void emit_rev_rewrite_rules(const StringMap<TGPattern> &patternMap,
     // trtrs do in reversed arg order.
     size_t i = (pattern.getName() != "trtrs") ? iteri
                                               : (activeArgs.size() - 1 - iteri);
-    StringRef extraCond;
+    std::string extraCond;
     auto rule = rules[i];
     const size_t actArg = activeArgs[i];
     const auto ruleDag = rule.getRuleDag();
@@ -2400,6 +2472,11 @@ void emit_rev_rewrite_rules(const StringMap<TGPattern> &patternMap,
       if (name == "B") {
         extraCond = "!active_A";
       }
+    }
+    if (retPtrIdx >= 0 && hasDiffeRet(ruleDag)) {
+      // no derivative of the result available if its pointer is inactive
+      extraCond += (extraCond.empty() ? "" : " && ");
+      extraCond += "dif";
     }
 
     emit_if_rule_condition(pattern, ruleDag, name, "      ", os, extraCond);
@@ -2433,7 +2510,7 @@ void emit_rev_rewrite_rules(const StringMap<TGPattern> &patternMap,
     }
     os << "      }\n";
   }
-  if (hasDiffeRetVal) {
+  if (hasDiffeRetVal && retPtrIdx < 0) {
     os << "    if (cublasv2) {\n";
     os << "      auto mod = gutils->oldFunc->getParent();\n";
     os << "      auto DL = mod->getDataLayout();\n";
@@ -2463,7 +2540,7 @@ void emit_rev_rewrite_rules(const StringMap<TGPattern> &patternMap,
     os << ((first) ? "" : ", ") << "d_" + name;
     first = false;
   }
-  if (hasDiffeRetVal) {
+  if (hasDiffeRetVal && retPtrIdx < 0) {
     os << ((first) ? "" : ", ") << "dif);\n";
     os << "  if (!cublasv2)\n"
        << "    setDiffe(\n"

--- a/enzyme/tools/enzyme-tblgen/blasDeclUpdater.h
+++ b/enzyme/tools/enzyme-tblgen/blasDeclUpdater.h
@@ -26,13 +26,7 @@ inline void emit_attributeBLAS(const TGPattern &pattern, raw_ostream &os) {
   os << "  if (!F->empty())\n";
   os << "    return F;\n";
   os << "  llvm::Type *fpType = blas.fpType(F->getContext());\n";
-  os << "  const bool byRef = blas.prefix == \"\" || blas.prefix == "
-        "\"cublas_\";\n";
-  os << "const bool byRefFloat = byRef || blas.prefix == \"cublas\";\n";
-  os << "(void)byRefFloat;\n";
-  os << "  const bool cblas = blas.prefix == \"cblas_\";\n";
-  os << "  const bool cublas = blas.prefix == \"cublas_\" || blas.prefix == "
-        "\"cublas\";\n";
+  emit_blas_abi_flags(os);
   os << "#if LLVM_VERSION_MAJOR >= 16\n"
      << "  F->setOnlyAccessesArgMemory();\n"
      << "#else\n"
@@ -118,7 +112,7 @@ inline void emit_attributeBLAS(const TGPattern &pattern, raw_ostream &os) {
   }
   os << "  }\n";
 
-  if (has_active_return(name)) {
+  if (has_active_return(name) && !returns_via_ptr(name)) {
     os << "const bool cublasv2 = blas.prefix == "
           "\"cublas\" && llvm::StringRef(blas.suffix).contains(\"v2\");\n";
     os << "  if (cublasv2) argTys.push_back(getUnqual(fpType));\n";
@@ -180,7 +174,10 @@ inline void emit_attributeBLAS(const TGPattern &pattern, raw_ostream &os) {
     auto typeOfArg = argTypeMap.lookup(argPos);
     size_t i = (lv23 ? argPos - 1 : argPos);
     if (typeOfArg == ArgType::vincData || typeOfArg == ArgType::mldData) {
-      os << "  addFunctionNoCapture(F, " << i << " + offset);\n";
+      // (pointers may be passed as integers, e.g. by julia)
+      os << "  if (F->getFunctionType()->getParamType(" << i
+         << " + offset)->isPointerTy())\n"
+         << "    addFunctionNoCapture(F, " << i << " + offset);\n";
       if (mutableArgs.count(argPos) == 0) {
         // Only emit ReadOnly if the arg isn't mutable
         os << "  F->removeParamAttr(" << i << " + offset"
@@ -191,9 +188,20 @@ inline void emit_attributeBLAS(const TGPattern &pattern, raw_ostream &os) {
            << ", llvm::Attribute::ReadOnly);\n";
       }
     }
+    if (typeOfArg == ArgType::fpret) {
+      // The result is only written through this pointer. It is deliberately
+      // not marked WriteOnly: the unused-value analysis would then consider a
+      // local result buffer (e.g. a Ref/alloca) unneeded and drop it, while the
+      // primal call writing to it is kept.
+      os << "  F->removeParamAttr(" << i << " + offset"
+         << ", llvm::Attribute::ReadNone);\n"
+         << "  if (F->getFunctionType()->getParamType(" << i
+         << " + offset)->isPointerTy())\n"
+         << "    addFunctionNoCapture(F, " << i << " + offset);\n";
+    }
   }
 
-  if (has_active_return(name)) {
+  if (has_active_return(name) && !returns_via_ptr(name)) {
     // under cublas, these functions have an extra return ptr argument
     size_t ptrRetArg = argTypeMap.size();
     os << "  if (cublas) {\n"

--- a/enzyme/tools/enzyme-tblgen/blasDiffUseUpdater.h
+++ b/enzyme/tools/enzyme-tblgen/blasDiffUseUpdater.h
@@ -20,14 +20,7 @@ inline void emit_BLASDiffUse(TGPattern &pattern, llvm::raw_ostream &os) {
 
   os << "if (blas.function == \"" << name << "\") {\n";
 
-  os << "  const bool byRef = blas.prefix == \"\" || blas.prefix == "
-        "\"cublas_\";\n";
-  os << "const bool byRefFloat = byRef || blas.prefix == \"cublas\";\n";
-  os << "(void)byRefFloat;\n";
-  if (lv23)
-    os << "  const bool cblas = blas.prefix == \"cblas_\";\n";
-  os << "  const bool cublas = blas.prefix == \"cublas_\" || blas.prefix == "
-        "\"cublas\";\n";
+  emit_blas_abi_flags(os);
   // lv 2 or 3 functions have an extra arg under the cblas_ abi
   os << "  const int offset = (";
   if (lv23) {
@@ -106,6 +99,9 @@ inline void emit_BLASDiffUse(TGPattern &pattern, llvm::raw_ostream &os) {
              << nameVec[derivOp.getHandledArgIdx()] << ") return true;\n";
         }
       }
+    } else if (typeMap[argPos] == ArgType::fpret) {
+      // the shadow of the result pointer provides the derivative of the result
+      os << "    if (shadow && active_" << argname << ") return true;\n";
     }
 
     os << "    if (!shadow && need_" << argname
@@ -124,7 +120,7 @@ inline void emit_BLASDiffUse(TGPattern &pattern, llvm::raw_ostream &os) {
     hasDiffeRetVal |= hasDiffeRet(derivOp.getRuleDag());
   }
 
-  if (hasDiffeRetVal) {
+  if (hasDiffeRetVal && pattern.getRetPtrArgIdx() < 0) {
     size_t ptrRetArg = typeMap.size();
     auto retarg =
         "CI->getArgOperand(" + std::to_string(ptrRetArg) + " + offset)";

--- a/enzyme/tools/enzyme-tblgen/blasTAUpdater.h
+++ b/enzyme/tools/enzyme-tblgen/blasTAUpdater.h
@@ -4,14 +4,7 @@
 #include "datastructures.h"
 
 inline void emit_BLASTypes(raw_ostream &os) {
-  os << "const bool byRef = blas.prefix == \"\" || blas.prefix == "
-        "\"cublas_\";\n";
-  os << "const bool byRefFloat = byRef || blas.prefix == "
-        "\"cublas\";\n";
-  os << "(void)byRefFloat;\n";
-  os << "const bool cblas = blas.prefix == \"cblas_\";\n";
-  os << "const bool cublas = blas.prefix == \"cublas_\" || blas.prefix == "
-        "\"cublas\";\n";
+  emit_blas_abi_flags(os);
   os << "const bool cublasv2 = blas.prefix == "
         "\"cublas\" && StringRef(blas.suffix).contains(\"v2\");\n";
 
@@ -146,6 +139,10 @@ inline void emit_BLASTA(TGPattern &pattern, raw_ostream &os) {
       os << "  updateAnalysis(call.getArgOperand(" << i
          << " + offset), ttFloat, &call);\n";
       break;
+    case ArgType::fpret:
+      os << "  updateAnalysis(call.getArgOperand(" << i
+         << " + offset), ttPtr, &call);\n";
+      break;
     case ArgType::ap:
       // TODO
       break;
@@ -163,7 +160,9 @@ inline void emit_BLASTA(TGPattern &pattern, raw_ostream &os) {
       break;
     }
   }
-  if (has_active_return(name)) {
+  if (returns_via_ptr(name)) {
+    // the result is typed through its fpret argument above
+  } else if (has_active_return(name)) {
     // under cublas, these functions have an extra return ptr argument
     size_t ptrRetArg = argTypeMap.size();
     os << "  if (cublasv2) {\n"

--- a/enzyme/tools/enzyme-tblgen/caching.cpp
+++ b/enzyme/tools/enzyme-tblgen/caching.cpp
@@ -120,7 +120,7 @@ void emit_cacheTypes(const TGPattern &pattern, raw_ostream &os) {
     } else if (ty == ArgType::fp) {
       scalarType = "fpType";
     } else {
-      assert(ty == ArgType::cblas_layout || isVecLikeArg(ty) || ty == ArgType::info);
+      assert(ty == ArgType::cblas_layout || isVecLikeArg(ty) || ty == ArgType::info || ty == ArgType::fpret);
       continue;
     }
   os

--- a/enzyme/tools/enzyme-tblgen/datastructures.cpp
+++ b/enzyme/tools/enzyme-tblgen/datastructures.cpp
@@ -34,7 +34,25 @@ bool is_char_arg(ArgType ty) {
 bool has_active_return(StringRef dfnc_name) {
   return dfnc_name == "dot" || dfnc_name == "asum" || dfnc_name == "nrm2" ||
          dfnc_name == "iamax" || dfnc_name == "iamin" ||
-         dfnc_name == "inner_prod";
+         dfnc_name == "inner_prod" || returns_via_ptr(dfnc_name);
+}
+
+bool returns_via_ptr(StringRef dfnc_name) {
+  return dfnc_name.size() > 4 &&
+         dfnc_name.substr(dfnc_name.size() - 4) == "_sub";
+}
+
+void emit_blas_abi_flags(raw_ostream &os) {
+  os << "  const bool byRef = blas.prefix == \"\" || blas.prefix == "
+        "\"cublas_\";\n";
+  os << "  const bool cblas = blas.prefix == \"cblas_\";\n";
+  os << "  const bool cublas = blas.prefix == \"cublas_\" || blas.prefix == "
+        "\"cublas\";\n";
+  // Complex scalars (alpha, beta, results) are always passed by pointer under
+  // the cblas ABI, real ones by value.
+  os << "  const bool byRefFloat = byRef || blas.prefix == \"cublas\" || "
+        "(cblas && (blas.floatType == \"c\" || blas.floatType == \"z\"));\n";
+  os << "  (void)byRef; (void)cblas; (void)cublas; (void)byRefFloat;\n";
 }
 
 const char *TyToString(ArgType ty) {
@@ -65,6 +83,8 @@ const char *TyToString(ArgType ty) {
     return "side";
   case ArgType::info:
     return "info";
+  case ArgType::fpret:
+    return "fpret";
   default:
     return "unknown";
   }
@@ -320,6 +340,8 @@ void fillArgTypes(const Record *pattern, DenseMap<size_t, ArgType> &argTypes) {
         argTypes.insert(std::make_pair(pos, ArgType::info));
       } else if (name == "fp") {
         argTypes.insert(std::make_pair(pos, ArgType::fp));
+      } else if (name == "fpret") {
+        argTypes.insert(std::make_pair(pos, ArgType::fpret));
       } else if (name == "cblas_layout") {
         assert(pos == 0);
         argTypes.insert(std::make_pair(pos, ArgType::cblas_layout));
@@ -518,4 +540,15 @@ ArgType TGPattern::getTypeOfArg(StringRef argName) const {
 
 const DagInit *TGPattern::getDuals() const {
   return record->getValueAsDag("ArgDuals");
+}
+
+ssize_t TGPattern::getRetPtrArgIdx() const {
+  for (size_t i = 0; i < args.size(); i++)
+    if (argTypes.lookup(i) == ArgType::fpret)
+      return i;
+  return -1;
+}
+
+bool TGPattern::supportsComplex() const {
+  return record->getValueAsBit("supportsComplex");
 }

--- a/enzyme/tools/enzyme-tblgen/datastructures.h
+++ b/enzyme/tools/enzyme-tblgen/datastructures.h
@@ -27,7 +27,10 @@ enum class ArgType {
   trans,
   diag,
   side,
-  info
+  info,
+  // pointer through which a scalar fp result is returned instead of a return
+  // value, e.g. the last argument of cblas_zdotc_sub
+  fpret
 };
 
 bool is_char_arg(ArgType ty);
@@ -44,6 +47,15 @@ bool isVecLikeArg(ArgType ty);
 
 // Whether the blas function returns an active value
 bool has_active_return(StringRef str);
+
+// Whether the blas function returns its (active) result through a pointer
+// passed as the last argument rather than as return value (the cblas `_sub`
+// variants of the complex dot products, e.g. cblas_zdotc_sub).
+bool returns_via_ptr(StringRef str);
+
+/// Emit the C++ declarations describing the calling convention of the blas
+/// call being handled (Fortran/cblas/cublas, scalars by reference or value).
+void emit_blas_abi_flags(raw_ostream &os);
 
 class TGPattern;
 
@@ -138,6 +150,11 @@ public:
   ArrayRef<SMLoc> getLoc() const;
   ArgType getTypeOfArg(StringRef name) const;
   const DagInit *getDuals() const;
+  /// Position of the fpret argument (result returned through a pointer),
+  /// or -1 if the function returns its result by value / has none.
+  ssize_t getRetPtrArgIdx() const;
+  /// Whether the reverse-mode rules are valid for complex (c/z) inputs.
+  bool supportsComplex() const;
 };
 
 #endif


### PR DESCRIPTION
Adds derivative rules for the complex dot products in their cblas `_sub` form (e.g. `cblas_zdotc_sub64_` as used by Julia's `BLAS.dotc`), whose result is written through a pointer passed as the last argument instead of being returned.

| | primal | reverse | forward |
|---|---|---|---|
| `dotc_sub` | `res = Σ conj(x_i)·y_i` | `dx += conj(dres)·y`, `dy += dres·x` | `dres = dotc(dx,y) + dotc(x,dy)` |
| `dotu_sub` | `res = Σ x_i·y_i` | `dx += dres·y`, `dy += dres·x` | `dres = dotu(dx,y) + dotu(x,dy)` |

All `c`/`z` variants and suffixes (`""`, `_`, `64_`, `_64_`) are recognized; the adjoints are emitted as `cblas_?axpy` calls, and overwritten inputs are cached via `cblas_?copy`.

### tblgen changes
- New `fpret` argument type for a scalar result returned through a pointer. In reverse mode its shadow provides `DiffeRet` and is reset afterwards (the primal overwrote the result); in forward mode it receives the dual. `BlasCall`s to `*_sub` functions get a result alloca appended and their result loaded back, mirroring the existing cublas v2 path.
- New `BConj` op (complex conjugate of an fp scalar, identity for real types).
- Per-pattern `supportsComplex` bit: the blanket "complex inputs not yet supported in reverse mode" error now only applies to patterns that have not opted in.
- Complex scalars are passed by pointer under the cblas ABI, so `byRefFloat` accounts for that; the ABI flags are now emitted by one shared helper for all four generators.
- Small runtime helpers in `Utils.cpp` for conjugation and for element-aligned load/store of a blas scalar through a pointer that may be passed as an integer (Julia).

### Notes
- The result pointer is attributed `nocapture` but deliberately **not** `writeonly`: with `writeonly`, the unused-value analysis considers a local result buffer (e.g. a Julia `Ref`/alloca) unneeded and replaces it with a fictitious phi, while the primal call writing to it is kept. That looks like a general gap in `calculateUnusedValuesInFunction` for calls whose only writes go to unneeded memory; left as is here.
- `nocapture` is no longer applied to integer-typed vector arguments (invalid IR, hit with Julia-style `i64` pointers).

### Testing
New lit tests for both functions in forward and reverse mode (`test/Enzyme/{ForwardMode,ReverseMode}/blas/cblas_zdot{c,u}_sub64_.ll`), including the caching path. Verified locally against LLVM 22; the CHECK lines use regexes tolerant of the typed-pointer / `nocapture` spelling on older LLVM. Also checked by hand that `cblas_cdotc_sub` (single precision, 32-bit ints) and the Julia-style form with pointers passed as `i64` produce the expected code, and that the existing `ddot` derivatives are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgNCvikUqowFPsvLWUJqVB
