### PR TITLE
TypeAnalysis: return analysis results by const reference

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -1899,7 +1899,7 @@ public:
               8;
 
         unsigned start = 0;
-        auto vd = TR.query(&EVI);
+        const auto &vd = TR.query(&EVI);
 
         while (1) {
           unsigned nextStart = storeSize;
@@ -2064,7 +2064,7 @@ public:
             8;
 
       if (!gutils->isConstantValue(orig_inserted)) {
-        auto TT = TR.query(orig_inserted);
+        const auto &TT = TR.query(orig_inserted);
 
         unsigned start = 0;
         Value *dindex = nullptr;
@@ -2127,8 +2127,6 @@ public:
                                       prediff);
             }
 
-            auto TT = TR.query(orig_inserted);
-
             ((DiffeGradientUtils *)gutils)
                 ->addToDiffe(orig_inserted, dindex, Builder2, flt, start,
                              nextStart - start);
@@ -2149,7 +2147,7 @@ public:
 
       if (!gutils->isConstantValue(orig_agg)) {
 
-        auto TT = TR.query(orig_agg);
+        const auto &TT = TR.query(orig_agg);
         const MDNode *MD = hasMetadata(&IVI, "enzyme_truetype");
 
         unsigned start = 0;

--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -618,8 +618,7 @@ uint8_t EnzymeGradientUtilsGetUncacheableArgs(GradientUtils *gutils,
 CTypeTreeRef EnzymeGradientUtilsAllocAndGetTypeTree(GradientUtils *gutils,
                                                     LLVMValueRef val) {
   auto v = unwrap(val);
-  TypeTree TT = gutils->TR.query(v);
-  TypeTree *pTT = new TypeTree(TT);
+  TypeTree *pTT = new TypeTree(gutils->TR.query(v));
   return (CTypeTreeRef)pTT;
 }
 

--- a/enzyme/Enzyme/DifferentialUseAnalysis.cpp
+++ b/enzyme/Enzyme/DifferentialUseAnalysis.cpp
@@ -1142,7 +1142,7 @@ bool DifferentialUseAnalysis::callShouldNotUseDerivative(
           if (!gutils->TR.anyPointer(a))
             continue;
 
-          auto vd = gutils->TR.query(a);
+          const auto &vd = gutils->TR.query(a);
 
           if (!vd[{-1, -1}].isPossiblePointer())
             continue;

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -3396,7 +3396,7 @@ void createInvertedTerminator(DiffeGradientUtils *gutils,
               7) /
              8;
 
-    auto PNtypeT = gutils->TR.query(orig);
+    const auto &PNtypeT = gutils->TR.query(orig);
     auto PNtype = PNtypeT[{-1}];
 
     // TODO remove explicit type check and only use PNtype

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -1032,12 +1032,15 @@ static void AugmentWithJuliaObjectType(TypeTree &TT, Type *T,
   }
 }
 
-TypeTree TypeAnalyzer::getAnalysis(Value *Val) {
+const TypeTree &TypeAnalyzer::getAnalysis(Value *Val) {
   // Integers with fewer than 16 bits (size of half)
   // must be integral, since it cannot possibly represent a float or pointer
   if (!isa<UndefValue>(Val) && Val->getType()->isIntegerTy() &&
-      cast<IntegerType>(Val->getType())->getBitWidth() < 16)
-    return TypeTree(BaseType::Integer).Only(-1, nullptr);
+      cast<IntegerType>(Val->getType())->getBitWidth() < 16) {
+    static const TypeTree SmallInt =
+        TypeTree(BaseType::Integer).Only(-1, nullptr);
+    return SmallInt;
+  }
   if (auto C = dyn_cast<Constant>(Val)) {
     getConstantAnalysis(C, *this, analysis);
     if (EnzymeJuliaAddrLoad)
@@ -2771,7 +2774,7 @@ void TypeAnalyzer::visitExtractElementInst(ExtractElementInst &I) {
 
   } else {
     if (direction & DOWN) {
-      TypeTree vecAnalysis = getAnalysis(I.getVectorOperand());
+      const TypeTree &vecAnalysis = getAnalysis(I.getVectorOperand());
       // TODO merge of anythings (see selectinst)
       TypeTree res = vecAnalysis.Lookup(size, dl);
       updateAnalysis(&I, res.Only(-1, &I), &I);
@@ -6211,7 +6214,7 @@ FnTypeInfo TypeResults::getCallInfo(CallBase &CI, Function &fn) const {
   return analyzer->getCallInfo(CI, fn);
 }
 
-TypeTree TypeResults::query(Value *val) const {
+const TypeTree &TypeResults::query(Value *val) const {
 #ifndef NDEBUG
   if (auto inst = dyn_cast<Instruction>(val)) {
     assert(inst->getParent()->getParent() == analyzer->fntypeinfo.Function);
@@ -6246,7 +6249,7 @@ size_t skippedBytes(SmallSet<size_t, 8> &offs, Type *T, const DataLayout &DL,
 bool TypeResults::allFloat(Value *val) const {
   assert(val);
   assert(val->getType());
-  auto q = query(val);
+  const auto &q = query(val);
   auto dt = q[{-1}];
   if (dt != BaseType::Anything && dt != BaseType::Unknown)
     return dt.isFloat();
@@ -6275,7 +6278,7 @@ bool TypeResults::allFloat(Value *val) const {
 bool TypeResults::anyFloat(Value *val, bool anythingIsFloat) const {
   assert(val);
   assert(val->getType());
-  auto q = query(val);
+  const auto &q = query(val);
   auto dt = q[{-1}];
   if (!anythingIsFloat && dt == BaseType::Anything)
     return false;
@@ -6314,7 +6317,7 @@ bool TypeResults::anyFloat(Value *val, bool anythingIsFloat) const {
 bool TypeResults::anyPointer(Value *val) const {
   assert(val);
   assert(val->getType());
-  auto q = query(val);
+  const auto &q = query(val);
   auto dt = q[{-1}];
   if (dt != BaseType::Anything && dt != BaseType::Unknown)
     return dt == BaseType::Pointer;
@@ -6352,7 +6355,7 @@ ConcreteType TypeResults::intType(size_t num, Value *val, llvm::Instruction *I,
                                   bool pointerIntSame) const {
   assert(val);
   assert(val->getType());
-  auto q = query(val);
+  const auto &q = query(val);
   auto dt = q[{0}];
   /*
   size_t ObjSize = 1;
@@ -6382,7 +6385,7 @@ ConcreteType TypeResults::intType(size_t num, Value *val, llvm::Instruction *I,
 Type *TypeResults::addingType(size_t num, Value *val, size_t start) const {
   assert(val);
   assert(val->getType());
-  auto q = query(val);
+  const auto &q = query(val);
   Type *ty = q[{-1}].isFloat();
   for (size_t i = start; i < num; ++i) {
     auto ty2 = q[{(int)i}].isFloat();

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.h
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.h
@@ -210,7 +210,7 @@ public:
                             bool pointerIntSame = false) const;
 
   /// The TypeTree of a particular Value
-  TypeTree query(llvm::Value *val) const;
+  const TypeTree &query(llvm::Value *val) const;
 
   /// Whether any part of the top level register can contain a float
   ///   e.g. { i64, float } can contain a  float, but { i64, i8* } would not.
@@ -312,7 +312,7 @@ public:
                bool PHIRecur = false);
 
   /// Get the current results for a given value
-  TypeTree getAnalysis(llvm::Value *Val);
+  const TypeTree &getAnalysis(llvm::Value *Val);
 
   /// Add additional information to the Type info of val, readding it to the
   /// work queue as necessary


### PR DESCRIPTION
`TypeAnalyzer::getAnalysis` and `TypeResults::query` returned the `TypeTree` by value. A `TypeTree` owns a `std::map`, so every call deep-copied the map node by node, and most of the ~200 call sites only read the result: `query(v).Lookup(...)`, `query(v)[{-1}]`, or the `TypeResults` helpers (`allFloat`, `anyFloat`, `intType`, `addingType`, `firstPointer`), which each copied a whole tree to index a few offsets.

Return a `const` reference into the analysis map instead. `std::map` references stay valid across insertions, and the only erase is of a temporary instruction local to `visitConstantExpr`. Call sites that assign to a `TypeTree` or `auto` local still copy, so behaviour is unchanged; the `TypeResults` helpers and a few read-only sites now bind by `const` reference. One site (`AdjointGenerator.h`, insertvalue handling) queried a tree it never used and is removed.

Benchmark: Enzyme.jl reverse mode over 2 time steps of an 80×160×32 Oceananigans `HydrostaticFreeSurfaceModel` (Julia 1.12, LLVM 18), timing the first `autodiff` call. All numbers are from the same machine under `perf record`.

Enzyme compile time 975 s → 748 s. Allocator (`malloc`/`free`) share of all samples drops from 21% to 7%, and the `_Rb_tree` copy/clone symbols leave the profile. Nested and plain gradients unchanged; lit failure set identical to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>