### PR TITLE
Only format CannotDeduceType warnings when they can be observed

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -413,17 +413,24 @@ public:
 
     IRBuilder<> BuilderZ(newi);
     if (!vd.isKnown()) {
-      std::string str;
-      raw_string_ostream ss(str);
-      ss << "Cannot deduce type of load " << I;
       auto ET = I.getType();
       if (looseTypeAnalysis || true) {
         vd = defaultTypeTreeForLLVM(ET, &I);
-        ss << ", assumed " << vd.str() << "\n";
-        EmitWarning("CannotDeduceType", I, ss.str());
+        if (EmitWarningEnabled(I.getContext())) {
+          std::string str;
+          raw_string_ostream ss(str);
+          ss << "Cannot deduce type of load " << I << ", assumed " << vd.str()
+             << "\n";
+          EmitWarning("CannotDeduceType", I, ss.str());
+        }
         goto known;
       }
-      EmitNoTypeError(str, I, gutils, BuilderZ);
+      {
+        std::string str;
+        raw_string_ostream ss(str);
+        ss << "Cannot deduce type of load " << I;
+        EmitNoTypeError(str, I, gutils, BuilderZ);
+      }
     known:;
     }
 
@@ -982,16 +989,23 @@ public:
     auto vd = TR.query(orig_ptr).Lookup(storeSize, DL);
 
     if (!vd.isKnown()) {
-      std::string str;
-      raw_string_ostream ss(str);
-      ss << "Cannot deduce type of store " << I;
       if (looseTypeAnalysis || true) {
         vd = defaultTypeTreeForLLVM(valType, &I);
-        ss << ", assumed " << vd.str() << "\n";
-        EmitWarning("CannotDeduceType", I, ss.str());
+        if (EmitWarningEnabled(I.getContext())) {
+          std::string str;
+          raw_string_ostream ss(str);
+          ss << "Cannot deduce type of store " << I << ", assumed " << vd.str()
+             << "\n";
+          EmitWarning("CannotDeduceType", I, ss.str());
+        }
         goto known;
       }
-      EmitNoTypeError(str, I, gutils, BuilderZ);
+      {
+        std::string str;
+        raw_string_ostream ss(str);
+        ss << "Cannot deduce type of store " << I;
+        EmitNoTypeError(str, I, gutils, BuilderZ);
+      }
       return;
     known:;
     }

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -227,6 +227,11 @@ extern llvm::StringMap<std::function<llvm::Value *(
     GradientUtils *)>>
     shadowHandlers;
 
+static inline bool EmitWarningEnabled(const llvm::LLVMContext &Ctx) {
+  return EnzymePrintPerf ||
+         Ctx.getDiagHandlerPtr()->isPassedOptRemarkEnabled("enzyme");
+}
+
 template <typename... Args>
 void EmitWarning(llvm::StringRef RemarkName,
                  const llvm::DiagnosticLocation &Loc,


### PR DESCRIPTION
The `CannotDeduceType` warnings in the load and store handlers printed the instruction and the `TypeTree` into a string before `EmitWarning` had a chance to check whether anything would be shown. Printing an `Instruction` without a slot tracker re-numbers the enclosing function, so this was O(function size) per untyped load or store, and with loose type analysis a large function has many of those.

Add `EmitWarningEnabled`, mirroring `EmitWarning`'s own conditions, and only build the message when it can be observed. The (dead) `EmitNoTypeError` branch keeps its message.

Benchmark: Enzyme.jl reverse mode over 2 time steps of an 80×160×32 Oceananigans `HydrostaticFreeSurfaceModel` (Julia 1.12, LLVM 18), timing the first `autodiff` call. All numbers are from the same machine under `perf record`.

Measured together with #3186: Enzyme compile time 1054 s → 975 s. In the earlier profile `visitCommonStore` spent ~36 s in `raw_ostream` writes for this message alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>