### PR TITLE
Forward mode for Fortran array assignment

### DIFF
--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -2447,6 +2447,72 @@ bool AdjointGenerator::handleKnownCallDerivatives(
       return true;
     }
 
+    // void _FortranAAssign(Descriptor &to, const Descriptor &from,
+    //                      const char *sourceFile, int sourceLine)
+    // is LLVM flang's assignment between descriptors. It moves data which may
+    // include reals, so it cannot be declared inactive; its derivative is the
+    // same assignment applied to the shadow data.
+    //
+    // The shadow of a descriptor is only shadow storage: the runtime metadata
+    // (element length, rank, type, and the derived type addendum) is never
+    // written to it, since none of that is differentiated. Handing such a
+    // descriptor to the runtime makes it read a zeroed rank and type. Copy the
+    // primal descriptor over the shadow first, keeping the shadow's own data
+    // pointer, so the runtime sees a well formed descriptor addressing the
+    // shadow data.
+    if (funcName == "_FortranAAssign" && call.arg_size() == 4) {
+      if (Mode == DerivativeMode::ForwardMode ||
+          Mode == DerivativeMode::ForwardModeError) {
+        const DataLayout &DL = called->getParent()->getDataLayout();
+
+        // The descriptors flang emits for this are stack slots, so their size
+        // is known. Without it there is nothing safe to copy, and falling
+        // through reports the call as underivable rather than guessing.
+        auto descriptorSize = [&](Value *v) -> uint64_t {
+          if (auto AI = dyn_cast<AllocaInst>(getBaseObject(v)))
+            if (auto Num = dyn_cast<ConstantInt>(AI->getArraySize()))
+              return Num->getZExtValue() *
+                     DL.getTypeAllocSize(AI->getAllocatedType());
+          return 0;
+        };
+        uint64_t toSize = descriptorSize(call.getArgOperand(0));
+        uint64_t fromSize = descriptorSize(call.getArgOperand(1));
+
+        if (toSize && fromSize && !gutils->isConstantInstruction(&call)) {
+          IRBuilder<> Builder2(&call);
+          getForwardBuilder(Builder2);
+
+          Value *primalTo = gutils->getNewFromOriginal(call.getArgOperand(0));
+          Value *primalFrom = gutils->getNewFromOriginal(call.getArgOperand(1));
+          Value *file = gutils->getNewFromOriginal(call.getArgOperand(2));
+          Value *line = gutils->getNewFromOriginal(call.getArgOperand(3));
+          Value *shadowTo =
+              gutils->invertPointerM(call.getArgOperand(0), Builder2);
+          Value *shadowFrom =
+              gutils->invertPointerM(call.getArgOperand(1), Builder2);
+
+          auto rule = [&](Value *sTo, Value *sFrom) {
+            auto reify = [&](Value *shadow, Value *primal, uint64_t size) {
+              Value *base = Builder2.CreateLoad(
+                  getInt8PtrTy(call.getContext()), shadow, "shadow.base_addr");
+              Builder2.CreateMemCpy(shadow, MaybeAlign(8), primal,
+                                    MaybeAlign(8), size);
+              Builder2.CreateStore(base, shadow);
+            };
+            reify(sTo, primalTo, toSize);
+            reify(sFrom, primalFrom, fromSize);
+            auto dcall = Builder2.CreateCall(called->getFunctionType(), called,
+                                             {sTo, sFrom, file, line});
+            dcall->setDebugLoc(gutils->getNewFromOriginal(call.getDebugLoc()));
+          };
+          applyChainRule(Builder2, rule, shadowTo, shadowFrom);
+
+          eraseIfUnused(call);
+          return true;
+        }
+      }
+    }
+
     /*
      * int gsl_sf_legendre_array_e(const gsl_sf_legendre_t norm,
                                    const size_t lmax,

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -2493,8 +2493,8 @@ bool AdjointGenerator::handleKnownCallDerivatives(
 
           auto rule = [&](Value *sTo, Value *sFrom) {
             auto reify = [&](Value *shadow, Value *primal, uint64_t size) {
-              Value *base = Builder2.CreateLoad(
-                  getInt8PtrTy(call.getContext()), shadow, "shadow.base_addr");
+              Value *base = Builder2.CreateLoad(getInt8PtrTy(call.getContext()),
+                                                shadow, "shadow.base_addr");
               Builder2.CreateMemCpy(shadow, MaybeAlign(8), primal,
                                     MaybeAlign(8), size);
               Builder2.CreateStore(base, shadow);

--- a/enzyme/test/Fortran/ForwardMode/allocatable_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ForwardMode/allocatable_with_explicit_interface.f90
@@ -7,7 +7,7 @@
 
 ! NOTE: This test is only configured to run with the ifx compiler
 !       For it to work with the flang compiler we will need to address
-!       https://github.com/EnzymeAD/Enzyme/issues/2820
+!       https://github.com/EnzymeAD/Enzyme/issues/2822
 
 module selectFirstForward
   implicit none

--- a/enzyme/test/Fortran/ForwardMode/norm_with_bindings_O0.f90
+++ b/enzyme/test/Fortran/ForwardMode/norm_with_bindings_O0.f90
@@ -1,0 +1,53 @@
+! REQUIRED: fortran
+! UNSUPPORTED: ifx
+! RUN: %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O0 -S -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
+
+! NOTE: This test is only configured to run with the flang compiler
+!       For it to work with the ifx compiler we will need to figure out how to
+!       handle the indirection involved in the enzyme_fwddiff binding
+
+program main
+  use enzyme, only: enzyme_const, enzyme_dup, enzyme_fwddiff
+  implicit none
+  integer, parameter :: n = 1000000
+  integer, parameter :: initial_value = 20
+  real :: x(n), dx(n)
+  real :: y(n), dy(n), yp
+
+  x(:) = initial_value
+  dx(:) = 1.0
+
+  call norm(n, x, y)
+
+  ! Rescale the output to avoid compiler-specific output formatting
+  yp = y(n) * 1.0e+06
+  write(*,"(f6.4)") yp
+
+  dy(:) = 0.0
+  call enzyme_fwddiff(norm, enzyme_const, n, &
+                      enzyme_dup, x, dx, enzyme_dup, y, dy)
+  write(*,"(f6.4)") dy(n)
+
+contains
+
+  subroutine norm(n, x, y)
+    integer, intent(in) :: n
+    real, dimension(n), intent(in) :: x
+    real, dimension(n), intent(out) :: y
+    real :: s
+    integer :: i
+    ! TODO: Use the `sum` intrinsic. Requires accounting for `_FortranASumReal4`
+    !       for this to work at -O0
+    ! y(:) = x / sum(x)
+    s = 0.0
+    do i = 1, n
+      s = s + x(i)
+    end do
+    y(:) = x(:) / s
+  end subroutine norm
+
+end program main
+
+! CHECK: 1.0000
+! CHECK-NEXT: 0.0000

--- a/enzyme/test/Fortran/ForwardMode/norm_with_bindings_opt.f90
+++ b/enzyme/test/Fortran/ForwardMode/norm_with_bindings_opt.f90
@@ -1,0 +1,50 @@
+! REQUIRED: fortran
+! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O1 -S -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O2 -S -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O3 -S -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
+
+program main
+  use enzyme, only: enzyme_const, enzyme_dup, enzyme_fwddiff
+  implicit none
+  integer, parameter :: n = 1000000
+  integer, parameter :: initial_value = 20
+  real :: x(n), dx(n)
+  real :: y(n), dy(n), yp
+
+  x(:) = initial_value
+  dx(:) = 1.0
+
+  call norm(n, x, y)
+
+  ! Rescale the output to avoid compiler-specific output formatting
+  yp = y(n) * 1.0e+06
+  write(*,"(f6.4)") yp
+
+  dy(:) = 0.0
+  call enzyme_fwddiff(norm, enzyme_const, n, &
+                      enzyme_dup, x, dx, enzyme_dup, y, dy)
+  write(*,"(f6.4)") dy(n)
+
+contains
+
+  subroutine norm(n, x, y)
+    integer, intent(in) :: n
+    real, dimension(n), intent(in) :: x
+    real, dimension(n), intent(out) :: y
+    real :: s
+    integer :: i
+    ! TODO: Use the `sum` intrinsic. Requires accounting for `_FortranASumReal4`
+    !       for this to work at -O0
+    ! y(:) = x / sum(x)
+    s = 0.0
+    do i = 1, n
+      s = s + x(i)
+    end do
+    y(:) = x(:) / s
+  end subroutine norm
+
+end program main
+
+! CHECK: 1.0000
+! CHECK-NEXT: 0.0000

--- a/enzyme/test/Fortran/ForwardMode/norm_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ForwardMode/norm_with_explicit_interface.f90
@@ -8,7 +8,6 @@
 
 ! NOTE: This test is only configured to run with the ifx compiler
 !       For it to work with the flang compiler we will need to address
-!       https://github.com/EnzymeAD/Enzyme/issues/2820
 !       https://github.com/EnzymeAD/Enzyme/issues/2822
 
 module normForward

--- a/enzyme/test/Fortran/ForwardMode/norm_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ForwardMode/norm_with_explicit_interface.f90
@@ -1,0 +1,69 @@
+! REQUIRES: fortran, ifx
+! RUN: %fc -flto -O0 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O0 -S -o %t.ll && %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O1 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O1 -S -o %t.ll && %fc -flto -O1 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O2 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O2 -S -o %t.ll && %fc -flto -O2 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %fc -flto -O3 -c %loadFortran %s -o /dev/stdout | %opt %loadEnzyme %enzyme -o /dev/stdout | %opt -O3 -S -o %t.ll && %fc -flto -O3 %t.ll -o %t1 && %t1 | FileCheck %s
+! RUN: %if flangenzyme %{ %fc -O0 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
+! RUN: %if flangenzyme %{ %fc -O2 %loadFortran %loadFlangEnzyme %s -o %t2 && %t2 | FileCheck %s %}
+
+! NOTE: This test is only configured to run with the ifx compiler
+!       For it to work with the flang compiler we will need to address
+!       https://github.com/EnzymeAD/Enzyme/issues/2820
+!       https://github.com/EnzymeAD/Enzyme/issues/2822
+
+module normForward
+  implicit none
+  public
+  interface
+    subroutine norm__enzyme_fwddiff(sr, x_desc, x, dx, y_desc, y, dy)
+      implicit none
+      interface
+        subroutine sr_decal(a, b)
+          implicit none
+          real, dimension(:), intent(in) :: a
+          real, dimension(:), intent(out) :: b
+        end subroutine sr_decal
+      end interface
+      procedure(sr_decal) :: sr
+      integer, intent(in) :: x_desc
+      real, dimension(:), intent(in) :: x
+      real, dimension(:), intent(in) :: dx
+      integer, intent(in) :: y_desc
+      real, dimension(:), intent(inout) :: y
+      real, dimension(:), intent(inout) :: dy
+    end subroutine norm__enzyme_fwddiff
+  end interface
+contains
+  subroutine norm(x, y)
+    real, dimension(:), intent(in) :: x
+    real, dimension(:), intent(out) :: y
+    y(:) = x / sum(x)
+  end subroutine norm
+end module normForward
+
+program main
+  use normForward, only: norm, norm__enzyme_fwddiff
+  use enzyme, only: enzyme_const, enzyme_dup
+  implicit none
+  integer, parameter :: n = 1000000
+  integer, parameter :: initial_value = 20
+  real :: x(n), dx(n)
+  real :: y(n), dy(n), yp
+
+  x(:) = initial_value
+  dx(:) = 1.0
+
+  call norm(n, x, y)
+
+  ! Rescale the output to avoid compiler-specific output formatting
+  yp = y(n) * 1.0e+06
+  write(*,"(f6.4)") yp
+
+  dy(:) = 0.0
+  call norm__enzyme_fwddiff(norm, enzyme_const, n, &
+                            enzyme_dup, x, dx, enzyme_dup, y, dy)
+  write(*,"(f6.4)") dy(n)
+end program main
+
+! CHECK: 1.0000
+! CHECK-NEXT: 0.0000

--- a/enzyme/test/Fortran/ForwardMode/norm_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ForwardMode/norm_with_explicit_interface.f90
@@ -53,15 +53,14 @@ program main
   x(:) = initial_value
   dx(:) = 1.0
 
-  call norm(n, x, y)
+  call norm(x, y)
 
   ! Rescale the output to avoid compiler-specific output formatting
   yp = y(n) * 1.0e+06
   write(*,"(f6.4)") yp
 
   dy(:) = 0.0
-  call norm__enzyme_fwddiff(norm, enzyme_const, n, &
-                            enzyme_dup, x, dx, enzyme_dup, y, dy)
+  call norm__enzyme_fwddiff(norm, enzyme_dup, x, dx, enzyme_dup, y, dy)
   write(*,"(f6.4)") dy(n)
 end program main
 

--- a/enzyme/test/Fortran/ReverseMode/allocatable_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ReverseMode/allocatable_with_explicit_interface.f90
@@ -7,7 +7,7 @@
 
 ! NOTE: This test is only configured to run with the ifx compiler
 !       For it to work with the flang compiler we will need to address
-!       https://github.com/EnzymeAD/Enzyme/issues/2820
+!       https://github.com/EnzymeAD/Enzyme/issues/2822
 
 module selectFirstReverse
   implicit none

--- a/enzyme/test/Fortran/ReverseMode/norm_with_explicit_interface.f90
+++ b/enzyme/test/Fortran/ReverseMode/norm_with_explicit_interface.f90
@@ -7,7 +7,6 @@
 
 ! NOTE: This test is only configured to run with the ifx compiler
 !       For it to work with the flang compiler we will need to address
-!       https://github.com/EnzymeAD/Enzyme/issues/2820
 !       https://github.com/EnzymeAD/Enzyme/issues/2822
 
 module normReverse


### PR DESCRIPTION
Closes #3008
Refinement of #3168 

This PR gets forward mode working for Fortran array assignment (`_FortranAAssign`) and adds tests to cover this.