### PR TITLE
TypeTree: order the offset map by sequence length

### DIFF
--- a/enzyme/Enzyme/TypeAnalysis/TypeTree.h
+++ b/enzyme/Enzyme/TypeAnalysis/TypeTree.h
@@ -33,6 +33,8 @@
 
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
+#include <algorithm>
+#include <limits>
 #include <map>
 #include <set>
 #include <string>
@@ -64,7 +66,25 @@ static inline std::string to_string(const std::vector<int> x) {
 class TypeTree;
 
 typedef std::shared_ptr<const TypeTree> TypeResult;
-typedef std::map<const std::vector<int>, ConcreteType> ConcreteTypeMapType;
+/// Orders offset sequences by length first, then lexicographically.
+///
+/// `insert` and `checkedOrIn` need to examine every entry whose offset
+/// sequence has the same length as the one being inserted. Under plain
+/// lexicographic order those entries are scattered through the map ([0] <
+/// [0,0] < [1]), so finding them means walking the whole map on every
+/// insertion. Ordering by length first makes each length class a contiguous
+/// range that can be found with a single lower_bound.
+struct SeqLess {
+  bool operator()(const std::vector<int> &lhs,
+                  const std::vector<int> &rhs) const {
+    if (lhs.size() != rhs.size())
+      return lhs.size() < rhs.size();
+    return lhs < rhs;
+  }
+};
+
+typedef std::map<const std::vector<int>, ConcreteType, SeqLess>
+    ConcreteTypeMapType;
 typedef std::map<const std::vector<int>, const TypeResult> TypeTreeMapType;
 
 /// Class representing the underlying types of values as
@@ -279,8 +299,14 @@ public:
     // Check if there is an existing match, e.g. [-1, -1, -1] and inserting
     // [-1, 8, -1]
     {
-      for (const auto &pair : llvm::make_early_inc_range(mapping)) {
-        if (pair.first.size() == SeqSize) {
+      // SeqLess keeps every sequence of length SeqSize contiguous, so only
+      // that range can match.
+      const std::vector<int> lowerKey(SeqSize, std::numeric_limits<int>::min());
+      for (auto it = mapping.lower_bound(lowerKey);
+           it != mapping.end() && it->first.size() == SeqSize;) {
+        const auto &pair = *it;
+        ++it;
+        {
           // Whether the the inserted val (e.g. [-1, 0] or [0, 0]) is at least
           // as general as the existing map val (e.g. [0, 0]).
           bool newMoreGeneralThanOld = true;
@@ -704,10 +730,13 @@ public:
       staging[next][pair.second].insert(pair.first[0]);
     }
 
-    // TypeTree mappings which did not get combined
-    std::map<const std::vector<int>, ConcreteType> unCombinedToAdd;
+    // TypeTree mappings which did not get combined. This is moved into
+    // `mapping` below, so it must use the same ordering.
+    ConcreteTypeMapType unCombinedToAdd;
 
-    // TypeTree mappings which did get combined into an outer -1
+    // TypeTree mappings which did get combined into an outer -1. Only iterated
+    // to re-insert, so it keeps plain lexicographic order to leave the
+    // resulting sequence of insertions unchanged.
     std::map<const std::vector<int>, ConcreteType> combinedToAdd;
 
     for (const auto &pair : staging) {
@@ -1204,8 +1233,15 @@ public:
       // Check if there is an existing match, e.g. [-1, -1, -1] and inserting
       // [-1, 8, -1]
       {
-        for (const auto &pair : llvm::make_early_inc_range(mapping)) {
-          if (pair.first.size() == SeqSize) {
+        // SeqLess keeps every sequence of length SeqSize contiguous, so only
+        // that range can match.
+        const std::vector<int> lowerKey(SeqSize,
+                                        std::numeric_limits<int>::min());
+        for (auto it = mapping.lower_bound(lowerKey);
+             it != mapping.end() && it->first.size() == SeqSize;) {
+          const auto &pair = *it;
+          ++it;
+          {
             // Whether the the inserted val (e.g. [-1, 0] or [0, 0]) is at least
             // as general as the existing map val (e.g. [0, 0]).
             bool newMoreGeneralThanOld = true;
@@ -1450,19 +1486,32 @@ public:
 
   /// Returns a string representation of this TypeTree
   std::string str() const {
+    // Print in lexicographic offset order rather than the map's own order, so
+    // that the textual form does not depend on how `mapping` is sorted
+    // internally (see SeqLess).
+    std::vector<const ConcreteTypeMapType::value_type *> entries;
+    entries.reserve(mapping.size());
+    for (auto &pair : mapping)
+      entries.push_back(&pair);
+    std::sort(entries.begin(), entries.end(),
+              [](const ConcreteTypeMapType::value_type *lhs,
+                 const ConcreteTypeMapType::value_type *rhs) {
+                return lhs->first < rhs->first;
+              });
+
     std::string out = "{";
     bool first = true;
-    for (auto &pair : mapping) {
+    for (const auto *pair : entries) {
       if (!first) {
         out += ", ";
       }
       out += "[";
-      for (unsigned i = 0; i < pair.first.size(); ++i) {
+      for (unsigned i = 0; i < pair->first.size(); ++i) {
         if (i != 0)
           out += ",";
-        out += std::to_string(pair.first[i]);
+        out += std::to_string(pair->first[i]);
       }
-      out += "]:" + pair.second.str();
+      out += "]:" + pair->second.str();
       first = false;
     }
     out += "}";


### PR DESCRIPTION
`TypeTree::insert` and `TypeTree::checkedOrIn` both need to examine every entry whose offset sequence has the *same length* as the one being inserted, to decide whether an existing entry is more or less general:

```cpp
for (const auto &pair : llvm::make_early_inc_range(mapping)) {
  if (pair.first.size() == SeqSize) {
```

`mapping` is keyed by `std::vector<int>` and ordered lexicographically, so entries of a given length are **not** contiguous (`[0] < [0,0] < [1]`). Finding the ones that matter walks the entire map, once per insertion, chasing red-black tree pointers.

This orders the map by sequence length first, lexicographically second. Each length class becomes a contiguous range reachable with one `lower_bound`, and the two scans iterate only over entries that can actually match.

## Measured effect

Workload: Enzyme differentiating an Oceananigans channel model (80x160x32, `HydrostaticFreeSurfaceModel`, WENO advection, reverse mode). Both libraries built from the same tree with identical cmake flags (`RelWithDebInfo`, LLVM 18.1.7), differing only in `TypeTree.h`; baseline is this PR's parent, 272285f9.

**End-to-end Enzyme compile time**, ASLR disabled (`setarch -R`), no sampling, two runs per arm:

| | run 1 | run 2 | mean | spread |
|---|---:|---:|---:|---:|
| base `272285f9` | 1152.1 s | 1147.4 s | **1149.7 s** | 4.7 s |
| this PR | 1117.5 s | 1120.9 s | **1119.2 s** | 3.4 s |

**-30.5 s, -2.7%.** The distributions do not overlap: the slower of the two patched runs still beats the faster baseline run by 26.4 s.

**Where it comes from** (separate sampled runs, 5 ms, cumulative seconds, two runs per arm):

| | base | base | PR | PR | mean delta |
|---|---:|---:|---:|---:|---:|
| `std::_Rb_tree_increment` | 91.0 | 96.6 | 34.8 | 37.6 | **-57.6 s (-61%)** |
| `TypeTree::insert` | 127.0 | 132.2 | 81.0 | 86.4 | -45.9 s (-35%) |
| `TypeTree::checkedOrIn` | 81.1 | 81.7 | 47.2 | 48.6 | -33.5 s (-41%) |
| `insert` u `checkedOrIn` | 169.5 | 175.0 | 107.7 | 114.0 | **-61.4 s (-36%)** |

Map walking falls from 8.5-9.0% to 3.3-3.4% of sampled time.

Two caveats on reading these, both of which argue for trusting the -30.5 s wall-clock figure over the -58 s sampled one:

- The sampler over-weights exactly the code being removed: `_Rb_tree_increment` sits at the bottom of deep stacks, and the per-sample cost scales with stack depth. The unsampled wall-clock delta is the honest number.
- Without `setarch -R`, this compile varies by ~10% run-to-run (one sampled pair gave -45 s, the next +128 s) even though forward-run times stay stable to within 0.4 s, so it is not machine load. Disabling ASLR collapses the spread to under 5 s, which is consistent with pointer-address-dependent iteration order somewhere in the pipeline. Anyone re-measuring this should disable ASLR or average many runs.

## Observability of the order

Every other access to `mapping` is a `find()`, so the order is unobservable - with one exception:

- **`str()`** iterated the map directly, so output would have regrouped by length (same entries, different order). It now sorts lexicographically before printing, so the textual form is exactly as before. This is the debug/print path only.
- **`toMD`** is unaffected - it regroups by leading offset into a `std::map<int, TypeTree>`.
- **`Canonicalize`'s `combinedToAdd`** deliberately keeps plain lexicographic order, since it is only iterated to re-insert and that insertion order is observable in the result. `unCombinedToAdd` is moved into `mapping`, so it takes the new ordering.
- **`TypeTree::operator<`** still delegates to the map's `operator<`, which compares elements with `std::vector`'s `operator<` rather than the map's comparator. The induced order changes but remains a strict weak ordering; `operator==` is unchanged. It has no `std::set<TypeTree>` / `std::map<TypeTree, ...>` users in tree.

## Correctness

Full lit suite on LLVM 16 is **byte-identical** before and after (same 1250 passed / 293 failed set; the failures are pre-existing in my local config, which disables MLIR/Fortran/Integration - `TypeAnalysis`, `ActivityAnalysis` and `Enzyme/*` are fully green).

Before the `str()` sort, exactly one test (`TypeAnalysis/multiiv.ll`) differed, and only by entry order - same 17 entries. That is what motivated stabilizing `str()` rather than updating the expectation.

## Review note

The scans keep a bare `{` block where the `if (pair.first.size() == SeqSize)` used to be, so the loop bodies stay at their original indentation and the diff stays reviewable. Happy to de-indent if you'd rather have it clean.

The commit message quotes the pre-change attribution (122 s of a 1932 s compile) as motivation; that figure is from the original profile against the 0.0.292 JLL and is not the size of the win. I can amend it to quote the measured -30.5 s instead - say the word and I'll force-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rj8Zm33cndJf3HGAKKeSHP
