### PR TITLE
MLIR: alias classes for globals, and alloc-like effect handling

### DIFF
--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.cpp
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.cpp
@@ -1061,9 +1061,64 @@ LogicalResult getEffectsForExternalCall(
   return failure();
 }
 
+// Whether an `llvm.mlir.addressof` of this symbol has to fall back on the
+// shared entry class, or can be given its own. Symbols that may be defined
+// outside the module can be aliased by an incoming pointer, so they share the
+// entry class; symbols whose definition the module owns get a unique class.
+static bool shouldUseEntryClassForAddressOf(Operation *symbol) {
+  if (isa<LLVM::GlobalOp>(symbol)) {
+    // A global's storage is a distinct object even when the definition is
+    // external: taking its address cannot produce a pointer into some other
+    // global. Give every global its own alias class.
+    //
+    // TODO: this ignores unnamed_addr. A global marked unnamed_addr has no
+    // meaningful identity and may be merged with an equivalent constant, so
+    // strictly it should not get a unique class of its own.
+    return false;
+  }
+
+  if (auto f = dyn_cast<LLVM::LLVMFuncOp>(symbol)) {
+    auto linkage = f.getLinkage();
+    return linkage == LLVM::Linkage::External ||
+           linkage == LLVM::Linkage::ExternWeak ||
+           linkage == LLVM::Linkage::AvailableExternally;
+  }
+
+  if (auto a = dyn_cast<LLVM::AliasOp>(symbol)) {
+    auto linkage = a.getLinkage();
+    return linkage == LLVM::Linkage::External ||
+           linkage == LLVM::Linkage::ExternWeak ||
+           linkage == LLVM::Linkage::AvailableExternally;
+  }
+
+  // Conservative fallback.
+  return true;
+}
+
 LogicalResult enzyme::AliasAnalysis::visitOperation(
     Operation *op, ArrayRef<const AliasClassLattice *> operands,
     ArrayRef<AliasClassLattice *> results) {
+  if (auto addr = dyn_cast<LLVM::AddressOfOp>(op)) {
+    AliasClassLattice *resultLattice = results[0];
+
+    Operation *symbol =
+        SymbolTable::lookupNearestSymbolFrom(op, addr.getGlobalNameAttr());
+
+    DistinctAttr cls = nullptr;
+    if (!symbol || shouldUseEntryClassForAddressOf(symbol)) {
+      cls = entryClass;
+    } else {
+      // Keyed on the symbol, not on this result: two `llvm.mlir.addressof` of
+      // the same global must land in the same alias class.
+      cls = originalClasses.getSymbolClass(symbol, addr.getGlobalNameAttr());
+    }
+
+    propagateIfChanged(resultLattice,
+                       resultLattice->join(AliasClassLattice::single(
+                           resultLattice->getAnchor(), cls)));
+
+    return success();
+  }
 
   // If we don't have memory effect information, don't assume anything about
   // values.

--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.cpp
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.cpp
@@ -823,11 +823,12 @@ void enzyme::AliasAnalysis::setToEntryState(AliasClassLattice *lattice) {
 static bool isAliasTransferFullyDescribedByMemoryEffects(Operation *op) {
   if (auto call = dyn_cast<CallOpInterface>(op)) {
     if (auto symbol = dyn_cast<SymbolRefAttr>(call.getCallableForCallee())) {
-      if (symbol.getLeafReference().getValue() == "malloc") {
+      StringRef name = symbol.getLeafReference().getValue();
+      if (name == "malloc" || name == "calloc" || name == "_Znwm")
         return true;
-      }
     }
   }
+
   return isa<memref::LoadOp, memref::StoreOp, affine::AffineLoadOp,
              affine::AffineStoreOp, LLVM::LoadOp, LLVM::StoreOp, enzyme::PushOp,
              enzyme::PopOp>(op);

--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.cpp
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.cpp
@@ -248,6 +248,51 @@ static bool isNoOp(Operation *op) {
              LLVM::LifetimeEndOp, LLVM::AssumeOp, LLVM::UnreachableOp>(op);
 }
 
+static bool isAliasRelevantEffect(const MemoryEffects::EffectInstance &effect) {
+  Value v = effect.getValue();
+  if (v)
+    return true;
+
+  if (const auto *resource = effect.getResource())
+    return resource->isAddressable();
+
+  return true;
+}
+
+static Value getSingleFreshAllocatedPointerLikeResultIfEffectOnlyAllocLike(
+    Operation *op, ArrayRef<MemoryEffects::EffectInstance> effects) {
+  Value allocatedValue = nullptr;
+  bool sawAllocate = false;
+
+  for (const auto &effect : effects) {
+    Value v = effect.getValue();
+
+    if (isa<MemoryEffects::Allocate>(effect.getEffect()) && v &&
+        v.getDefiningOp() == op && isPointerLike(v.getType())) {
+      sawAllocate = true;
+
+      // Single-result helper: reject multiple allocated pointer-like results.
+      if (!allocatedValue)
+        allocatedValue = v;
+      else
+        return nullptr;
+
+      continue;
+    }
+
+    // Ignore non-alias-relevant effects, e.g. runtime/comm effects on
+    // non-addressable resources.
+    if (!isAliasRelevantEffect(effect))
+      continue;
+
+    // Any other alias-relevant effect means this op is not "pure alloc-like"
+    // for our purposes.
+    return nullptr;
+  }
+
+  return sawAllocate ? allocatedValue : nullptr;
+}
+
 LogicalResult enzyme::PointsToPointerAnalysis::visitOperation(
     Operation *op, const PointsToSets &before, PointsToSets *after) {
   join(after, before);
@@ -267,11 +312,11 @@ LogicalResult enzyme::PointsToPointerAnalysis::visitOperation(
 
   // If the operation allocates fresh memory and doesn't write into it, that
   // memory is known not to point to any known alias class.
-  if (effects.size() == 1 &&
-      isa<MemoryEffects::Allocate>(effects.front().getEffect()) &&
-      effects.front().getValue()) {
+  if (Value allocatedValue =
+          getSingleFreshAllocatedPointerLikeResultIfEffectOnlyAllocLike(
+              op, effects)) {
     const auto *destClasses = getOrCreateFor<AliasClassLattice>(
-        getProgramPointAfter(op), effects.front().getValue());
+        getProgramPointAfter(op), allocatedValue);
     propagateIfChanged(
         after, after->setPointingToEmpty(destClasses->getAliasClassesObject()));
     return success();
@@ -820,7 +865,8 @@ void enzyme::AliasAnalysis::setToEntryState(AliasClassLattice *lattice) {
 // would need additional processing.
 //
 // TODO: turn this into an interface.
-static bool isAliasTransferFullyDescribedByMemoryEffects(Operation *op) {
+static bool isAliasTransferFullyDescribedByMemoryEffects(
+    Operation *op, ArrayRef<MemoryEffects::EffectInstance> effects) {
   if (auto call = dyn_cast<CallOpInterface>(op)) {
     if (auto symbol = dyn_cast<SymbolRefAttr>(call.getCallableForCallee())) {
       StringRef name = symbol.getLeafReference().getValue();
@@ -829,9 +875,15 @@ static bool isAliasTransferFullyDescribedByMemoryEffects(Operation *op) {
     }
   }
 
-  return isa<memref::LoadOp, memref::StoreOp, affine::AffineLoadOp,
-             affine::AffineStoreOp, LLVM::LoadOp, LLVM::StoreOp, enzyme::PushOp,
-             enzyme::PopOp>(op);
+  if (isa<memref::LoadOp, memref::StoreOp, affine::AffineLoadOp,
+          affine::AffineStoreOp, LLVM::LoadOp, LLVM::StoreOp, enzyme::PushOp,
+          enzyme::PopOp>(op))
+    return true;
+
+  // Generic alloc-like op: fresh pointer-like result, no alias-relevant
+  // effects other than the allocation itself.
+  return getSingleFreshAllocatedPointerLikeResultIfEffectOnlyAllocLike(
+             op, effects) != nullptr;
 }
 
 void enzyme::AliasAnalysis::transfer(
@@ -843,7 +895,8 @@ void enzyme::AliasAnalysis::transfer(
     // If the effect is global read, record that.
     Value value = effect.getValue();
     if (!value) {
-      globalRead |= isa<MemoryEffects::Read>(effect.getEffect());
+      globalRead |= isa<MemoryEffects::Read>(effect.getEffect()) &&
+                    isAliasRelevantEffect(effect);
       continue;
     }
 
@@ -914,7 +967,8 @@ void enzyme::AliasAnalysis::transfer(
   }
 
   // If it was enough to reason about effects, exit here.
-  if (!effects.empty() && isAliasTransferFullyDescribedByMemoryEffects(op))
+  if (!effects.empty() &&
+      isAliasTransferFullyDescribedByMemoryEffects(op, effects))
     return;
 
   // Conservatively assume all results alias all operands.

--- a/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.h
+++ b/enzyme/Enzyme/MLIR/Analysis/DataFlowAliasAnalysis.h
@@ -69,6 +69,19 @@ public:
     return aliasClass;
   }
 
+  /// Alias class of the storage designated by a symbol, e.g. an
+  /// `llvm.mlir.global`. Keyed on the symbol operation rather than on a value
+  /// so that every reference to the same symbol gets the same class.
+  DistinctAttr getSymbolClass(Operation *symbol, Attribute referenced) {
+    DistinctAttr &aliasClass = symbolClasses[symbol];
+    if (!aliasClass) {
+      if (!referenced)
+        referenced = UnitAttr::get(symbol->getContext());
+      aliasClass = DistinctAttr::create(referenced);
+    }
+    return aliasClass;
+  }
+
   DistinctAttr getSameOriginalClass(ValueRange values, StringRef debugLabel) {
     if (values.empty())
       return nullptr;
@@ -94,6 +107,7 @@ public:
 
 private:
   DenseMap<Value, DistinctAttr> originalClasses;
+  DenseMap<Operation *, DistinctAttr> symbolClasses;
 };
 
 //===----------------------------------------------------------------------===//

--- a/enzyme/test/MLIR/AliasAnalysis/globals.mlir
+++ b/enzyme/test/MLIR/AliasAnalysis/globals.mlir
@@ -1,0 +1,98 @@
+// RUN: %eopt --test-print-alias-analysis --split-input-file %s 2>&1 | FileCheck %s
+
+// The address of a global is a concrete alias class. Before, `llvm.mlir.addressof`
+// had no transfer function at all, so its lattice stayed undefined and any query
+// against it hit the "incomplete alias analysis" assertion.
+
+// Two distinct globals are distinct objects: taking the address of one can never
+// produce a pointer into the other, whatever their linkage.
+
+// CHECK: "a" and "b": NoAlias
+llvm.mlir.global external @ext1(0 : i64) : i64
+llvm.mlir.global external @ext2(0 : i64) : i64
+func.func @two_external_globals() {
+  %a = llvm.mlir.addressof @ext1 {tag = "a"} : !llvm.ptr
+  %b = llvm.mlir.addressof @ext2 {tag = "b"} : !llvm.ptr
+  return
+}
+
+// -----
+
+// CHECK: "a" and "b": NoAlias
+llvm.mlir.global internal @g1(0 : i64) : i64
+llvm.mlir.global internal @g2(0 : i64) : i64
+func.func @two_internal_globals() {
+  %a = llvm.mlir.addressof @g1 {tag = "a"} : !llvm.ptr
+  %b = llvm.mlir.addressof @g2 {tag = "b"} : !llvm.ptr
+  return
+}
+
+// -----
+
+// Mixed linkage is no different: still two separate objects.
+
+// CHECK: "a" and "b": NoAlias
+llvm.mlir.global external @pub(0 : i64) : i64
+llvm.mlir.global internal @priv(0 : i64) : i64
+func.func @mixed_linkage() {
+  %a = llvm.mlir.addressof @pub {tag = "a"} : !llvm.ptr
+  %b = llvm.mlir.addressof @priv {tag = "b"} : !llvm.ptr
+  return
+}
+
+// -----
+
+// Conversely, two addresses of the *same* global are the same object. The class
+// is keyed on the symbol rather than on the `llvm.mlir.addressof` result, which
+// matters because the LLVM importer emits one `addressof` per use.
+
+// CHECK: "a" and "b": MayAlias
+llvm.mlir.global external @same(0 : i64) : i64
+func.func @same_global_twice() {
+  %a = llvm.mlir.addressof @same {tag = "a"} : !llvm.ptr
+  %b = llvm.mlir.addressof @same {tag = "b"} : !llvm.ptr
+  return
+}
+
+// -----
+
+// A global keeps its own class across functions too.
+
+// CHECK: "a" and "b": MayAlias
+llvm.mlir.global external @shared(0 : i64) : i64
+func.func @user1() {
+  %a = llvm.mlir.addressof @shared {tag = "a"} : !llvm.ptr
+  return
+}
+func.func @user2() {
+  %b = llvm.mlir.addressof @shared {tag = "b"} : !llvm.ptr
+  return
+}
+
+// -----
+
+// An `llvm.mlir.addressof` of a function is not data storage; it stays in the
+// shared entry class when the function may be defined elsewhere.
+
+// CHECK: "a" and "b": MayAlias
+llvm.func external @decl()
+func.func @address_of_external_func() {
+  %a = llvm.mlir.addressof @decl {tag = "a"} : !llvm.ptr
+  %b = llvm.mlir.addressof @decl {tag = "b"} : !llvm.ptr
+  return
+}
+
+// -----
+
+// A global does not alias an unannotated pointer argument: argument classes and
+// global classes are disjoint. Note that this asserts no incoming pointer points
+// into a global, which a caller passing `&g` would violate. The analysis answered
+// NoAlias here before this file existed too, but only because the addressof side
+// was undefined rather than because anything had decided it.
+
+// CHECK: "arg" and "glob": NoAlias
+llvm.mlir.global external @escapes(0 : i64) : i64
+func.func @global_vs_argument(%arg0: !llvm.ptr {enzyme.tag = "arg"}) {
+  %glob = llvm.mlir.addressof @escapes {tag = "glob"} : !llvm.ptr
+  return
+}


### PR DESCRIPTION
`AliasAnalysis` has no transfer function for `llvm.mlir.addressof`, so the result
lattice stays undefined. An alias query involving the address of a global then
trips

```
assert(!isUndefined() && !rhs->isUndefined() && "incomplete alias analysis");
```

in `AliasClassLattice::alias`, and in a build without assertions compares two
empty class sets and quietly answers `NoAlias` — the right answer for two
distinct globals, by accident, and the wrong one for two addresses of the same
global.

This gives the address of a global its own alias class. Three commits, each
buildable on its own:

1. `isAliasTransferFullyDescribedByMemoryEffects` named only `malloc` while
   `getEffectsForExternalCall` already synthesized an `Allocate` effect for
   `calloc` and `_Znwm` too. Name all three in both places.
2. The fresh-allocation check required an operation to carry exactly one memory
   effect. That fits `memref.alloc` and `llvm.alloca`, but rejects an operation
   that allocates *and* carries an effect on a resource that is not addressable
   memory — a runtime handle, a communication resource — even though such an
   effect says nothing about aliasing. Factored into a helper that ignores
   effects on non-addressable resources. No in-tree operation changes behaviour;
   every allocator currently modelled has a single effect.
3. The `llvm.mlir.addressof` transfer function itself, plus
   `test/MLIR/AliasAnalysis/globals.mlir`.

### Keying on the symbol

The class is cached on the symbol operation, not on the `addressof` result, so
every `llvm.mlir.addressof @g` in the module lands in the same class. Keying on
the result value instead gives two addresses of one global two distinct classes
and hence `NoAlias`, which is wrong — and it is the common case rather than a
corner one, since the LLVM importer emits one `addressof` per use.

### Globals get a unique class regardless of linkage

A global is a distinct object even when its definition lives in another module,
so taking its address cannot produce a pointer into a *different* global.
External linkage does not change that, and folding external globals together
would lose precision for no soundness benefit.

Addresses of functions and of `llvm.mlir.alias` are treated differently: they
keep the shared entry class when they may be defined elsewhere.

### One consequence worth flagging

Because argument classes and global classes are disjoint, the address of a
global is now `NoAlias` with an unannotated pointer argument. That asserts no
incoming pointer points into a global, which a caller passing `&g` violates.

I have left it that way deliberately, for two reasons. The analysis already
answered `NoAlias` here before this patch — via the undefined lattice above — so
this is not a new answer, only a deliberate one where there used to be an
accident. And widening it means putting globals into the entry class, which
costs exactly the global-vs-global precision this patch is for.

The alternative would be to give externally-visible globals both their own class
and the entry class, so they stay distinct from each other but may-alias
incoming pointers. Happy to do that instead if you would rather have the
conservative answer; it is a small change and I would add the test alongside it.
`test/MLIR/AliasAnalysis/globals.mlir` pins the current behaviour either way.

There is also a `TODO` in the patch about `unnamed_addr`: a global marked
`unnamed_addr` has no meaningful identity and may be merged with an equivalent
constant, so strictly it should not get a unique class. Not handled here.

### Testing

`test/MLIR/AliasAnalysis/globals.mlir` covers two external globals, two internal
globals, mixed linkage, two addresses of the same global within a function and
across two functions, the address of an external function, and global vs.
argument.

Ran the full `test/MLIR` suite against this branch and against `main`: 228 pass,
and the one failure (`ReverseMode/func_call_write.mlir`) fails on `main` too.
Each of the three commits builds warning-free, and both touched files are clean
under `clang-format` 16.
