### PR TITLE
Make per-call lookup tables static

### DIFF
--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -225,7 +225,7 @@ struct {
 bool isInactiveCall(CallBase &CI) {
 
   // clang-format off
-const char *KnownInactiveFunctionsStartingWith[] = {
+static const char *KnownInactiveFunctionsStartingWith[] = {
     "f90io",
     "$ss5print",
     "strcpy",
@@ -235,11 +235,11 @@ const char *KnownInactiveFunctionsStartingWith[] = {
     "_ZNSaIcEC1Ev",
 };
 
-const char *KnownInactiveFunctionsContains[] = {
+static const char *KnownInactiveFunctionsContains[] = {
     "__enzyme_float", "__enzyme_double", "__enzyme_integer",
     "__enzyme_pointer", "__enzyme_ignore_derivatives"};
 
-const StringSet<> KnownInactiveFunctions = {
+static const StringSet<> KnownInactiveFunctions = {
     "mpfr_greater_p",
     "__nv_isnand",
     "__nv_isnanf",
@@ -374,7 +374,7 @@ const StringSet<> KnownInactiveFunctions = {
     "cudaGetLastError",
 };
 
-const std::set<Intrinsic::ID> KnownInactiveIntrinsics = {
+static const std::set<Intrinsic::ID> KnownInactiveIntrinsics = {
     Intrinsic::experimental_noalias_scope_decl,
     Intrinsic::objectsize,
     Intrinsic::floor,
@@ -436,7 +436,7 @@ const std::set<Intrinsic::ID> KnownInactiveIntrinsics = {
     Intrinsic::is_constant,
     Intrinsic::memset};
 
-const char *DemangledKnownInactiveFunctionsStartingWith[] = {
+static const char *DemangledKnownInactiveFunctionsStartingWith[] = {
     // TODO this returns allocated memory and thus can be an active value
     // "std::allocator"
     "std::__u::basic_streambuf",

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -6429,7 +6429,7 @@ llvm::Function *EnzymeLogic::CreateNoFree(RequestContext context, Function *F) {
     return F;
 
   // clang-format off
-  StringSet<> NoFreeDemangles = {
+  static const StringSet<> NoFreeDemangles = {
       "std::__u::basic_istream<char, std::__u::char_traits<char>>::~basic_istream()",
       "std::__u::basic_filebuf<char, std::__u::char_traits<char>>::~basic_filebuf()",
       "std::__u::basic_ostream<char, std::__u::char_traits<char>>::~basic_ostream()",
@@ -6639,7 +6639,7 @@ llvm::Function *EnzymeLogic::CreateNoFree(RequestContext context, Function *F) {
       "std::io::stdio::_eprint",
   };
 
-  StringSet<> NoFrees = {"mpfr_greater_p",
+  static const StringSet<> NoFrees = {"mpfr_greater_p",
                         "vprintf",
                         "fprintf",
                         "fputc",

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -1552,7 +1552,7 @@ void TypeAnalyzer::considerTBAA() {
           updateAnalysis(call->getOperand(0), TT.Only(-1, call), call);
         }
         if (F) {
-          StringSet<> JuliaKnownTypes = {"julia.gc_alloc_obj",
+          static const StringSet<> JuliaKnownTypes = {"julia.gc_alloc_obj",
                                          "jl_alloc_array_1d",
                                          "jl_alloc_array_2d",
                                          "jl_alloc_array_3d",

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -1552,21 +1552,22 @@ void TypeAnalyzer::considerTBAA() {
           updateAnalysis(call->getOperand(0), TT.Only(-1, call), call);
         }
         if (F) {
-          static const StringSet<> JuliaKnownTypes = {"julia.gc_alloc_obj",
-                                         "jl_alloc_array_1d",
-                                         "jl_alloc_array_2d",
-                                         "jl_alloc_array_3d",
-                                         "ijl_alloc_array_1d",
-                                         "ijl_alloc_array_2d",
-                                         "ijl_alloc_array_3d",
-                                         "jl_gc_alloc_typed",
-                                         "ijl_gc_alloc_typed",
-                                         "jl_alloc_genericmemory",
-                                         "ijl_alloc_genericmemory",
-                                         "jl_alloc_genericmemory_unchecked",
-                                         "ijl_alloc_genericmemory_unchecked",
-                                         "jl_new_array",
-                                         "ijl_new_array"};
+          static const StringSet<> JuliaKnownTypes = {
+              "julia.gc_alloc_obj",
+              "jl_alloc_array_1d",
+              "jl_alloc_array_2d",
+              "jl_alloc_array_3d",
+              "ijl_alloc_array_1d",
+              "ijl_alloc_array_2d",
+              "ijl_alloc_array_3d",
+              "jl_gc_alloc_typed",
+              "ijl_gc_alloc_typed",
+              "jl_alloc_genericmemory",
+              "ijl_alloc_genericmemory",
+              "jl_alloc_genericmemory_unchecked",
+              "ijl_alloc_genericmemory_unchecked",
+              "jl_new_array",
+              "ijl_new_array"};
           if (JuliaKnownTypes.count(F->getName())) {
             visitCallBase(*call);
             continue;


### PR DESCRIPTION
`isInactiveCall` built a `StringSet` of ~130 known-inactive function names, a `std::set` of intrinsic IDs and several string arrays on every call, as the tables were function-local but not `static`. Activity analysis calls it from several hot paths. The same applied to `JuliaKnownTypes` in the type-analysis preparation loop (once per call instruction) and to the `NoFrees` / `NoFreeDemangles` sets in `CreateNoFree`.

Make all of them `static`.

Benchmark: Enzyme.jl reverse mode over 2 time steps of an 80×160×32 Oceananigans `HydrostaticFreeSurfaceModel` (Julia 1.12, LLVM 18), timing the first `autodiff` call. All numbers are from the same machine under `perf record`.

Measured together with #3187: Enzyme compile time 1054 s → 975 s. `isInactiveCall` and the `StringMap` rehash/lookup it caused disappear from the profile entirely. The lit suite has the same set of (pre-existing, opaque-pointer related) failures before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>