### PR TITLE
Make extractBLAS allocation-free

### DIFF
--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -3688,66 +3688,97 @@ Function *getFirstFunctionDefinition(Module &M) {
   return nullptr;
 }
 
+/// Decompose `in` as `prefix + floatType + stem + suffix` using the supplied
+/// tables, setting the out-parameters to the entries that matched.
+///
+/// No name the tables in `extractBLAS` can spell decomposes in more than one
+/// way, so peeling the fixed parts off either end of `in` and looking up what
+/// remains is equivalent to comparing `in` against every name the tables can
+/// generate -- but it allocates nothing. That matters: `extractBLAS` runs for
+/// every call instruction visited by type analysis and by
+/// `is_use_directly_needed_in_reverse`, and materialising the ~1200 candidate
+/// `std::string`s per query dominated compile time on call-heavy modules that
+/// contain no BLAS at all.
+static bool matchBLASName(StringRef in, ArrayRef<const char *> prefixes,
+                          ArrayRef<const char *> floatTypes,
+                          ArrayRef<const char *> stems,
+                          ArrayRef<const char *> suffixes,
+                          const char *&prefixOut, const char *&floatTypeOut,
+                          const char *&stemOut, const char *&suffixOut) {
+  for (const char *p : prefixes) {
+    StringRef afterPrefix = in;
+    if (!afterPrefix.consume_front(p))
+      continue;
+    for (const char *t : floatTypes) {
+      StringRef afterType = afterPrefix;
+      if (!afterType.consume_front(t))
+        continue;
+      for (const char *s : suffixes) {
+        StringRef stem = afterType;
+        if (!stem.consume_back(s))
+          continue;
+        for (const char *f : stems) {
+          if (stem != f)
+            continue;
+          prefixOut = p;
+          floatTypeOut = t;
+          stemOut = f;
+          suffixOut = s;
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
 #if LLVM_VERSION_MAJOR >= 16
 std::optional<BlasInfo> extractBLAS(llvm::StringRef in)
 #else
 llvm::Optional<BlasInfo> extractBLAS(llvm::StringRef in)
 #endif
 {
-  const char *extractable[] = {
+  static const char *extractable[] = {
       "dot",   "scal",  "axpy",  "gemv",  "gemm",  "spmv", "syrk",  "nrm2",
       "trmm",  "trmv",  "symm",  "potrf", "potrs", "copy", "spmv",  "syr2k",
       "potrs", "getrf", "getrs", "trtrs", "getri", "symv", "lacpy", "trsv",
   };
-  const char *floatType[] = {"s", "d", "c", "z"};
-  const char *prefixes[] = {"" /*Fortran*/, "cblas_"};
-  const char *suffixes[] = {"", "_", "64_", "_64_"};
-  for (auto t : floatType) {
-    for (auto f : extractable) {
-      for (auto p : prefixes) {
-        for (auto s : suffixes) {
-          if (in == (Twine(p) + t + f + s).str()) {
-            bool is64 = llvm::StringRef(s).contains("64");
-            return BlasInfo{
-                t, p, s, f, is64,
-            };
-          }
-        }
-      }
-    }
+  static const char *floatType[] = {"s", "d", "c", "z"};
+  static const char *prefixes[] = {"" /*Fortran*/, "cblas_"};
+  static const char *suffixes[] = {"", "_", "64_", "_64_"};
+
+  const char *p = nullptr, *t = nullptr, *f = nullptr, *s = nullptr;
+  if (matchBLASName(in, prefixes, floatType, extractable, suffixes, p, t, f,
+                    s)) {
+    bool is64 = llvm::StringRef(s).contains("64");
+    return BlasInfo{
+        t, p, s, f, is64,
+    };
   }
+
   // c interface to cublas
-  const char *cuCFloatType[] = {"S", "D", "C", "Z"};
-  const char *cuFFloatType[] = {"s", "d", "c", "z"};
-  const char *cuCPrefixes[] = {"cublas"};
-  const char *cuSuffixes[] = {"", "_v2", "_64", "_v2_64"};
-  for (auto t : llvm::enumerate(cuCFloatType)) {
-    for (auto f : extractable) {
-      for (auto p : cuCPrefixes) {
-        for (auto s : cuSuffixes) {
-          if (in == (Twine(p) + t.value() + f + s).str()) {
-            bool is64 = llvm::StringRef(s).contains("64");
-            return BlasInfo{
-                t.value(), p, s, f, is64,
-            };
-          }
-        }
-      }
-    }
+  static const char *cuCFloatType[] = {"S", "D", "C", "Z"};
+  static const char *cuCPrefixes[] = {"cublas"};
+  static const char *cuSuffixes[] = {"", "_v2", "_64", "_v2_64"};
+  if (matchBLASName(in, cuCPrefixes, cuCFloatType, extractable, cuSuffixes, p,
+                    t, f, s)) {
+    bool is64 = llvm::StringRef(s).contains("64");
+    return BlasInfo{
+        t, p, s, f, is64,
+    };
   }
+
   // Fortran interface to cublas
-  const char *cuFPrefixes[] = {"cublas_"};
-  for (auto t : cuFFloatType) {
-    for (auto f : extractable) {
-      for (auto p : cuFPrefixes) {
-        if (in == (Twine(p) + t + f).str()) {
-          return BlasInfo{
-              t, p, "", f, false,
-          };
-        }
-      }
-    }
+  static const char *cuFFloatType[] = {"s", "d", "c", "z"};
+  static const char *cuFPrefixes[] = {"cublas_"};
+  static const char *cuFSuffixes[] = {""};
+  if (matchBLASName(in, cuFPrefixes, cuFFloatType, extractable, cuFSuffixes, p,
+                    t, f, s)) {
+    return BlasInfo{
+        t, p, "", f, false,
+    };
   }
+
   return {};
 }
 


### PR DESCRIPTION
`extractBLAS` decided whether a name is a BLAS routine by generating every name it could recognise and comparing against it:

```cpp
for (auto t : floatType)          // 4
  for (auto f : extractable)      // 24
    for (auto p : prefixes)       // 2
      for (auto s : suffixes)     // 4
        if (in == (Twine(p) + t + f + s).str())
```

with two more nests for the cuBLAS C and Fortran interfaces — **~1250 heap-allocated `std::string`s per query**.

That would be tolerable if it were rare, but `extractBLAS` runs for every call instruction visited by type analysis and by `is_use_directly_needed_in_reverse`, so on call-heavy modules containing no BLAS at all it dominates compile time. A sampling profile of Enzyme differentiating an [Oceananigans](https://github.com/CliMA/Oceananigans.jl) ocean model (80×160×32, CPU, Float64) charged **1855 s of a 2972 s compile — 62% — to `extractBLAS`**, essentially all of it in `llvm::Twine::str()` and `raw_ostream`:

| stage | self time |
|---|---:|
| **`extractBLAS`** | **1855 s (62.4%)** |
| LLVM (optimization) | 659 s |
| Enzyme TypeAnalysis | 274 s |
| everything else | ~180 s |

Of the `extractBLAS` samples, 99.8% arrive via `is_use_directly_needed_in_reverse` (`BlasDiffUse.inc`). The profile lands on `Utils.cpp:3709/3728/3743` — the three comparison lines — in a 872 : 494 : 97 ratio, matching those loops' 800 : 400 : 100 iteration counts.

## The change

Match by peeling the prefix, float-type character and suffix off the ends of the name with `consume_front`/`consume_back` and looking up what remains, instead of materialising candidates. Same tables, same `BlasInfo`, no allocation.

This reorders the loops, which is only sound if a name cannot decompose two ways. That holds: the tables spell 1248 combinations → 1144 distinct names, **none** of which maps to conflicting `BlasInfo` (the 104 collisions are `spmv`/`potrs` being listed twice in `extractable`, which yield identical results).

## Verification

**Equivalence.** Compiled the old and new function bodies side by side and compared them on **210,019 names**: every name the tables generate, each mutated seven ways (prefixed, suffixed, truncated at both ends, upper/lower-cased, Julia-mangled), realistic mangled symbol names, and 200k random strings over a BLAS-like alphabet.

```
corpus            : 210019 names (1248 generated-valid)
recognised as BLAS: 2307
mismatches        : 0
```

**No test changed status.** Built `LLVMEnzyme-16.so` and ran the full 1568-test lit suite twice, once at `origin/main` and once with this commit:

```
BASELINE : 294 failures
PATCHED  : 294 failures
DIFF     : IDENTICAL — no test changed status
```

33/35 BLAS `.ll` tests pass in both. The absolute failure count reflects my local setup (built with `ENZYME_CLANG=OFF`/`ENZYME_FLANG=OFF`, so every `Integration/*` test fails for want of a driver); only the delta is meaningful, and it is zero.

**Speed**, 2M queries of non-BLAS symbol names:

```
old       106.857 s   (53428 ns/query)
new         0.134 s   (   67 ns/query)
speedup  : 796x
```

`clang-format` 16 (`--style=llvm`) reports no changes, matching `origin/main`.

## Note

The cuBLAS-C loop returned `t.value()` from `llvm::enumerate(cuCFloatType)` — the *uppercase* letter — as `BlasInfo::floatType`, while `cuFFloatType` sat unused in that nest. I preserved that behaviour exactly. If the uppercase `floatType` was unintended, it is a separate bug worth a look.

Assisted-by: Claude Code (Opus 5)
