### PR TITLE
Add simple Fortran+MPI tests

### DIFF
--- a/.github/workflows/fortran.yml
+++ b/.github/workflows/fortran.yml
@@ -56,9 +56,16 @@ jobs:
         sudo apt-add-repository "deb http://apt.llvm.org/`lsb_release -c | cut -f2`/ llvm-toolchain-`lsb_release -c | cut -f2`-${{ matrix.llvm }} main"
         sudo apt-get update && sudo apt-get install -y cmake gcc g++ llvm-${{ matrix.llvm }}-dev libomp-${{ matrix.llvm }}-dev ninja-build pip clang-${{ matrix.llvm }} flang-${{ matrix.llvm }}
         sudo python3 -m pip install --upgrade pip lit
+    - name: install openmpi
+      run: |
+        git clone https://github.com/spack/spack.git
+        . spack/share/spack/setup-env.sh
+        spack compiler find
+        spack install openmpi ^llvm
     - uses: actions/checkout@v4
     - name: generate build system
       run: |
+        spack load openmpi
         rm -rf build && mkdir build && cd build
         cmake ../enzyme -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build }} -DLLVM_DIR=/usr/lib/llvm-${{ matrix.llvm }}/lib/cmake/llvm -DLLVM_EXTERNAL_LIT=`which lit` -DENZYME_FORTRAN=ON -DENZYME_FLANG=ON -DCMAKE_Fortran_COMPILER=${{ matrix.compiler }}-${{ matrix.llvm }}
     - name: build enzyme
@@ -101,9 +108,16 @@ jobs:
         sudo apt-get update && sudo apt-get install -y intel-oneapi-compiler-fortran-${{ matrix.versions.ifx }} intel-oneapi-mpi-${{ matrix.mpi }} intel-oneapi-mpi-devel-${{ matrix.mpi }}
         source /opt/intel/oneapi/setvars.sh
         printenv >> $GITHUB_ENV
+    - name: install openmpi
+      run: |
+        git clone https://github.com/spack/spack.git
+        . spack/share/spack/setup-env.sh
+        spack compiler find
+        spack install openmpi ^intel-oneapi-compilers
     - uses: actions/checkout@v4
     - name: generate build system
       run: |
+        spack load openmpi
         rm -rf build && mkdir build && cd build
         cmake ../enzyme -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build }} -DLLVM_DIR=/usr/lib/llvm-${{ matrix.versions.llvm }}/lib/cmake/llvm -DLLVM_EXTERNAL_LIT=`which lit` -DENZYME_FORTRAN=ON -DCMAKE_Fortran_COMPILER=${{ matrix.compiler }}
     - name: build enzyme

--- a/.github/workflows/fortran.yml
+++ b/.github/workflows/fortran.yml
@@ -65,6 +65,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: generate build system
       run: |
+        . spack/share/spack/setup-env.sh
         spack load openmpi
         rm -rf build && mkdir build && cd build
         cmake ../enzyme -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build }} -DLLVM_DIR=/usr/lib/llvm-${{ matrix.llvm }}/lib/cmake/llvm -DLLVM_EXTERNAL_LIT=`which lit` -DENZYME_FORTRAN=ON -DENZYME_FLANG=ON -DCMAKE_Fortran_COMPILER=${{ matrix.compiler }}-${{ matrix.llvm }}
@@ -117,6 +118,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: generate build system
       run: |
+        . spack/share/spack/setup-env.sh
         spack load openmpi
         rm -rf build && mkdir build && cd build
         cmake ../enzyme -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build }} -DLLVM_DIR=/usr/lib/llvm-${{ matrix.versions.llvm }}/lib/cmake/llvm -DLLVM_EXTERNAL_LIT=`which lit` -DENZYME_FORTRAN=ON -DCMAKE_Fortran_COMPILER=${{ matrix.compiler }}

--- a/.github/workflows/fortran.yml
+++ b/.github/workflows/fortran.yml
@@ -56,13 +56,13 @@ jobs:
         sudo apt-add-repository "deb http://apt.llvm.org/`lsb_release -c | cut -f2`/ llvm-toolchain-`lsb_release -c | cut -f2`-${{ matrix.llvm }} main"
         sudo apt-get update && sudo apt-get install -y cmake gcc g++ llvm-${{ matrix.llvm }}-dev libomp-${{ matrix.llvm }}-dev ninja-build pip clang-${{ matrix.llvm }} flang-${{ matrix.llvm }}
         sudo python3 -m pip install --upgrade pip lit
+    - uses: actions/checkout@v4
     - name: install openmpi
       run: |
         git clone https://github.com/spack/spack.git
         . spack/share/spack/setup-env.sh
         spack compiler find
         spack install openmpi ^llvm
-    - uses: actions/checkout@v4
     - name: generate build system
       run: |
         . spack/share/spack/setup-env.sh

--- a/.github/workflows/fortran.yml
+++ b/.github/workflows/fortran.yml
@@ -109,13 +109,13 @@ jobs:
         sudo apt-get update && sudo apt-get install -y intel-oneapi-compiler-fortran-${{ matrix.versions.ifx }} intel-oneapi-mpi-${{ matrix.mpi }} intel-oneapi-mpi-devel-${{ matrix.mpi }}
         source /opt/intel/oneapi/setvars.sh
         printenv >> $GITHUB_ENV
+    - uses: actions/checkout@v4
     - name: install openmpi
       run: |
         git clone https://github.com/spack/spack.git
         . spack/share/spack/setup-env.sh
         spack compiler find
         spack install openmpi ^intel-oneapi-compilers
-    - uses: actions/checkout@v4
     - name: generate build system
       run: |
         . spack/share/spack/setup-env.sh

--- a/.github/workflows/fortran.yml
+++ b/.github/workflows/fortran.yml
@@ -72,13 +72,13 @@ jobs:
     - name: build enzyme
       working-directory: 'build'
       run: |
-        . spack/share/spack/setup-env.sh
+        . ../spack/share/spack/setup-env.sh
         spack load openmpi
         ninja LLVMEnzyme-${{ matrix.llvm }} FlangEnzyme-${{ matrix.llvm }}
     - name: run Fortran tests
       working-directory: 'build'
       run: |
-        . spack/share/spack/setup-env.sh
+        . ../spack/share/spack/setup-env.sh
         spack load openmpi
         ninja check-enzyme-fortran
   build-and-test-fortran-ifx:
@@ -131,12 +131,12 @@ jobs:
     - name: build enzyme
       working-directory: 'build'
       run: |
-        . spack/share/spack/setup-env.sh
+        . ../spack/share/spack/setup-env.sh
         spack load openmpi
         ninja LLVMEnzyme-${{ matrix.versions.llvm }}
     - name: run Fortran tests
       working-directory: 'build'
       run: |
-        . spack/share/spack/setup-env.sh
+        . ../spack/share/spack/setup-env.sh
         spack load openmpi
         ninja check-enzyme-fortran

--- a/.github/workflows/fortran.yml
+++ b/.github/workflows/fortran.yml
@@ -71,10 +71,16 @@ jobs:
         cmake ../enzyme -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build }} -DLLVM_DIR=/usr/lib/llvm-${{ matrix.llvm }}/lib/cmake/llvm -DLLVM_EXTERNAL_LIT=`which lit` -DENZYME_FORTRAN=ON -DENZYME_FLANG=ON -DCMAKE_Fortran_COMPILER=${{ matrix.compiler }}-${{ matrix.llvm }}
     - name: build enzyme
       working-directory: 'build'
-      run: ninja LLVMEnzyme-${{ matrix.llvm }} FlangEnzyme-${{ matrix.llvm }}
+      run: |
+        . spack/share/spack/setup-env.sh
+        spack load openmpi
+        ninja LLVMEnzyme-${{ matrix.llvm }} FlangEnzyme-${{ matrix.llvm }}
     - name: run Fortran tests
       working-directory: 'build'
-      run: ninja check-enzyme-fortran
+      run: |
+        . spack/share/spack/setup-env.sh
+        spack load openmpi
+        ninja check-enzyme-fortran
   build-and-test-fortran-ifx:
     name: Fortran ${{matrix.build}} ${{matrix.os}} ${{matrix.compiler}} ${{matrix.versions.ifx}} llvm ${{matrix.versions.llvm}}
     runs-on: ${{matrix.os}}
@@ -124,7 +130,13 @@ jobs:
         cmake ../enzyme -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build }} -DLLVM_DIR=/usr/lib/llvm-${{ matrix.versions.llvm }}/lib/cmake/llvm -DLLVM_EXTERNAL_LIT=`which lit` -DENZYME_FORTRAN=ON -DCMAKE_Fortran_COMPILER=${{ matrix.compiler }}
     - name: build enzyme
       working-directory: 'build'
-      run: ninja LLVMEnzyme-${{ matrix.versions.llvm }}
+      run: |
+        . spack/share/spack/setup-env.sh
+        spack load openmpi
+        ninja LLVMEnzyme-${{ matrix.versions.llvm }}
     - name: run Fortran tests
       working-directory: 'build'
-      run: ninja check-enzyme-fortran
+      run: |
+        . spack/share/spack/setup-env.sh
+        spack load openmpi
+        ninja check-enzyme-fortran

--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -594,7 +594,22 @@ const char *DemangledKnownInactiveFunctionsStartingWith[] = {
     return true;
   }
 
+  // Also recognize Fortran ABI manglings of MPI routines (e.g. "mpi_init_",
+  // "mpi_comm_rank_") by their canonical C name.
+  StringRef CanonicalMPIName = canonicalizeMPIName(Name);
+
+  if (!CanonicalMPIName.empty() &&
+      KnownInactiveFunctions.count(CanonicalMPIName)) {
+    return true;
+  }
+
   if (MPIInactiveCommAllocators.find(Name) != MPIInactiveCommAllocators.end()) {
+    return true;
+  }
+
+  if (!CanonicalMPIName.empty() &&
+      MPIInactiveCommAllocators.find(CanonicalMPIName) !=
+          MPIInactiveCommAllocators.end()) {
     return true;
   }
   Intrinsic::ID ID;
@@ -712,23 +727,44 @@ bool ActivityAnalyzer::isFunctionArgumentConstant(CallInst *CI, Value *val) {
       CI->getArgOperand(0) != val && CI->getArgOperand(1) != val)
     return true;
 
+  // Canonicalize MPI names across calling conventions (C "MPI_Recv",
+  // "PMPI_Recv" and Fortran "mpi_recv_" etc.): the leading argument indices
+  // match between the ABIs, the Fortran ABI only appends an `ierr` argument.
+  StringRef CanonicalMPIName = canonicalizeMPIName(Name);
+
   // only the buffer is active for mpi send/recv
-  if (Name == "MPI_Recv" || Name == "MPI_Send" || Name == "PMPI_Recv" ||
-      Name == "PMPI_Send") {
+  if (CanonicalMPIName == "MPI_Recv" || CanonicalMPIName == "MPI_Send") {
     return val != CI->getOperand(0);
   }
   // only the recv buffer and request is active for mpi isend/irecv
-  if (Name == "MPI_Irecv" || Name == "MPI_Isend" || Name == "PMPI_Irecv" ||
-      Name == "PMPI_Isend") {
+  if (CanonicalMPIName == "MPI_Irecv" || CanonicalMPIName == "MPI_Isend") {
     return val != CI->getOperand(0) && val != CI->getOperand(6);
   }
 
   // only request is active
-  if (Name == "MPI_Wait" || Name == "PMPI_Wait")
+  if (CanonicalMPIName == "MPI_Wait")
     return val != CI->getOperand(0);
 
-  if (Name == "MPI_Waitall" || Name == "PMPI_Waitall")
+  if (CanonicalMPIName == "MPI_Waitall")
     return val != CI->getOperand(1);
+
+  // only the send/recv buffers are active for mpi reduce/allreduce
+  if (CanonicalMPIName == "MPI_Reduce" ||
+      CanonicalMPIName == "MPI_Allreduce" ||
+      CanonicalMPIName == "MPI_Reduce_scatter_block") {
+    return val != CI->getOperand(0) && val != CI->getOperand(1);
+  }
+
+  // only the buffer is active for mpi bcast
+  if (CanonicalMPIName == "MPI_Bcast") {
+    return val != CI->getOperand(0);
+  }
+
+  // mpi init/finalize and rank/size queries have no active arguments
+  if (CanonicalMPIName == "MPI_Init" || CanonicalMPIName == "MPI_Finalize" ||
+      CanonicalMPIName == "MPI_Comm_rank" ||
+      CanonicalMPIName == "MPI_Comm_size" || CanonicalMPIName == "MPI_Barrier")
+    return true;
 
   // TODO interprocedural detection
   // Before potential introprocedural detection, any function without definition

--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -731,41 +731,45 @@ bool ActivityAnalyzer::isFunctionArgumentConstant(CallInst *CI, Value *val) {
   // "PMPI_Recv" and Fortran "mpi_recv_" etc.): the leading argument indices
   // match between the ABIs, the Fortran ABI only appends an `ierr` argument.
   StringRef CanonicalMPIName = canonicalizeMPIName(Name);
-  if (CanonicalMPIName.empty())
-    return false;
 
-  // only the buffer is active for mpi send/recv
-  if (CanonicalMPIName == "MPI_Recv" || CanonicalMPIName == "MPI_Send") {
-    return val != CI->getOperand(0);
+  // Handle MPI functions
+  if (!CanonicalMPIName.empty()) {
+
+    // only the buffer is active for mpi send/recv
+    if (CanonicalMPIName == "MPI_Recv" || CanonicalMPIName == "MPI_Send") {
+      return val != CI->getOperand(0);
+    }
+    // only the recv buffer and request is active for mpi isend/irecv
+    if (CanonicalMPIName == "MPI_Irecv" || CanonicalMPIName == "MPI_Isend") {
+      return val != CI->getOperand(0) && val != CI->getOperand(6);
+    }
+
+    // only request is active
+    if (CanonicalMPIName == "MPI_Wait")
+      return val != CI->getOperand(0);
+
+    if (CanonicalMPIName == "MPI_Waitall")
+      return val != CI->getOperand(1);
+
+    // only the send/recv buffers are active for mpi reduce/allreduce
+    if (CanonicalMPIName == "MPI_Reduce" ||
+        CanonicalMPIName == "MPI_Allreduce" ||
+        CanonicalMPIName == "MPI_Reduce_scatter_block") {
+      return val != CI->getOperand(0) && val != CI->getOperand(1);
+    }
+
+    // only the buffer is active for mpi bcast
+    if (CanonicalMPIName == "MPI_Bcast") {
+      return val != CI->getOperand(0);
+    }
+
+    // mpi init/finalize and rank/size queries have no active arguments
+    if (CanonicalMPIName == "MPI_Init" || CanonicalMPIName == "MPI_Finalize" ||
+        CanonicalMPIName == "MPI_Comm_rank" ||
+        CanonicalMPIName == "MPI_Comm_size" ||
+        CanonicalMPIName == "MPI_Barrier")
+      return true;
   }
-  // only the recv buffer and request is active for mpi isend/irecv
-  if (CanonicalMPIName == "MPI_Irecv" || CanonicalMPIName == "MPI_Isend") {
-    return val != CI->getOperand(0) && val != CI->getOperand(6);
-  }
-
-  // only request is active
-  if (CanonicalMPIName == "MPI_Wait")
-    return val != CI->getOperand(0);
-
-  if (CanonicalMPIName == "MPI_Waitall")
-    return val != CI->getOperand(1);
-
-  // only the send/recv buffers are active for mpi reduce/allreduce
-  if (CanonicalMPIName == "MPI_Reduce" || CanonicalMPIName == "MPI_Allreduce" ||
-      CanonicalMPIName == "MPI_Reduce_scatter_block") {
-    return val != CI->getOperand(0) && val != CI->getOperand(1);
-  }
-
-  // only the buffer is active for mpi bcast
-  if (CanonicalMPIName == "MPI_Bcast") {
-    return val != CI->getOperand(0);
-  }
-
-  // mpi init/finalize and rank/size queries have no active arguments
-  if (CanonicalMPIName == "MPI_Init" || CanonicalMPIName == "MPI_Finalize" ||
-      CanonicalMPIName == "MPI_Comm_rank" ||
-      CanonicalMPIName == "MPI_Comm_size" || CanonicalMPIName == "MPI_Barrier")
-    return true;
 
   // TODO interprocedural detection
   // Before potential introprocedural detection, any function without definition

--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -749,8 +749,7 @@ bool ActivityAnalyzer::isFunctionArgumentConstant(CallInst *CI, Value *val) {
     return val != CI->getOperand(1);
 
   // only the send/recv buffers are active for mpi reduce/allreduce
-  if (CanonicalMPIName == "MPI_Reduce" ||
-      CanonicalMPIName == "MPI_Allreduce" ||
+  if (CanonicalMPIName == "MPI_Reduce" || CanonicalMPIName == "MPI_Allreduce" ||
       CanonicalMPIName == "MPI_Reduce_scatter_block") {
     return val != CI->getOperand(0) && val != CI->getOperand(1);
   }

--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -731,6 +731,8 @@ bool ActivityAnalyzer::isFunctionArgumentConstant(CallInst *CI, Value *val) {
   // "PMPI_Recv" and Fortran "mpi_recv_" etc.): the leading argument indices
   // match between the ABIs, the Fortran ABI only appends an `ierr` argument.
   StringRef CanonicalMPIName = canonicalizeMPIName(Name);
+  if (CanonicalMPIName.empty())
+    return false;
 
   // only the buffer is active for mpi send/recv
   if (CanonicalMPIName == "MPI_Recv" || CanonicalMPIName == "MPI_Send") {

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -136,6 +136,28 @@ public:
                              llvm::Type *intType, llvm::Function *caller) {
     using namespace llvm;
 
+    // Fortran ABI ("mpi_type_size_"): all arguments are passed by reference
+    // and the call takes an extra trailing `ierr` argument.
+    if (isFortranMPICall(caller->getName())) {
+      Type *i32 = Type::getInt32Ty(DT->getContext());
+      Type *pargs[] = {getInt8PtrTy(DT->getContext()), getUnqual(i32),
+                       getUnqual(i32)};
+      auto FT = FunctionType::get(Type::getVoidTy(DT->getContext()), pargs,
+                                  false);
+      IRBuilder<> AllocaBuilder(gutils->inversionAllocs);
+      auto alloc = AllocaBuilder.CreateAlloca(i32);
+      auto ierr = AllocaBuilder.CreateAlloca(i32);
+      llvm::Value *args[] = {DT, alloc, ierr};
+      if (DT->getType() != pargs[0])
+        args[0] = B.CreateBitCast(args[0], pargs[0]);
+      B.CreateCall(
+          B.GetInsertBlock()->getParent()->getParent()->getOrInsertFunction(
+              getRenamedPerCallingConv(caller->getName(), "MPI_Type_size"),
+              FT),
+          args);
+      return B.CreateLoad(i32, alloc);
+    }
+
     if (DT->getType()->isIntegerTy())
       DT = B.CreateIntToPtr(DT, getInt8PtrTy(DT->getContext()));
 
@@ -199,6 +221,28 @@ public:
   llvm::Value *MPI_COMM_RANK(llvm::Value *comm, llvm::IRBuilder<> &B,
                              llvm::Type *rankTy, llvm::Function *caller) {
     using namespace llvm;
+
+    // Fortran ABI ("mpi_comm_rank_"): all arguments are passed by reference
+    // and the call takes an extra trailing `ierr` argument.
+    if (isFortranMPICall(caller->getName())) {
+      Type *i32 = Type::getInt32Ty(comm->getContext());
+      Type *pargs[] = {getInt8PtrTy(comm->getContext()), getUnqual(i32),
+                       getUnqual(i32)};
+      auto FT = FunctionType::get(Type::getVoidTy(comm->getContext()), pargs,
+                                  false);
+      IRBuilder<> AllocaBuilder(gutils->inversionAllocs);
+      auto alloc = AllocaBuilder.CreateAlloca(i32);
+      auto ierr = AllocaBuilder.CreateAlloca(i32);
+      llvm::Value *args[] = {comm, alloc, ierr};
+      if (comm->getType() != pargs[0])
+        args[0] = B.CreateBitCast(args[0], pargs[0]);
+      B.CreateCall(
+          B.GetInsertBlock()->getParent()->getParent()->getOrInsertFunction(
+              getRenamedPerCallingConv(caller->getName(), "MPI_Comm_rank"),
+              FT),
+          args);
+      return B.CreateLoad(i32, alloc);
+    }
 
     Type *pargs[] = {comm->getType(), getUnqual(rankTy)};
     auto FT = FunctionType::get(rankTy, pargs, false);
@@ -4934,15 +4978,57 @@ public:
                    .Only(0, &call);
           goto knownF;
         }
+        // Handle LoadInst (common for the Fortran ABI where arguments are
+        // passed by reference: the buffer argument is a load of the array's
+        // address from an alloca'd variable)
+        if (auto LI = dyn_cast<LoadInst>(origArg)) {
+          auto *PT = dyn_cast<PointerType>(LI->getType());
+          if (PT && PT->getPointerElementType()->isFPOrFPVectorTy()) {
+            vd = TypeTree(ConcreteType(
+                   PT->getPointerElementType()->getScalarType()))
+                   .Only(0, &call);
+            goto knownF;
+          }
+        }
+        // Handle pointer arguments directly (Fortran MPI routines pass all
+        // arguments by reference, so the buffer argument may be a pointer to
+        // real data)
+        if (origArg->getType()->isPointerTy() &&
+            origArg->getType()->getPointerElementType()->isFPOrFPVectorTy()) {
+          vd = TypeTree(ConcreteType(
+                   origArg->getType()->getPointerElementType()->getScalarType()))
+                   .Only(0, &call);
+          goto knownF;
+        }
       }
 #endif
+      // With opaque pointers (LLVM >= 17) the pointee type of a pointer is
+      // not available from its type. Fall back to the element type when the
+      // buffer argument is an alloca or a GEP thereof, which is ground truth
+      // even with opaque pointers. This covers the Fortran ABI,
+      // where every argument is passed by reference and the buffer may be
+      // the address of a local variable that is only ever accessed by MPI
+      // routines (so TypeAnalysis never observes its contents).
+      if (auto AI = dyn_cast<AllocaInst>(origArg)) {
+        if (AI->getAllocatedType()->isFPOrFPVectorTy()) {
+          vd = TypeTree(ConcreteType(AI->getAllocatedType()->getScalarType()))
+                   .Only(0, &call);
+          goto knownF;
+        }
+      }
+      if (auto GEP = dyn_cast<GetElementPtrInst>(origArg)) {
+        if (GEP->getSourceElementType()->isFPOrFPVectorTy()) {
+          vd = TypeTree(
+                   ConcreteType(GEP->getSourceElementType()->getScalarType()))
+                   .Only(0, &call);
+          goto knownF;
+        }
+      }
       TR.dump();
       EmitFailure("CannotDeduceType", call.getDebugLoc(), &call,
                   "failed to deduce type of copy ", call);
     }
-#if LLVM_VERSION_MAJOR < 17
   knownF:
-#endif
     unsigned start = 0;
     while (1) {
       unsigned nextStart = size;

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -276,6 +276,27 @@ public:
                              llvm::Type *rankTy, llvm::Function *caller) {
     using namespace llvm;
 
+    // Fortran ABI ("mpi_comm_size_"): all arguments are passed by reference
+    // and the call takes an extra trailing `ierr` argument.
+    if (isFortranMPICall(caller->getName())) {
+      Type *i32 = Type::getInt32Ty(comm->getContext());
+      Type *pargs[] = {getInt8PtrTy(comm->getContext()), getUnqual(i32),
+                       getUnqual(i32)};
+      auto FT =
+          FunctionType::get(Type::getVoidTy(comm->getContext()), pargs, false);
+      IRBuilder<> AllocaBuilder(gutils->inversionAllocs);
+      auto alloc = AllocaBuilder.CreateAlloca(i32);
+      auto ierr = AllocaBuilder.CreateAlloca(i32);
+      llvm::Value *args[] = {comm, alloc, ierr};
+      if (comm->getType() != pargs[0])
+        args[0] = B.CreateBitCast(args[0], pargs[0]);
+      B.CreateCall(
+          B.GetInsertBlock()->getParent()->getParent()->getOrInsertFunction(
+              getRenamedPerCallingConv(caller->getName(), "MPI_Comm_size"), FT),
+          args);
+      return B.CreateLoad(i32, alloc);
+    }
+
     Type *pargs[] = {comm->getType(), getUnqual(rankTy)};
     auto FT = FunctionType::get(rankTy, pargs, false);
     auto &context = comm->getContext();

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -142,8 +142,8 @@ public:
       Type *i32 = Type::getInt32Ty(DT->getContext());
       Type *pargs[] = {getInt8PtrTy(DT->getContext()), getUnqual(i32),
                        getUnqual(i32)};
-      auto FT = FunctionType::get(Type::getVoidTy(DT->getContext()), pargs,
-                                  false);
+      auto FT =
+          FunctionType::get(Type::getVoidTy(DT->getContext()), pargs, false);
       IRBuilder<> AllocaBuilder(gutils->inversionAllocs);
       auto alloc = AllocaBuilder.CreateAlloca(i32);
       auto ierr = AllocaBuilder.CreateAlloca(i32);
@@ -152,8 +152,7 @@ public:
         args[0] = B.CreateBitCast(args[0], pargs[0]);
       B.CreateCall(
           B.GetInsertBlock()->getParent()->getParent()->getOrInsertFunction(
-              getRenamedPerCallingConv(caller->getName(), "MPI_Type_size"),
-              FT),
+              getRenamedPerCallingConv(caller->getName(), "MPI_Type_size"), FT),
           args);
       return B.CreateLoad(i32, alloc);
     }
@@ -228,8 +227,8 @@ public:
       Type *i32 = Type::getInt32Ty(comm->getContext());
       Type *pargs[] = {getInt8PtrTy(comm->getContext()), getUnqual(i32),
                        getUnqual(i32)};
-      auto FT = FunctionType::get(Type::getVoidTy(comm->getContext()), pargs,
-                                  false);
+      auto FT =
+          FunctionType::get(Type::getVoidTy(comm->getContext()), pargs, false);
       IRBuilder<> AllocaBuilder(gutils->inversionAllocs);
       auto alloc = AllocaBuilder.CreateAlloca(i32);
       auto ierr = AllocaBuilder.CreateAlloca(i32);
@@ -238,8 +237,7 @@ public:
         args[0] = B.CreateBitCast(args[0], pargs[0]);
       B.CreateCall(
           B.GetInsertBlock()->getParent()->getParent()->getOrInsertFunction(
-              getRenamedPerCallingConv(caller->getName(), "MPI_Comm_rank"),
-              FT),
+              getRenamedPerCallingConv(caller->getName(), "MPI_Comm_rank"), FT),
           args);
       return B.CreateLoad(i32, alloc);
     }
@@ -4984,9 +4982,9 @@ public:
         if (auto LI = dyn_cast<LoadInst>(origArg)) {
           auto *PT = dyn_cast<PointerType>(LI->getType());
           if (PT && PT->getPointerElementType()->isFPOrFPVectorTy()) {
-            vd = TypeTree(ConcreteType(
-                   PT->getPointerElementType()->getScalarType()))
-                   .Only(0, &call);
+            vd = TypeTree(
+                     ConcreteType(PT->getPointerElementType()->getScalarType()))
+                     .Only(0, &call);
             goto knownF;
           }
         }
@@ -4995,8 +4993,9 @@ public:
         // real data)
         if (origArg->getType()->isPointerTy() &&
             origArg->getType()->getPointerElementType()->isFPOrFPVectorTy()) {
-          vd = TypeTree(ConcreteType(
-                   origArg->getType()->getPointerElementType()->getScalarType()))
+          vd = TypeTree(ConcreteType(origArg->getType()
+                                         ->getPointerElementType()
+                                         ->getScalarType()))
                    .Only(0, &call);
           goto knownF;
         }

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -1130,6 +1130,10 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
       Value *orig_root = call.getOperand(5);
       Value *orig_comm = call.getOperand(6);
 
+      // The Fortran MPI ABI ("mpi_reduce_", "mpi_reduce__", ...) passes all
+      // arguments by reference and appends an `ierr` argument.
+      bool fortranABI = isFortranMPICall(called->getName());
+
       bool isSum = false;
       if (Constant *C = dyn_cast<Constant>(orig_op)) {
         while (ConstantExpr *CE = dyn_cast<ConstantExpr>(C)) {
@@ -1138,6 +1142,16 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
         if (auto GV = dyn_cast<GlobalVariable>(C)) {
           if (GV->getName() == "ompi_mpi_op_sum") {
             isSum = true;
+          } else if (fortranABI && GV->isConstant() &&
+                     GV->hasDefinitiveInitializer()) {
+            // The Fortran ABI passes the operator as a reference to an
+            // integer handle
+            if (auto *CI = dyn_cast<ConstantInt>(GV->getInitializer())) {
+              // MPICH
+              if (CI->getValue() == 1476395011) {
+                isSum = true;
+              }
+            }
           }
         }
         // MPICH
@@ -1148,12 +1162,20 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
         }
       }
       if (!isSum) {
-        std::string s;
-        llvm::raw_string_ostream ss(s);
-        ss << " call: " << call << "\n";
-        ss << " unhandled mpi_reduce op: " << *orig_op << "\n";
-        EmitNoDerivativeError(ss.str(), call, gutils, BuilderZ);
-        return;
+        if (fortranABI) {
+          // Integer MPI operator handles of the Fortran ABI are
+          // implementation-defined and cannot be mapped portably at compile
+          // time; warn and assume the common case of MPI_SUM.
+          llvm::errs() << "warning: cannot determine MPI op used in `" << call
+                       << "`, assuming MPI_SUM\n";
+        } else {
+          std::string s;
+          llvm::raw_string_ostream ss(s);
+          ss << " call: " << call << "\n";
+          ss << " unhandled mpi_reduce op: " << *orig_op << "\n";
+          EmitNoDerivativeError(ss.str(), call, gutils, BuilderZ);
+          return;
+        }
       }
 
       Value *shadow_recvbuf = gutils->invertPointerM(orig_recvbuf, Builder2);
@@ -1170,13 +1192,16 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
         shadow_sendbuf = Builder2.CreateIntToPtr(
             shadow_sendbuf, getInt8PtrTy(call.getContext()));
 
-      // Need to preserve the shadow send/recv buffers.
-      auto BufferDefs = gutils->getInvertedBundles(
-          &call,
-          {ValueType::Shadow, ValueType::Shadow, ValueType::Primal,
-           ValueType::Primal, ValueType::Primal, ValueType::Primal,
-           ValueType::Primal},
-          Builder2, /*lookup*/ !forwardMode);
+      // Need to preserve the shadow send/recv buffers. The Fortran ABI call
+      // has an extra `ierr` argument, so build the bundle to match the actual
+      // call arity: shadow send/recv buffers, primal everything else.
+      std::vector<ValueType> BufferBundleTypes(call.arg_size(),
+                                               ValueType::Primal);
+      BufferBundleTypes[0] = ValueType::Shadow;
+      BufferBundleTypes[1] = ValueType::Shadow;
+      auto BufferDefs = gutils->getInvertedBundles(&call, BufferBundleTypes,
+                                                   Builder2,
+                                                   /*lookup*/ !forwardMode);
 
       Value *count = gutils->getNewFromOriginal(orig_count);
       if (!forwardMode)
@@ -1198,25 +1223,27 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
       if (!forwardMode)
         comm = lookup(comm, Builder2);
 
-      Value *rank = MPI_COMM_RANK(comm, Builder2, root->getType(), called);
+      // The Fortran ABI passes the count and root arguments by reference;
+      // load them where their value is needed.
+      Type *i32Ty = Type::getInt32Ty(call.getContext());
+      Value *countVal = fortranABI ? Builder2.CreateLoad(i32Ty, count) : count;
+      Value *rootVal = fortranABI ? Builder2.CreateLoad(i32Ty, root) : root;
+
+      Value *rank = MPI_COMM_RANK(comm, Builder2, rootVal->getType(), called);
 
       if (forwardMode) {
-        Value *args[] = {
+        SmallVector<Value *, 8> args = {
             /*sendbuf*/ shadow_sendbuf,
             /*recvbuf*/ shadow_recvbuf,
-            /*count*/ count,
-            /*datatype*/ datatype,
-            /*op*/ op,
-            /*root*/ root,
-            /*comm*/ comm,
         };
+        for (size_t i = 2, e = call.arg_size(); i < e; i++)
+          args.push_back(gutils->getNewFromOriginal(call.getArgOperand(i)));
 
-        auto Defs = gutils->getInvertedBundles(
-            &call,
-            {ValueType::Shadow, ValueType::Shadow, ValueType::Primal,
-             ValueType::Primal, ValueType::Primal, ValueType::Primal,
-             ValueType::Primal},
-            Builder2, /*lookup*/ false);
+        std::vector<ValueType> BundleTypes(call.arg_size(), ValueType::Primal);
+        BundleTypes[0] = ValueType::Shadow;
+        BundleTypes[1] = ValueType::Shadow;
+        auto Defs = gutils->getInvertedBundles(&call, BundleTypes, Builder2,
+                                               /*lookup*/ false);
 
         auto callval = call.getCalledOperand();
         Builder2.CreateCall(call.getFunctionType(), callval, args, Defs);
@@ -1227,7 +1254,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
 
       // Get the length for the allocation of the intermediate buffer
       auto len_arg = Builder2.CreateZExtOrTrunc(
-          count, Type::getInt64Ty(call.getContext()));
+          countVal, Type::getInt64Ty(call.getContext()));
       len_arg =
           Builder2.CreateMul(len_arg,
                              Builder2.CreateZExtOrTrunc(
@@ -1248,7 +1275,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
         BasicBlock *mergeBlock = gutils->addReverseBlock(
             rootBlock, currentBlock->getName() + "_post", gutils->newFunc);
 
-        Builder2.CreateCondBr(Builder2.CreateICmpEQ(rank, root), rootBlock,
+        Builder2.CreateCondBr(Builder2.CreateICmpEQ(rank, rootVal), rootBlock,
                               mergeBlock);
 
         Builder2.SetInsertPoint(rootBlock);
@@ -1277,18 +1304,28 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
         // int MPI_Bcast( void *buffer, int count, MPI_Datatype datatype, int
         // root,
         //     MPI_Comm comm )
-        Value *args[] = {
+        // The Fortran ABI passes count/datatype/root/comm by reference (as
+        // held here) and appends an `ierr` argument.
+        SmallVector<Value *, 8> args = {
             /*buf*/ buf,
             /*count*/ count,
             /*datatype*/ datatype,
             /*int root*/ root,
             /*comm*/ comm,
         };
-        Type *types[sizeof(args) / sizeof(*args)];
-        for (size_t i = 0; i < sizeof(args) / sizeof(*args); i++)
-          types[i] = args[i]->getType();
+        if (fortranABI) {
+          args.push_back(
+              IRBuilder<>(gutils->inversionAllocs)
+                  .CreateAlloca(i32Ty, nullptr, "enzyme_mpi_ierr"));
+        }
+        SmallVector<Type *, 8> types;
+        for (auto *arg : args) {
+          types.push_back(arg->getType());
+        }
 
-        FunctionType *FT = FunctionType::get(call.getType(), types, false);
+        FunctionType *FT = FunctionType::get(
+            fortranABI ? Type::getVoidTy(call.getContext()) : call.getType(),
+            types, false);
         Builder2.CreateCall(
             called->getParent()->getOrInsertFunction(
                 getRenamedPerCallingConv(called->getName(), "MPI_Bcast"), FT),
@@ -1303,7 +1340,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
         BasicBlock *mergeBlock = gutils->addReverseBlock(
             rootBlock, currentBlock->getName() + "_post", gutils->newFunc);
 
-        Builder2.CreateCondBr(Builder2.CreateICmpEQ(rank, root), rootBlock,
+        Builder2.CreateCondBr(Builder2.CreateICmpEQ(rank, rootVal), rootBlock,
                               mergeBlock);
 
         Builder2.SetInsertPoint(rootBlock);
@@ -2164,8 +2201,12 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
       IRBuilder<> Builder2(&call);
       getReverseBuilder(Builder2);
       auto callval = call.getCalledOperand();
-      Value *args[] = {
-          lookup(gutils->getNewFromOriginal(call.getOperand(0)), Builder2)};
+      // Copy all arguments to match the call's arity: Fortran ABI manglings
+      // of MPI_Barrier (e.g. "mpi_barrier_") take an extra `ierr` argument.
+      SmallVector<Value *, 4> args;
+      for (unsigned i = 0; i < call.arg_size(); i++)
+        args.push_back(
+            lookup(gutils->getNewFromOriginal(call.getArgOperand(i)), Builder2));
       Builder2.CreateCall(call.getFunctionType(), callval, args);
     }
     if (Mode == DerivativeMode::ReverseModeGradient)
@@ -2198,6 +2239,81 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
           called->getParent()->getOrInsertFunction(
               getRenamedPerCallingConv(called->getName(), "MPI_Comm_free"), FT),
           args);
+    }
+    if (Mode == DerivativeMode::ReverseModeGradient)
+      eraseIfUnused(call, /*erase*/ true, /*check*/ false);
+    return;
+  }
+
+  // Simple MPI functions that don't affect differentiation - just duplicate
+  // them in both forward and reverse passes. These functions query MPI
+  // state (communicator size, rank, processor name, etc.) but don't
+  // participate in the computation being differentiated.
+  if (funcName == "MPI_Comm_size" || funcName == "PMPI_Comm_size" ||
+      funcName == "MPI_Comm_rank" || funcName == "PMPI_Comm_rank" ||
+      funcName == "MPI_Get_processor_name" ||
+      funcName == "PMPI_Get_processor_name") {
+    if (Mode == DerivativeMode::ReverseModeGradient ||
+        Mode == DerivativeMode::ReverseModeCombined ||
+        Mode == DerivativeMode::ReverseModePrimal) {
+      IRBuilder<> Builder2(&call);
+      getReverseBuilder(Builder2);
+      SmallVector<Value *, 8> args;
+      for (unsigned i = 0; i < call.arg_size(); ++i) {
+        args.push_back(lookup(gutils->getNewFromOriginal(call.getArgOperand(i)),
+                              Builder2));
+      }
+      Builder2.CreateCall(call.getFunctionType(), call.getCalledOperand(),
+                          args);
+    }
+    if (Mode == DerivativeMode::ForwardMode ||
+        Mode == DerivativeMode::ForwardModeError ||
+        Mode == DerivativeMode::ForwardModeSplit) {
+      IRBuilder<> Builder2(&call);
+      getForwardBuilder(Builder2);
+      SmallVector<Value *, 8> args;
+      for (unsigned i = 0; i < call.arg_size(); ++i) {
+        args.push_back(gutils->getNewFromOriginal(call.getArgOperand(i)));
+      }
+      Builder2.CreateCall(call.getFunctionType(), call.getCalledOperand(),
+                          args);
+    }
+    if (Mode == DerivativeMode::ReverseModeGradient)
+      eraseIfUnused(call, /*erase*/ true, /*check*/ false);
+    return;
+  }
+
+  // MPI_Init / MPI_Finalize don't participate in the computation being
+  // differentiated - just duplicate them as-is in both passes.
+  if (funcName == "MPI_Init" || funcName == "PMPI_Init" ||
+      funcName == "MPI_Init_thread" || funcName == "PMPI_Init_thread" ||
+      funcName == "MPI_Finalize" || funcName == "PMPI_Finalize" ||
+      funcName == "MPI_Test" || funcName == "PMPI_Test" ||
+      funcName == "MPI_Probe" || funcName == "PMPI_Probe") {
+    if (Mode == DerivativeMode::ReverseModeGradient ||
+        Mode == DerivativeMode::ReverseModeCombined ||
+        Mode == DerivativeMode::ReverseModePrimal) {
+      IRBuilder<> Builder2(&call);
+      getReverseBuilder(Builder2);
+      SmallVector<Value *, 8> args;
+      for (unsigned i = 0; i < call.arg_size(); ++i) {
+        args.push_back(lookup(gutils->getNewFromOriginal(call.getArgOperand(i)),
+                              Builder2));
+      }
+      Builder2.CreateCall(call.getFunctionType(), call.getCalledOperand(),
+                          args);
+    }
+    if (Mode == DerivativeMode::ForwardMode ||
+        Mode == DerivativeMode::ForwardModeError ||
+        Mode == DerivativeMode::ForwardModeSplit) {
+      IRBuilder<> Builder2(&call);
+      getForwardBuilder(Builder2);
+      SmallVector<Value *, 8> args;
+      for (unsigned i = 0; i < call.arg_size(); ++i) {
+        args.push_back(gutils->getNewFromOriginal(call.getArgOperand(i)));
+      }
+      Builder2.CreateCall(call.getFunctionType(), call.getCalledOperand(),
+                          args);
     }
     if (Mode == DerivativeMode::ReverseModeGradient)
       eraseIfUnused(call, /*erase*/ true, /*check*/ false);
@@ -2251,6 +2367,14 @@ bool AdjointGenerator::handleKnownCallDerivatives(
        CanonicalMPIName == "MPI_Barrier" ||
        CanonicalMPIName == "MPI_Comm_free" ||
        CanonicalMPIName == "MPI_Comm_disconnect" ||
+       CanonicalMPIName == "MPI_Comm_size" ||
+       CanonicalMPIName == "MPI_Comm_rank" ||
+       CanonicalMPIName == "MPI_Init" ||
+       CanonicalMPIName == "MPI_Init_thread" ||
+       CanonicalMPIName == "MPI_Finalize" ||
+       CanonicalMPIName == "MPI_Get_processor_name" ||
+       CanonicalMPIName == "MPI_Test" ||
+       CanonicalMPIName == "MPI_Probe" ||
        MPIInactiveCommAllocators.find(CanonicalMPIName) !=
            MPIInactiveCommAllocators.end())) {
     handleMPI(call, called, CanonicalMPIName);

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -2241,12 +2241,19 @@ bool AdjointGenerator::handleKnownCallDerivatives(
     }
   }
 
-  if ((startsWith(funcName, "MPI_") || startsWith(funcName, "PMPI_")) &&
-      (!gutils->isConstantInstruction(&call) || funcName == "MPI_Barrier" ||
-       funcName == "MPI_Comm_free" || funcName == "MPI_Comm_disconnect" ||
-       MPIInactiveCommAllocators.find(funcName) !=
+  // Canonicalize MPI routine names across calling conventions: the C
+  // convention ("MPI_Recv", "PMPI_Recv") as well as Fortran ABI manglings
+  // ("mpi_recv_", "mpi_comm_rank__", ...) all map to the canonical C name
+  // (without profiling prefix) used throughout handleMPI.
+  llvm::StringRef CanonicalMPIName = canonicalizeMPIName(funcName);
+  if (!CanonicalMPIName.empty() &&
+      (!gutils->isConstantInstruction(&call) ||
+       CanonicalMPIName == "MPI_Barrier" ||
+       CanonicalMPIName == "MPI_Comm_free" ||
+       CanonicalMPIName == "MPI_Comm_disconnect" ||
+       MPIInactiveCommAllocators.find(CanonicalMPIName) !=
            MPIInactiveCommAllocators.end())) {
-    handleMPI(call, called, funcName);
+    handleMPI(call, called, CanonicalMPIName);
     return true;
   }
 

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -1121,7 +1121,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
         getReverseBuilder(Builder2);
       }
 
-      // Get the operations from MPI_Receive
+      // Get the operations from MPI_Reduce
       Value *orig_sendbuf = call.getOperand(0);
       Value *orig_recvbuf = call.getOperand(1);
       Value *orig_count = call.getOperand(2);

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -1618,6 +1618,8 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
       if (!forwardMode)
         sendtype = lookup(sendtype, Builder2);
 
+      bool fortranABI = isFortranMPICall(called->getName());
+
       Value *root = gutils->getNewFromOriginal(orig_root);
       if (!forwardMode)
         root = lookup(root, Builder2);
@@ -1626,36 +1628,43 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
       if (!forwardMode)
         comm = lookup(comm, Builder2);
 
-      Value *rank = MPI_COMM_RANK(comm, Builder2, root->getType(), called);
+      Type *i32Ty = Type::getInt32Ty(call.getContext());
+      Value *sendcountVal = fortranABI ? Builder2.CreateLoad(i32Ty, sendcount) : sendcount;
+      Value *recvcountVal = fortranABI ? Builder2.CreateLoad(i32Ty, recvcount) : recvcount;
+      Value *rootVal = fortranABI ? Builder2.CreateLoad(i32Ty, root) : root;
+
+      Value *rank = MPI_COMM_RANK(comm, Builder2, rootVal->getType(), called);
       Value *tysize = MPI_TYPE_SIZE(sendtype, Builder2, call.getType(), called);
 
       if (forwardMode) {
-        Value *args[] = {
+        // Account for extra `ierr` argument in Fortran ABI
+        SmallVector<Value *, 8> args_vec = {
             /*sendbuf*/ shadow_sendbuf,
-            /*sendcount*/ sendcount,
+            /*sendcount*/ gutils->getNewFromOriginal(orig_sendcount),
             /*sendtype*/ sendtype,
             /*recvbuf*/ shadow_recvbuf,
-            /*recvcount*/ recvcount,
+            /*recvcount*/ gutils->getNewFromOriginal(orig_recvcount),
             /*recvtype*/ recvtype,
-            /*root*/ root,
+            /*root*/ gutils->getNewFromOriginal(orig_root),
             /*comm*/ comm,
         };
+        for (size_t i = 8, e = call.arg_size(); i < e; i++)
+          args_vec.push_back(gutils->getNewFromOriginal(call.getArgOperand(i)));
 
-        auto Defs = gutils->getInvertedBundles(
-            &call,
-            {ValueType::Shadow, ValueType::Primal, ValueType::Primal,
-             ValueType::Shadow, ValueType::Primal, ValueType::Primal,
-             ValueType::Primal, ValueType::Primal},
-            Builder2, /*lookup*/ false);
+        std::vector<ValueType> BundleTypes(call.arg_size(), ValueType::Primal);
+        BundleTypes[0] = ValueType::Shadow;
+        BundleTypes[3] = ValueType::Shadow;
+        auto Defs = gutils->getInvertedBundles(&call, BundleTypes, Builder2,
+                                                /*lookup*/ false);
 
         auto callval = call.getCalledOperand();
-        Builder2.CreateCall(call.getFunctionType(), callval, args, Defs);
+        Builder2.CreateCall(call.getFunctionType(), callval, args_vec, Defs);
         return;
       }
 
       // Get the length for the allocation of the intermediate buffer
       auto sendlen_arg = Builder2.CreateZExtOrTrunc(
-          sendcount, Type::getInt64Ty(call.getContext()));
+          sendcountVal, Type::getInt64Ty(call.getContext()));
       sendlen_arg =
           Builder2.CreateMul(sendlen_arg,
                              Builder2.CreateZExtOrTrunc(
@@ -1675,59 +1684,59 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
           CreateAllocation(Builder2, Type::getInt8Ty(call.getContext()),
                            sendlen_arg, "mpireduce_malloccache");
 
-      // 2. Scatter diff(recvbuffer) to intermediate buffer
-      {
-        // int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype
-        // sendtype,
-        //     void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-        //     MPI_Comm comm)
-        Value *args[] = {
-            /*sendbuf*/ shadow_recvbuf,
-            /*sendcount*/ recvcount,
-            /*sendtype*/ recvtype,
-            /*recvbuf*/ buf,
-            /*recvcount*/ sendcount,
-            /*recvtype*/ sendtype,
-            /*op*/ root,
-            /*comm*/ comm,
-        };
-        Type *types[sizeof(args) / sizeof(*args)];
-        for (size_t i = 0; i < sizeof(args) / sizeof(*args); i++)
-          types[i] = args[i]->getType();
+       // 2. Scatter diff(recvbuffer) to intermediate buffer
+       {
+         // int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype
+         // sendtype,
+         //     void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+         //     MPI_Comm comm)
+         Value *args[] = {
+             /*sendbuf*/ shadow_recvbuf,
+             /*sendcount*/ recvcountVal,
+             /*sendtype*/ recvtype,
+             /*recvbuf*/ buf,
+             /*recvcount*/ sendcountVal,
+             /*recvtype*/ sendtype,
+             /*op*/ rootVal,
+             /*comm*/ comm,
+         };
+         Type *types[sizeof(args) / sizeof(*args)];
+         for (size_t i = 0; i < sizeof(args) / sizeof(*args); i++)
+           types[i] = args[i]->getType();
 
-        FunctionType *FT = FunctionType::get(call.getType(), types, false);
-        Builder2.CreateCall(
-            called->getParent()->getOrInsertFunction(
-                getRenamedPerCallingConv(called->getName(), "MPI_Scatter"), FT),
-            args, BufferDefs);
-      }
+         FunctionType *FT = FunctionType::get(call.getType(), types, false);
+         Builder2.CreateCall(
+             called->getParent()->getOrInsertFunction(
+                 getRenamedPerCallingConv(called->getName(), "MPI_Scatter"), FT),
+             args, BufferDefs);
+       }
 
-      // 3. if root, Zero diff(recvbuffer) [memset to 0]
-      {
+       // 3. if root, Zero diff(recvbuffer) [memset to 0]
+       {
 
-        BasicBlock *currentBlock = Builder2.GetInsertBlock();
-        BasicBlock *rootBlock = gutils->addReverseBlock(
-            currentBlock, currentBlock->getName() + "_root", gutils->newFunc);
-        BasicBlock *mergeBlock = gutils->addReverseBlock(
-            rootBlock, currentBlock->getName() + "_post", gutils->newFunc);
+         BasicBlock *currentBlock = Builder2.GetInsertBlock();
+         BasicBlock *rootBlock = gutils->addReverseBlock(
+             currentBlock, currentBlock->getName() + "_root", gutils->newFunc);
+         BasicBlock *mergeBlock = gutils->addReverseBlock(
+             rootBlock, currentBlock->getName() + "_post", gutils->newFunc);
 
-        Builder2.CreateCondBr(Builder2.CreateICmpEQ(rank, root), rootBlock,
-                              mergeBlock);
+         Builder2.CreateCondBr(Builder2.CreateICmpEQ(rank, rootVal), rootBlock,
+                               mergeBlock);
 
-        Builder2.SetInsertPoint(rootBlock);
-        auto recvlen_arg = Builder2.CreateZExtOrTrunc(
-            recvcount, Type::getInt64Ty(call.getContext()));
-        recvlen_arg =
-            Builder2.CreateMul(recvlen_arg,
-                               Builder2.CreateZExtOrTrunc(
-                                   tysize, Type::getInt64Ty(call.getContext())),
-                               "", true, true);
-        recvlen_arg = Builder2.CreateMul(
-            recvlen_arg,
-            Builder2.CreateZExtOrTrunc(
-                MPI_COMM_SIZE(comm, Builder2, root->getType(), called),
-                Type::getInt64Ty(call.getContext())),
-            "", true, true);
+         Builder2.SetInsertPoint(rootBlock);
+         auto recvlen_arg = Builder2.CreateZExtOrTrunc(
+             recvcountVal, Type::getInt64Ty(call.getContext()));
+         recvlen_arg =
+             Builder2.CreateMul(recvlen_arg,
+                                Builder2.CreateZExtOrTrunc(
+                                    tysize, Type::getInt64Ty(call.getContext())),
+                                "", true, true);
+         recvlen_arg = Builder2.CreateMul(
+             recvlen_arg,
+             Builder2.CreateZExtOrTrunc(
+                 MPI_COMM_SIZE(comm, Builder2, rootVal->getType(), called),
+                 Type::getInt64Ty(call.getContext())),
+             "", true, true);
 
         auto val_arg = ConstantInt::get(Type::getInt8Ty(call.getContext()), 0);
         auto volatile_arg = ConstantInt::getFalse(call.getContext());

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -1103,7 +1103,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
   // MPI_Datatype datatype,
   //                      MPI_Op op, int root, MPI_Comm comm)
 
-  if (funcName == "MPI_Reduce" || funcName == "PMPI_Reduce") {
+  if (canonicalizeMPIName(funcName) == "MPI_Reduce") {
     if (Mode == DerivativeMode::ReverseModeGradient ||
         Mode == DerivativeMode::ReverseModeCombined ||
         Mode == DerivativeMode::ForwardMode ||
@@ -1402,7 +1402,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
   // int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count,
   //              MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
 
-  if (funcName == "MPI_Allreduce" || funcName == "PMPI_Allreduce") {
+  if (canonicalizeMPIName(funcName) == "MPI_Allreduce") {
     if (Mode == DerivativeMode::ReverseModeGradient ||
         Mode == DerivativeMode::ReverseModeCombined ||
         Mode == DerivativeMode::ForwardMode ||
@@ -1869,7 +1869,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
   // sendtype,
   //           void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
   //           MPI_Comm comm)
-  if (funcName == "MPI_Scatter" || funcName == "PMPI_Scatter") {
+  if (canonicalizeMPIName(funcName) == "MPI_Scatter") {
     if (Mode == DerivativeMode::ReverseModeGradient ||
         Mode == DerivativeMode::ReverseModeCombined ||
         Mode == DerivativeMode::ForwardMode ||

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -1103,7 +1103,9 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
   // MPI_Datatype datatype,
   //                      MPI_Op op, int root, MPI_Comm comm)
 
-  if (canonicalizeMPIName(funcName) == "MPI_Reduce") {
+  llvm::StringRef canonMPIName = canonicalizeMPIName(funcName);
+
+  if (canonMPIName == "MPI_Reduce") {
     if (Mode == DerivativeMode::ReverseModeGradient ||
         Mode == DerivativeMode::ReverseModeCombined ||
         Mode == DerivativeMode::ForwardMode ||
@@ -1402,7 +1404,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
   // int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count,
   //              MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
 
-  if (canonicalizeMPIName(funcName) == "MPI_Allreduce") {
+  if (canonMPIName == "MPI_Allreduce") {
     if (Mode == DerivativeMode::ReverseModeGradient ||
         Mode == DerivativeMode::ReverseModeCombined ||
         Mode == DerivativeMode::ForwardMode ||
@@ -1869,7 +1871,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
   // sendtype,
   //           void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
   //           MPI_Comm comm)
-  if (canonicalizeMPIName(funcName) == "MPI_Scatter") {
+  if (canonMPIName == "MPI_Scatter") {
     if (Mode == DerivativeMode::ReverseModeGradient ||
         Mode == DerivativeMode::ReverseModeCombined ||
         Mode == DerivativeMode::ForwardMode ||
@@ -2441,19 +2443,16 @@ bool AdjointGenerator::handleKnownCallDerivatives(
   // convention ("MPI_Recv", "PMPI_Recv") as well as Fortran ABI manglings
   // ("mpi_recv_", "mpi_comm_rank__", ...) all map to the canonical C name
   // (without profiling prefix) used throughout handleMPI.
-  llvm::StringRef CanonicalMPIName = canonicalizeMPIName(funcName);
-  if (!CanonicalMPIName.empty() &&
-      (!gutils->isConstantInstruction(&call) ||
-       CanonicalMPIName == "MPI_Barrier" ||
-       CanonicalMPIName == "MPI_Comm_free" ||
-       CanonicalMPIName == "MPI_Comm_disconnect" ||
-       CanonicalMPIName == "MPI_Init" ||
-       CanonicalMPIName == "MPI_Init_thread" ||
-       CanonicalMPIName == "MPI_Finalize" || CanonicalMPIName == "MPI_Test" ||
-       CanonicalMPIName == "MPI_Probe" ||
-       MPIInactiveCommAllocators.find(CanonicalMPIName) !=
+  llvm::StringRef canonMPIName = canonicalizeMPIName(funcName);
+  if (!canonMPIName.empty() &&
+      (!gutils->isConstantInstruction(&call) || canonMPIName == "MPI_Barrier" ||
+       canonMPIName == "MPI_Comm_free" ||
+       canonMPIName == "MPI_Comm_disconnect" || canonMPIName == "MPI_Init" ||
+       canonMPIName == "MPI_Init_thread" || canonMPIName == "MPI_Finalize" ||
+       canonMPIName == "MPI_Test" || canonMPIName == "MPI_Probe" ||
+       MPIInactiveCommAllocators.find(canonMPIName) !=
            MPIInactiveCommAllocators.end())) {
-    handleMPI(call, called, CanonicalMPIName);
+    handleMPI(call, called, canonMPIName);
     return true;
   }
 

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -1147,25 +1147,45 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
             // The Fortran ABI passes the operator as a reference to an
             // integer handle
             if (auto *CI = dyn_cast<ConstantInt>(GV->getInitializer())) {
-              // MPICH
+              // MPICH native ABI (also covers the MPICH ABI Compatibility
+              // Initiative: Intel MPI, MVAPICH, Cray MPICH)
               if (CI->getValue() == 1476395011) {
+                isSum = true;
+              }
+              // MPI 5.0 standard ABI (Chapter 20), where predefined op
+              // handles are fixed compile-time constants, identical in C
+              // and Fortran: MPI_SUM == 33.
+              if (CI->getValue() == 33) {
                 isSum = true;
               }
             }
           }
         }
-        // MPICH
+        // MPICH native ABI
         if (ConstantInt *CI = dyn_cast<ConstantInt>(C)) {
           if (CI->getValue() == 1476395011) {
+            isSum = true;
+          }
+        }
+        // MPI 5.0 standard ABI: predefined op handles are small-integer
+        // pointer constants (inttoptr), with MPI_SUM == 33.
+        if (ConstantInt *CI = dyn_cast<ConstantInt>(C)) {
+          if (CI->getValue() == 33) {
             isSum = true;
           }
         }
       }
       if (!isSum) {
         if (fortranABI) {
-          // Integer MPI operator handles of the Fortran ABI are
+          // Integer MPI operator handles of a native Fortran ABI are
           // implementation-defined and cannot be mapped portably at compile
-          // time; warn and assume the common case of MPI_SUM.
+          // time; warn and assume the common case of MPI_SUM. This remains
+          // true with MPI 5.0: although its standard ABI (Chapter 20) does
+          // fix handle values as portable compile-time constants (MPI_SUM
+          // == 33, recognized above), supporting that ABI is optional and
+          // neither Open MPI nor MPICH use it by default, so code compiled
+          // against the default/native ABIs still carries
+          // implementation-defined handle values.
           llvm::errs() << "warning: cannot determine MPI op used in `" << call
                        << "`, assuming MPI_SUM\n";
         } else {

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -2266,10 +2266,9 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
   // them in both forward and reverse passes. These functions query MPI
   // state (communicator size, rank, processor name, etc.) but don't
   // participate in the computation being differentiated.
-  if (funcName == "MPI_Comm_size" || funcName == "PMPI_Comm_size" ||
-      funcName == "MPI_Comm_rank" || funcName == "PMPI_Comm_rank" ||
-      funcName == "MPI_Get_processor_name" ||
-      funcName == "PMPI_Get_processor_name") {
+  if (canonicalizeMPIName(funcName) == "MPI_Comm_size" ||
+      canonicalizeMPIName(funcName) == "MPI_Comm_rank" ||
+      canonicalizeMPIName(funcName) == "MPI_Get_processor_name") {
     if (Mode == DerivativeMode::ReverseModeGradient ||
         Mode == DerivativeMode::ReverseModeCombined ||
         Mode == DerivativeMode::ReverseModePrimal) {

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -1629,8 +1629,10 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
         comm = lookup(comm, Builder2);
 
       Type *i32Ty = Type::getInt32Ty(call.getContext());
-      Value *sendcountVal = fortranABI ? Builder2.CreateLoad(i32Ty, sendcount) : sendcount;
-      Value *recvcountVal = fortranABI ? Builder2.CreateLoad(i32Ty, recvcount) : recvcount;
+      Value *sendcountVal =
+          fortranABI ? Builder2.CreateLoad(i32Ty, sendcount) : sendcount;
+      Value *recvcountVal =
+          fortranABI ? Builder2.CreateLoad(i32Ty, recvcount) : recvcount;
       Value *rootVal = fortranABI ? Builder2.CreateLoad(i32Ty, root) : root;
 
       Value *rank = MPI_COMM_RANK(comm, Builder2, rootVal->getType(), called);
@@ -1655,7 +1657,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
         BundleTypes[0] = ValueType::Shadow;
         BundleTypes[3] = ValueType::Shadow;
         auto Defs = gutils->getInvertedBundles(&call, BundleTypes, Builder2,
-                                                /*lookup*/ false);
+                                               /*lookup*/ false);
 
         auto callval = call.getCalledOperand();
         Builder2.CreateCall(call.getFunctionType(), callval, args_vec, Defs);
@@ -1671,72 +1673,79 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
                                  tysize, Type::getInt64Ty(call.getContext())),
                              "", true, true);
 
-      // Need to preserve the shadow send/recv buffers.
-      auto BufferDefs = gutils->getInvertedBundles(
-          &call,
-          {ValueType::Shadow, ValueType::Primal, ValueType::Primal,
-           ValueType::Shadow, ValueType::Primal, ValueType::Primal,
-           ValueType::Primal, ValueType::Primal},
-          Builder2, /*lookup*/ true);
+      // Need to preserve the shadow send/recv buffers. The Fortran ABI call
+      // has an extra `ierr` argument, so size the bundle to match the actual
+      // call arity: shadow send/recv buffers, primal everything else.
+      std::vector<ValueType> BufferBundleTypes(call.arg_size(),
+                                               ValueType::Primal);
+      BufferBundleTypes[0] = ValueType::Shadow;
+      BufferBundleTypes[3] = ValueType::Shadow;
+      auto BufferDefs = gutils->getInvertedBundles(&call, BufferBundleTypes,
+                                                   Builder2, /*lookup*/ true);
 
       // 1. Alloc intermediate buffer
       Value *buf =
           CreateAllocation(Builder2, Type::getInt8Ty(call.getContext()),
                            sendlen_arg, "mpireduce_malloccache");
 
-       // 2. Scatter diff(recvbuffer) to intermediate buffer
-       {
-         // int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype
-         // sendtype,
-         //     void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-         //     MPI_Comm comm)
-         Value *args[] = {
-             /*sendbuf*/ shadow_recvbuf,
-             /*sendcount*/ recvcountVal,
-             /*sendtype*/ recvtype,
-             /*recvbuf*/ buf,
-             /*recvcount*/ sendcountVal,
-             /*recvtype*/ sendtype,
-             /*op*/ rootVal,
-             /*comm*/ comm,
-         };
-         Type *types[sizeof(args) / sizeof(*args)];
-         for (size_t i = 0; i < sizeof(args) / sizeof(*args); i++)
-           types[i] = args[i]->getType();
+      // 2. Scatter diff(recvbuffer) to intermediate buffer
+      {
+        // int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype
+        // sendtype,
+        //     void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+        //     MPI_Comm comm)
+        //
+        // The Fortran MPI ABI passes all arguments by reference and appends
+        // an `ierr` argument, so the generated call must match the convention
+        // of the caller.
+        SmallVector<Value *, 10> args;
+        if (fortranABI) {
+          args = {shadow_recvbuf, recvcount, recvtype, buf,
+                  sendcount,      sendtype,  root,     comm};
+          for (size_t i = 8, e = call.arg_size(); i < e; i++)
+            args.push_back(lookup(
+                gutils->getNewFromOriginal(call.getArgOperand(i)), Builder2));
+        } else {
+          args = {shadow_recvbuf, recvcountVal, recvtype, buf,
+                  sendcountVal,   sendtype,     rootVal,  comm};
+        }
+        SmallVector<Type *, 10> types;
+        for (auto *arg : args)
+          types.push_back(arg->getType());
 
-         FunctionType *FT = FunctionType::get(call.getType(), types, false);
-         Builder2.CreateCall(
-             called->getParent()->getOrInsertFunction(
-                 getRenamedPerCallingConv(called->getName(), "MPI_Scatter"), FT),
-             args, BufferDefs);
-       }
+        FunctionType *FT = FunctionType::get(call.getType(), types, false);
+        Builder2.CreateCall(
+            called->getParent()->getOrInsertFunction(
+                getRenamedPerCallingConv(called->getName(), "MPI_Scatter"), FT),
+            args, BufferDefs);
+      }
 
-       // 3. if root, Zero diff(recvbuffer) [memset to 0]
-       {
+      // 3. if root, Zero diff(recvbuffer) [memset to 0]
+      {
 
-         BasicBlock *currentBlock = Builder2.GetInsertBlock();
-         BasicBlock *rootBlock = gutils->addReverseBlock(
-             currentBlock, currentBlock->getName() + "_root", gutils->newFunc);
-         BasicBlock *mergeBlock = gutils->addReverseBlock(
-             rootBlock, currentBlock->getName() + "_post", gutils->newFunc);
+        BasicBlock *currentBlock = Builder2.GetInsertBlock();
+        BasicBlock *rootBlock = gutils->addReverseBlock(
+            currentBlock, currentBlock->getName() + "_root", gutils->newFunc);
+        BasicBlock *mergeBlock = gutils->addReverseBlock(
+            rootBlock, currentBlock->getName() + "_post", gutils->newFunc);
 
-         Builder2.CreateCondBr(Builder2.CreateICmpEQ(rank, rootVal), rootBlock,
-                               mergeBlock);
+        Builder2.CreateCondBr(Builder2.CreateICmpEQ(rank, rootVal), rootBlock,
+                              mergeBlock);
 
-         Builder2.SetInsertPoint(rootBlock);
-         auto recvlen_arg = Builder2.CreateZExtOrTrunc(
-             recvcountVal, Type::getInt64Ty(call.getContext()));
-         recvlen_arg =
-             Builder2.CreateMul(recvlen_arg,
-                                Builder2.CreateZExtOrTrunc(
-                                    tysize, Type::getInt64Ty(call.getContext())),
-                                "", true, true);
-         recvlen_arg = Builder2.CreateMul(
-             recvlen_arg,
-             Builder2.CreateZExtOrTrunc(
-                 MPI_COMM_SIZE(comm, Builder2, rootVal->getType(), called),
-                 Type::getInt64Ty(call.getContext())),
-             "", true, true);
+        Builder2.SetInsertPoint(rootBlock);
+        auto recvlen_arg = Builder2.CreateZExtOrTrunc(
+            recvcountVal, Type::getInt64Ty(call.getContext()));
+        recvlen_arg =
+            Builder2.CreateMul(recvlen_arg,
+                               Builder2.CreateZExtOrTrunc(
+                                   tysize, Type::getInt64Ty(call.getContext())),
+                               "", true, true);
+        recvlen_arg = Builder2.CreateMul(
+            recvlen_arg,
+            Builder2.CreateZExtOrTrunc(
+                MPI_COMM_SIZE(comm, Builder2, rootVal->getType(), called),
+                Type::getInt64Ty(call.getContext())),
+            "", true, true);
 
         auto val_arg = ConstantInt::get(Type::getInt8Ty(call.getContext()), 0);
         auto volatile_arg = ConstantInt::getFalse(call.getContext());

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -1199,9 +1199,9 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
                                                ValueType::Primal);
       BufferBundleTypes[0] = ValueType::Shadow;
       BufferBundleTypes[1] = ValueType::Shadow;
-      auto BufferDefs = gutils->getInvertedBundles(&call, BufferBundleTypes,
-                                                   Builder2,
-                                                   /*lookup*/ !forwardMode);
+      auto BufferDefs =
+          gutils->getInvertedBundles(&call, BufferBundleTypes, Builder2,
+                                     /*lookup*/ !forwardMode);
 
       Value *count = gutils->getNewFromOriginal(orig_count);
       if (!forwardMode)
@@ -1314,9 +1314,8 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
             /*comm*/ comm,
         };
         if (fortranABI) {
-          args.push_back(
-              IRBuilder<>(gutils->inversionAllocs)
-                  .CreateAlloca(i32Ty, nullptr, "enzyme_mpi_ierr"));
+          args.push_back(IRBuilder<>(gutils->inversionAllocs)
+                             .CreateAlloca(i32Ty, nullptr, "enzyme_mpi_ierr"));
         }
         SmallVector<Type *, 8> types;
         for (auto *arg : args) {
@@ -2205,8 +2204,8 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
       // of MPI_Barrier (e.g. "mpi_barrier_") take an extra `ierr` argument.
       SmallVector<Value *, 4> args;
       for (unsigned i = 0; i < call.arg_size(); i++)
-        args.push_back(
-            lookup(gutils->getNewFromOriginal(call.getArgOperand(i)), Builder2));
+        args.push_back(lookup(gutils->getNewFromOriginal(call.getArgOperand(i)),
+                              Builder2));
       Builder2.CreateCall(call.getFunctionType(), callval, args);
     }
     if (Mode == DerivativeMode::ReverseModeGradient)
@@ -2368,13 +2367,11 @@ bool AdjointGenerator::handleKnownCallDerivatives(
        CanonicalMPIName == "MPI_Comm_free" ||
        CanonicalMPIName == "MPI_Comm_disconnect" ||
        CanonicalMPIName == "MPI_Comm_size" ||
-       CanonicalMPIName == "MPI_Comm_rank" ||
-       CanonicalMPIName == "MPI_Init" ||
+       CanonicalMPIName == "MPI_Comm_rank" || CanonicalMPIName == "MPI_Init" ||
        CanonicalMPIName == "MPI_Init_thread" ||
        CanonicalMPIName == "MPI_Finalize" ||
        CanonicalMPIName == "MPI_Get_processor_name" ||
-       CanonicalMPIName == "MPI_Test" ||
-       CanonicalMPIName == "MPI_Probe" ||
+       CanonicalMPIName == "MPI_Test" || CanonicalMPIName == "MPI_Probe" ||
        MPIInactiveCommAllocators.find(CanonicalMPIName) !=
            MPIInactiveCommAllocators.end())) {
     handleMPI(call, called, CanonicalMPIName);

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -2282,43 +2282,6 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
     return;
   }
 
-  // Simple MPI functions that don't affect differentiation - just duplicate
-  // them in both forward and reverse passes. These functions query MPI
-  // state (communicator size, rank, processor name, etc.) but don't
-  // participate in the computation being differentiated.
-  if (canonicalizeMPIName(funcName) == "MPI_Comm_size" ||
-      canonicalizeMPIName(funcName) == "MPI_Comm_rank" ||
-      canonicalizeMPIName(funcName) == "MPI_Get_processor_name") {
-    if (Mode == DerivativeMode::ReverseModeGradient ||
-        Mode == DerivativeMode::ReverseModeCombined ||
-        Mode == DerivativeMode::ReverseModePrimal) {
-      IRBuilder<> Builder2(&call);
-      getReverseBuilder(Builder2);
-      SmallVector<Value *, 8> args;
-      for (unsigned i = 0; i < call.arg_size(); ++i) {
-        args.push_back(lookup(gutils->getNewFromOriginal(call.getArgOperand(i)),
-                              Builder2));
-      }
-      Builder2.CreateCall(call.getFunctionType(), call.getCalledOperand(),
-                          args);
-    }
-    if (Mode == DerivativeMode::ForwardMode ||
-        Mode == DerivativeMode::ForwardModeError ||
-        Mode == DerivativeMode::ForwardModeSplit) {
-      IRBuilder<> Builder2(&call);
-      getForwardBuilder(Builder2);
-      SmallVector<Value *, 8> args;
-      for (unsigned i = 0; i < call.arg_size(); ++i) {
-        args.push_back(gutils->getNewFromOriginal(call.getArgOperand(i)));
-      }
-      Builder2.CreateCall(call.getFunctionType(), call.getCalledOperand(),
-                          args);
-    }
-    if (Mode == DerivativeMode::ReverseModeGradient)
-      eraseIfUnused(call, /*erase*/ true, /*check*/ false);
-    return;
-  }
-
   // MPI_Init / MPI_Finalize don't participate in the computation being
   // differentiated - just duplicate them as-is in both passes.
   if (funcName == "MPI_Init" || funcName == "PMPI_Init" ||
@@ -2403,12 +2366,10 @@ bool AdjointGenerator::handleKnownCallDerivatives(
        CanonicalMPIName == "MPI_Barrier" ||
        CanonicalMPIName == "MPI_Comm_free" ||
        CanonicalMPIName == "MPI_Comm_disconnect" ||
-       CanonicalMPIName == "MPI_Comm_size" ||
-       CanonicalMPIName == "MPI_Comm_rank" || CanonicalMPIName == "MPI_Init" ||
+       CanonicalMPIName == "MPI_Init" ||
        CanonicalMPIName == "MPI_Init_thread" ||
-       CanonicalMPIName == "MPI_Finalize" ||
-       CanonicalMPIName == "MPI_Get_processor_name" ||
-       CanonicalMPIName == "MPI_Test" || CanonicalMPIName == "MPI_Probe" ||
+       CanonicalMPIName == "MPI_Finalize" || CanonicalMPIName == "MPI_Test" ||
+       CanonicalMPIName == "MPI_Probe" ||
        MPIInactiveCommAllocators.find(CanonicalMPIName) !=
            MPIInactiveCommAllocators.end())) {
     handleMPI(call, called, CanonicalMPIName);

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -1869,48 +1869,61 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
       if (!forwardMode)
         comm = lookup(comm, Builder2);
 
-      Value *rank = MPI_COMM_RANK(comm, Builder2, root->getType(), called);
+      bool fortranABI = isFortranMPICall(called->getName());
+
+      Type *i32Ty = Type::getInt32Ty(call.getContext());
+      Value *sendcountVal =
+          fortranABI ? Builder2.CreateLoad(i32Ty, sendcount) : sendcount;
+      Value *recvcountVal =
+          fortranABI ? Builder2.CreateLoad(i32Ty, recvcount) : recvcount;
+      Value *rootVal = fortranABI ? Builder2.CreateLoad(i32Ty, root) : root;
+
+      Value *rank = MPI_COMM_RANK(comm, Builder2, rootVal->getType(), called);
       Value *tysize = MPI_TYPE_SIZE(sendtype, Builder2, call.getType(), called);
 
       if (forwardMode) {
-        Value *args[] = {
+        // Account for extra `ierr` argument in Fortran ABI
+        SmallVector<Value *, 8> args_vec = {
             /*sendbuf*/ shadow_sendbuf,
-            /*sendcount*/ sendcount,
+            /*sendcount*/ gutils->getNewFromOriginal(orig_sendcount),
             /*sendtype*/ sendtype,
             /*recvbuf*/ shadow_recvbuf,
-            /*recvcount*/ recvcount,
+            /*recvcount*/ gutils->getNewFromOriginal(orig_recvcount),
             /*recvtype*/ recvtype,
-            /*root*/ root,
+            /*root*/ gutils->getNewFromOriginal(orig_root),
             /*comm*/ comm,
         };
+        for (size_t i = 8, e = call.arg_size(); i < e; i++)
+          args_vec.push_back(gutils->getNewFromOriginal(call.getArgOperand(i)));
 
-        auto Defs = gutils->getInvertedBundles(
-            &call,
-            {ValueType::Shadow, ValueType::Primal, ValueType::Primal,
-             ValueType::Shadow, ValueType::Primal, ValueType::Primal,
-             ValueType::Primal, ValueType::Primal},
-            Builder2, /*lookup*/ false);
+        std::vector<ValueType> BundleTypes(call.arg_size(), ValueType::Primal);
+        BundleTypes[0] = ValueType::Shadow;
+        BundleTypes[3] = ValueType::Shadow;
+        auto Defs = gutils->getInvertedBundles(&call, BundleTypes, Builder2,
+                                               /*lookup*/ false);
 
         auto callval = call.getCalledOperand();
-        Builder2.CreateCall(call.getFunctionType(), callval, args, Defs);
+        Builder2.CreateCall(call.getFunctionType(), callval, args_vec, Defs);
         return;
       }
       // Get the length for the allocation of the intermediate buffer
       auto recvlen_arg = Builder2.CreateZExtOrTrunc(
-          recvcount, Type::getInt64Ty(call.getContext()));
+          recvcountVal, Type::getInt64Ty(call.getContext()));
       recvlen_arg =
           Builder2.CreateMul(recvlen_arg,
                              Builder2.CreateZExtOrTrunc(
                                  tysize, Type::getInt64Ty(call.getContext())),
                              "", true, true);
 
-      // Need to preserve the shadow send/recv buffers.
-      auto BufferDefs = gutils->getInvertedBundles(
-          &call,
-          {ValueType::Shadow, ValueType::Primal, ValueType::Primal,
-           ValueType::Shadow, ValueType::Primal, ValueType::Primal,
-           ValueType::Primal, ValueType::Primal},
-          Builder2, /*lookup*/ true);
+      // Need to preserve the shadow send/recv buffers. The Fortran ABI call
+      // has an extra `ierr` argument, so size the bundle to match the actual
+      // call arity: shadow send/recv buffers, primal everything else.
+      std::vector<ValueType> BufferBundleTypes(call.arg_size(),
+                                               ValueType::Primal);
+      BufferBundleTypes[0] = ValueType::Shadow;
+      BufferBundleTypes[3] = ValueType::Shadow;
+      auto BufferDefs = gutils->getInvertedBundles(&call, BufferBundleTypes,
+                                                   Builder2, /*lookup*/ true);
 
       // 1. if root, malloc intermediate buffer, else undef
       PHINode *buf;
@@ -1923,13 +1936,13 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
         BasicBlock *mergeBlock = gutils->addReverseBlock(
             rootBlock, currentBlock->getName() + "_post", gutils->newFunc);
 
-        Builder2.CreateCondBr(Builder2.CreateICmpEQ(rank, root), rootBlock,
+        Builder2.CreateCondBr(Builder2.CreateICmpEQ(rank, rootVal), rootBlock,
                               mergeBlock);
 
         Builder2.SetInsertPoint(rootBlock);
 
         auto sendlen_arg = Builder2.CreateZExtOrTrunc(
-            sendcount, Type::getInt64Ty(call.getContext()));
+            sendcountVal, Type::getInt64Ty(call.getContext()));
         sendlen_arg =
             Builder2.CreateMul(sendlen_arg,
                                Builder2.CreateZExtOrTrunc(
@@ -1938,7 +1951,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
         sendlen_arg = Builder2.CreateMul(
             sendlen_arg,
             Builder2.CreateZExtOrTrunc(
-                MPI_COMM_SIZE(comm, Builder2, root->getType(), called),
+                MPI_COMM_SIZE(comm, Builder2, rootVal->getType(), called),
                 Type::getInt64Ty(call.getContext())),
             "", true, true);
 
@@ -1966,19 +1979,24 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
         // sendtype,
         //     void *recvbuf, int recvcount, MPI_Datatype recvtype,
         //     int root, MPI_Comm comm)
-        Value *args[] = {
-            /*sendbuf*/ shadow_recvbuf,
-            /*sendcount*/ recvcount,
-            /*sendtype*/ recvtype,
-            /*recvbuf*/ buf,
-            /*recvcount*/ sendcount,
-            /*recvtype*/ sendtype,
-            /*root*/ root,
-            /*comm*/ comm,
-        };
-        Type *types[sizeof(args) / sizeof(*args)];
-        for (size_t i = 0; i < sizeof(args) / sizeof(*args); i++)
-          types[i] = args[i]->getType();
+        //
+        // The Fortran MPI ABI passes all arguments by reference and appends
+        // an `ierr` argument, so the generated call must match the convention
+        // of the caller.
+        SmallVector<Value *, 10> args;
+        if (fortranABI) {
+          args = {shadow_recvbuf, recvcount, recvtype, buf,
+                  sendcount,      sendtype,  root,     comm};
+          for (size_t i = 8, e = call.arg_size(); i < e; i++)
+            args.push_back(lookup(
+                gutils->getNewFromOriginal(call.getArgOperand(i)), Builder2));
+        } else {
+          args = {shadow_recvbuf, recvcountVal, recvtype, buf,
+                  sendcountVal,   sendtype,     rootVal,  comm};
+        }
+        SmallVector<Type *, 10> types;
+        for (auto *arg : args)
+          types.push_back(arg->getType());
 
         FunctionType *FT = FunctionType::get(call.getType(), types, false);
         Builder2.CreateCall(
@@ -2010,7 +2028,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
         BasicBlock *mergeBlock = gutils->addReverseBlock(
             rootBlock, currentBlock->getName() + "_post", gutils->newFunc);
 
-        Builder2.CreateCondBr(Builder2.CreateICmpEQ(rank, root), rootBlock,
+        Builder2.CreateCondBr(Builder2.CreateICmpEQ(rank, rootVal), rootBlock,
                               mergeBlock);
 
         Builder2.SetInsertPoint(rootBlock);

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -1420,13 +1420,17 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
         getReverseBuilder(Builder2);
       }
 
-      // Get the operations from MPI_Receive
+      // Get the operations from MPI_Allreduce
       Value *orig_sendbuf = call.getOperand(0);
       Value *orig_recvbuf = call.getOperand(1);
       Value *orig_count = call.getOperand(2);
       Value *orig_datatype = call.getOperand(3);
       Value *orig_op = call.getOperand(4);
       Value *orig_comm = call.getOperand(5);
+
+      // The Fortran MPI ABI ("mpi_allreduce_", "mpi_allreduce__", ...) passes
+      // all arguments by reference and appends an `ierr` argument.
+      bool fortranABI = isFortranMPICall(called->getName());
 
       bool isSum = false;
       if (Constant *C = dyn_cast<Constant>(orig_op)) {
@@ -1436,22 +1440,60 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
         if (auto GV = dyn_cast<GlobalVariable>(C)) {
           if (GV->getName() == "ompi_mpi_op_sum") {
             isSum = true;
+          } else if (fortranABI && GV->isConstant() &&
+                     GV->hasDefinitiveInitializer()) {
+            // The Fortran ABI passes the operator as a reference to an
+            // integer handle
+            if (auto *CI = dyn_cast<ConstantInt>(GV->getInitializer())) {
+              // MPICH native ABI (also covers the MPICH ABI Compatibility
+              // Initiative: Intel MPI, MVAPICH, Cray MPICH)
+              if (CI->getValue() == 1476395011) {
+                isSum = true;
+              }
+              // MPI 5.0 standard ABI (Chapter 20), where predefined op
+              // handles are fixed compile-time constants, identical in C
+              // and Fortran: MPI_SUM == 33.
+              if (CI->getValue() == 33) {
+                isSum = true;
+              }
+            }
           }
         }
-        // MPICH
+        // MPICH native ABI
         if (ConstantInt *CI = dyn_cast<ConstantInt>(C)) {
           if (CI->getValue() == 1476395011) {
             isSum = true;
           }
         }
+        // MPI 5.0 standard ABI: predefined op handles are small-integer
+        // pointer constants (inttoptr), with MPI_SUM == 33.
+        if (ConstantInt *CI = dyn_cast<ConstantInt>(C)) {
+          if (CI->getValue() == 33) {
+            isSum = true;
+          }
+        }
       }
       if (!isSum) {
-        std::string s;
-        llvm::raw_string_ostream ss(s);
-        ss << " call: " << call << "\n";
-        ss << " unhandled mpi_allreduce op: " << *orig_op << "\n";
-        EmitNoDerivativeError(ss.str(), call, gutils, BuilderZ);
-        return;
+        if (fortranABI) {
+          // Integer MPI operator handles of a native Fortran ABI are
+          // implementation-defined and cannot be mapped portably at compile
+          // time; warn and assume the common case of MPI_SUM. This remains
+          // true with MPI 5.0: although its standard ABI (Chapter 20) does
+          // fix handle values as portable compile-time constants (MPI_SUM
+          // == 33, recognized above), supporting that ABI is optional and
+          // neither Open MPI nor MPICH use it by default, so code compiled
+          // against the default/native ABIs still carries
+          // implementation-defined handle values.
+          llvm::errs() << "warning: cannot determine MPI op used in `" << call
+                       << "`, assuming MPI_SUM\n";
+        } else {
+          std::string s;
+          llvm::raw_string_ostream ss(s);
+          ss << " call: " << call << "\n";
+          ss << " unhandled mpi_allreduce op: " << *orig_op << "\n";
+          EmitNoDerivativeError(ss.str(), call, gutils, BuilderZ);
+          return;
+        }
       }
 
       Value *shadow_recvbuf = gutils->invertPointerM(orig_recvbuf, Builder2);
@@ -1468,12 +1510,16 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
         shadow_sendbuf = Builder2.CreateIntToPtr(
             shadow_sendbuf, getInt8PtrTy(call.getContext()));
 
-      // Need to preserve the shadow send/recv buffers.
-      auto BufferDefs = gutils->getInvertedBundles(
-          &call,
-          {ValueType::Shadow, ValueType::Shadow, ValueType::Primal,
-           ValueType::Primal, ValueType::Primal, ValueType::Primal},
-          Builder2, /*lookup*/ !forwardMode);
+      // Need to preserve the shadow send/recv buffers. The Fortran ABI call
+      // has an extra `ierr` argument, so build the bundle to match the actual
+      // call arity: shadow send/recv buffers, primal everything else.
+      std::vector<ValueType> BufferBundleTypes(call.arg_size(),
+                                               ValueType::Primal);
+      BufferBundleTypes[0] = ValueType::Shadow;
+      BufferBundleTypes[1] = ValueType::Shadow;
+      auto BufferDefs =
+          gutils->getInvertedBundles(&call, BufferBundleTypes, Builder2,
+                                     /*lookup*/ !forwardMode);
 
       Value *count = gutils->getNewFromOriginal(orig_count);
       if (!forwardMode)
@@ -1491,18 +1537,27 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
       if (!forwardMode)
         op = lookup(op, Builder2);
 
+      // The Fortran ABI passes the count argument by reference; load it
+      // where its value is needed.
+      Type *i32Ty = Type::getInt32Ty(call.getContext());
+      Value *countVal = fortranABI ? Builder2.CreateLoad(i32Ty, count) : count;
+
       if (forwardMode) {
-        Value *args[] = {
+        SmallVector<Value *, 8> args = {
             /*sendbuf*/ shadow_sendbuf,
             /*recvbuf*/ shadow_recvbuf,
-            /*count*/ count,
-            /*datatype*/ datatype,
-            /*op*/ op,
-            /*comm*/ comm,
         };
+        for (size_t i = 2, e = call.arg_size(); i < e; i++)
+          args.push_back(gutils->getNewFromOriginal(call.getArgOperand(i)));
+
+        std::vector<ValueType> BundleTypes(call.arg_size(), ValueType::Primal);
+        BundleTypes[0] = ValueType::Shadow;
+        BundleTypes[1] = ValueType::Shadow;
+        auto Defs = gutils->getInvertedBundles(&call, BundleTypes, Builder2,
+                                               /*lookup*/ false);
 
         auto callval = call.getCalledOperand();
-        Builder2.CreateCall(call.getFunctionType(), callval, args, BufferDefs);
+        Builder2.CreateCall(call.getFunctionType(), callval, args, Defs);
 
         return;
       }
@@ -1511,7 +1566,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
 
       // Get the length for the allocation of the intermediate buffer
       auto len_arg = Builder2.CreateZExtOrTrunc(
-          count, Type::getInt64Ty(call.getContext()));
+          countVal, Type::getInt64Ty(call.getContext()));
       len_arg =
           Builder2.CreateMul(len_arg,
                              Builder2.CreateZExtOrTrunc(
@@ -1527,7 +1582,9 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
       {
         // int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count,
         //              MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
-        Value *args[] = {
+        // The Fortran ABI passes count/datatype/op/comm by reference (as
+        // held here) and appends an `ierr` argument.
+        SmallVector<Value *, 8> args = {
             /*sendbuf*/ shadow_recvbuf,
             /*recvbuf*/ buf,
             /*count*/ count,
@@ -1535,11 +1592,17 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
             /*op*/ op,
             /*comm*/ comm,
         };
-        Type *types[sizeof(args) / sizeof(*args)];
-        for (size_t i = 0; i < sizeof(args) / sizeof(*args); i++)
-          types[i] = args[i]->getType();
+        if (fortranABI) {
+          args.push_back(IRBuilder<>(gutils->inversionAllocs)
+                             .CreateAlloca(i32Ty, nullptr, "enzyme_mpi_ierr"));
+        }
+        SmallVector<Type *, 8> types;
+        for (auto *arg : args)
+          types.push_back(arg->getType());
 
-        FunctionType *FT = FunctionType::get(call.getType(), types, false);
+        FunctionType *FT = FunctionType::get(
+            fortranABI ? Type::getVoidTy(call.getContext()) : call.getType(),
+            types, false);
         Builder2.CreateCall(
             called->getParent()->getOrInsertFunction(
                 getRenamedPerCallingConv(called->getName(), "MPI_Allreduce"),

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -9402,7 +9402,7 @@ void GradientUtils::computeForwardingProperties(Instruction *V) {
   SmallVector<LoadInst *, 1> loads;
   SmallVector<LoadLikeCall, 1> loadLikeCalls;
   SmallPtrSet<Instruction *, 1> stores;
-  SmallPtrSet<Instruction *, 1> storingOps;
+  SetVector<Instruction *> storingOps;
   SmallPtrSet<Instruction *, 1> frees;
   SmallPtrSet<IntrinsicInst *, 1> LifetimeStarts;
   bool promotable = true;
@@ -9637,8 +9637,9 @@ void GradientUtils::computeForwardingProperties(Instruction *V) {
       for (auto S : storingOps)
         if (!stores.count(S)) {
           SmallVector<Instruction *, 2> results;
-          SmallPtrSet<Instruction *, 2> shadowPtrLoadSet(
-              shadowPointerLoads.begin(), shadowPointerLoads.end());
+          SetVector<Instruction *> shadowPtrLoadSet;
+          shadowPtrLoadSet.insert(shadowPointerLoads.begin(),
+                                  shadowPointerLoads.end());
           mayExecuteAfter(results, S, shadowPtrLoadSet, outer);
           if (results.size()) {
             EmitWarning("NotPromotable", *results[0],

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -5370,18 +5370,52 @@ void TypeAnalyzer::visitCallBase(CallBase &call) {
       updateAnalysis(&call, TypeTree(BaseType::Integer).Only(-1, &call), &call);
       return;
     }
-    if (funcName == "MPI_Gather" || funcName == "MPI_Scatter") {
+    if (canonicalizeMPIName(funcName) == "MPI_Gather" ||
+        canonicalizeMPIName(funcName) == "MPI_Scatter") {
+      bool fortranABI = isFortranMPICall(funcName);
       updateAnalysis(call.getOperand(0),
                      TypeTree(BaseType::Pointer).Only(-1, &call), &call);
-      updateAnalysis(call.getOperand(1),
-                     TypeTree(BaseType::Integer).Only(-1, &call), &call);
       updateAnalysis(call.getOperand(3),
                      TypeTree(BaseType::Pointer).Only(-1, &call), &call);
-      updateAnalysis(call.getOperand(4),
-                     TypeTree(BaseType::Integer).Only(-1, &call), &call);
-      updateAnalysis(call.getOperand(6),
-                     TypeTree(BaseType::Integer).Only(-1, &call), &call);
-      updateAnalysis(&call, TypeTree(BaseType::Integer).Only(-1, &call), &call);
+      if (!fortranABI) {
+        // The C ABI passes the count and root arguments by value and returns
+        // an error code. The Fortran ABI passes them all by reference (with
+        // an extra trailing `ierr` argument) and is void, so those operands
+        // keep just their pointer classification; their pointee types are
+        // deduced from the stores that initialize them.
+        updateAnalysis(call.getOperand(1),
+                       TypeTree(BaseType::Integer).Only(-1, &call), &call);
+        updateAnalysis(call.getOperand(4),
+                       TypeTree(BaseType::Integer).Only(-1, &call), &call);
+        updateAnalysis(call.getOperand(6),
+                       TypeTree(BaseType::Integer).Only(-1, &call), &call);
+        updateAnalysis(&call, TypeTree(BaseType::Integer).Only(-1, &call),
+                       &call);
+      }
+      // The data copied between the send and receive buffers has the same
+      // underlying element type. Propagate type information between the two
+      // buffers so that a buffer whose contents are otherwise unobserved
+      // (e.g. a dummy argument that is only referenced by the MPI call)
+      // inherits it.
+      if (direction & UP) {
+        auto &dl = call.getParent()->getParent()->getParent()->getDataLayout();
+        TypeTree res = getAnalysis(call.getOperand(0))
+                           .PurgeAnything()
+                           .Data0()
+                           .ShiftIndices(dl, 0, 1, 0);
+        TypeTree res2 = getAnalysis(call.getOperand(3))
+                            .PurgeAnything()
+                            .Data0()
+                            .ShiftIndices(dl, 0, 1, 0);
+        bool Legal = true;
+        res.checkedOrIn(res2, /*PointerIntSame*/ false, Legal);
+        if (Legal) {
+          res.insert({}, BaseType::Pointer);
+          res = res.Only(-1, &call);
+          updateAnalysis(call.getOperand(0), res, &call);
+          updateAnalysis(call.getOperand(3), res, &call);
+        }
+      }
       return;
     }
     if (funcName == "MPI_Allgather") {

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -5288,27 +5288,33 @@ void TypeAnalyzer::visitCallBase(CallBase &call) {
       updateAnalysis(&call, TypeTree(BaseType::Integer).Only(-1, &call), &call);
       return;
     }
-    if (funcName == "MPI_Allreduce" || funcName == "PMPI_Allreduce") {
+    if (canonicalizeMPIName(funcName) == "MPI_Allreduce") {
+      bool fortranABI = isFortranMPICall(funcName);
       TypeTree buf = TypeTree(BaseType::Pointer);
 
-      if (Constant *C = dyn_cast<Constant>(call.getOperand(3))) {
-        while (ConstantExpr *CE = dyn_cast<ConstantExpr>(C)) {
-          C = CE->getOperand(0);
-        }
-        if (auto GV = dyn_cast<GlobalVariable>(C)) {
-          if (GV->getName() == "ompi_mpi_double") {
-            buf.insert({0}, Type::getDoubleTy(C->getContext()));
-          } else if (GV->getName() == "ompi_mpi_float") {
-            buf.insert({0}, Type::getFloatTy(C->getContext()));
-          } else if (GV->getName() == "ompi_mpi_cxx_bool") {
-            buf.insert({0}, BaseType::Integer);
+      // The C ABI passes the datatype handle by value, allowing the buffer
+      // element type to be deduced from it. The Fortran ABI passes it by
+      // reference, where its classification remains a pointer.
+      if (!fortranABI) {
+        if (Constant *C = dyn_cast<Constant>(call.getOperand(3))) {
+          while (ConstantExpr *CE = dyn_cast<ConstantExpr>(C)) {
+            C = CE->getOperand(0);
           }
-        } else if (auto CI = dyn_cast<ConstantInt>(C)) {
-          // MPICH
-          if (CI->getValue() == 1275070475) {
-            buf.insert({0}, Type::getDoubleTy(C->getContext()));
-          } else if (CI->getValue() == 1275069450) {
-            buf.insert({0}, Type::getFloatTy(C->getContext()));
+          if (auto GV = dyn_cast<GlobalVariable>(C)) {
+            if (GV->getName() == "ompi_mpi_double") {
+              buf.insert({0}, Type::getDoubleTy(C->getContext()));
+            } else if (GV->getName() == "ompi_mpi_float") {
+              buf.insert({0}, Type::getFloatTy(C->getContext()));
+            } else if (GV->getName() == "ompi_mpi_cxx_bool") {
+              buf.insert({0}, BaseType::Integer);
+            }
+          } else if (auto CI = dyn_cast<ConstantInt>(C)) {
+            // MPICH
+            if (CI->getValue() == 1275070475) {
+              buf.insert({0}, Type::getDoubleTy(C->getContext()));
+            } else if (CI->getValue() == 1275069450) {
+              buf.insert({0}, Type::getFloatTy(C->getContext()));
+            }
           }
         }
       }
@@ -5318,14 +5324,46 @@ void TypeAnalyzer::visitCallBase(CallBase &call) {
       updateAnalysis(call.getOperand(0), buf.Only(-1, &call), &call);
       // recvbuf
       updateAnalysis(call.getOperand(1), buf.Only(-1, &call), &call);
-      // count
-      updateAnalysis(call.getOperand(2),
-                     TypeTree(BaseType::Integer).Only(-1, &call), &call);
-      // datatype
-      // op
-      // comm
-      // result
-      updateAnalysis(&call, TypeTree(BaseType::Integer).Only(-1, &call), &call);
+      if (!fortranABI) {
+        // The C ABI passes the count argument by value and returns an error
+        // code. The Fortran ABI passes it by reference (with an extra
+        // trailing `ierr` argument) and is void, so the operand keeps just
+        // its pointer classification; the pointee type is deduced from the
+        // stores that initialize it.
+        // count
+        updateAnalysis(call.getOperand(2),
+                       TypeTree(BaseType::Integer).Only(-1, &call), &call);
+        // datatype
+        // op
+        // comm
+        // result
+        updateAnalysis(&call, TypeTree(BaseType::Integer).Only(-1, &call),
+                       &call);
+      }
+      // The data copied between the send and receive buffers has the same
+      // underlying element type. Propagate type information between the two
+      // buffers so that a buffer whose contents are otherwise unobserved
+      // (e.g. a dummy argument that is only referenced by the MPI call)
+      // inherits it.
+      if (direction & UP) {
+        auto &dl = call.getParent()->getParent()->getParent()->getDataLayout();
+        TypeTree res = getAnalysis(call.getOperand(0))
+                           .PurgeAnything()
+                           .Data0()
+                           .ShiftIndices(dl, 0, 1, 0);
+        TypeTree res2 = getAnalysis(call.getOperand(1))
+                            .PurgeAnything()
+                            .Data0()
+                            .ShiftIndices(dl, 0, 1, 0);
+        bool Legal = true;
+        res.checkedOrIn(res2, /*PointerIntSame*/ false, Legal);
+        if (Legal) {
+          res.insert({}, BaseType::Pointer);
+          res = res.Only(-1, &call);
+          updateAnalysis(call.getOperand(0), res, &call);
+          updateAnalysis(call.getOperand(1), res, &call);
+        }
+      }
       return;
     }
     if (funcName == "MPI_Sendrecv_replace") {

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -5247,27 +5247,33 @@ void TypeAnalyzer::visitCallBase(CallBase &call) {
       updateAnalysis(&call, TypeTree(BaseType::Integer).Only(-1, &call), &call);
       return;
     }
-    if (funcName == "MPI_Reduce" || funcName == "PMPI_Reduce") {
+    if (canonicalizeMPIName(funcName) == "MPI_Reduce") {
+      bool fortranABI = isFortranMPICall(funcName);
       TypeTree buf = TypeTree(BaseType::Pointer);
 
-      if (Constant *C = dyn_cast<Constant>(call.getOperand(3))) {
-        while (ConstantExpr *CE = dyn_cast<ConstantExpr>(C)) {
-          C = CE->getOperand(0);
-        }
-        if (auto GV = dyn_cast<GlobalVariable>(C)) {
-          if (GV->getName() == "ompi_mpi_double") {
-            buf.insert({0}, Type::getDoubleTy(C->getContext()));
-          } else if (GV->getName() == "ompi_mpi_float") {
-            buf.insert({0}, Type::getFloatTy(C->getContext()));
-          } else if (GV->getName() == "ompi_mpi_cxx_bool") {
-            buf.insert({0}, BaseType::Integer);
+      // The C ABI passes the datatype handle by value, allowing the buffer
+      // element type to be deduced from it. The Fortran ABI passes it by
+      // reference, where its classification remains a pointer.
+      if (!fortranABI) {
+        if (Constant *C = dyn_cast<Constant>(call.getOperand(3))) {
+          while (ConstantExpr *CE = dyn_cast<ConstantExpr>(C)) {
+            C = CE->getOperand(0);
           }
-        } else if (auto CI = dyn_cast<ConstantInt>(C)) {
-          // MPICH
-          if (CI->getValue() == 1275070475) {
-            buf.insert({0}, Type::getDoubleTy(C->getContext()));
-          } else if (CI->getValue() == 1275069450) {
-            buf.insert({0}, Type::getFloatTy(C->getContext()));
+          if (auto GV = dyn_cast<GlobalVariable>(C)) {
+            if (GV->getName() == "ompi_mpi_double") {
+              buf.insert({0}, Type::getDoubleTy(C->getContext()));
+            } else if (GV->getName() == "ompi_mpi_float") {
+              buf.insert({0}, Type::getFloatTy(C->getContext()));
+            } else if (GV->getName() == "ompi_mpi_cxx_bool") {
+              buf.insert({0}, BaseType::Integer);
+            }
+          } else if (auto CI = dyn_cast<ConstantInt>(C)) {
+            // MPICH
+            if (CI->getValue() == 1275070475) {
+              buf.insert({0}, Type::getDoubleTy(C->getContext()));
+            } else if (CI->getValue() == 1275069450) {
+              buf.insert({0}, Type::getFloatTy(C->getContext()));
+            }
           }
         }
       }
@@ -5278,14 +5284,46 @@ void TypeAnalyzer::visitCallBase(CallBase &call) {
       updateAnalysis(call.getOperand(0), buf.Only(-1, &call), &call);
       // recvbuf
       updateAnalysis(call.getOperand(1), buf.Only(-1, &call), &call);
-      // count
-      updateAnalysis(call.getOperand(2),
-                     TypeTree(BaseType::Integer).Only(-1, &call), &call);
-      // datatype
-      // op
-      // comm
-      // result
-      updateAnalysis(&call, TypeTree(BaseType::Integer).Only(-1, &call), &call);
+      if (!fortranABI) {
+        // The C ABI passes the count argument by value and returns an error
+        // code. The Fortran ABI passes it by reference (with an extra
+        // trailing `ierr` argument) and is void, so the operand keeps just
+        // its pointer classification; the pointee type is deduced from the
+        // stores that initialize it.
+        // count
+        updateAnalysis(call.getOperand(2),
+                       TypeTree(BaseType::Integer).Only(-1, &call), &call);
+        // datatype
+        // op
+        // comm
+        // result
+        updateAnalysis(&call, TypeTree(BaseType::Integer).Only(-1, &call),
+                       &call);
+      }
+      // The data copied between the send and receive buffers has the same
+      // underlying element type. Propagate type information between the two
+      // buffers so that a buffer whose contents are otherwise unobserved
+      // (e.g. a dummy argument that is only referenced by the MPI call)
+      // inherits it.
+      if (direction & UP) {
+        auto &dl = call.getParent()->getParent()->getParent()->getDataLayout();
+        TypeTree res = getAnalysis(call.getOperand(0))
+                           .PurgeAnything()
+                           .Data0()
+                           .ShiftIndices(dl, 0, 1, 0);
+        TypeTree res2 = getAnalysis(call.getOperand(1))
+                            .PurgeAnything()
+                            .Data0()
+                            .ShiftIndices(dl, 0, 1, 0);
+        bool Legal = true;
+        res.checkedOrIn(res2, /*PointerIntSame*/ false, Legal);
+        if (Legal) {
+          res.insert({}, BaseType::Pointer);
+          res = res.Only(-1, &call);
+          updateAnalysis(call.getOperand(0), res, &call);
+          updateAnalysis(call.getOperand(1), res, &call);
+        }
+      }
       return;
     }
     if (canonicalizeMPIName(funcName) == "MPI_Allreduce") {

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -172,7 +172,11 @@ bool attributeKnownFunctions(llvm::Function &F) {
     changed = true;
     F.addFnAttr(Attribute::NoFree);
   }
-  if (F.getName() == "MPI_Irecv" || F.getName() == "PMPI_Irecv") {
+  // Canonical MPI name across calling conventions (C "MPI_Recv", "PMPI_Recv"
+  // and Fortran "mpi_recv_" etc.). Parameter indices are shared between the
+  // ABIs; the Fortran ABI only appends a trailing `ierr` argument.
+  StringRef canonMPIName = canonicalizeMPIName(F.getName());
+  if (canonMPIName == "MPI_Irecv") {
     auto FT = F.getFunctionType();
     bool PointerABI = true;
     changed = true;
@@ -205,7 +209,7 @@ bool attributeKnownFunctions(llvm::Function &F) {
     }
   }
   auto name = getFuncName(&F);
-  if (name == "MPI_Isend" || name == "PMPI_Isend") {
+  if (canonMPIName == "MPI_Isend") {
     auto FT = F.getFunctionType();
     bool PointerABI = true;
     changed = true;
@@ -237,8 +241,7 @@ bool attributeKnownFunctions(llvm::Function &F) {
 #endif
     }
   }
-  if (name == "MPI_Comm_rank" || name == "PMPI_Comm_rank" ||
-      name == "MPI_Comm_size" || name == "PMPI_Comm_size") {
+  if (canonMPIName == "MPI_Comm_rank" || canonMPIName == "MPI_Comm_size") {
     auto FT = F.getFunctionType();
     bool PointerABI = true;
     changed = true;
@@ -267,7 +270,7 @@ bool attributeKnownFunctions(llvm::Function &F) {
 #endif
     }
   }
-  if (name == "MPI_Wait" || name == "PMPI_Wait") {
+  if (canonMPIName == "MPI_Wait") {
     changed = true;
     F.addFnAttr(Attribute::NoUnwind);
     F.addFnAttr(Attribute::NoRecurse);
@@ -282,7 +285,7 @@ bool attributeKnownFunctions(llvm::Function &F) {
       addFunctionNoCapture(&F, 1);
     }
   }
-  if (name == "MPI_Waitall" || name == "PMPI_Waitall") {
+  if (canonMPIName == "MPI_Waitall") {
     changed = true;
     F.addFnAttr(Attribute::NoUnwind);
     F.addFnAttr(Attribute::NoRecurse);
@@ -311,7 +314,7 @@ bool attributeKnownFunctions(llvm::Function &F) {
 
       {"MPI_Allreduce", 3}, {"PMPI_Allreduce", 3}};
   {
-    auto found = MPI_TYPE_ARGS.find(name.str());
+    auto found = MPI_TYPE_ARGS.find(canonMPIName.str());
     if (found != MPI_TYPE_ARGS.end()) {
       for (auto user : F.users()) {
         if (auto CI = dyn_cast<CallBase>(user))

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -2646,7 +2646,7 @@ llvm::Value *getOrInsertOpFloatSum(llvm::Module &M, llvm::Function *templateFn,
 
 void mayExecuteAfter(llvm::SmallVectorImpl<llvm::Instruction *> &results,
                      llvm::Instruction *inst,
-                     const llvm::SmallPtrSetImpl<Instruction *> &stores,
+                     const llvm::SetVector<Instruction *> &stores,
                      const llvm::Loop *region) {
   using namespace llvm;
   std::map<BasicBlock *, SmallVector<Instruction *, 1>> maybeBlocks;

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -2610,6 +2610,84 @@ arePointersGuaranteedNoAlias(llvm::TargetLibraryInfo &TLI, llvm::AAResults &AA,
                              llvm::Value *op0, llvm::Value *op1,
                              bool offsetAllowed = false);
 
+/// MPI routines recognized by Enzyme, keyed by their lowercase,
+/// underscore-free base name and mapped to the canonical C name (without the
+/// profiling "P" prefix).
+static const std::pair<const char *, const char *> KnownMPIFunctions[] = {
+    {"abort", "MPI_Abort"},
+    {"allgather", "MPI_Allgather"},
+    {"allreduce", "MPI_Allreduce"},
+    {"barrier", "MPI_Barrier"},
+    {"bcast", "MPI_Bcast"},
+    {"brecv", "MPI_Brecv"},
+    {"bsend", "MPI_Bsend"},
+    {"comm_accept", "MPI_Comm_accept"},
+    {"comm_call_errhandler", "MPI_Comm_call_errhandler"},
+    {"comm_compare", "MPI_Comm_compare"},
+    {"comm_connect", "MPI_Comm_connect"},
+    {"comm_create", "MPI_Comm_create"},
+    {"comm_create_errhandler", "MPI_Comm_create_errhandler"},
+    {"comm_create_group", "MPI_Comm_create_group"},
+    {"comm_disconnect", "MPI_Comm_disconnect"},
+    {"comm_dup", "MPI_Comm_dup"},
+    {"comm_free", "MPI_Comm_free"},
+    {"comm_get_info", "MPI_Comm_get_info"},
+    {"comm_get_name", "MPI_Comm_get_name"},
+    {"comm_get_parent", "MPI_Comm_get_parent"},
+    {"comm_idup", "MPI_Comm_idup"},
+    {"comm_join", "MPI_Comm_join"},
+    {"comm_rank", "MPI_Comm_rank"},
+    {"comm_remote_size", "MPI_Comm_remote_size"},
+    {"comm_set_info", "MPI_Comm_set_info"},
+    {"comm_set_name", "MPI_Comm_set_name"},
+    {"comm_size", "MPI_Comm_size"},
+    {"comm_spawn", "MPI_Comm_spawn"},
+    {"comm_spawn_multiple", "MPI_Comm_spawn_multiple"},
+    {"comm_split", "MPI_Comm_split"},
+    {"finalize", "MPI_Finalize"},
+    {"gather", "MPI_Gather"},
+    {"get_count", "MPI_Get_count"},
+    {"get_processor_name", "MPI_Get_processor_name"},
+    {"graph_create", "MPI_Graph_create"},
+    {"init", "MPI_Init"},
+    {"intercomm_create", "MPI_Intercomm_create"},
+    {"irecv", "MPI_Irecv"},
+    {"isend", "MPI_Isend"},
+    {"op_create", "MPI_Op_create"},
+    {"probe", "MPI_Probe"},
+    {"recv", "MPI_Recv"},
+    {"reduce", "MPI_Reduce"},
+    {"reduce_scatter_block", "MPI_Reduce_scatter_block"},
+    {"scatter", "MPI_Scatter"},
+    {"send", "MPI_Send"},
+    {"ssend", "MPI_Ssend"},
+    {"test", "MPI_Test"},
+    {"type_size", "MPI_Type_size"},
+    {"wait", "MPI_Wait"},
+    {"waitall", "MPI_Waitall"},
+    {"wtime", "MPI_Wtime"},
+};
+
+/// Canonicalize the name of an MPI routine across calling conventions: both
+/// the C convention ("MPI_Recv", "PMPI_Recv") and common Fortran ABI
+/// manglings ("mpi_recv_", "mpi_recv__", "pmpi_recv_", "MPI_RECV", ...) map
+/// to the canonical C name without profiling prefix (e.g. "MPI_Recv").
+/// Returns an empty StringRef if the name is not a known MPI routine.
+static inline llvm::StringRef canonicalizeMPIName(llvm::StringRef Name) {
+  llvm::StringRef Base = Name;
+  if (!Base.consume_front_insensitive("pmpi_") &&
+      !Base.consume_front_insensitive("mpi_"))
+    return "";
+  while (Base.consume_back("_")) {
+  }
+  if (Base.empty())
+    return "";
+  for (const auto &E : KnownMPIFunctions)
+    if (Base.equals_insensitive(E.first))
+      return E.second;
+  return "";
+}
+
 static inline std::tuple<llvm::StringRef, llvm::StringRef, llvm::StringRef>
 tripleSplitDollar(llvm::StringRef caller) {
   if (!startsWith(caller, "ejl")) {

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -2688,6 +2688,13 @@ static inline llvm::StringRef canonicalizeMPIName(llvm::StringRef Name) {
   return "";
 }
 
+/// True if `Name` uses a Fortran ABI mangling of an MPI routine (trailing
+/// underscore(s), e.g. "mpi_recv_", "mpi_comm_rank__"). Such calls pass all
+/// arguments by reference and take an extra trailing `ierr` argument.
+static inline bool isFortranMPICall(llvm::StringRef Name) {
+  return Name.ends_with("_") && !canonicalizeMPIName(Name).empty();
+}
+
 static inline std::tuple<llvm::StringRef, llvm::StringRef, llvm::StringRef>
 tripleSplitDollar(llvm::StringRef caller) {
   if (!startsWith(caller, "ejl")) {
@@ -2709,6 +2716,20 @@ static inline std::string getRenamedPerCallingConv(llvm::StringRef caller,
   if (startsWith(caller, "PMPI_")) {
     assert(startsWith(callee, "MPI"));
     return ("P" + callee).str();
+  }
+  // A caller using a Fortran MPI ABI convention (e.g. "mpi_reduce_") needs
+  // the callee mangled the same way so that the call resolves against the
+  // MPI library's Fortran bindings (e.g. "mpi_bcast_").
+  if (startsWith(callee, "MPI_") && isFortranMPICall(caller)) {
+    bool profiling = caller.substr(0, 5).equals_insensitive("pmpi_");
+    size_t underscores = 0;
+    while (underscores < caller.size() &&
+           caller[caller.size() - 1 - underscores] == '_')
+      underscores++;
+    std::string result = profiling ? "pmpi_" : "mpi_";
+    result += callee.drop_front(strlen("MPI_")).lower();
+    result.append(underscores, '_');
+    return result;
   }
   return callee.str();
 }

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -1183,7 +1183,7 @@ static inline llvm::Loop *getAncestor(llvm::Loop *R1, llvm::Loop *R2) {
 // into the resutls vector.
 void mayExecuteAfter(llvm::SmallVectorImpl<llvm::Instruction *> &results,
                      llvm::Instruction *inst,
-                     const llvm::SmallPtrSetImpl<llvm::Instruction *> &stores,
+                     const llvm::SetVector<llvm::Instruction *> &stores,
                      const llvm::Loop *region);
 
 /// Return whether maybeReader can read from memory written to by maybeWriter

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -2692,7 +2692,7 @@ static inline llvm::StringRef canonicalizeMPIName(llvm::StringRef Name) {
 /// underscore(s), e.g. "mpi_recv_", "mpi_comm_rank__"). Such calls pass all
 /// arguments by reference and take an extra trailing `ierr` argument.
 static inline bool isFortranMPICall(llvm::StringRef Name) {
-  return Name.ends_with("_") && !canonicalizeMPIName(Name).empty();
+  return endsWith(Name, "_") && !canonicalizeMPIName(Name).empty();
 }
 
 static inline std::tuple<llvm::StringRef, llvm::StringRef, llvm::StringRef>

--- a/enzyme/test/CMakeLists.txt
+++ b/enzyme/test/CMakeLists.txt
@@ -4,6 +4,41 @@ else()
   set(ENZYME_FLANG_ENABLED 0)
 endif()
 
+# Locate an MPI implementation for the Fortran MPI regression tests
+# (enzyme/test/Fortran/MPI); the tests are marked unsupported if none is
+# found. The include and link flags are serialized into lit substitutions
+# %mpi_include and %mpi_libs.
+set(ENZYME_MPI_FORTRAN_ENABLED 0)
+set(ENZYME_MPI_INCLUDE_FLAGS "")
+set(ENZYME_MPI_LINK_FLAGS "")
+if (ENZYME_FORTRAN)
+  # enable_language(Fortran) in ../Fortran only covers that directory scope.
+  enable_language(Fortran)
+  find_package(MPI COMPONENTS Fortran QUIET)
+  if (MPI_Fortran_FOUND)
+    set(ENZYME_MPI_FORTRAN_ENABLED 1)
+    foreach(dir IN LISTS MPI_Fortran_INCLUDE_DIRS MPI_Fortran_MODULE_DIR)
+      string(APPEND ENZYME_MPI_INCLUDE_FLAGS " -I${dir}")
+    endforeach()
+    foreach(dir IN LISTS MPI_Fortran_LIBRARY_DIRS)
+      string(APPEND ENZYME_MPI_LINK_FLAGS " -L${dir}")
+    endforeach()
+    if (MPI_Fortran_LINK_FLAGS)
+      string(APPEND ENZYME_MPI_LINK_FLAGS " ${MPI_Fortran_LINK_FLAGS}")
+    endif()
+    foreach(lib IN LISTS MPI_Fortran_LIBRARIES)
+      if (EXISTS "${lib}")
+        string(APPEND ENZYME_MPI_LINK_FLAGS " ${lib}")
+      else()
+        string(APPEND ENZYME_MPI_LINK_FLAGS " -l${lib}")
+      endif()
+    endforeach()
+    message(STATUS "Enzyme Fortran MPI tests enabled: ${ENZYME_MPI_INCLUDE_FLAGS} / ${ENZYME_MPI_LINK_FLAGS}")
+  else()
+    message(STATUS "MPI Fortran bindings not found: MPI Fortran tests unsupported")
+  endif()
+endif()
+
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/enzyme/test/CMakeLists.txt
+++ b/enzyme/test/CMakeLists.txt
@@ -5,7 +5,7 @@ else()
 endif()
 
 # Locate an MPI implementation for the Fortran MPI regression tests
-# (enzyme/test/Fortran/MPI); the tests are marked unsupported if none is
+# (enzyme/test/Fortran/mpi); the tests are marked unsupported if none is
 # found. The include and link flags are serialized into lit substitutions
 # %mpi_include and %mpi_libs.
 set(ENZYME_MPI_FORTRAN_ENABLED 0)

--- a/enzyme/test/Fortran/CMakeLists.txt
+++ b/enzyme/test/Fortran/CMakeLists.txt
@@ -2,6 +2,7 @@ message("Building Fortran tests")
 
 add_subdirectory(BatchMode)
 add_subdirectory(ForwardMode)
+add_subdirectory(mpi)
 add_subdirectory(OpenMP)
 add_subdirectory(ReverseMode)
 

--- a/enzyme/test/Fortran/mpi/CMakeLists.txt
+++ b/enzyme/test/Fortran/mpi/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Run regression and unit tests
+add_lit_testsuite(check-enzyme-fortran-mpi "Running enzyme MPI fortran integration tests"
+    ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${ENZYME_TEST_DEPS} LLVMEnzyme-${LLVM_VERSION_MAJOR}
+    ARGS -v
+)
+
+set_target_properties(check-enzyme-fortran-mpi PROPERTIES FOLDER "Tests")

--- a/enzyme/test/Fortran/mpi/allreduce_with_bindings_O0.f90
+++ b/enzyme/test/Fortran/mpi/allreduce_with_bindings_O0.f90
@@ -1,0 +1,78 @@
+! Test differentiation through mpi_allreduce
+!
+! REQUIRES: fortran, mpi
+! UNSUPPORTED: ifx
+! RUN: %fc -flto -O0 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+
+! NOTE: This test is only configured to run with the flang compiler at -O0.
+!       For it to work with the ifx compiler we will need to figure out how to
+!       handle the indirection involved in the enzyme_autodiff binding.
+
+program main
+  use enzyme, only: enzyme_dup, enzyme_autodiff, enzyme_fwddiff
+  use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_finalize, &
+                 mpi_comm_world, mpi_gather, mpi_real
+  implicit none
+
+  real :: xl, dxl, dxg(2), yg(2), dyg(2), seed(2)
+  integer :: ierr, rank, numprocs
+
+  call mpi_init(ierr)
+  call mpi_comm_rank(mpi_comm_world, rank, ierr)
+  call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+
+  if (numprocs /= 2) then
+    error stop "This test runs with 2 MPI processes"
+  end if
+
+  ! Compute the derivatives with forward mode: 1 (rank 0), 4 (rank 1)
+  ! The tangent of mpi_allreduce allreduces the tangents, so every process
+  ! obtains the total derivative 1 + 4 = 5.
+  xl = 2.0
+  seed = 1.0
+  dyg = 0.0
+  call enzyme_fwddiff(power, enzyme_dup, xl, seed, enzyme_dup, yg, dyg)
+  if (rank == 0) then
+    write(*,"(f0.1)") dyg(1)
+  end if
+
+  ! Do the same thing with reverse mode: 2 (rank 0), 12 (rank 1)
+  ! The adjoint of mpi_allreduce allreduces the adjoints of the reduced
+  ! values, so each process obtains the derivative of the sum of the
+  ! per-process losses with respect to its local contribution; collect
+  ! these local derivatives on the root process.
+  xl = 3.0
+  dxl = 0.0
+  seed = 1.0
+  call enzyme_autodiff(power, enzyme_dup, xl, dxl, enzyme_dup, yg, seed)
+  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") dxg(1)
+    write(*,"(f0.1)") dxg(2)
+  end if
+
+  call mpi_finalize(ierr)
+
+contains
+
+  ! Compute the power (rank + 1) of a real and allreduce the local values
+  subroutine power(xl, yg)
+    use mpi, only: mpi_comm_rank, mpi_comm_world, mpi_allreduce, mpi_real, &
+                   mpi_sum
+    real, intent(in) :: xl
+    real, intent(out) :: yg(2)
+    real :: yl
+    integer :: ierr
+    integer :: rank
+
+    call mpi_comm_rank(mpi_comm_world, rank, ierr)
+    yl = xl**(rank + 1)
+    call mpi_allreduce(yl, yg, 1, mpi_real, mpi_sum, mpi_comm_world, ierr)
+  end subroutine power
+
+end program main
+
+! CHECK: 5.0
+! CHECK-NEXT: 2.0
+! CHECK-NEXT: 12.0

--- a/enzyme/test/Fortran/mpi/allreduce_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/mpi/allreduce_with_bindings_opt.f90
@@ -1,0 +1,75 @@
+! Test differentiation through mpi_allreduce
+!
+! REQUIRES: fortran, mpi
+! RUN: %fc -flto -O1 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+
+program main
+  use enzyme, only: enzyme_dup, enzyme_autodiff, enzyme_fwddiff
+  use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_finalize, &
+                 mpi_comm_world, mpi_gather, mpi_real
+  implicit none
+
+  real :: xl, dxl, dxg(2), yg(2), dyg(2), seed(2)
+  integer :: ierr, rank, numprocs
+
+  call mpi_init(ierr)
+  call mpi_comm_rank(mpi_comm_world, rank, ierr)
+  call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+
+  if (numprocs /= 2) then
+    error stop "This test runs with 2 MPI processes"
+  end if
+
+  ! Compute the derivatives with forward mode: 1 (rank 0), 4 (rank 1)
+  ! The tangent of mpi_allreduce allreduces the tangents, so every process
+  ! obtains the total derivative 1 + 4 = 5.
+  xl = 2.0
+  seed = 1.0
+  dyg = 0.0
+  call enzyme_fwddiff(power, enzyme_dup, xl, seed, enzyme_dup, yg, dyg)
+  if (rank == 0) then
+    write(*,"(f0.1)") dyg(1)
+  end if
+
+  ! Do the same thing with reverse mode: 2 (rank 0), 12 (rank 1)
+  ! The adjoint of mpi_allreduce allreduces the adjoints of the reduced
+  ! values, so each process obtains the derivative of the sum of the
+  ! per-process losses with respect to its local contribution; collect
+  ! these local derivatives on the root process.
+  xl = 3.0
+  dxl = 0.0
+  seed = 1.0
+  call enzyme_autodiff(power, enzyme_dup, xl, dxl, enzyme_dup, yg, seed)
+  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") dxg(1)
+    write(*,"(f0.1)") dxg(2)
+  end if
+
+  call mpi_finalize(ierr)
+
+contains
+
+  ! Compute the power (rank + 1) of a real and allreduce the local values
+  subroutine power(xl, yg)
+    use mpi, only: mpi_comm_rank, mpi_comm_world, mpi_allreduce, mpi_real, &
+                   mpi_sum
+    real, intent(in) :: xl
+    real, intent(out) :: yg(2)
+    real :: yl
+    integer :: ierr
+    integer :: rank
+
+    call mpi_comm_rank(mpi_comm_world, rank, ierr)
+    yl = xl**(rank + 1)
+    call mpi_allreduce(yl, yg, 1, mpi_real, mpi_sum, mpi_comm_world, ierr)
+  end subroutine power
+
+end program main
+
+! CHECK: 5.0
+! CHECK-NEXT: 2.0
+! CHECK-NEXT: 12.0

--- a/enzyme/test/Fortran/mpi/allreduce_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/mpi/allreduce_with_explicit_interface.f90
@@ -1,0 +1,118 @@
+! Test differentiation through mpi_allreduce
+!
+! REQUIRES: fortran, mpi
+! RUN: %fc -flto -O0 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O1 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+
+module mpiAllreduce
+  implicit none
+  public
+  interface
+    subroutine power__enzyme_autodiff(sr, x_desc, x, dx, y_desc, y, dy)
+      implicit none
+      interface
+        subroutine sr_decal(a, b)
+          implicit none
+          real, intent(in) :: a
+          real, intent(out) :: b(2)
+        end subroutine sr_decal
+      end interface
+      procedure(sr_decal) :: sr
+      integer, intent(in) :: x_desc
+      real, intent(in) :: x
+      real, intent(inout) :: dx
+      integer, intent(in) :: y_desc
+      real, intent(out) :: y(2)
+      real, intent(inout) :: dy(2)
+    end subroutine power__enzyme_autodiff
+  end interface
+  interface
+    subroutine power__enzyme_fwddiff(sr, x_desc, x, dx, y_desc, y, dy)
+      implicit none
+      interface
+        subroutine sr_decal(a, b)
+          implicit none
+          real, intent(in) :: a
+          real, intent(out) :: b(2)
+        end subroutine sr_decal
+      end interface
+      procedure(sr_decal) :: sr
+      integer, intent(in) :: x_desc
+      real, intent(in) :: x
+      real, intent(inout) :: dx(2)
+      integer, intent(in) :: y_desc
+      real, intent(out) :: y(2)
+      real, intent(inout) :: dy(2)
+    end subroutine power__enzyme_fwddiff
+  end interface
+contains
+  ! Compute the power (rank + 1) of a real and allreduce the local values
+  subroutine power(xl, yg)
+    use mpi, only: mpi_comm_rank, mpi_comm_world, mpi_allreduce, mpi_real, &
+                   mpi_sum
+    real, intent(in) :: xl
+    real, intent(out) :: yg(2)
+    real :: yl
+    integer :: ierr
+    integer :: rank
+
+    call mpi_comm_rank(mpi_comm_world, rank, ierr)
+    yl = xl**(rank + 1)
+    call mpi_allreduce(yl, yg, 1, mpi_real, mpi_sum, mpi_comm_world, ierr)
+  end subroutine power
+end module mpiAllreduce
+
+program main
+  use mpiAllreduce, only: power, power__enzyme_autodiff, power__enzyme_fwddiff
+  use enzyme, only: enzyme_dup
+  use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_comm_world, &
+                 mpi_gather, mpi_real, mpi_finalize
+  implicit none
+
+  real :: xl, dxl, dxg(2), yg(2), dyg(2), seed(2)
+  integer :: rank, ierr, numprocs
+
+  call mpi_init(ierr)
+  call mpi_comm_rank(mpi_comm_world, rank, ierr)
+  call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+
+  if (numprocs /= 2) then
+    error stop "This test runs with 2 MPI processes"
+  end if
+
+  ! Compute the derivatives with forward mode: 1 (rank 0), 4 (rank 1)
+  ! The tangent of mpi_allreduce allreduces the tangents, so every process
+  ! obtains the total derivative 1 + 4 = 5.
+  xl = 2.0
+  seed = 1.0
+  dyg = 0.0
+  call power__enzyme_fwddiff(power, enzyme_dup, xl, seed, enzyme_dup, yg, dyg)
+  if (rank == 0) then
+    write(*,"(f0.1)") dyg(1)
+  end if
+
+  ! Do the same thing with reverse mode: 2 (rank 0), 12 (rank 1)
+  ! The adjoint of mpi_allreduce allreduces the adjoints of the reduced
+  ! values, so each process obtains the derivative of the sum of the
+  ! per-process losses with respect to its local contribution; collect
+  ! these local derivatives on the root process.
+  xl = 3.0
+  dxl = 0.0
+  seed = 1.0
+  call power__enzyme_autodiff(power, enzyme_dup, xl, dxl, enzyme_dup, yg, seed)
+  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") dxg(1)
+    write(*,"(f0.1)") dxg(2)
+  end if
+
+  call mpi_finalize(ierr)
+end program main
+
+! CHECK: 5.0
+! CHECK-NEXT: 2.0
+! CHECK-NEXT: 12.0

--- a/enzyme/test/Fortran/mpi/gather_with_bindings_O0.f90
+++ b/enzyme/test/Fortran/mpi/gather_with_bindings_O0.f90
@@ -1,4 +1,4 @@
-! Test differentiation through mpi_comm_gather
+! Test differentiation through mpi_gather
 !
 ! REQUIRES: fortran, mpi
 ! UNSUPPORTED: ifx

--- a/enzyme/test/Fortran/mpi/gather_with_bindings_O0.f90
+++ b/enzyme/test/Fortran/mpi/gather_with_bindings_O0.f90
@@ -15,7 +15,7 @@ program main
                  mpi_comm_world, mpi_gather, mpi_real
   implicit none
 
-  real :: x, dxl, dxg(2), y(2), dyl, dgy(2), seed(2)
+  real :: x, dxl, dxg(2), y(2), dyl, dy(2), seed(2)
   integer :: ierr, rank, numprocs
 
   call mpi_init(ierr)
@@ -30,12 +30,12 @@ program main
   ! Here the gathered array of derivatives is produced directly by the
   ! differentiated gather on the root process.
   x = 2.0
-  dyl = 1.0
-  dgy = 0.0
-  call enzyme_fwddiff(power, enzyme_dup, x, dyl, enzyme_dup, y, dgy)
+  seed = 1.0
+  dy = 0.0
+  call enzyme_fwddiff(power, enzyme_dup, x, seed, enzyme_dup, y, dy)
   if (rank == 0) then
-    write(*,"(f0.1)") dgy(1)
-    write(*,"(f0.1)") dgy(2)
+    write(*,"(f0.1)") dy(1)
+    write(*,"(f0.1)") dy(2)
   end if
 
   ! Do the same thing with reverse mode: 1 (rank 0), 6 (rank 1)

--- a/enzyme/test/Fortran/mpi/gather_with_bindings_O0.f90
+++ b/enzyme/test/Fortran/mpi/gather_with_bindings_O0.f90
@@ -1,0 +1,78 @@
+! Test differentiation through mpi_comm_gather
+!
+! REQUIRES: fortran, mpi
+! UNSUPPORTED: ifx
+! RUN: %fc -flto -O0 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+
+! NOTE: This test is only configured to run with the flang compiler at -O0.
+!       For it to work with the ifx compiler we will need to figure out how to
+!       handle the indirection involved in the enzyme_autodiff binding.
+
+program main
+  use enzyme, only: enzyme_dup, enzyme_autodiff, enzyme_fwddiff
+  use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_finalize, &
+                 mpi_comm_world, mpi_gather, mpi_real
+  implicit none
+
+  real :: x, dxl, dxg(2), y(2), dyl, dgy(2), seed(2)
+  integer :: ierr, rank, numprocs
+
+  call mpi_init(ierr)
+  call mpi_comm_rank(mpi_comm_world, rank, ierr)
+  call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+
+  if (numprocs /= 2) then
+    error stop "This test runs with 2 MPI processes"
+  end if
+
+  ! Compute the derivatives with forward mode: 1 (rank 0), 4 (rank 1)
+  ! Here the gathered array of derivatives is produced directly by the
+  ! differentiated gather on the root process.
+  x = 2.0
+  dyl = 1.0
+  dgy = 0.0
+  call enzyme_fwddiff(power, enzyme_dup, x, dyl, enzyme_dup, y, dgy)
+  if (rank == 0) then
+    write(*,"(f0.1)") dgy(1)
+    write(*,"(f0.1)") dgy(2)
+  end if
+
+  ! Do the same thing with reverse mode: 1 (rank 0), 6 (rank 1)
+  ! The adjoint of mpi_gather scatters the adjoints of the gathered array, so
+  ! each process obtains the derivative of its own contribution to the gather;
+  ! collect these local derivatives on the root process.
+  x = 3.0
+  dxl = 0.0
+  seed = 1.0
+  call enzyme_autodiff(power, enzyme_dup, x, dxl, enzyme_dup, y, seed)
+  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") dxg(1)
+    write(*,"(f0.1)") dxg(2)
+  end if
+
+  call mpi_finalize(ierr)
+
+contains
+
+  ! Compute the power (rank + 1) of a real and gather the local values
+  subroutine power(x, yg)
+    use mpi, only: mpi_comm_rank, mpi_comm_world, mpi_gather, mpi_real
+    real, intent(in) :: x
+    real, intent(out) :: yg(2)
+    real :: yl
+    integer :: ierr
+    integer :: rank
+
+    call mpi_comm_rank(mpi_comm_world, rank, ierr)
+    yl = x**(rank + 1)
+    call mpi_gather(yl, 1, mpi_real, yg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  end subroutine power
+
+end program main
+
+! CHECK: 1.0
+! CHECK-NEXT: 4.0
+! CHECK-NEXT: 1.0
+! CHECK-NEXT: 6.0

--- a/enzyme/test/Fortran/mpi/gather_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/mpi/gather_with_bindings_opt.f90
@@ -12,7 +12,7 @@ program main
                  mpi_comm_world, mpi_gather, mpi_real
   implicit none
 
-  real :: x, dxl, dxg(2), y(2), dyl, dgy(2), seed(2)
+  real :: x, dxl, dxg(2), y(2), dy(2), seed(2)
   integer :: ierr, rank, numprocs
 
   call mpi_init(ierr)
@@ -27,12 +27,12 @@ program main
   ! Here the gathered array of derivatives is produced directly by the
   ! differentiated gather on the root process.
   x = 2.0
-  dyl = 1.0
-  dgy = 0.0
-  call enzyme_fwddiff(power, enzyme_dup, x, dyl, enzyme_dup, y, dgy)
+  seed = 1.0
+  dy = 0.0
+  call enzyme_fwddiff(power, enzyme_dup, x, seed, enzyme_dup, y, dy)
   if (rank == 0) then
-    write(*,"(f0.1)") dgy(1)
-    write(*,"(f0.1)") dgy(2)
+    write(*,"(f0.1)") dy(1)
+    write(*,"(f0.1)") dy(2)
   end if
 
   ! Do the same thing with reverse mode: 1 (rank 0), 6 (rank 1)

--- a/enzyme/test/Fortran/mpi/gather_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/mpi/gather_with_bindings_opt.f90
@@ -1,4 +1,4 @@
-! Test differentiation through mpi_comm_gather
+! Test differentiation through mpi_gather
 !
 ! REQUIRES: fortran, mpi
 ! RUN: %fc -flto -O1 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s

--- a/enzyme/test/Fortran/mpi/gather_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/mpi/gather_with_bindings_opt.f90
@@ -1,0 +1,75 @@
+! Test differentiation through mpi_comm_gather
+!
+! REQUIRES: fortran, mpi
+! RUN: %fc -flto -O1 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+
+program main
+  use enzyme, only: enzyme_dup, enzyme_autodiff, enzyme_fwddiff
+  use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_finalize, &
+                 mpi_comm_world, mpi_gather, mpi_real
+  implicit none
+
+  real :: x, dxl, dxg(2), y(2), dyl, dgy(2), seed(2)
+  integer :: ierr, rank, numprocs
+
+  call mpi_init(ierr)
+  call mpi_comm_rank(mpi_comm_world, rank, ierr)
+  call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+
+  if (numprocs /= 2) then
+    error stop "This test runs with 2 MPI processes"
+  end if
+
+  ! Compute the derivatives with forward mode: 1 (rank 0), 4 (rank 1)
+  ! Here the gathered array of derivatives is produced directly by the
+  ! differentiated gather on the root process.
+  x = 2.0
+  dyl = 1.0
+  dgy = 0.0
+  call enzyme_fwddiff(power, enzyme_dup, x, dyl, enzyme_dup, y, dgy)
+  if (rank == 0) then
+    write(*,"(f0.1)") dgy(1)
+    write(*,"(f0.1)") dgy(2)
+  end if
+
+  ! Do the same thing with reverse mode: 1 (rank 0), 6 (rank 1)
+  ! The adjoint of mpi_gather scatters the adjoints of the gathered array, so
+  ! each process obtains the derivative of its own contribution to the gather;
+  ! collect these local derivatives on the root process.
+  x = 3.0
+  dxl = 0.0
+  seed = 1.0
+  call enzyme_autodiff(power, enzyme_dup, x, dxl, enzyme_dup, y, seed)
+  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") dxg(1)
+    write(*,"(f0.1)") dxg(2)
+  end if
+
+  call mpi_finalize(ierr)
+
+contains
+
+  ! Compute the power (rank + 1) of a real and gather the local values
+  subroutine power(x, yg)
+    use mpi, only: mpi_comm_rank, mpi_comm_world, mpi_gather, mpi_real
+    real, intent(in) :: x
+    real, intent(out) :: yg(2)
+    real :: yl
+    integer :: ierr
+    integer :: rank
+
+    call mpi_comm_rank(mpi_comm_world, rank, ierr)
+    yl = x**(rank + 1)
+    call mpi_gather(yl, 1, mpi_real, yg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  end subroutine power
+
+end program main
+
+! CHECK: 1.0
+! CHECK-NEXT: 4.0
+! CHECK-NEXT: 1.0
+! CHECK-NEXT: 6.0

--- a/enzyme/test/Fortran/mpi/gather_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/mpi/gather_with_explicit_interface.f90
@@ -1,4 +1,4 @@
-! Test differentiation through mpi_comm_gather
+! Test differentiation through mpi_gather
 !
 ! REQUIRES: fortran, mpi
 ! RUN: %fc -flto -O0 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s

--- a/enzyme/test/Fortran/mpi/gather_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/mpi/gather_with_explicit_interface.f90
@@ -1,0 +1,118 @@
+! Test differentiation through mpi_comm_gather
+!
+! REQUIRES: fortran, mpi
+! RUN: %fc -flto -O0 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O1 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+
+module mpiGather
+  implicit none
+  public
+  interface
+    subroutine power__enzyme_autodiff(sr, x_desc, x, dx, y_desc, y, dy)
+      implicit none
+      interface
+        subroutine sr_decal(a, b)
+          implicit none
+          real, intent(in) :: a
+          real, intent(out) :: b(2)
+        end subroutine sr_decal
+      end interface
+      procedure(sr_decal) :: sr
+      integer, intent(in) :: x_desc
+      real, intent(in) :: x
+      real, intent(inout) :: dx
+      integer, intent(in) :: y_desc
+      real, intent(out) :: y(2)
+      real, intent(inout) :: dy(2)
+    end subroutine power__enzyme_autodiff
+  end interface
+  interface
+    subroutine power__enzyme_fwddiff(sr, x_desc, x, dx, y_desc, y, dy)
+      implicit none
+      interface
+        subroutine sr_decal(a, b)
+          implicit none
+          real, intent(in) :: a
+          real, intent(out) :: b(2)
+        end subroutine sr_decal
+      end interface
+      procedure(sr_decal) :: sr
+      integer, intent(in) :: x_desc
+      real, intent(in) :: x
+      real, intent(inout) :: dx(2)
+      integer, intent(in) :: y_desc
+      real, intent(out) :: y(2)
+      real, intent(inout) :: dy(2)
+    end subroutine power__enzyme_fwddiff
+  end interface
+contains
+  ! Compute the power (rank + 1) of a real and gather the local values
+  subroutine power(x, yg)
+    use mpi, only: mpi_comm_rank, mpi_comm_world, mpi_gather, mpi_real
+    real, intent(in) :: x
+    real, intent(out) :: yg(2)
+    real :: yl
+    integer :: ierr
+    integer :: rank
+
+    call mpi_comm_rank(mpi_comm_world, rank, ierr)
+    yl = x**(rank + 1)
+    call mpi_gather(yl, 1, mpi_real, yg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  end subroutine power
+end module mpiGather
+
+program main
+  use mpiGather, only: power, power__enzyme_autodiff, power__enzyme_fwddiff
+  use enzyme, only: enzyme_dup
+  use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_comm_world, &
+                 mpi_gather, mpi_real, mpi_finalize
+  implicit none
+
+  real :: x, dxl, dxg(2), y(2), dy(2), seed(2)
+  integer :: rank, ierr, numprocs
+
+  call mpi_init(ierr)
+  call mpi_comm_rank(mpi_comm_world, rank, ierr)
+  call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+
+  if (numprocs /= 2) then
+    error stop "This test runs with 2 MPI processes"
+  end if
+
+  ! Compute the derivatives with forward mode: 1 (rank 0), 4 (rank 1)
+  ! Here the gathered array of derivatives is produced directly by the
+  ! differentiated gather on the root process.
+  x = 2.0
+  seed = 1.0
+  dy = 0.0
+  call power__enzyme_fwddiff(power, enzyme_dup, x, seed, enzyme_dup, y, dy)
+  if (rank == 0) then
+    write(*,"(f0.1)") dy(1)
+    write(*,"(f0.1)") dy(2)
+  end if
+
+  ! Do the same thing with reverse mode: 1 (rank 0), 6 (rank 1)
+  ! The adjoint of mpi_gather scatters the adjoints of the gathered array, so
+  ! each process obtains the derivative of its own contribution to the gather;
+  ! collect these local derivatives on the root process.
+  x = 3.0
+  dxl = 0.0
+  seed = 1.0
+  call power__enzyme_autodiff(power, enzyme_dup, x, dxl, enzyme_dup, y, seed)
+  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") dxg(1)
+    write(*,"(f0.1)") dxg(2)
+  end if
+
+  call mpi_finalize(ierr)
+end program main
+
+! CHECK: 1.0
+! CHECK-NEXT: 4.0
+! CHECK-NEXT: 1.0
+! CHECK-NEXT: 6.0

--- a/enzyme/test/Fortran/mpi/power_with_bindings_O0.f90
+++ b/enzyme/test/Fortran/mpi/power_with_bindings_O0.f90
@@ -1,0 +1,70 @@
+! REQUIRES: fortran, mpi
+! UNSUPPORTED: ifx
+! RUN: %fc -flto -O0 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+
+! NOTE: This test is only configured to run with the flang compiler at -O0.
+!       For it to work with the ifx compiler we will need to figure out how to
+!       handle the indirection involved in the enzyme_autodiff binding.
+
+program main
+  use enzyme, only: enzyme_dup, enzyme_autodiff, enzyme_fwddiff
+  use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_finalize, &
+                 mpi_comm_world, mpi_reduce, mpi_real, mpi_sum
+  implicit none
+
+  real :: x, dx, y, dy, s
+  integer :: ierr, rank, numprocs
+
+  call mpi_init(ierr)
+  call mpi_comm_rank(mpi_comm_world, rank, ierr)
+  call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+
+  if (numprocs /= 2) then
+    error stop "This test runs with 2 MPI processes"
+  end if
+
+  ! Compute the derivatives with reverse mode: 1 (rank 0), 6 (rank 1)
+  x = 2.0
+  dx = 0.0
+  dy = 1.0
+  call enzyme_autodiff(power, enzyme_dup, x, dx, enzyme_dup, y, dy)
+
+  ! Take reduction, summing to print on rank 0
+  call mpi_reduce(dx, s, 1, mpi_real, mpi_sum, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") s
+  end if
+
+  ! Do the same thing with forward mode
+  x = 3.0
+  dx = 1.0
+  dy = 0.0
+  call enzyme_fwddiff(power, enzyme_dup, x, dx, enzyme_dup, y, dy)
+
+  ! Take reduction, summing to print on rank 0
+  call mpi_reduce(dy, s, 1, mpi_real, mpi_sum, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") s
+  end if
+
+  call mpi_finalize(ierr)
+
+contains
+
+  ! Compute the power (rank + 1) of a real
+  subroutine power(x, y)
+    use mpi, only: mpi_comm_world
+    real, intent(in) :: x
+    real, intent(out) :: y
+    integer :: ierr
+    integer :: rank
+
+    call mpi_comm_rank(mpi_comm_world, rank, ierr)
+    y = x**(rank + 1)
+  end subroutine power
+
+end program main
+
+! CHECK: 5.0
+! CHECK-NEXT: 7.0

--- a/enzyme/test/Fortran/mpi/power_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/mpi/power_with_bindings_opt.f90
@@ -1,0 +1,68 @@
+! REQUIRES: fortran, mpi
+! RUN: %fc -flto -O1 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+
+program main
+  use enzyme, only: enzyme_dup, enzyme_autodiff, enzyme_fwddiff
+  use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_finalize, &
+                 mpi_comm_world, mpi_reduce, mpi_real, mpi_sum
+  implicit none
+
+  real :: x, dx, y, dy, s
+  integer :: ierr, rank, numprocs
+
+  call mpi_init(ierr)
+  call mpi_comm_rank(mpi_comm_world, rank, ierr)
+  call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+
+  if (numprocs /= 2) then
+    error stop "This test runs with 2 MPI processes"
+  end if
+
+  ! Compute the derivatives with reverse mode: 1 (rank 0), 6 (rank 1)
+  x = 2.0
+  dx = 0.0
+  dy = 1.0
+  call enzyme_autodiff(power, enzyme_dup, x, dx, enzyme_dup, y, dy)
+
+  ! Take reduction, summing to print on rank 0
+  call mpi_reduce(dx, s, 1, mpi_real, mpi_sum, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") s
+  end if
+
+  ! Do the same thing with forward mode
+  x = 3.0
+  dx = 1.0
+  dy = 0.0
+  call enzyme_fwddiff(power, enzyme_dup, x, dx, enzyme_dup, y, dy)
+
+  ! Take reduction, summing to print on rank 0
+  call mpi_reduce(dy, s, 1, mpi_real, mpi_sum, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") s
+  end if
+
+
+  call mpi_finalize(ierr)
+
+contains
+
+  ! Compute the power (rank + 1) of a real
+  subroutine power(x, y)
+    use mpi, only: mpi_comm_world
+    real, intent(in) :: x
+    real, intent(out) :: y
+    integer :: ierr
+    integer :: rank
+
+    call mpi_comm_rank(mpi_comm_world, rank, ierr)
+    y = x**(rank + 1)
+  end subroutine power
+
+end program main
+
+! CHECK: 5.0
+! CHECK-NEXT: 7.0

--- a/enzyme/test/Fortran/mpi/power_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/mpi/power_with_explicit_interface.f90
@@ -1,0 +1,110 @@
+! REQUIRES: fortran, mpi
+! RUN: %fc -flto -O0 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O1 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+
+module power_mod
+  implicit none
+  public
+  interface
+    subroutine power__enzyme_autodiff(sr, x_desc, x, dx, y_desc, y, dy)
+      implicit none
+      interface
+        subroutine sr_decal(a, b)
+          implicit none
+          real, intent(in) :: a
+          real, intent(out) :: b
+        end subroutine sr_decal
+      end interface
+      procedure(sr_decal) :: sr
+      integer, intent(in) :: x_desc
+      real, intent(in) :: x
+      real, intent(inout) :: dx
+      integer, intent(in) :: y_desc
+      real, intent(out) :: y
+      real, intent(inout) :: dy
+    end subroutine power__enzyme_autodiff
+  end interface
+  interface
+    subroutine power__enzyme_fwddiff(sr, x_desc, x, dx, y_desc, y, dy)
+      implicit none
+      interface
+        subroutine sr_decal(a, b)
+          implicit none
+          real, intent(in) :: a
+          real, intent(out) :: b
+        end subroutine sr_decal
+      end interface
+      procedure(sr_decal) :: sr
+      integer, intent(in) :: x_desc
+      real, intent(in) :: x
+      real, intent(inout) :: dx
+      integer, intent(in) :: y_desc
+      real, intent(out) :: y
+      real, intent(inout) :: dy
+    end subroutine power__enzyme_fwddiff
+  end interface
+contains
+  ! Compute the power (rank + 1) of a real
+  subroutine power(x, y)
+    use mpi, only: mpi_comm_world
+    real, intent(in) :: x
+    real, intent(out) :: y
+    integer :: ierr
+    integer :: rank
+
+    call mpi_comm_rank(mpi_comm_world, rank, ierr)
+    y = x**(rank + 1)
+  end subroutine power
+end module power_mod
+
+program main
+  use power_mod, only: power, power__enzyme_autodiff, power__enzyme_fwddiff
+  use enzyme, only: enzyme_dup
+  use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_comm_world, &
+                 mpi_reduce, mpi_real, mpi_sum, mpi_finalize
+  implicit none
+
+  real :: x, dx, y, dy, s
+  integer :: rank, ierr, numprocs
+
+  call mpi_init(ierr)
+  call mpi_comm_rank(mpi_comm_world, rank, ierr)
+  call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+
+  if (numprocs /= 2) then
+    error stop "This test runs with 2 MPI processes"
+  end if
+
+  ! Compute the derivatives: 1 (rank 0), 6 (rank 1)
+  x = 2.0
+  dx = 0.0
+  dy = 1.0
+  call power__enzyme_autodiff(power, enzyme_dup, x, dx, enzyme_dup, y, dy)
+
+  ! Take reduction, summing to print on rank 0
+  call mpi_reduce(dx, s, 1, mpi_real, mpi_sum, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") s
+  end if
+
+  ! Do the same thing with forward mode
+  x = 3.0
+  dx = 1.0
+  dy = 0.0
+  call power__enzyme_fwddiff(power, enzyme_dup, x, dx, enzyme_dup, y, dy)
+
+  ! Take reduction, summing to print on rank 0
+  call mpi_reduce(dy, s, 1, mpi_real, mpi_sum, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") s
+  end if
+
+  call mpi_finalize(ierr)
+end program main
+
+! CHECK: 5.0
+! CHECK-NEXT: 7.0

--- a/enzyme/test/Fortran/mpi/rank_with_bindings_O0.f90
+++ b/enzyme/test/Fortran/mpi/rank_with_bindings_O0.f90
@@ -10,10 +10,10 @@
 program main
   use enzyme, only: enzyme_dup, enzyme_autodiff, enzyme_fwddiff
   use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_finalize, &
-                 mpi_comm_world, mpi_reduce, mpi_real, mpi_sum
+                 mpi_comm_world, mpi_gather, mpi_real
   implicit none
 
-  real :: x, dx, y, dy, s
+  real :: x, dxl, dxg(2), y, dyl, dyg(2)
   integer :: ierr, rank, numprocs
 
   call mpi_init(ierr)
@@ -26,26 +26,24 @@ program main
 
   ! Compute the derivatives with reverse mode: 1 (rank 0), 6 (rank 1)
   x = 2.0
-  dx = 0.0
-  dy = 1.0
-  call enzyme_autodiff(power, enzyme_dup, x, dx, enzyme_dup, y, dy)
-
-  ! Take reduction, summing to print on rank 0
-  call mpi_reduce(dx, s, 1, mpi_real, mpi_sum, 0, mpi_comm_world, ierr)
+  dxl = 0.0
+  dyl = 1.0
+  call enzyme_autodiff(power, enzyme_dup, x, dxl, enzyme_dup, y, dyl)
+  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
   if (rank == 0) then
-    write(*,"(f0.1)") s
+    write(*,"(f0.1)") dxg(1)
+    write(*,"(f0.1)") dxg(2)
   end if
 
   ! Do the same thing with forward mode
   x = 3.0
-  dx = 1.0
-  dy = 0.0
-  call enzyme_fwddiff(power, enzyme_dup, x, dx, enzyme_dup, y, dy)
-
-  ! Take reduction, summing to print on rank 0
-  call mpi_reduce(dy, s, 1, mpi_real, mpi_sum, 0, mpi_comm_world, ierr)
+  dxl = 1.0
+  dyl = 0.0
+  call enzyme_fwddiff(power, enzyme_dup, x, dxl, enzyme_dup, y, dyl)
+  call mpi_gather(dyl, 1, mpi_real, dyg, 1, mpi_real, 0, mpi_comm_world, ierr)
   if (rank == 0) then
-    write(*,"(f0.1)") s
+    write(*,"(f0.1)") dyg(1)
+    write(*,"(f0.1)") dyg(2)
   end if
 
   call mpi_finalize(ierr)
@@ -66,5 +64,7 @@ contains
 
 end program main
 
-! CHECK: 5.0
-! CHECK-NEXT: 7.0
+! CHECK: 1.0
+! CHECK-NEXT: 4.0
+! CHECK-NEXT: 1.0
+! CHECK-NEXT: 6.0

--- a/enzyme/test/Fortran/mpi/rank_with_bindings_O0.f90
+++ b/enzyme/test/Fortran/mpi/rank_with_bindings_O0.f90
@@ -1,3 +1,5 @@
+! Test differentiation through mpi_comm_rank
+!
 ! REQUIRES: fortran, mpi
 ! UNSUPPORTED: ifx
 ! RUN: %fc -flto -O0 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s

--- a/enzyme/test/Fortran/mpi/rank_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/mpi/rank_with_bindings_opt.f90
@@ -7,10 +7,10 @@
 program main
   use enzyme, only: enzyme_dup, enzyme_autodiff, enzyme_fwddiff
   use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_finalize, &
-                 mpi_comm_world, mpi_reduce, mpi_real, mpi_sum
+                 mpi_comm_world, mpi_gather, mpi_real
   implicit none
 
-  real :: x, dx, y, dy, s
+  real :: x, dxl, dxg(2), y, dyl, dyg(2)
   integer :: ierr, rank, numprocs
 
   call mpi_init(ierr)
@@ -23,28 +23,25 @@ program main
 
   ! Compute the derivatives with reverse mode: 1 (rank 0), 6 (rank 1)
   x = 2.0
-  dx = 0.0
-  dy = 1.0
-  call enzyme_autodiff(power, enzyme_dup, x, dx, enzyme_dup, y, dy)
-
-  ! Take reduction, summing to print on rank 0
-  call mpi_reduce(dx, s, 1, mpi_real, mpi_sum, 0, mpi_comm_world, ierr)
+  dxl = 0.0
+  dyl = 1.0
+  call enzyme_autodiff(power, enzyme_dup, x, dxl, enzyme_dup, y, dyl)
+  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
   if (rank == 0) then
-    write(*,"(f0.1)") s
+    write(*,"(f0.1)") dxg(1)
+    write(*,"(f0.1)") dxg(2)
   end if
 
   ! Do the same thing with forward mode
   x = 3.0
-  dx = 1.0
-  dy = 0.0
-  call enzyme_fwddiff(power, enzyme_dup, x, dx, enzyme_dup, y, dy)
-
-  ! Take reduction, summing to print on rank 0
-  call mpi_reduce(dy, s, 1, mpi_real, mpi_sum, 0, mpi_comm_world, ierr)
+  dxl = 1.0
+  dyl = 0.0
+  call enzyme_fwddiff(power, enzyme_dup, x, dxl, enzyme_dup, y, dyl)
+  call mpi_gather(dyl, 1, mpi_real, dyg, 1, mpi_real, 0, mpi_comm_world, ierr)
   if (rank == 0) then
-    write(*,"(f0.1)") s
+    write(*,"(f0.1)") dyg(1)
+    write(*,"(f0.1)") dyg(2)
   end if
-
 
   call mpi_finalize(ierr)
 
@@ -64,5 +61,7 @@ contains
 
 end program main
 
-! CHECK: 5.0
-! CHECK-NEXT: 7.0
+! CHECK: 1.0
+! CHECK-NEXT: 4.0
+! CHECK-NEXT: 1.0
+! CHECK-NEXT: 6.0

--- a/enzyme/test/Fortran/mpi/rank_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/mpi/rank_with_bindings_opt.f90
@@ -1,3 +1,5 @@
+! Test differentiation through mpi_comm_rank
+!
 ! REQUIRES: fortran, mpi
 ! RUN: %fc -flto -O1 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
 ! RUN: %fc -flto -O2 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s

--- a/enzyme/test/Fortran/mpi/rank_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/mpi/rank_with_explicit_interface.f90
@@ -1,3 +1,5 @@
+! Test differentiation through mpi_comm_rank
+!
 ! REQUIRES: fortran, mpi
 ! RUN: %fc -flto -O0 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
 ! RUN: %fc -flto -O1 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s

--- a/enzyme/test/Fortran/mpi/rank_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/mpi/rank_with_explicit_interface.f90
@@ -6,7 +6,7 @@
 ! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
 ! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
 
-module power_mod
+module mpiRank
   implicit none
   public
   interface
@@ -59,16 +59,16 @@ contains
     call mpi_comm_rank(mpi_comm_world, rank, ierr)
     y = x**(rank + 1)
   end subroutine power
-end module power_mod
+end module mpiRank
 
 program main
-  use power_mod, only: power, power__enzyme_autodiff, power__enzyme_fwddiff
+  use mpiRank, only: power, power__enzyme_autodiff, power__enzyme_fwddiff
   use enzyme, only: enzyme_dup
   use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_comm_world, &
-                 mpi_reduce, mpi_real, mpi_sum, mpi_finalize
+                 mpi_gather, mpi_real, mpi_finalize
   implicit none
 
-  real :: x, dx, y, dy, s
+  real :: x, dxl, dxg(2), y, dyl, dyg(2)
   integer :: rank, ierr, numprocs
 
   call mpi_init(ierr)
@@ -79,32 +79,32 @@ program main
     error stop "This test runs with 2 MPI processes"
   end if
 
-  ! Compute the derivatives: 1 (rank 0), 6 (rank 1)
+  ! Compute the derivatives with reverse mode: 1 (rank 0), 6 (rank 1)
   x = 2.0
-  dx = 0.0
-  dy = 1.0
-  call power__enzyme_autodiff(power, enzyme_dup, x, dx, enzyme_dup, y, dy)
-
-  ! Take reduction, summing to print on rank 0
-  call mpi_reduce(dx, s, 1, mpi_real, mpi_sum, 0, mpi_comm_world, ierr)
+  dxl = 0.0
+  dyl = 1.0
+  call power__enzyme_autodiff(power, enzyme_dup, x, dxl, enzyme_dup, y, dyl)
+  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
   if (rank == 0) then
-    write(*,"(f0.1)") s
+    write(*,"(f0.1)") dxg(1)
+    write(*,"(f0.1)") dxg(2)
   end if
 
   ! Do the same thing with forward mode
   x = 3.0
-  dx = 1.0
-  dy = 0.0
-  call power__enzyme_fwddiff(power, enzyme_dup, x, dx, enzyme_dup, y, dy)
-
-  ! Take reduction, summing to print on rank 0
-  call mpi_reduce(dy, s, 1, mpi_real, mpi_sum, 0, mpi_comm_world, ierr)
+  dxl = 1.0
+  dyl = 0.0
+  call power__enzyme_fwddiff(power, enzyme_dup, x, dxl, enzyme_dup, y, dyl)
+  call mpi_gather(dyl, 1, mpi_real, dyg, 1, mpi_real, 0, mpi_comm_world, ierr)
   if (rank == 0) then
-    write(*,"(f0.1)") s
+    write(*,"(f0.1)") dyg(1)
+    write(*,"(f0.1)") dyg(2)
   end if
 
   call mpi_finalize(ierr)
 end program main
 
-! CHECK: 5.0
-! CHECK-NEXT: 7.0
+! CHECK: 1.0
+! CHECK-NEXT: 4.0
+! CHECK-NEXT: 1.0
+! CHECK-NEXT: 6.0

--- a/enzyme/test/Fortran/mpi/reduce_with_bindings_O0.f90
+++ b/enzyme/test/Fortran/mpi/reduce_with_bindings_O0.f90
@@ -1,0 +1,78 @@
+! Test differentiation through mpi_reduce
+!
+! REQUIRES: fortran, mpi
+! UNSUPPORTED: ifx
+! RUN: %fc -flto -O0 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+
+! NOTE: This test is only configured to run with the flang compiler at -O0.
+!       For it to work with the ifx compiler we will need to figure out how to
+!       handle the indirection involved in the enzyme_autodiff binding.
+
+program main
+  use enzyme, only: enzyme_dup, enzyme_autodiff, enzyme_fwddiff
+  use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_finalize, &
+                 mpi_comm_world, mpi_gather, mpi_real
+  implicit none
+
+  real :: xl, dxl, dxg(2), yg(2), dyg(2), seed(2)
+  integer :: ierr, rank, numprocs
+
+  call mpi_init(ierr)
+  call mpi_comm_rank(mpi_comm_world, rank, ierr)
+  call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+
+  if (numprocs /= 2) then
+    error stop "This test runs with 2 MPI processes"
+  end if
+
+  ! Compute the derivatives with forward mode: 1 (rank 0), 4 (rank 1)
+  ! The tangent of mpi_reduce reduces the tangents, so the root process
+  ! obtains the total derivative 1 + 4 = 5.
+  xl = 2.0
+  seed = 1.0
+  dyg = 0.0
+  call enzyme_fwddiff(power, enzyme_dup, xl, seed, enzyme_dup, yg, dyg)
+  if (rank == 0) then
+    write(*,"(f0.1)") dyg(1)
+  end if
+
+  ! Do the same thing with reverse mode: 1 (rank 0), 6 (rank 1)
+  ! The adjoint of mpi_reduce broadcasts the adjoints of the reduced values
+  ! on the root process out to every process, so each process obtains the
+  ! derivative of the root process' loss with respect to its local
+  ! contribution; collect these local derivatives on the root process.
+  xl = 3.0
+  dxl = 0.0
+  seed = 1.0
+  call enzyme_autodiff(power, enzyme_dup, xl, dxl, enzyme_dup, yg, seed)
+  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") dxg(1)
+    write(*,"(f0.1)") dxg(2)
+  end if
+
+  call mpi_finalize(ierr)
+
+contains
+
+  ! Compute the power (rank + 1) of a real and reduce the local values
+  subroutine power(xl, yg)
+    use mpi, only: mpi_comm_rank, mpi_comm_world, mpi_reduce, mpi_real, &
+                   mpi_sum
+    real, intent(in) :: xl
+    real, intent(out) :: yg(2)
+    real :: yl
+    integer :: ierr
+    integer :: rank
+
+    call mpi_comm_rank(mpi_comm_world, rank, ierr)
+    yl = xl**(rank + 1)
+    call mpi_reduce(yl, yg, 1, mpi_real, mpi_sum, 0, mpi_comm_world, ierr)
+  end subroutine power
+
+end program main
+
+! CHECK: 5.0
+! CHECK-NEXT: 1.0
+! CHECK-NEXT: 6.0

--- a/enzyme/test/Fortran/mpi/reduce_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/mpi/reduce_with_bindings_opt.f90
@@ -1,0 +1,75 @@
+! Test differentiation through mpi_reduce
+!
+! REQUIRES: fortran, mpi
+! RUN: %fc -flto -O1 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+
+program main
+  use enzyme, only: enzyme_dup, enzyme_autodiff, enzyme_fwddiff
+  use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_finalize, &
+                 mpi_comm_world, mpi_gather, mpi_real
+  implicit none
+
+  real :: xl, dxl, dxg(2), yg(2), dyg(2), seed(2)
+  integer :: ierr, rank, numprocs
+
+  call mpi_init(ierr)
+  call mpi_comm_rank(mpi_comm_world, rank, ierr)
+  call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+
+  if (numprocs /= 2) then
+    error stop "This test runs with 2 MPI processes"
+  end if
+
+  ! Compute the derivatives with forward mode: 1 (rank 0), 4 (rank 1)
+  ! The tangent of mpi_reduce reduces the tangents, so the root process
+  ! obtains the total derivative 1 + 4 = 5.
+  xl = 2.0
+  seed = 1.0
+  dyg = 0.0
+  call enzyme_fwddiff(power, enzyme_dup, xl, seed, enzyme_dup, yg, dyg)
+  if (rank == 0) then
+    write(*,"(f0.1)") dyg(1)
+  end if
+
+  ! Do the same thing with reverse mode: 1 (rank 0), 6 (rank 1)
+  ! The adjoint of mpi_reduce broadcasts the adjoints of the reduced values
+  ! on the root process out to every process, so each process obtains the
+  ! derivative of the root process' loss with respect to its local
+  ! contribution; collect these local derivatives on the root process.
+  xl = 3.0
+  dxl = 0.0
+  seed = 1.0
+  call enzyme_autodiff(power, enzyme_dup, xl, dxl, enzyme_dup, yg, seed)
+  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") dxg(1)
+    write(*,"(f0.1)") dxg(2)
+  end if
+
+  call mpi_finalize(ierr)
+
+contains
+
+  ! Compute the power (rank + 1) of a real and reduce the local values
+  subroutine power(xl, yg)
+    use mpi, only: mpi_comm_rank, mpi_comm_world, mpi_reduce, mpi_real, &
+                   mpi_sum
+    real, intent(in) :: xl
+    real, intent(out) :: yg(2)
+    real :: yl
+    integer :: ierr
+    integer :: rank
+
+    call mpi_comm_rank(mpi_comm_world, rank, ierr)
+    yl = xl**(rank + 1)
+    call mpi_reduce(yl, yg, 1, mpi_real, mpi_sum, 0, mpi_comm_world, ierr)
+  end subroutine power
+
+end program main
+
+! CHECK: 5.0
+! CHECK-NEXT: 1.0
+! CHECK-NEXT: 6.0

--- a/enzyme/test/Fortran/mpi/reduce_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/mpi/reduce_with_explicit_interface.f90
@@ -1,0 +1,118 @@
+! Test differentiation through mpi_reduce
+!
+! REQUIRES: fortran, mpi
+! RUN: %fc -flto -O0 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O1 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+
+module mpiReduce
+  implicit none
+  public
+  interface
+    subroutine power__enzyme_autodiff(sr, x_desc, x, dx, y_desc, y, dy)
+      implicit none
+      interface
+        subroutine sr_decal(a, b)
+          implicit none
+          real, intent(in) :: a
+          real, intent(out) :: b(2)
+        end subroutine sr_decal
+      end interface
+      procedure(sr_decal) :: sr
+      integer, intent(in) :: x_desc
+      real, intent(in) :: x
+      real, intent(inout) :: dx
+      integer, intent(in) :: y_desc
+      real, intent(out) :: y(2)
+      real, intent(inout) :: dy(2)
+    end subroutine power__enzyme_autodiff
+  end interface
+  interface
+    subroutine power__enzyme_fwddiff(sr, x_desc, x, dx, y_desc, y, dy)
+      implicit none
+      interface
+        subroutine sr_decal(a, b)
+          implicit none
+          real, intent(in) :: a
+          real, intent(out) :: b(2)
+        end subroutine sr_decal
+      end interface
+      procedure(sr_decal) :: sr
+      integer, intent(in) :: x_desc
+      real, intent(in) :: x
+      real, intent(inout) :: dx(2)
+      integer, intent(in) :: y_desc
+      real, intent(out) :: y(2)
+      real, intent(inout) :: dy(2)
+    end subroutine power__enzyme_fwddiff
+  end interface
+contains
+  ! Compute the power (rank + 1) of a real and reduce the local values
+  subroutine power(xl, yg)
+    use mpi, only: mpi_comm_rank, mpi_comm_world, mpi_reduce, mpi_real, &
+                   mpi_sum
+    real, intent(in) :: xl
+    real, intent(out) :: yg(2)
+    real :: yl
+    integer :: ierr
+    integer :: rank
+
+    call mpi_comm_rank(mpi_comm_world, rank, ierr)
+    yl = xl**(rank + 1)
+    call mpi_reduce(yl, yg, 1, mpi_real, mpi_sum, 0, mpi_comm_world, ierr)
+  end subroutine power
+end module mpiReduce
+
+program main
+  use mpiReduce, only: power, power__enzyme_autodiff, power__enzyme_fwddiff
+  use enzyme, only: enzyme_dup
+  use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_comm_world, &
+                 mpi_gather, mpi_real, mpi_finalize
+  implicit none
+
+  real :: xl, dxl, dxg(2), yg(2), dyg(2), seed(2)
+  integer :: rank, ierr, numprocs
+
+  call mpi_init(ierr)
+  call mpi_comm_rank(mpi_comm_world, rank, ierr)
+  call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+
+  if (numprocs /= 2) then
+    error stop "This test runs with 2 MPI processes"
+  end if
+
+  ! Compute the derivatives with forward mode: 1 (rank 0), 4 (rank 1)
+  ! The tangent of mpi_reduce reduces the tangents, so the root process
+  ! obtains the total derivative 1 + 4 = 5.
+  xl = 2.0
+  seed = 1.0
+  dyg = 0.0
+  call power__enzyme_fwddiff(power, enzyme_dup, xl, seed, enzyme_dup, yg, dyg)
+  if (rank == 0) then
+    write(*,"(f0.1)") dyg(1)
+  end if
+
+  ! Do the same thing with reverse mode: 1 (rank 0), 6 (rank 1)
+  ! The adjoint of mpi_reduce broadcasts the adjoints of the reduced values
+  ! on the root process out to every process, so each process obtains the
+  ! derivative of the root process' loss with respect to its local
+  ! contribution; collect these local derivatives on the root process.
+  xl = 3.0
+  dxl = 0.0
+  seed = 1.0
+  call power__enzyme_autodiff(power, enzyme_dup, xl, dxl, enzyme_dup, yg, seed)
+  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") dxg(1)
+    write(*,"(f0.1)") dxg(2)
+  end if
+
+  call mpi_finalize(ierr)
+end program main
+
+! CHECK: 5.0
+! CHECK-NEXT: 1.0
+! CHECK-NEXT: 6.0

--- a/enzyme/test/Fortran/mpi/scatter_with_bindings_O0.f90
+++ b/enzyme/test/Fortran/mpi/scatter_with_bindings_O0.f90
@@ -1,4 +1,4 @@
-! Test differentiation through mpi_comm_scatter
+! Test differentiation through mpi_scatter
 !
 ! REQUIRES: fortran, mpi
 ! UNSUPPORTED: ifx

--- a/enzyme/test/Fortran/mpi/scatter_with_bindings_O0.f90
+++ b/enzyme/test/Fortran/mpi/scatter_with_bindings_O0.f90
@@ -1,4 +1,4 @@
-! Test differentiation through mpi_comm_gather
+! Test differentiation through mpi_comm_scatter
 !
 ! REQUIRES: fortran, mpi
 ! UNSUPPORTED: ifx
@@ -15,7 +15,7 @@ program main
                  mpi_comm_world, mpi_gather, mpi_real
   implicit none
 
-  real :: xl, dxl, dxg(2), yg(2), dyl, dyg(2), seed(2)
+  real :: xg(2), dxg(2), yl, dyl, dyg(2), seed(2)
   integer :: ierr, rank, numprocs
 
   call mpi_init(ierr)
@@ -27,26 +27,25 @@ program main
   end if
 
   ! Compute the derivatives with forward mode: 1 (rank 0), 4 (rank 1)
-  ! Here the gathered array of derivatives is produced directly by the
-  ! differentiated gather on the root process.
-  xl = 2.0
+  ! The tangent of mpi_scatter still scatters the tangents, so we need to
+  ! gather them back to the root process for testing.
+  xg = [2.0, 3.0]
   seed = 1.0
-  dyg = 0.0
-  call enzyme_fwddiff(power, enzyme_dup, xl, seed, enzyme_dup, yg, dyg)
+  dyl = 0.0
+  call enzyme_fwddiff(power, enzyme_dup, xg, seed, enzyme_dup, yl, dyl)
+  call mpi_gather(dyl, 1, mpi_real, dyg, 1, mpi_real, 0, mpi_comm_world, ierr)
   if (rank == 0) then
     write(*,"(f0.1)") dyg(1)
     write(*,"(f0.1)") dyg(2)
   end if
 
   ! Do the same thing with reverse mode: 1 (rank 0), 6 (rank 1)
-  ! The adjoint of mpi_gather scatters the adjoints of the gathered array, so
-  ! each process obtains the derivative of its own contribution to the gather;
-  ! collect these local derivatives on the root process.
-  xl = 3.0
-  dxl = 0.0
+  ! The adjoint of mpi_scatter gathers the adjoints of the gathered array, so
+  ! the root process obtains the derivatives it needs for testing.
+  xg = [4.0, 5.0]
+  dxg = 0.0
   seed = 1.0
-  call enzyme_autodiff(power, enzyme_dup, xl, dxl, enzyme_dup, yg, seed)
-  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  call enzyme_autodiff(power, enzyme_dup, xg, dxg, enzyme_dup, yl, seed)
   if (rank == 0) then
     write(*,"(f0.1)") dxg(1)
     write(*,"(f0.1)") dxg(2)
@@ -56,23 +55,23 @@ program main
 
 contains
 
-  ! Compute the power (rank + 1) of a real and gather the local values
-  subroutine power(xl, yg)
-    use mpi, only: mpi_comm_rank, mpi_comm_world, mpi_gather, mpi_real
-    real, intent(in) :: xl
-    real, intent(out) :: yg(2)
-    real :: yl
+  ! Scatter the input argument then compute its power numprocs
+  subroutine power(x, y)
+    use mpi, only: mpi_comm_size, mpi_comm_world, mpi_scatter, mpi_real
+    real, intent(in) :: x(2)
+    real, intent(out) :: y
+    real :: xl
     integer :: ierr
-    integer :: rank
+    integer :: numprocs
 
-    call mpi_comm_rank(mpi_comm_world, rank, ierr)
-    yl = xl**(rank + 1)
-    call mpi_gather(yl, 1, mpi_real, yg, 1, mpi_real, 0, mpi_comm_world, ierr)
+    call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+    call mpi_scatter(x, 1, mpi_real, xl, 1, mpi_real, 0, mpi_comm_world, ierr)
+    y = xl**numprocs
   end subroutine power
 
 end program main
 
-! CHECK: 1.0
-! CHECK-NEXT: 4.0
-! CHECK-NEXT: 1.0
+! CHECK: 4.0
 ! CHECK-NEXT: 6.0
+! CHECK-NEXT: 8.0
+! CHECK-NEXT: 10.0

--- a/enzyme/test/Fortran/mpi/scatter_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/mpi/scatter_with_bindings_opt.f90
@@ -1,4 +1,4 @@
-! Test differentiation through mpi_comm_scatter
+! Test differentiation through mpi_scatter
 !
 ! REQUIRES: fortran, mpi
 ! RUN: %fc -flto -O1 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s

--- a/enzyme/test/Fortran/mpi/scatter_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/mpi/scatter_with_bindings_opt.f90
@@ -1,4 +1,4 @@
-! Test differentiation through mpi_comm_gather
+! Test differentiation through mpi_comm_scatter
 !
 ! REQUIRES: fortran, mpi
 ! RUN: %fc -flto -O1 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
@@ -12,7 +12,7 @@ program main
                  mpi_comm_world, mpi_gather, mpi_real
   implicit none
 
-  real :: xl, dxl, dxg(2), yg(2), dyl, dyg(2), seed(2)
+  real :: xg(2), dxg(2), yl, dyl, dyg(2), seed(2)
   integer :: ierr, rank, numprocs
 
   call mpi_init(ierr)
@@ -24,26 +24,25 @@ program main
   end if
 
   ! Compute the derivatives with forward mode: 1 (rank 0), 4 (rank 1)
-  ! Here the gathered array of derivatives is produced directly by the
-  ! differentiated gather on the root process.
-  xl = 2.0
+  ! The tangent of mpi_scatter still scatters the tangents, so we need to
+  ! gather them back to the root process for testing.
+  xg = [2.0, 3.0]
   seed = 1.0
-  dyg = 0.0
-  call enzyme_fwddiff(power, enzyme_dup, xl, seed, enzyme_dup, yg, dyg)
+  dyl = 0.0
+  call enzyme_fwddiff(power, enzyme_dup, xg, seed, enzyme_dup, yl, dyl)
+  call mpi_gather(dyl, 1, mpi_real, dyg, 1, mpi_real, 0, mpi_comm_world, ierr)
   if (rank == 0) then
     write(*,"(f0.1)") dyg(1)
     write(*,"(f0.1)") dyg(2)
   end if
 
   ! Do the same thing with reverse mode: 1 (rank 0), 6 (rank 1)
-  ! The adjoint of mpi_gather scatters the adjoints of the gathered array, so
-  ! each process obtains the derivative of its own contribution to the gather;
-  ! collect these local derivatives on the root process.
-  xl = 3.0
-  dxl = 0.0
+  ! The adjoint of mpi_scatter gathers the adjoints of the gathered array, so
+  ! the root process obtains the derivatives it needs for testing.
+  xg = [4.0, 5.0]
+  dxg = 0.0
   seed = 1.0
-  call enzyme_autodiff(power, enzyme_dup, xl, dxl, enzyme_dup, yg, seed)
-  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  call enzyme_autodiff(power, enzyme_dup, xg, dxg, enzyme_dup, yl, seed)
   if (rank == 0) then
     write(*,"(f0.1)") dxg(1)
     write(*,"(f0.1)") dxg(2)
@@ -53,23 +52,23 @@ program main
 
 contains
 
-  ! Compute the power (rank + 1) of a real and gather the local values
-  subroutine power(xl, yg)
-    use mpi, only: mpi_comm_rank, mpi_comm_world, mpi_gather, mpi_real
-    real, intent(in) :: xl
-    real, intent(out) :: yg(2)
-    real :: yl
+  ! Scatter the input argument then compute its power numprocs
+  subroutine power(x, y)
+    use mpi, only: mpi_comm_size, mpi_comm_world, mpi_scatter, mpi_real
+    real, intent(in) :: x(2)
+    real, intent(out) :: y
+    real :: xl
     integer :: ierr
-    integer :: rank
+    integer :: numprocs
 
-    call mpi_comm_rank(mpi_comm_world, rank, ierr)
-    yl = xl**(rank + 1)
-    call mpi_gather(yl, 1, mpi_real, yg, 1, mpi_real, 0, mpi_comm_world, ierr)
+    call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+    call mpi_scatter(x, 1, mpi_real, xl, 1, mpi_real, 0, mpi_comm_world, ierr)
+    y = xl**numprocs
   end subroutine power
 
 end program main
 
-! CHECK: 1.0
-! CHECK-NEXT: 4.0
-! CHECK-NEXT: 1.0
+! CHECK: 4.0
 ! CHECK-NEXT: 6.0
+! CHECK-NEXT: 8.0
+! CHECK-NEXT: 10.0

--- a/enzyme/test/Fortran/mpi/scatter_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/mpi/scatter_with_explicit_interface.f90
@@ -1,4 +1,4 @@
-! Test differentiation through mpi_comm_gather
+! Test differentiation through mpi_comm_scatter
 !
 ! REQUIRES: fortran, mpi
 ! RUN: %fc -flto -O0 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
@@ -8,7 +8,7 @@
 ! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
 ! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
 
-module mpiGather
+module mpiScatter
   implicit none
   public
   interface
@@ -17,16 +17,16 @@ module mpiGather
       interface
         subroutine sr_decal(a, b)
           implicit none
-          real, intent(in) :: a
-          real, intent(out) :: b(2)
+          real, intent(in) :: a(2)
+          real, intent(out) :: b
         end subroutine sr_decal
       end interface
       procedure(sr_decal) :: sr
       integer, intent(in) :: x_desc
-      real, intent(in) :: x
-      real, intent(inout) :: dx
+      real, intent(in) :: x(2)
+      real, intent(inout) :: dx(2)
       integer, intent(in) :: y_desc
-      real, intent(out) :: y(2)
+      real, intent(out) :: y
       real, intent(inout) :: dy(2)
     end subroutine power__enzyme_autodiff
   end interface
@@ -36,43 +36,43 @@ module mpiGather
       interface
         subroutine sr_decal(a, b)
           implicit none
-          real, intent(in) :: a
-          real, intent(out) :: b(2)
+          real, intent(in) :: a(2)
+          real, intent(out) :: b
         end subroutine sr_decal
       end interface
       procedure(sr_decal) :: sr
       integer, intent(in) :: x_desc
-      real, intent(in) :: x
+      real, intent(in) :: x(2)
       real, intent(inout) :: dx(2)
       integer, intent(in) :: y_desc
-      real, intent(out) :: y(2)
-      real, intent(inout) :: dy(2)
+      real, intent(out) :: y
+      real, intent(inout) :: dy
     end subroutine power__enzyme_fwddiff
   end interface
 contains
-  ! Compute the power (rank + 1) of a real and gather the local values
-  subroutine power(xl, yg)
-    use mpi, only: mpi_comm_rank, mpi_comm_world, mpi_gather, mpi_real
-    real, intent(in) :: xl
-    real, intent(out) :: yg(2)
-    real :: yl
+  ! Scatter the input argument then compute its power numprocs
+  subroutine power(x, y)
+    use mpi, only: mpi_comm_size, mpi_comm_world, mpi_scatter, mpi_real
+    real, intent(in) :: x(2)
+    real, intent(out) :: y
+    real :: xl
     integer :: ierr
-    integer :: rank
+    integer :: numprocs
 
-    call mpi_comm_rank(mpi_comm_world, rank, ierr)
-    yl = xl**(rank + 1)
-    call mpi_gather(yl, 1, mpi_real, yg, 1, mpi_real, 0, mpi_comm_world, ierr)
+    call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+    call mpi_scatter(x, 1, mpi_real, xl, 1, mpi_real, 0, mpi_comm_world, ierr)
+    y = xl**numprocs
   end subroutine power
-end module mpiGather
+end module mpiScatter
 
 program main
-  use mpiGather, only: power, power__enzyme_autodiff, power__enzyme_fwddiff
+  use mpiScatter, only: power, power__enzyme_autodiff, power__enzyme_fwddiff
   use enzyme, only: enzyme_dup
   use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_comm_world, &
                  mpi_gather, mpi_real, mpi_finalize
   implicit none
 
-  real :: xl, dxl, dxg(2), yg(2), dyg(2), seed(2)
+  real :: xg(2), dxg(2), yl, dyl, dyg(2), seed(2)
   integer :: rank, ierr, numprocs
 
   call mpi_init(ierr)
@@ -84,26 +84,25 @@ program main
   end if
 
   ! Compute the derivatives with forward mode: 1 (rank 0), 4 (rank 1)
-  ! Here the gathered array of derivatives is produced directly by the
-  ! differentiated gather on the root process.
-  xl = 2.0
+  ! The tangent of mpi_scatter still scatters the tangents, so we need to
+  ! gather them back to the root process for testing.
+  xg = [2.0, 3.0]
   seed = 1.0
-  dyg = 0.0
-  call power__enzyme_fwddiff(power, enzyme_dup, xl, seed, enzyme_dup, yg, dyg)
+  dyl = 0.0
+  call power__enzyme_fwddiff(power, enzyme_dup, xg, seed, enzyme_dup, yl, dyl)
+  call mpi_gather(dyl, 1, mpi_real, dyg, 1, mpi_real, 0, mpi_comm_world, ierr)
   if (rank == 0) then
     write(*,"(f0.1)") dyg(1)
     write(*,"(f0.1)") dyg(2)
   end if
 
   ! Do the same thing with reverse mode: 1 (rank 0), 6 (rank 1)
-  ! The adjoint of mpi_gather scatters the adjoints of the gathered array, so
-  ! each process obtains the derivative of its own contribution to the gather;
-  ! collect these local derivatives on the root process.
-  xl = 3.0
-  dxl = 0.0
+  ! The adjoint of mpi_scatter gathers the adjoints of the gathered array, so
+  ! the root process obtains the derivatives it needs for testing.
+  xg = [4.0, 5.0]
+  dxg = 0.0
   seed = 1.0
-  call power__enzyme_autodiff(power, enzyme_dup, xl, dxl, enzyme_dup, yg, seed)
-  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  call power__enzyme_autodiff(power, enzyme_dup, xg, dxg, enzyme_dup, yl, seed)
   if (rank == 0) then
     write(*,"(f0.1)") dxg(1)
     write(*,"(f0.1)") dxg(2)
@@ -112,7 +111,7 @@ program main
   call mpi_finalize(ierr)
 end program main
 
-! CHECK: 1.0
-! CHECK-NEXT: 4.0
-! CHECK-NEXT: 1.0
+! CHECK: 4.0
 ! CHECK-NEXT: 6.0
+! CHECK-NEXT: 8.0
+! CHECK-NEXT: 10.0

--- a/enzyme/test/Fortran/mpi/scatter_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/mpi/scatter_with_explicit_interface.f90
@@ -1,4 +1,4 @@
-! Test differentiation through mpi_comm_scatter
+! Test differentiation through mpi_scatter
 !
 ! REQUIRES: fortran, mpi
 ! RUN: %fc -flto -O0 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s

--- a/enzyme/test/Fortran/mpi/size_with_bindings_O0.f90
+++ b/enzyme/test/Fortran/mpi/size_with_bindings_O0.f90
@@ -1,0 +1,72 @@
+! Test differentiation through mpi_comm_size
+!
+! REQUIRES: fortran, mpi
+! UNSUPPORTED: ifx
+! RUN: %fc -flto -O0 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+
+! NOTE: This test is only configured to run with the flang compiler at -O0.
+!       For it to work with the ifx compiler we will need to figure out how to
+!       handle the indirection involved in the enzyme_autodiff binding.
+
+program main
+  use enzyme, only: enzyme_dup, enzyme_autodiff, enzyme_fwddiff
+  use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_finalize, &
+                 mpi_comm_world, mpi_gather, mpi_real
+  implicit none
+
+  real :: x, dxl, dxg(2), y, dyl, dyg(2)
+  integer :: ierr, rank, numprocs
+
+  call mpi_init(ierr)
+  call mpi_comm_rank(mpi_comm_world, rank, ierr)
+  call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+
+  if (numprocs /= 2) then
+    error stop "This test runs with 2 MPI processes"
+  end if
+
+  ! Compute the derivatives with reverse mode: 1 (rank 0), 6 (rank 1)
+  x = 2.0
+  dxl = 0.0
+  dyl = 1.0
+  call enzyme_autodiff(power, enzyme_dup, x, dxl, enzyme_dup, y, dyl)
+  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") dxg(1)
+    write(*,"(f0.1)") dxg(2)
+  end if
+
+  ! Do the same thing with forward mode
+  x = 3.0
+  dxl = 1.0
+  dyl = 0.0
+  call enzyme_fwddiff(power, enzyme_dup, x, dxl, enzyme_dup, y, dyl)
+  call mpi_gather(dyl, 1, mpi_real, dyg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") dyg(1)
+    write(*,"(f0.1)") dyg(2)
+  end if
+
+  call mpi_finalize(ierr)
+
+contains
+
+  ! Compute the power numprocs of a real
+  subroutine power(x, y)
+    use mpi, only: mpi_comm_world
+    real, intent(in) :: x
+    real, intent(out) :: y
+    integer :: ierr
+    integer :: numprocs
+
+    call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+    y = x**numprocs
+  end subroutine power
+
+end program main
+
+! CHECK: 4.0
+! CHECK-NEXT: 4.0
+! CHECK-NEXT: 6.0
+! CHECK-NEXT: 6.0

--- a/enzyme/test/Fortran/mpi/size_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/mpi/size_with_bindings_opt.f90
@@ -1,0 +1,69 @@
+! Test differentiation through mpi_comm_size
+!
+! REQUIRES: fortran, mpi
+! RUN: %fc -flto -O1 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+
+program main
+  use enzyme, only: enzyme_dup, enzyme_autodiff, enzyme_fwddiff
+  use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_finalize, &
+                 mpi_comm_world, mpi_gather, mpi_real
+  implicit none
+
+  real :: x, dxl, dxg(2), y, dyl, dyg(2)
+  integer :: ierr, rank, numprocs
+
+  call mpi_init(ierr)
+  call mpi_comm_rank(mpi_comm_world, rank, ierr)
+  call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+
+  if (numprocs /= 2) then
+    error stop "This test runs with 2 MPI processes"
+  end if
+
+  ! Compute the derivatives with reverse mode: 1 (rank 0), 6 (rank 1)
+  x = 2.0
+  dxl = 0.0
+  dyl = 1.0
+  call enzyme_autodiff(power, enzyme_dup, x, dxl, enzyme_dup, y, dyl)
+  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") dxg(1)
+    write(*,"(f0.1)") dxg(2)
+  end if
+
+  ! Do the same thing with forward mode
+  x = 3.0
+  dxl = 1.0
+  dyl = 0.0
+  call enzyme_fwddiff(power, enzyme_dup, x, dxl, enzyme_dup, y, dyl)
+  call mpi_gather(dyl, 1, mpi_real, dyg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") dyg(1)
+    write(*,"(f0.1)") dyg(2)
+  end if
+
+  call mpi_finalize(ierr)
+
+contains
+
+  ! Compute the power numprocs of a real
+  subroutine power(x, y)
+    use mpi, only: mpi_comm_world
+    real, intent(in) :: x
+    real, intent(out) :: y
+    integer :: ierr
+    integer :: numprocs
+
+    call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+    y = x**numprocs
+  end subroutine power
+
+end program main
+
+! CHECK: 4.0
+! CHECK-NEXT: 4.0
+! CHECK-NEXT: 6.0
+! CHECK-NEXT: 6.0

--- a/enzyme/test/Fortran/mpi/size_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/mpi/size_with_explicit_interface.f90
@@ -1,0 +1,112 @@
+! Test differentiation through mpi_comm_size
+!
+! REQUIRES: fortran, mpi
+! RUN: %fc -flto -O0 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O0 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O1 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %mpi_include %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o %t.ll && %fc -flto -O1 %t.ll %mpi_libs -o %t1 && mpirun -np 2 %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %mpi_include %loadFlangEnzyme %s %mpi_libs -o %t2 && mpirun -np 2 %t2 | FileCheck %s %}
+
+module mpiSize
+  implicit none
+  public
+  interface
+    subroutine power__enzyme_autodiff(sr, x_desc, x, dx, y_desc, y, dy)
+      implicit none
+      interface
+        subroutine sr_decal(a, b)
+          implicit none
+          real, intent(in) :: a
+          real, intent(out) :: b
+        end subroutine sr_decal
+      end interface
+      procedure(sr_decal) :: sr
+      integer, intent(in) :: x_desc
+      real, intent(in) :: x
+      real, intent(inout) :: dx
+      integer, intent(in) :: y_desc
+      real, intent(out) :: y
+      real, intent(inout) :: dy
+    end subroutine power__enzyme_autodiff
+  end interface
+  interface
+    subroutine power__enzyme_fwddiff(sr, x_desc, x, dx, y_desc, y, dy)
+      implicit none
+      interface
+        subroutine sr_decal(a, b)
+          implicit none
+          real, intent(in) :: a
+          real, intent(out) :: b
+        end subroutine sr_decal
+      end interface
+      procedure(sr_decal) :: sr
+      integer, intent(in) :: x_desc
+      real, intent(in) :: x
+      real, intent(inout) :: dx
+      integer, intent(in) :: y_desc
+      real, intent(out) :: y
+      real, intent(inout) :: dy
+    end subroutine power__enzyme_fwddiff
+  end interface
+contains
+  ! Compute the power numprocs of a real
+  subroutine power(x, y)
+    use mpi, only: mpi_comm_world
+    real, intent(in) :: x
+    real, intent(out) :: y
+    integer :: ierr
+    integer :: numprocs
+
+    call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+    y = x**numprocs
+  end subroutine power
+end module mpiSize
+
+program main
+  use mpiSize, only: power, power__enzyme_autodiff, power__enzyme_fwddiff
+  use enzyme, only: enzyme_dup
+  use mpi, only: mpi_init, mpi_comm_rank, mpi_comm_size, mpi_comm_world, &
+                 mpi_gather, mpi_real, mpi_finalize
+  implicit none
+
+  real :: x, dxl, dxg(2), y, dyl, dyg(2)
+  integer :: rank, ierr, numprocs
+
+  call mpi_init(ierr)
+  call mpi_comm_rank(mpi_comm_world, rank, ierr)
+  call mpi_comm_size(mpi_comm_world, numprocs, ierr)
+
+  if (numprocs /= 2) then
+    error stop "This test runs with 2 MPI processes"
+  end if
+
+  ! Compute the derivatives with reverse mode: 1 (rank 0), 6 (rank 1)
+  x = 2.0
+  dxl = 0.0
+  dyl = 1.0
+  call power__enzyme_autodiff(power, enzyme_dup, x, dxl, enzyme_dup, y, dyl)
+  call mpi_gather(dxl, 1, mpi_real, dxg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") dxg(1)
+    write(*,"(f0.1)") dxg(2)
+  end if
+
+  ! Do the same thing with forward mode
+  x = 3.0
+  dxl = 1.0
+  dyl = 0.0
+  call power__enzyme_fwddiff(power, enzyme_dup, x, dxl, enzyme_dup, y, dyl)
+  call mpi_gather(dyl, 1, mpi_real, dyg, 1, mpi_real, 0, mpi_comm_world, ierr)
+  if (rank == 0) then
+    write(*,"(f0.1)") dyg(1)
+    write(*,"(f0.1)") dyg(2)
+  end if
+
+  call mpi_finalize(ierr)
+end program main
+
+! CHECK: 4.0
+! CHECK-NEXT: 4.0
+! CHECK-NEXT: 6.0
+! CHECK-NEXT: 6.0

--- a/enzyme/test/lit.site.cfg.py.in
+++ b/enzyme/test/lit.site.cfg.py.in
@@ -134,6 +134,10 @@ config.substitutions.append(('%mpi_include', '@ENZYME_MPI_INCLUDE_FLAGS@'))
 config.substitutions.append(('%mpi_libs', '@ENZYME_MPI_LINK_FLAGS@'))
 if "@ENZYME_MPI_FORTRAN_ENABLED@" == "1":
     config.available_features.add('mpi')
+    # mpirun resolves the user home directory via the HOME environment
+    # variable, which lit does not propagate by default.
+    if 'HOME' in os.environ:
+        config.environment['HOME'] = os.environ['HOME']
 
 # Built by ENZYME_FLANG=ON; lets flang run Enzyme itself instead of piping IR to opt.
 config.substitutions.append(('%loadFlangEnzyme',

--- a/enzyme/test/lit.site.cfg.py.in
+++ b/enzyme/test/lit.site.cfg.py.in
@@ -127,6 +127,14 @@ if config.fc == "ifx":
     config.available_features.add('ifx')
 config.substitutions.append(('%loadFortran', '-I@ENZYME_BINARY_DIR@/modules'))
 
+# Include and link flags for the MPI Fortran bindings, detected by CMake's
+# FindMPI. The MPI tests (enzyme/test/Fortran/MPI) are gated on
+# `REQUIRES: mpi` and are unsupported when no MPI Fortran bindings are found.
+config.substitutions.append(('%mpi_include', '@ENZYME_MPI_INCLUDE_FLAGS@'))
+config.substitutions.append(('%mpi_libs', '@ENZYME_MPI_LINK_FLAGS@'))
+if "@ENZYME_MPI_FORTRAN_ENABLED@" == "1":
+    config.available_features.add('mpi')
+
 # Built by ENZYME_FLANG=ON; lets flang run Enzyme itself instead of piping IR to opt.
 config.substitutions.append(('%loadFlangEnzyme',
                              ' -fpass-plugin=@ENZYME_BINARY_DIR@/Enzyme/FlangEnzyme-'


### PR DESCRIPTION
Closes #3066

This PR adds simple tests for Fortran+MPI.

- [x] Rank
- [x] Size
- [x] Gather
- [x] Scatter
- [x] Allreduce
- [x] Reduce

To get it working, I needed to:
* Canonicalize MPI calls to support the different equivalent variants (Fortran ones have trailing underscores).
* (Attempt to) handle MPI Fortran ABI inconsistenties.
* Set the `HOME` environment variable in the lit config because this is needed by MPI.
* Install OpenMPI in the Fortran CI.