### PR TITLE
Hand the frontend's external context to the callbacks that need it

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -5241,12 +5241,11 @@ public:
           newcalled = BuilderZ.CreateExtractValue(newcalled, {0});
         }
 
-        ErrorIfRuntimeInactive(gutils->externalContext(), BuilderZ,
-                               gutils->getNewFromOriginal(callval), newcalled,
-                               "Attempting to call an indirect active function "
-                               "whose runtime value is inactive",
-                               gutils->getNewFromOriginal(call.getDebugLoc()),
-                               &call);
+        ErrorIfRuntimeInactive(
+            gutils, BuilderZ, gutils->getNewFromOriginal(callval), newcalled,
+            "Attempting to call an indirect active function "
+            "whose runtime value is inactive",
+            gutils->getNewFromOriginal(call.getDebugLoc()), &call);
 
         auto ft = call.getFunctionType();
         bool retActive = subretType != DIFFE_TYPE::CONSTANT;
@@ -5645,8 +5644,7 @@ public:
 
         if (Mode != DerivativeMode::ReverseModeGradient)
           ErrorIfRuntimeInactive(
-              gutils->externalContext(), BuilderZ,
-              gutils->getNewFromOriginal(callval), newcalled,
+              gutils, BuilderZ, gutils->getNewFromOriginal(callval), newcalled,
               "Attempting to call an indirect active function "
               "whose runtime value is inactive",
               gutils->getNewFromOriginal(call.getDebugLoc()), &call);

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -4897,7 +4897,7 @@ public:
 
         if (tape && shouldFree()) {
           for (auto idx : subdata->tapeIndiciesToFree) {
-            CreateDealloc(gutils->externalContext(), Builder2,
+            CreateDealloc(Builder2,
                           idx == -1 ? tape
                                     : Builder2.CreateExtractValue(tape, idx));
           }
@@ -5122,8 +5122,7 @@ public:
             (writeOnlyNoCapture && readOnly);
 
         if (replace) {
-          argi = getUndefinedValueForType(gutils->externalContext(), M,
-                                          argi->getType());
+          argi = getUndefinedValueForType(M, argi->getType());
         }
         argsInverted.push_back(argTy);
         args.push_back(argi);
@@ -5242,7 +5241,7 @@ public:
         }
 
         ErrorIfRuntimeInactive(
-            gutils, BuilderZ, gutils->getNewFromOriginal(callval), newcalled,
+            BuilderZ, gutils->getNewFromOriginal(callval), newcalled,
             "Attempting to call an indirect active function "
             "whose runtime value is inactive",
             gutils->getNewFromOriginal(call.getDebugLoc()), &call);
@@ -5251,9 +5250,8 @@ public:
         bool retActive = subretType != DIFFE_TYPE::CONSTANT;
 
         FT = getFunctionTypeForClone(
-            gutils->externalContext(), ft, Mode, gutils->getWidth(),
-            tape ? tape->getType() : nullptr, argsInverted, false,
-            /*returnTape*/ false,
+            ft, Mode, gutils->getWidth(), tape ? tape->getType() : nullptr,
+            argsInverted, false, /*returnTape*/ false,
             /*returnPrimal*/ subretused, /*returnShadow*/ retActive);
         PointerType *fptype = getUnqual(FT);
         newcalled = BuilderZ.CreatePointerCast(newcalled, getUnqual(fptype));
@@ -5420,8 +5418,7 @@ public:
           (argTy == DIFFE_TYPE::DUP_NONEED &&
            (writeOnlyNoCapture ||
             !isa<Argument>(getBaseObject(call.getArgOperand(i)))))) {
-        prearg = getUndefinedValueForType(gutils->externalContext(), M,
-                                          argi->getType());
+        prearg = getUndefinedValueForType(M, argi->getType());
         preType = ValueType::None;
       }
       pre_args.push_back(prearg);
@@ -5439,8 +5436,7 @@ public:
              (argTy == DIFFE_TYPE::DUP_NONEED &&
               (writeOnlyNoCapture ||
                !isa<Argument>(getBaseObject(call.getOperand(i))))))) {
-          argi = getUndefinedValueForType(gutils->externalContext(), M,
-                                          argi->getType());
+          argi = getUndefinedValueForType(M, argi->getType());
           revType = ValueType::None;
         }
         args.push_back(lookup(argi, Builder2));
@@ -5517,8 +5513,7 @@ public:
                gutils->isConstantInstruction(&call)) &&
               !replaceFunction) {
             darg = getUndefinedValueForType(
-                gutils->externalContext(), M,
-                gutils->getShadowType(argi->getType()));
+                M, gutils->getShadowType(argi->getType()));
           } else {
             darg = gutils->invertPointerM(call.getArgOperand(i), Builder2);
             revType = (revType == ValueType::None) ? ValueType::Shadow
@@ -5555,8 +5550,7 @@ public:
 
         if (Mode == DerivativeMode::ReverseModeGradient && !replaceFunction) {
           nowrite_shadows.back() = true;
-          pre_args.push_back(getUndefinedValueForType(gutils->externalContext(),
-                                                      M, argi->getType()));
+          pre_args.push_back(getUndefinedValueForType(M, argi->getType()));
         } else {
           pre_args.push_back(
               gutils->invertPointerM(call.getArgOperand(i), BuilderZ));
@@ -5644,7 +5638,7 @@ public:
 
         if (Mode != DerivativeMode::ReverseModeGradient)
           ErrorIfRuntimeInactive(
-              gutils, BuilderZ, gutils->getNewFromOriginal(callval), newcalled,
+              BuilderZ, gutils->getNewFromOriginal(callval), newcalled,
               "Attempting to call an indirect active function "
               "whose runtime value is inactive",
               gutils->getNewFromOriginal(call.getDebugLoc()), &call);
@@ -6051,7 +6045,7 @@ public:
         truetape->setMetadata("enzyme_mustcache",
                               MDNode::get(truetape->getContext(), {}));
 
-        CreateDealloc(gutils->externalContext(), BuilderZ, tape);
+        CreateDealloc(BuilderZ, tape);
         tape = truetape;
       }
     } else {

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -1038,9 +1038,10 @@ public:
             ss << "Mismatched activity for: " << I
                << " const val: " << *orig_val;
             if (CustomErrorHandler) {
-              diff = unwrap(CustomErrorHandler(
-                  str.c_str(), wrap(&I), ErrorType::MixedActivityError, gutils,
-                  wrap(orig_val), wrap(&BuilderZ)));
+              diff = unwrap(
+                  CustomErrorHandler(gutils->externalContext(), str.c_str(),
+                                     wrap(&I), ErrorType::MixedActivityError,
+                                     gutils, wrap(orig_val), wrap(&BuilderZ)));
               if (diff)
                 needs_writebarrier = true;
             } else
@@ -1302,8 +1303,9 @@ public:
                      << " const val: " << *orig_val;
                   if (CustomErrorHandler) {
                     valueop = unwrap(CustomErrorHandler(
-                        str.c_str(), wrap(&I), ErrorType::MixedActivityError,
-                        gutils, wrap(orig_val), wrap(&BuilderZ)));
+                        gutils->externalContext(), str.c_str(), wrap(&I),
+                        ErrorType::MixedActivityError, gutils, wrap(orig_val),
+                        wrap(&BuilderZ)));
                     if (valueop)
                       needs_writebarrier = true;
                   } else
@@ -4895,7 +4897,7 @@ public:
 
         if (tape && shouldFree()) {
           for (auto idx : subdata->tapeIndiciesToFree) {
-            CreateDealloc(Builder2,
+            CreateDealloc(gutils->externalContext(), Builder2,
                           idx == -1 ? tape
                                     : Builder2.CreateExtractValue(tape, idx));
           }
@@ -5120,7 +5122,8 @@ public:
             (writeOnlyNoCapture && readOnly);
 
         if (replace) {
-          argi = getUndefinedValueForType(M, argi->getType());
+          argi = getUndefinedValueForType(gutils->externalContext(), M,
+                                          argi->getType());
         }
         argsInverted.push_back(argTy);
         args.push_back(argi);
@@ -5238,18 +5241,20 @@ public:
           newcalled = BuilderZ.CreateExtractValue(newcalled, {0});
         }
 
-        ErrorIfRuntimeInactive(
-            BuilderZ, gutils->getNewFromOriginal(callval), newcalled,
-            "Attempting to call an indirect active function "
-            "whose runtime value is inactive",
-            gutils->getNewFromOriginal(call.getDebugLoc()), &call);
+        ErrorIfRuntimeInactive(gutils->externalContext(), BuilderZ,
+                               gutils->getNewFromOriginal(callval), newcalled,
+                               "Attempting to call an indirect active function "
+                               "whose runtime value is inactive",
+                               gutils->getNewFromOriginal(call.getDebugLoc()),
+                               &call);
 
         auto ft = call.getFunctionType();
         bool retActive = subretType != DIFFE_TYPE::CONSTANT;
 
         FT = getFunctionTypeForClone(
-            ft, Mode, gutils->getWidth(), tape ? tape->getType() : nullptr,
-            argsInverted, false, /*returnTape*/ false,
+            gutils->externalContext(), ft, Mode, gutils->getWidth(),
+            tape ? tape->getType() : nullptr, argsInverted, false,
+            /*returnTape*/ false,
             /*returnPrimal*/ subretused, /*returnShadow*/ retActive);
         PointerType *fptype = getUnqual(FT);
         newcalled = BuilderZ.CreatePointerCast(newcalled, getUnqual(fptype));
@@ -5416,7 +5421,8 @@ public:
           (argTy == DIFFE_TYPE::DUP_NONEED &&
            (writeOnlyNoCapture ||
             !isa<Argument>(getBaseObject(call.getArgOperand(i)))))) {
-        prearg = getUndefinedValueForType(M, argi->getType());
+        prearg = getUndefinedValueForType(gutils->externalContext(), M,
+                                          argi->getType());
         preType = ValueType::None;
       }
       pre_args.push_back(prearg);
@@ -5434,7 +5440,8 @@ public:
              (argTy == DIFFE_TYPE::DUP_NONEED &&
               (writeOnlyNoCapture ||
                !isa<Argument>(getBaseObject(call.getOperand(i))))))) {
-          argi = getUndefinedValueForType(M, argi->getType());
+          argi = getUndefinedValueForType(gutils->externalContext(), M,
+                                          argi->getType());
           revType = ValueType::None;
         }
         args.push_back(lookup(argi, Builder2));
@@ -5511,7 +5518,8 @@ public:
                gutils->isConstantInstruction(&call)) &&
               !replaceFunction) {
             darg = getUndefinedValueForType(
-                M, gutils->getShadowType(argi->getType()));
+                gutils->externalContext(), M,
+                gutils->getShadowType(argi->getType()));
           } else {
             darg = gutils->invertPointerM(call.getArgOperand(i), Builder2);
             revType = (revType == ValueType::None) ? ValueType::Shadow
@@ -5548,7 +5556,8 @@ public:
 
         if (Mode == DerivativeMode::ReverseModeGradient && !replaceFunction) {
           nowrite_shadows.back() = true;
-          pre_args.push_back(getUndefinedValueForType(M, argi->getType()));
+          pre_args.push_back(getUndefinedValueForType(gutils->externalContext(),
+                                                      M, argi->getType()));
         } else {
           pre_args.push_back(
               gutils->invertPointerM(call.getArgOperand(i), BuilderZ));
@@ -5566,9 +5575,9 @@ public:
              << " expected DUP_ARG or CONSTANT found " << wt
              << ", call = " << call << "\n";
           if (CustomErrorHandler) {
-            CustomErrorHandler(str.c_str(), wrap(&call),
-                               ErrorType::InternalError, nullptr, nullptr,
-                               nullptr);
+            CustomErrorHandler(gutils->externalContext(), str.c_str(),
+                               wrap(&call), ErrorType::InternalError, nullptr,
+                               nullptr, nullptr);
           } else {
             EmitFailure("MismatchArgType", call.getDebugLoc(), &call, ss.str());
           }
@@ -5636,7 +5645,8 @@ public:
 
         if (Mode != DerivativeMode::ReverseModeGradient)
           ErrorIfRuntimeInactive(
-              BuilderZ, gutils->getNewFromOriginal(callval), newcalled,
+              gutils->externalContext(), BuilderZ,
+              gutils->getNewFromOriginal(callval), newcalled,
               "Attempting to call an indirect active function "
               "whose runtime value is inactive",
               gutils->getNewFromOriginal(call.getDebugLoc()), &call);
@@ -5916,9 +5926,9 @@ public:
                 ss << "Failed to compute consistent cache index for operation: "
                    << call << "\n";
                 if (CustomErrorHandler) {
-                  CustomErrorHandler(str.c_str(), wrap(&call),
-                                     ErrorType::InternalError, nullptr, nullptr,
-                                     nullptr);
+                  CustomErrorHandler(gutils->externalContext(), str.c_str(),
+                                     wrap(&call), ErrorType::InternalError,
+                                     nullptr, nullptr, nullptr);
                 } else {
                   EmitFailure("GetIndexError", call.getDebugLoc(), &call,
                               ss.str());
@@ -5983,9 +5993,9 @@ public:
               ss << " call" << call << "\n";
               ss << " augmentcall" << *augmentcall << "\n";
               if (CustomErrorHandler) {
-                CustomErrorHandler(str.c_str(), wrap(&call),
-                                   ErrorType::InternalError, nullptr, nullptr,
-                                   nullptr);
+                CustomErrorHandler(gutils->externalContext(), str.c_str(),
+                                   wrap(&call), ErrorType::InternalError,
+                                   nullptr, nullptr, nullptr);
               } else {
                 EmitFailure("GetIndexError", call.getDebugLoc(), &call,
                             ss.str());
@@ -6043,7 +6053,7 @@ public:
         truetape->setMetadata("enzyme_mustcache",
                               MDNode::get(truetape->getContext(), {}));
 
-        CreateDealloc(BuilderZ, tape);
+        CreateDealloc(gutils->externalContext(), BuilderZ, tape);
         tape = truetape;
       }
     } else {

--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -186,8 +186,6 @@ FnTypeInfo eunwrap(CFnTypeInfo CTI, llvm::Function *F) {
 // Defined in FixupJuliaCallingConvention.cpp
 void EnzymeFixupJuliaCallingConvention(EnzymeContextRef ExternalContext,
                                        llvm::Function *F, bool sret_jlvalue);
-void EnzymeFixupBatchedJuliaCallingConvention(EnzymeContextRef ExternalContext,
-                                              llvm::Function *F);
 
 extern "C" {
 
@@ -237,16 +235,6 @@ void EnzymeFixupJuliaCallingConventionModule(LLVMModuleRef M,
       Functions.push_back(&F);
   for (auto *F : Functions)
     EnzymeFixupJuliaCallingConvention(ExternalContext, F, (bool)sret_jlvalue);
-}
-
-void EnzymeFixupBatchedJuliaCallingConventionModule(LLVMModuleRef M,
-                                                    void *ExternalContext) {
-  SmallVector<Function *, 16> Functions;
-  for (auto &F : *unwrap(M))
-    if (!F.empty())
-      Functions.push_back(&F);
-  for (auto *F : Functions)
-    EnzymeFixupBatchedJuliaCallingConvention(ExternalContext, F);
 }
 
 EnzymeTraceInterfaceRef FindEnzymeStaticTraceInterface(LLVMModuleRef M) {

--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -183,6 +183,12 @@ FnTypeInfo eunwrap(CFnTypeInfo CTI, llvm::Function *F) {
   return FTI;
 }
 
+// Defined in FixupJuliaCallingConvention.cpp
+void EnzymeFixupJuliaCallingConvention(EnzymeContextRef ExternalContext,
+                                       llvm::Function *F, bool sret_jlvalue);
+void EnzymeFixupBatchedJuliaCallingConvention(EnzymeContextRef ExternalContext,
+                                              llvm::Function *F);
+
 extern "C" {
 
 void EnzymeSetCLBool(void *ptr, uint8_t val) {
@@ -220,6 +226,27 @@ void EnzymeLogicSetExternalContext(EnzymeLogicRef Ref, void *ExternalContext) {
 
 void *EnzymeLogicGetExternalContext(EnzymeLogicRef Ref) {
   return eunwrap(Ref).ExternalContext;
+}
+
+void EnzymeFixupJuliaCallingConventionModule(LLVMModuleRef M,
+                                             uint8_t sret_jlvalue,
+                                             void *ExternalContext) {
+  SmallVector<Function *, 16> Functions;
+  for (auto &F : *unwrap(M))
+    if (!F.empty())
+      Functions.push_back(&F);
+  for (auto *F : Functions)
+    EnzymeFixupJuliaCallingConvention(ExternalContext, F, (bool)sret_jlvalue);
+}
+
+void EnzymeFixupBatchedJuliaCallingConventionModule(LLVMModuleRef M,
+                                                    void *ExternalContext) {
+  SmallVector<Function *, 16> Functions;
+  for (auto &F : *unwrap(M))
+    if (!F.empty())
+      Functions.push_back(&F);
+  for (auto *F : Functions)
+    EnzymeFixupBatchedJuliaCallingConvention(ExternalContext, F);
 }
 
 EnzymeTraceInterfaceRef FindEnzymeStaticTraceInterface(LLVMModuleRef M) {

--- a/enzyme/Enzyme/CApi.h
+++ b/enzyme/Enzyme/CApi.h
@@ -177,6 +177,17 @@ void FreeEnzymeLogic(EnzymeLogicRef);
 void EnzymeLogicSetExternalContext(EnzymeLogicRef, void *ExternalContext);
 void *EnzymeLogicGetExternalContext(EnzymeLogicRef);
 
+/// Run the Julia calling-convention fixup over every function of \p M. The
+/// named passes ("enzyme-fixup-julia", "enzyme-fixup-julia-sret",
+/// "enzyme-fixup-batched-julia") do the same with a null external context;
+/// call these instead when the frontend has a context to hand to the error
+/// callback the fixup can reach.
+void EnzymeFixupJuliaCallingConventionModule(LLVMModuleRef M,
+                                             uint8_t sret_jlvalue,
+                                             void *ExternalContext);
+void EnzymeFixupBatchedJuliaCallingConventionModule(LLVMModuleRef M,
+                                                    void *ExternalContext);
+
 void EnzymeExtractReturnInfo(EnzymeAugmentedReturnPtr ret, int64_t *data,
                              uint8_t *existed, size_t len);
 

--- a/enzyme/Enzyme/CApi.h
+++ b/enzyme/Enzyme/CApi.h
@@ -178,15 +178,12 @@ void EnzymeLogicSetExternalContext(EnzymeLogicRef, void *ExternalContext);
 void *EnzymeLogicGetExternalContext(EnzymeLogicRef);
 
 /// Run the Julia calling-convention fixup over every function of \p M. The
-/// named passes ("enzyme-fixup-julia", "enzyme-fixup-julia-sret",
-/// "enzyme-fixup-batched-julia") do the same with a null external context;
-/// call these instead when the frontend has a context to hand to the error
-/// callback the fixup can reach.
+/// named passes ("enzyme-fixup-julia", "enzyme-fixup-julia-sret") do the same
+/// with a null external context; call this instead when the frontend has a
+/// context to hand to the error callback the fixup reaches.
 void EnzymeFixupJuliaCallingConventionModule(LLVMModuleRef M,
                                              uint8_t sret_jlvalue,
                                              void *ExternalContext);
-void EnzymeFixupBatchedJuliaCallingConventionModule(LLVMModuleRef M,
-                                                    void *ExternalContext);
 
 void EnzymeExtractReturnInfo(EnzymeAugmentedReturnPtr ret, int64_t *data,
                              uint8_t *existed, size_t len);

--- a/enzyme/Enzyme/CacheUtility.cpp
+++ b/enzyme/Enzyme/CacheUtility.cpp
@@ -25,6 +25,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "CacheUtility.h"
+#include "EnzymeLogic.h"
 #include "FunctionUtils.h"
 
 using namespace llvm;
@@ -50,6 +51,10 @@ llvm::cl::opt<bool> EfficientMaxCache(
 }
 
 CacheUtility::~CacheUtility() {}
+
+EnzymeContextRef CacheUtility::externalContext() const {
+  return Logic.externalContext();
+}
 
 /// Erase this instruction both from LLVM modules and any local data-structures
 void CacheUtility::erase(Instruction *I) {

--- a/enzyme/Enzyme/CacheUtility.cpp
+++ b/enzyme/Enzyme/CacheUtility.cpp
@@ -76,8 +76,8 @@ void CacheUtility::erase(Instruction *I) {
     ss << *newFunc << "\n";
     ss << *I << "\n";
     if (CustomErrorHandler) {
-      CustomErrorHandler(str.c_str(), wrap(I), ErrorType::InternalError,
-                         nullptr, nullptr, nullptr);
+      CustomErrorHandler(externalContext(), str.c_str(), wrap(I),
+                         ErrorType::InternalError, nullptr, nullptr, nullptr);
     } else {
       EmitFailure("GetIndexError", I->getDebugLoc(), I, ss.str());
     }
@@ -826,10 +826,10 @@ AllocaInst *CacheUtility::createCacheForScope(LimitContext ctx, Type *T,
 
       CallInst *malloccall;
       Instruction *Zero;
-      allocType = cast<PointerType>(CreateAllocation(B, types.back(), P,
-                                                     "tmpfortypecalc",
-                                                     &malloccall, &Zero)
-                                        ->getType());
+      allocType = cast<PointerType>(
+          CreateAllocation(externalContext(), B, types.back(), P,
+                           "tmpfortypecalc", &malloccall, &Zero)
+              ->getType());
       malloctypes.push_back(cast<PointerType>(malloccall->getType()));
       for (auto &I : make_early_inc_range(reverse(*BB)))
         I.eraseFromParent();
@@ -853,7 +853,8 @@ AllocaInst *CacheUtility::createCacheForScope(LimitContext ctx, Type *T,
         getCacheAlignment((unsigned)byteSizeOfType->getZExtValue());
     alloc->setAlignment(Align(align));
   }
-  auto undef_v = getUndefinedValueForType(*newFunc->getParent(), types.back(),
+  auto undef_v = getUndefinedValueForType(externalContext(),
+                                          *newFunc->getParent(), types.back(),
                                           /*forceZero*/ false);
   if (!isa<UndefValue>(undef_v))
     scopeInstructions[alloc].push_back(
@@ -912,9 +913,10 @@ AllocaInst *CacheUtility::createCacheForScope(LimitContext ctx, Type *T,
       // Statically allocate memory for all iterations if possible
       if (sublimits[i].second.back().first.maxLimit) {
         Instruction *ZeroInst = nullptr;
-        Value *firstallocation = CreateAllocation(
-            allocationBuilder, myType, size, name + "_malloccache", &malloccall,
-            /*ZeroMem*/ EnzymeZeroCache ? &ZeroInst : nullptr);
+        Value *firstallocation =
+            CreateAllocation(externalContext(), allocationBuilder, myType, size,
+                             name + "_malloccache", &malloccall,
+                             /*ZeroMem*/ EnzymeZeroCache ? &ZeroInst : nullptr);
 
         if (malloccall) {
           auto ident = MDNode::getDistinct(
@@ -962,7 +964,8 @@ AllocaInst *CacheUtility::createCacheForScope(LimitContext ctx, Type *T,
             LLVMContext::MD_invariant_group,
             CachePointerInvariantGroups[std::make_pair((Value *)alloc, i)]);
         scopeInstructions[alloc].push_back(storealloc);
-        for (auto post : PostCacheStore(storealloc, allocationBuilder)) {
+        for (auto post :
+             PostCacheStore(externalContext(), storealloc, allocationBuilder)) {
           scopeInstructions[alloc].push_back(post);
         }
       } else {
@@ -973,7 +976,8 @@ AllocaInst *CacheUtility::createCacheForScope(LimitContext ctx, Type *T,
         // TODO change this to a power-of-two allocation strategy
 
         auto zerostore = allocationBuilder.CreateStore(
-            getUndefinedValueForType(*newFunc->getParent(), allocType,
+            getUndefinedValueForType(externalContext(), *newFunc->getParent(),
+                                     allocType,
                                      /*forceZero*/ true),
             storeInto);
         scopeInstructions[alloc].push_back(zerostore);
@@ -990,8 +994,9 @@ AllocaInst *CacheUtility::createCacheForScope(LimitContext ctx, Type *T,
 
         CallInst *realloccall = nullptr;
         auto reallocation = CreateReAllocation(
-            build, allocation, myType, containedloops.back().first.incvar, size,
-            name + "_realloccache", &realloccall, EnzymeZeroCache && i == 0);
+            externalContext(), build, allocation, myType,
+            containedloops.back().first.incvar, size, name + "_realloccache",
+            &realloccall, EnzymeZeroCache && i == 0);
 
         scopeInstructions[alloc].push_back(cast<Instruction>(reallocation));
 
@@ -1009,7 +1014,7 @@ AllocaInst *CacheUtility::createCacheForScope(LimitContext ctx, Type *T,
         // since we are reloading/storing based off the number of loop
         // iterations
         scopeInstructions[alloc].push_back(storealloc);
-        for (auto post : PostCacheStore(storealloc, build)) {
+        for (auto post : PostCacheStore(externalContext(), storealloc, build)) {
           scopeInstructions[alloc].push_back(post);
         }
       }
@@ -1473,7 +1478,7 @@ void CacheUtility::storeInstructionInCache(LimitContext ctx,
   storeinst->setMetadata(LLVMContext::MD_tbaa, TBAA);
   storeinst->setAlignment(Align(align));
   scopeInstructions[cache].push_back(storeinst);
-  for (auto post : PostCacheStore(storeinst, v)) {
+  for (auto post : PostCacheStore(externalContext(), storeinst, v)) {
     scopeInstructions[cache].push_back(post);
   }
 }
@@ -1535,10 +1540,10 @@ Value *CacheUtility::getCachePointer(llvm::Type *T, bool inForwardPass,
 
       CallInst *malloccall;
       Instruction *Zero;
-      allocType = cast<PointerType>(CreateAllocation(B, types.back(), P,
-                                                     "tmpfortypecalc",
-                                                     &malloccall, &Zero)
-                                        ->getType());
+      allocType = cast<PointerType>(
+          CreateAllocation(externalContext(), B, types.back(), P,
+                           "tmpfortypecalc", &malloccall, &Zero)
+              ->getType());
       for (auto &I : make_early_inc_range(reverse(*BB)))
         I.eraseFromParent();
 

--- a/enzyme/Enzyme/CacheUtility.cpp
+++ b/enzyme/Enzyme/CacheUtility.cpp
@@ -858,8 +858,7 @@ AllocaInst *CacheUtility::createCacheForScope(LimitContext ctx, Type *T,
         getCacheAlignment((unsigned)byteSizeOfType->getZExtValue());
     alloc->setAlignment(Align(align));
   }
-  auto undef_v = getUndefinedValueForType(externalContext(),
-                                          *newFunc->getParent(), types.back(),
+  auto undef_v = getUndefinedValueForType(*newFunc->getParent(), types.back(),
                                           /*forceZero*/ false);
   if (!isa<UndefValue>(undef_v))
     scopeInstructions[alloc].push_back(
@@ -969,8 +968,7 @@ AllocaInst *CacheUtility::createCacheForScope(LimitContext ctx, Type *T,
             LLVMContext::MD_invariant_group,
             CachePointerInvariantGroups[std::make_pair((Value *)alloc, i)]);
         scopeInstructions[alloc].push_back(storealloc);
-        for (auto post :
-             PostCacheStore(externalContext(), storealloc, allocationBuilder)) {
+        for (auto post : PostCacheStore(storealloc, allocationBuilder)) {
           scopeInstructions[alloc].push_back(post);
         }
       } else {
@@ -981,8 +979,7 @@ AllocaInst *CacheUtility::createCacheForScope(LimitContext ctx, Type *T,
         // TODO change this to a power-of-two allocation strategy
 
         auto zerostore = allocationBuilder.CreateStore(
-            getUndefinedValueForType(externalContext(), *newFunc->getParent(),
-                                     allocType,
+            getUndefinedValueForType(*newFunc->getParent(), allocType,
                                      /*forceZero*/ true),
             storeInto);
         scopeInstructions[alloc].push_back(zerostore);
@@ -1019,7 +1016,7 @@ AllocaInst *CacheUtility::createCacheForScope(LimitContext ctx, Type *T,
         // since we are reloading/storing based off the number of loop
         // iterations
         scopeInstructions[alloc].push_back(storealloc);
-        for (auto post : PostCacheStore(externalContext(), storealloc, build)) {
+        for (auto post : PostCacheStore(storealloc, build)) {
           scopeInstructions[alloc].push_back(post);
         }
       }
@@ -1483,7 +1480,7 @@ void CacheUtility::storeInstructionInCache(LimitContext ctx,
   storeinst->setMetadata(LLVMContext::MD_tbaa, TBAA);
   storeinst->setAlignment(Align(align));
   scopeInstructions[cache].push_back(storeinst);
-  for (auto post : PostCacheStore(externalContext(), storeinst, v)) {
+  for (auto post : PostCacheStore(storeinst, v)) {
     scopeInstructions[cache].push_back(post);
   }
 }

--- a/enzyme/Enzyme/CacheUtility.h
+++ b/enzyme/Enzyme/CacheUtility.h
@@ -146,10 +146,8 @@ public:
   /// The function whose instructions we are caching
   llvm::Function *const newFunc;
 
-  /// The frontend state this differentiation request belongs to, as installed
-  /// on the EnzymeLogic that created us. Passed to every frontend callback
-  /// reached from here, notably the allocation and caching hooks.
-  const EnzymeContextRef ExternalContext;
+  /// The logic serving the differentiation request this belongs to.
+  EnzymeLogic &Logic;
 
   /// Various analysis results of newFunc
   llvm::TargetLibraryInfo &TLI;
@@ -166,17 +164,17 @@ public:
   llvm::BasicBlock *inversionAllocs;
 
 protected:
-  CacheUtility(llvm::TargetLibraryInfo &TLI, llvm::Function *newFunc,
-               EnzymeContextRef ExternalContext)
-      : newFunc(newFunc), ExternalContext(ExternalContext), TLI(TLI),
-        DT(*newFunc), LI(DT), AC(*newFunc), SE(*newFunc, TLI, AC, DT, LI) {
+  CacheUtility(EnzymeLogic &Logic, llvm::TargetLibraryInfo &TLI,
+               llvm::Function *newFunc)
+      : newFunc(newFunc), Logic(Logic), TLI(TLI), DT(*newFunc), LI(DT),
+        AC(*newFunc), SE(*newFunc, TLI, AC, DT, LI) {
     inversionAllocs = llvm::BasicBlock::Create(newFunc->getContext(),
                                                "allocsForInversion", newFunc);
   }
 
 public:
-  /// The frontend state this differentiation request belongs to.
-  EnzymeContextRef externalContext() const { return ExternalContext; }
+  /// The frontend state of the request being served, taken from Logic.
+  EnzymeContextRef externalContext() const;
 
   virtual ~CacheUtility();
 

--- a/enzyme/Enzyme/CacheUtility.h
+++ b/enzyme/Enzyme/CacheUtility.h
@@ -146,6 +146,11 @@ public:
   /// The function whose instructions we are caching
   llvm::Function *const newFunc;
 
+  /// The frontend state this differentiation request belongs to, as installed
+  /// on the EnzymeLogic that created us. Passed to every frontend callback
+  /// reached from here, notably the allocation and caching hooks.
+  const EnzymeContextRef ExternalContext;
+
   /// Various analysis results of newFunc
   llvm::TargetLibraryInfo &TLI;
   llvm::DominatorTree DT;
@@ -161,14 +166,18 @@ public:
   llvm::BasicBlock *inversionAllocs;
 
 protected:
-  CacheUtility(llvm::TargetLibraryInfo &TLI, llvm::Function *newFunc)
-      : newFunc(newFunc), TLI(TLI), DT(*newFunc), LI(DT), AC(*newFunc),
-        SE(*newFunc, TLI, AC, DT, LI) {
+  CacheUtility(llvm::TargetLibraryInfo &TLI, llvm::Function *newFunc,
+               EnzymeContextRef ExternalContext)
+      : newFunc(newFunc), ExternalContext(ExternalContext), TLI(TLI),
+        DT(*newFunc), LI(DT), AC(*newFunc), SE(*newFunc, TLI, AC, DT, LI) {
     inversionAllocs = llvm::BasicBlock::Create(newFunc->getContext(),
                                                "allocsForInversion", newFunc);
   }
 
 public:
+  /// The frontend state this differentiation request belongs to.
+  EnzymeContextRef externalContext() const { return ExternalContext; }
+
   virtual ~CacheUtility();
 
 protected:

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -496,7 +496,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
       }
 
       Function *dsave = getOrInsertDifferentialWaitallSave(
-          gutils->externalContext(), *gutils->oldFunc->getParent(),
+          gutils, *gutils->oldFunc->getParent(),
           {count->getType(), req->getType(), d_req->getType()}, reqType);
 
       d_reqp = BuilderZ.CreateCall(dsave, {count, req, d_req});

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -29,9 +29,8 @@
 using namespace llvm;
 
 extern "C" {
-void (*EnzymeShadowAllocRewrite)(EnzymeContextRef, LLVMValueRef, void *,
-                                 LLVMValueRef, uint64_t, LLVMValueRef,
-                                 uint8_t) = nullptr;
+void (*EnzymeShadowAllocRewrite)(LLVMValueRef, void *, LLVMValueRef, uint64_t,
+                                 LLVMValueRef, uint8_t) = nullptr;
 }
 
 void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
@@ -290,12 +289,12 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
                                       shadow, len_arg, Builder2, BufferDefs);
 
           if (shouldFree()) {
-            CreateDealloc(gutils->externalContext(), Builder2, firstallocation);
+            CreateDealloc(Builder2, firstallocation);
           }
         } else
           assert(0 && "illegal mpi");
 
-        CreateDealloc(gutils->externalContext(), Builder2, helper);
+        CreateDealloc(Builder2, helper);
       }
       if (Mode == DerivativeMode::ForwardMode ||
           Mode == DerivativeMode::ForwardModeError) {
@@ -609,7 +608,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
       }
       Builder2.SetInsertPoint(endBlock);
       if (shouldFree()) {
-        CreateDealloc(gutils->externalContext(), Builder2, d_reqp);
+        CreateDealloc(Builder2, d_reqp);
       }
     } else if (Mode == DerivativeMode::ForwardMode ||
                Mode == DerivativeMode::ForwardModeError) {
@@ -778,7 +777,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
                                   shadow, len_arg, Builder2, BufferDefs);
 
       if (shouldFree()) {
-        CreateDealloc(gutils->externalContext(), Builder2, firstallocation);
+        CreateDealloc(Builder2, firstallocation);
       }
     }
     if (Mode == DerivativeMode::ReverseModeGradient)
@@ -1066,7 +1065,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
 
         // Free up the memory of the buffer
         if (shouldFree()) {
-          CreateDealloc(gutils->externalContext(), Builder2, buf);
+          CreateDealloc(Builder2, buf);
         }
       }
 
@@ -1330,7 +1329,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
 
       // Free up intermediate buffer
       if (shouldFree()) {
-        CreateDealloc(gutils->externalContext(), Builder2, buf);
+        CreateDealloc(Builder2, buf);
       }
     }
     if (Mode == DerivativeMode::ReverseModeGradient)
@@ -1510,7 +1509,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
 
       // Free up intermediate buffer
       if (shouldFree()) {
-        CreateDealloc(gutils->externalContext(), Builder2, buf);
+        CreateDealloc(Builder2, buf);
       }
     }
     if (Mode == DerivativeMode::ReverseModeGradient)
@@ -1715,7 +1714,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
 
       // Free up intermediate buffer
       if (shouldFree()) {
-        CreateDealloc(gutils->externalContext(), Builder2, buf);
+        CreateDealloc(Builder2, buf);
       }
     }
     if (Mode == DerivativeMode::ReverseModeGradient)
@@ -1949,7 +1948,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
 
         // Free up intermediate buffer
         if (shouldFree()) {
-          CreateDealloc(gutils->externalContext(), Builder2, buf);
+          CreateDealloc(Builder2, buf);
         }
 
         Builder2.CreateBr(mergeBlock);
@@ -2150,7 +2149,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
 
       // Free up intermediate buffer
       if (shouldFree()) {
-        CreateDealloc(gutils->externalContext(), Builder2, buf);
+        CreateDealloc(Builder2, buf);
       }
     }
     if (Mode == DerivativeMode::ReverseModeGradient)
@@ -2515,7 +2514,7 @@ bool AdjointGenerator::handleKnownCallDerivatives(
 
         Builder2.CreateCall(F, args, Defs);
         Builder2.CreateLifetimeEnd(tmp);
-        CreateDealloc(gutils->externalContext(), Builder2, tmp);
+        CreateDealloc(Builder2, tmp);
 
         BasicBlock *currentBlock = Builder2.GetInsertBlock();
 
@@ -2574,7 +2573,7 @@ bool AdjointGenerator::handleKnownCallDerivatives(
         fin_idx->addIncoming(acc, loopBlock);
 
         Builder2.CreateLifetimeEnd(dtmp);
-        CreateDealloc(gutils->externalContext(), Builder2, dtmp);
+        CreateDealloc(Builder2, dtmp);
 
         ((DiffeGradientUtils *)gutils)
             ->addToDiffe(call.getOperand(2), fin_idx, Builder2, types[2]);
@@ -2978,8 +2977,7 @@ bool AdjointGenerator::handleKnownCallDerivatives(
             if (Mode == DerivativeMode::ReverseModePrimal) {
               // Needs a stronger replacement check/assertion.
               Value *replacement = getUndefinedValueForType(
-                  gutils->externalContext(), *gutils->oldFunc->getParent(),
-                  placeholder->getType());
+                  *gutils->oldFunc->getParent(), placeholder->getType());
               gutils->replaceAWithB(placeholder, replacement);
               gutils->invertedPointers.erase(found);
               gutils->invertedPointers.insert(std::make_pair(
@@ -3076,8 +3074,7 @@ bool AdjointGenerator::handleKnownCallDerivatives(
                   if (EnzymeShadowAllocRewrite) {
                     bool used = unnecessaryInstructions.find(&call) ==
                                 unnecessaryInstructions.end();
-                    EnzymeShadowAllocRewrite(gutils->externalContext(),
-                                             wrap(anti), gutils, wrap(&call),
+                    EnzymeShadowAllocRewrite(wrap(anti), gutils, wrap(&call),
                                              idx, wrap(prev), used);
                   }
                 }
@@ -3290,9 +3287,8 @@ bool AdjointGenerator::handleKnownCallDerivatives(
             if (EnzymeShadowAllocRewrite) {
               bool used = unnecessaryInstructions.find(&call) ==
                           unnecessaryInstructions.end();
-              EnzymeShadowAllocRewrite(gutils->externalContext(), wrap(CI),
-                                       gutils, wrap(&call), idx, wrap(prev),
-                                       used);
+              EnzymeShadowAllocRewrite(wrap(CI), gutils, wrap(&call), idx,
+                                       wrap(prev), used);
             }
           }
           idx++;

--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -29,8 +29,9 @@
 using namespace llvm;
 
 extern "C" {
-void (*EnzymeShadowAllocRewrite)(LLVMValueRef, void *, LLVMValueRef, uint64_t,
-                                 LLVMValueRef, uint8_t) = nullptr;
+void (*EnzymeShadowAllocRewrite)(EnzymeContextRef, LLVMValueRef, void *,
+                                 LLVMValueRef, uint64_t, LLVMValueRef,
+                                 uint8_t) = nullptr;
 }
 
 void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
@@ -60,8 +61,8 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
         auto i64 = Type::getInt64Ty(call.getContext());
         auto impi = getMPIHelper(call.getContext());
 
-        Value *impialloc =
-            CreateAllocation(BuilderZ, impi, ConstantInt::get(i64, 1));
+        Value *impialloc = CreateAllocation(gutils->externalContext(), BuilderZ,
+                                            impi, ConstantInt::get(i64, 1));
         BuilderZ.SetInsertPoint(gutils->getNewFromOriginal(&call));
 
         d_req = BuilderZ.CreateBitCast(d_req, getUnqual(impialloc->getType()));
@@ -87,8 +88,9 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
               "", true, true);
 
           Value *firstallocation =
-              CreateAllocation(BuilderZ, Type::getInt8Ty(call.getContext()),
-                               len_arg, "mpirecv_malloccache");
+              CreateAllocation(gutils->externalContext(), BuilderZ,
+                               Type::getInt8Ty(call.getContext()), len_arg,
+                               "mpirecv_malloccache");
           BuilderZ.CreateStore(firstallocation, getMPIMemberPtr<MPI_Elem::Buf>(
                                                     BuilderZ, impialloc, impi));
           BuilderZ.SetInsertPoint(gutils->getNewFromOriginal(&call));
@@ -288,12 +290,12 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
                                       shadow, len_arg, Builder2, BufferDefs);
 
           if (shouldFree()) {
-            CreateDealloc(Builder2, firstallocation);
+            CreateDealloc(gutils->externalContext(), Builder2, firstallocation);
           }
         } else
           assert(0 && "illegal mpi");
 
-        CreateDealloc(Builder2, helper);
+        CreateDealloc(gutils->externalContext(), Builder2, helper);
       }
       if (Mode == DerivativeMode::ForwardMode ||
           Mode == DerivativeMode::ForwardModeError) {
@@ -494,7 +496,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
       }
 
       Function *dsave = getOrInsertDifferentialWaitallSave(
-          *gutils->oldFunc->getParent(),
+          gutils->externalContext(), *gutils->oldFunc->getParent(),
           {count->getType(), req->getType(), d_req->getType()}, reqType);
 
       d_reqp = BuilderZ.CreateCall(dsave, {count, req, d_req});
@@ -607,7 +609,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
       }
       Builder2.SetInsertPoint(endBlock);
       if (shouldFree()) {
-        CreateDealloc(Builder2, d_reqp);
+        CreateDealloc(gutils->externalContext(), Builder2, d_reqp);
       }
     } else if (Mode == DerivativeMode::ForwardMode ||
                Mode == DerivativeMode::ForwardModeError) {
@@ -748,9 +750,9 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
                                  tysize, Type::getInt64Ty(call.getContext())),
                              "", true, true);
 
-      Value *firstallocation =
-          CreateAllocation(Builder2, Type::getInt8Ty(call.getContext()),
-                           len_arg, "mpirecv_malloccache");
+      Value *firstallocation = CreateAllocation(
+          gutils->externalContext(), Builder2,
+          Type::getInt8Ty(call.getContext()), len_arg, "mpirecv_malloccache");
       args[0] = firstallocation;
 
       Type *types[sizeof(args) / sizeof(*args)];
@@ -776,7 +778,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
                                   shadow, len_arg, Builder2, BufferDefs);
 
       if (shouldFree()) {
-        CreateDealloc(Builder2, firstallocation);
+        CreateDealloc(gutils->externalContext(), Builder2, firstallocation);
       }
     }
     if (Mode == DerivativeMode::ReverseModeGradient)
@@ -987,9 +989,9 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
 
         Builder2.SetInsertPoint(rootBlock);
 
-        Value *rootbuf =
-            CreateAllocation(Builder2, Type::getInt8Ty(call.getContext()),
-                             len_arg, "mpireduce_malloccache");
+        Value *rootbuf = CreateAllocation(gutils->externalContext(), Builder2,
+                                          Type::getInt8Ty(call.getContext()),
+                                          len_arg, "mpireduce_malloccache");
         Builder2.CreateBr(mergeBlock);
 
         Builder2.SetInsertPoint(mergeBlock);
@@ -1064,7 +1066,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
 
         // Free up the memory of the buffer
         if (shouldFree()) {
-          CreateDealloc(Builder2, buf);
+          CreateDealloc(gutils->externalContext(), Builder2, buf);
         }
       }
 
@@ -1235,9 +1237,9 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
                              "", true, true);
 
       // 1. Alloc intermediate buffer
-      Value *buf =
-          CreateAllocation(Builder2, Type::getInt8Ty(call.getContext()),
-                           len_arg, "mpireduce_malloccache");
+      Value *buf = CreateAllocation(gutils->externalContext(), Builder2,
+                                    Type::getInt8Ty(call.getContext()), len_arg,
+                                    "mpireduce_malloccache");
 
       // 1.5 if root, set intermediate = diff(recvbuffer)
       {
@@ -1328,7 +1330,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
 
       // Free up intermediate buffer
       if (shouldFree()) {
-        CreateDealloc(Builder2, buf);
+        CreateDealloc(gutils->externalContext(), Builder2, buf);
       }
     }
     if (Mode == DerivativeMode::ReverseModeGradient)
@@ -1463,9 +1465,9 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
                              "", true, true);
 
       // 1. Alloc intermediate buffer
-      Value *buf =
-          CreateAllocation(Builder2, Type::getInt8Ty(call.getContext()),
-                           len_arg, "mpireduce_malloccache");
+      Value *buf = CreateAllocation(gutils->externalContext(), Builder2,
+                                    Type::getInt8Ty(call.getContext()), len_arg,
+                                    "mpireduce_malloccache");
 
       // 2. MPI_Allreduce (sum) of diff(recvbuffer) to intermediate
       {
@@ -1508,7 +1510,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
 
       // Free up intermediate buffer
       if (shouldFree()) {
-        CreateDealloc(Builder2, buf);
+        CreateDealloc(gutils->externalContext(), Builder2, buf);
       }
     }
     if (Mode == DerivativeMode::ReverseModeGradient)
@@ -1635,9 +1637,9 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
           Builder2, /*lookup*/ true);
 
       // 1. Alloc intermediate buffer
-      Value *buf =
-          CreateAllocation(Builder2, Type::getInt8Ty(call.getContext()),
-                           sendlen_arg, "mpireduce_malloccache");
+      Value *buf = CreateAllocation(gutils->externalContext(), Builder2,
+                                    Type::getInt8Ty(call.getContext()),
+                                    sendlen_arg, "mpireduce_malloccache");
 
       // 2. Scatter diff(recvbuffer) to intermediate buffer
       {
@@ -1713,7 +1715,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
 
       // Free up intermediate buffer
       if (shouldFree()) {
-        CreateDealloc(Builder2, buf);
+        CreateDealloc(gutils->externalContext(), Builder2, buf);
       }
     }
     if (Mode == DerivativeMode::ReverseModeGradient)
@@ -1868,9 +1870,9 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
                 Type::getInt64Ty(call.getContext())),
             "", true, true);
 
-        Value *rootbuf =
-            CreateAllocation(Builder2, Type::getInt8Ty(call.getContext()),
-                             sendlen_arg, "mpireduce_malloccache");
+        Value *rootbuf = CreateAllocation(gutils->externalContext(), Builder2,
+                                          Type::getInt8Ty(call.getContext()),
+                                          sendlen_arg, "mpireduce_malloccache");
 
         Builder2.CreateBr(mergeBlock);
 
@@ -1947,7 +1949,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
 
         // Free up intermediate buffer
         if (shouldFree()) {
-          CreateDealloc(Builder2, buf);
+          CreateDealloc(gutils->externalContext(), Builder2, buf);
         }
 
         Builder2.CreateBr(mergeBlock);
@@ -2074,9 +2076,9 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
           Builder2, /*lookup*/ true);
 
       // 1. Alloc intermediate buffer
-      Value *buf =
-          CreateAllocation(Builder2, Type::getInt8Ty(call.getContext()),
-                           sendlen_arg, "mpireduce_malloccache");
+      Value *buf = CreateAllocation(gutils->externalContext(), Builder2,
+                                    Type::getInt8Ty(call.getContext()),
+                                    sendlen_arg, "mpireduce_malloccache");
 
       ConcreteType CT =
           TR.firstPointer(1, orig_sendbuf, &call, gutils, &Builder2);
@@ -2148,7 +2150,7 @@ void AdjointGenerator::handleMPI(llvm::CallInst &call, llvm::Function *called,
 
       // Free up intermediate buffer
       if (shouldFree()) {
-        CreateDealloc(Builder2, buf);
+        CreateDealloc(gutils->externalContext(), Builder2, buf);
       }
     }
     if (Mode == DerivativeMode::ReverseModeGradient)
@@ -2501,8 +2503,10 @@ bool AdjointGenerator::handleKnownCallDerivatives(
         auto FS = getOrInsertPerCallingConv(*called->getParent(), called,
                                             "gsl_sf_legendre_array_n", FTS);
         Value *alSize = Builder2.CreateCall(FS, args[1]);
-        Value *tmp = CreateAllocation(Builder2, types[2], alSize);
-        Value *dtmp = CreateAllocation(Builder2, types[2], alSize);
+        Value *tmp = CreateAllocation(gutils->externalContext(), Builder2,
+                                      types[2], alSize);
+        Value *dtmp = CreateAllocation(gutils->externalContext(), Builder2,
+                                       types[2], alSize);
         Builder2.CreateLifetimeStart(tmp);
         Builder2.CreateLifetimeStart(dtmp);
 
@@ -2511,7 +2515,7 @@ bool AdjointGenerator::handleKnownCallDerivatives(
 
         Builder2.CreateCall(F, args, Defs);
         Builder2.CreateLifetimeEnd(tmp);
-        CreateDealloc(Builder2, tmp);
+        CreateDealloc(gutils->externalContext(), Builder2, tmp);
 
         BasicBlock *currentBlock = Builder2.GetInsertBlock();
 
@@ -2570,7 +2574,7 @@ bool AdjointGenerator::handleKnownCallDerivatives(
         fin_idx->addIncoming(acc, loopBlock);
 
         Builder2.CreateLifetimeEnd(dtmp);
-        CreateDealloc(Builder2, dtmp);
+        CreateDealloc(gutils->externalContext(), Builder2, dtmp);
 
         ((DiffeGradientUtils *)gutils)
             ->addToDiffe(call.getOperand(2), fin_idx, Builder2, types[2]);
@@ -2974,7 +2978,8 @@ bool AdjointGenerator::handleKnownCallDerivatives(
             if (Mode == DerivativeMode::ReverseModePrimal) {
               // Needs a stronger replacement check/assertion.
               Value *replacement = getUndefinedValueForType(
-                  *gutils->oldFunc->getParent(), placeholder->getType());
+                  gutils->externalContext(), *gutils->oldFunc->getParent(),
+                  placeholder->getType());
               gutils->replaceAWithB(placeholder, replacement);
               gutils->invertedPointers.erase(found);
               gutils->invertedPointers.insert(std::make_pair(
@@ -3071,7 +3076,8 @@ bool AdjointGenerator::handleKnownCallDerivatives(
                   if (EnzymeShadowAllocRewrite) {
                     bool used = unnecessaryInstructions.find(&call) ==
                                 unnecessaryInstructions.end();
-                    EnzymeShadowAllocRewrite(wrap(anti), gutils, wrap(&call),
+                    EnzymeShadowAllocRewrite(gutils->externalContext(),
+                                             wrap(anti), gutils, wrap(&call),
                                              idx, wrap(prev), used);
                   }
                 }
@@ -3284,8 +3290,9 @@ bool AdjointGenerator::handleKnownCallDerivatives(
             if (EnzymeShadowAllocRewrite) {
               bool used = unnecessaryInstructions.find(&call) ==
                           unnecessaryInstructions.end();
-              EnzymeShadowAllocRewrite(wrap(CI), gutils, wrap(&call), idx,
-                                       wrap(prev), used);
+              EnzymeShadowAllocRewrite(gutils->externalContext(), wrap(CI),
+                                       gutils, wrap(&call), idx, wrap(prev),
+                                       used);
             }
           }
           idx++;

--- a/enzyme/Enzyme/DiffeGradientUtils.cpp
+++ b/enzyme/Enzyme/DiffeGradientUtils.cpp
@@ -211,7 +211,7 @@ AllocaInst *DiffeGradientUtils::getDifferential(Value *val) {
     auto Alignment =
         oldFunc->getParent()->getDataLayout().getPrefTypeAlign(type);
     differentials[val]->setAlignment(Alignment);
-    ZeroMemory(externalContext(), entryBuilder, type, differentials[val],
+    ZeroMemory(entryBuilder, type, differentials[val],
                /*isTape*/ false);
   }
 #if LLVM_VERSION_MAJOR < 17
@@ -956,7 +956,7 @@ CallInst *DiffeGradientUtils::freeCache(BasicBlock *forwardPreheader,
       (unsigned)newFunc->getParent()->getDataLayout().getPointerSize());
   forfree->setAlignment(Align(align));
 
-  CallInst *ci = CreateDealloc(externalContext(), tbuild, forfree);
+  CallInst *ci = CreateDealloc(tbuild, forfree);
   if (ci) {
     if (newFunc->getSubprogram())
       ci->setDebugLoc(DILocation::get(newFunc->getContext(), 0, 0,

--- a/enzyme/Enzyme/DiffeGradientUtils.cpp
+++ b/enzyme/Enzyme/DiffeGradientUtils.cpp
@@ -211,7 +211,7 @@ AllocaInst *DiffeGradientUtils::getDifferential(Value *val) {
     auto Alignment =
         oldFunc->getParent()->getDataLayout().getPrefTypeAlign(type);
     differentials[val]->setAlignment(Alignment);
-    ZeroMemory(entryBuilder, type, differentials[val],
+    ZeroMemory(externalContext(), entryBuilder, type, differentials[val],
                /*isTape*/ false);
   }
 #if LLVM_VERSION_MAJOR < 17
@@ -513,8 +513,9 @@ SmallVector<SelectInst *, 4> DiffeGradientUtils::addToDiffe(
   else
     ss << " addingType: null\n";
   if (CustomErrorHandler) {
-    CustomErrorHandler(ss.str().c_str(), wrap(val), ErrorType::NoAccumulate,
-                       nullptr, nullptr, wrap(&BuilderM));
+    CustomErrorHandler(externalContext(), ss.str().c_str(), wrap(val),
+                       ErrorType::NoAccumulate, nullptr, nullptr,
+                       wrap(&BuilderM));
   } else {
     DebugLoc loc;
     if (auto inst = dyn_cast<Instruction>(val))
@@ -556,14 +557,15 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
         if (bi->getOpcode() == BinaryOperator::FSub && ci->isZero()) {
           Value *res = BuilderM.CreateFSub(old, bi->getOperand(1));
           if (san)
-            res = SanitizeDerivatives(val, res, BuilderM, mask);
+            res = SanitizeDerivatives(externalContext(), val, res, BuilderM,
+                                      mask);
           return res;
         }
       }
     }
     Value *res = BuilderM.CreateFAdd(old, inc);
     if (san)
-      res = SanitizeDerivatives(val, res, BuilderM, mask);
+      res = SanitizeDerivatives(externalContext(), val, res, BuilderM, mask);
     return res;
   };
 
@@ -576,7 +578,8 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
               select->getCondition(), old,
               faddForNeg(old, select->getFalseValue(), false)));
           addedSelects.push_back(res);
-          return SanitizeDerivatives(val, res, BuilderM, mask);
+          return SanitizeDerivatives(externalContext(), val, res, BuilderM,
+                                     mask);
         }
       }
       if (Constant *ci = dyn_cast<Constant>(select->getFalseValue())) {
@@ -585,7 +588,8 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
               select->getCondition(),
               faddForNeg(old, select->getTrueValue(), false), old));
           addedSelects.push_back(res);
-          return SanitizeDerivatives(val, res, BuilderM, mask);
+          return SanitizeDerivatives(externalContext(), val, res, BuilderM,
+                                     mask);
         }
       }
     }
@@ -603,7 +607,8 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
                                                bc->getDestTy()),
                            false)));
             addedSelects.push_back(res);
-            return SanitizeDerivatives(val, res, BuilderM, mask);
+            return SanitizeDerivatives(externalContext(), val, res, BuilderM,
+                                       mask);
           }
         }
         if (Constant *ci = dyn_cast<Constant>(select->getFalseValue())) {
@@ -617,7 +622,8 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
                            false),
                 old));
             addedSelects.push_back(res);
-            return SanitizeDerivatives(val, res, BuilderM, mask);
+            return SanitizeDerivatives(externalContext(), val, res, BuilderM,
+                                       mask);
           }
         }
       }
@@ -689,8 +695,9 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
         EmitNoTypeError(ss.str(), *inst, this, BuilderM);
         return addedSelects;
       } else if (CustomErrorHandler) {
-        CustomErrorHandler(ss.str().c_str(), wrap(val), ErrorType::NoType,
-                           TR.analyzer, nullptr, wrap(&BuilderM));
+        CustomErrorHandler(externalContext(), ss.str().c_str(), wrap(val),
+                           ErrorType::NoType, TR.analyzer, nullptr,
+                           wrap(&BuilderM));
         return addedSelects;
       } else {
         TR.dump(ss);
@@ -722,8 +729,9 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
          << " oldBitSize: " << oldBitSize << " newBitSize: " << newBitSize
          << "\n";
       if (CustomErrorHandler) {
-        CustomErrorHandler(ss.str().c_str(), wrap(val), ErrorType::NoType,
-                           TR.analyzer, nullptr, wrap(&BuilderM));
+        CustomErrorHandler(externalContext(), ss.str().c_str(), wrap(val),
+                           ErrorType::NoType, TR.analyzer, nullptr,
+                           wrap(&BuilderM));
         return addedSelects;
       } else {
         DebugLoc loc;
@@ -872,7 +880,7 @@ void DiffeGradientUtils::setDiffe(Value *val, Value *toset,
   }
   assert(!isConstantValue(val));
 #endif
-  toset = SanitizeDerivatives(val, toset, BuilderM);
+  toset = SanitizeDerivatives(externalContext(), val, toset, BuilderM);
   if (mode == DerivativeMode::ForwardMode ||
       mode == DerivativeMode::ForwardModeSplit ||
       mode == DerivativeMode::ForwardModeError) {
@@ -953,7 +961,7 @@ CallInst *DiffeGradientUtils::freeCache(BasicBlock *forwardPreheader,
       (unsigned)newFunc->getParent()->getDataLayout().getPointerSize());
   forfree->setAlignment(Align(align));
 
-  CallInst *ci = CreateDealloc(tbuild, forfree);
+  CallInst *ci = CreateDealloc(externalContext(), tbuild, forfree);
   if (ci) {
     if (newFunc->getSubprogram())
       ci->setDebugLoc(DILocation::get(newFunc->getContext(), 0, 0,
@@ -1123,7 +1131,7 @@ void DiffeGradientUtils::addToInvertedPtrDiffe(Instruction *orig,
       ss << "Unimplemented masked atomic fadd for ptr:" << *ptr
          << " dif:" << *dif << " mask: " << *mask << " orig: " << *orig << "\n";
       if (CustomErrorHandler) {
-        CustomErrorHandler(ss.str().c_str(), wrap(orig),
+        CustomErrorHandler(externalContext(), ss.str().c_str(), wrap(orig),
                            ErrorType::NoDerivative, this, nullptr,
                            wrap(&BuilderM));
         return;
@@ -1150,7 +1158,7 @@ void DiffeGradientUtils::addToInvertedPtrDiffe(Instruction *orig,
       auto rule = [&](Value *dif, Value *ptr) {
         for (size_t i = 0; i < numElems; ++i) {
           auto vdif = BuilderM.CreateExtractElement(dif, i);
-          vdif = SanitizeDerivatives(orig, vdif, BuilderM);
+          vdif = SanitizeDerivatives(externalContext(), orig, vdif, BuilderM);
           Value *Idxs[] = {
               ConstantInt::get(Type::getInt64Ty(vt->getContext()), 0),
               ConstantInt::get(Type::getInt32Ty(vt->getContext()), i)};
@@ -1173,7 +1181,7 @@ void DiffeGradientUtils::addToInvertedPtrDiffe(Instruction *orig,
       applyChainRule(BuilderM, rule, dif, ptr);
     } else {
       auto rule = [&](Value *dif, Value *ptr) {
-        dif = SanitizeDerivatives(orig, dif, BuilderM);
+        dif = SanitizeDerivatives(externalContext(), orig, dif, BuilderM);
         MaybeAlign alignv = align;
         if (alignv) {
           if (start != 0) {
@@ -1199,7 +1207,7 @@ void DiffeGradientUtils::addToInvertedPtrDiffe(Instruction *orig,
       auto LI = BuilderM.CreateLoad(addingType, ptr);
 
       Value *res = BuilderM.CreateFAdd(LI, dif);
-      res = SanitizeDerivatives(orig, res, BuilderM);
+      res = SanitizeDerivatives(externalContext(), orig, res, BuilderM);
       StoreInst *st = BuilderM.CreateStore(res, ptr);
 
       SmallVector<Metadata *, 1> scopeMD = {
@@ -1281,7 +1289,7 @@ void DiffeGradientUtils::addToInvertedPtrDiffe(Instruction *orig,
                         Constant::getNullValue(dif->getType())};
       Value *LI = BuilderM.CreateCall(LF, largs);
       Value *res = BuilderM.CreateFAdd(LI, dif);
-      res = SanitizeDerivatives(orig, res, BuilderM, mask);
+      res = SanitizeDerivatives(externalContext(), orig, res, BuilderM, mask);
       Value *sargs[] = {res, ptr, alignv, mask};
       BuilderM.CreateCall(SF, sargs);
     };

--- a/enzyme/Enzyme/DiffeGradientUtils.cpp
+++ b/enzyme/Enzyme/DiffeGradientUtils.cpp
@@ -557,15 +557,14 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
         if (bi->getOpcode() == BinaryOperator::FSub && ci->isZero()) {
           Value *res = BuilderM.CreateFSub(old, bi->getOperand(1));
           if (san)
-            res = SanitizeDerivatives(externalContext(), val, res, BuilderM,
-                                      mask);
+            res = SanitizeDerivatives(this, val, res, BuilderM, mask);
           return res;
         }
       }
     }
     Value *res = BuilderM.CreateFAdd(old, inc);
     if (san)
-      res = SanitizeDerivatives(externalContext(), val, res, BuilderM, mask);
+      res = SanitizeDerivatives(this, val, res, BuilderM, mask);
     return res;
   };
 
@@ -578,8 +577,7 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
               select->getCondition(), old,
               faddForNeg(old, select->getFalseValue(), false)));
           addedSelects.push_back(res);
-          return SanitizeDerivatives(externalContext(), val, res, BuilderM,
-                                     mask);
+          return SanitizeDerivatives(this, val, res, BuilderM, mask);
         }
       }
       if (Constant *ci = dyn_cast<Constant>(select->getFalseValue())) {
@@ -588,8 +586,7 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
               select->getCondition(),
               faddForNeg(old, select->getTrueValue(), false), old));
           addedSelects.push_back(res);
-          return SanitizeDerivatives(externalContext(), val, res, BuilderM,
-                                     mask);
+          return SanitizeDerivatives(this, val, res, BuilderM, mask);
         }
       }
     }
@@ -607,8 +604,7 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
                                                bc->getDestTy()),
                            false)));
             addedSelects.push_back(res);
-            return SanitizeDerivatives(externalContext(), val, res, BuilderM,
-                                       mask);
+            return SanitizeDerivatives(this, val, res, BuilderM, mask);
           }
         }
         if (Constant *ci = dyn_cast<Constant>(select->getFalseValue())) {
@@ -622,8 +618,7 @@ DiffeGradientUtils::addToDiffe(Value *val, Value *dif, IRBuilder<> &BuilderM,
                            false),
                 old));
             addedSelects.push_back(res);
-            return SanitizeDerivatives(externalContext(), val, res, BuilderM,
-                                       mask);
+            return SanitizeDerivatives(this, val, res, BuilderM, mask);
           }
         }
       }
@@ -880,7 +875,7 @@ void DiffeGradientUtils::setDiffe(Value *val, Value *toset,
   }
   assert(!isConstantValue(val));
 #endif
-  toset = SanitizeDerivatives(externalContext(), val, toset, BuilderM);
+  toset = SanitizeDerivatives(this, val, toset, BuilderM);
   if (mode == DerivativeMode::ForwardMode ||
       mode == DerivativeMode::ForwardModeSplit ||
       mode == DerivativeMode::ForwardModeError) {
@@ -1158,7 +1153,7 @@ void DiffeGradientUtils::addToInvertedPtrDiffe(Instruction *orig,
       auto rule = [&](Value *dif, Value *ptr) {
         for (size_t i = 0; i < numElems; ++i) {
           auto vdif = BuilderM.CreateExtractElement(dif, i);
-          vdif = SanitizeDerivatives(externalContext(), orig, vdif, BuilderM);
+          vdif = SanitizeDerivatives(this, orig, vdif, BuilderM);
           Value *Idxs[] = {
               ConstantInt::get(Type::getInt64Ty(vt->getContext()), 0),
               ConstantInt::get(Type::getInt32Ty(vt->getContext()), i)};
@@ -1181,7 +1176,7 @@ void DiffeGradientUtils::addToInvertedPtrDiffe(Instruction *orig,
       applyChainRule(BuilderM, rule, dif, ptr);
     } else {
       auto rule = [&](Value *dif, Value *ptr) {
-        dif = SanitizeDerivatives(externalContext(), orig, dif, BuilderM);
+        dif = SanitizeDerivatives(this, orig, dif, BuilderM);
         MaybeAlign alignv = align;
         if (alignv) {
           if (start != 0) {
@@ -1207,7 +1202,7 @@ void DiffeGradientUtils::addToInvertedPtrDiffe(Instruction *orig,
       auto LI = BuilderM.CreateLoad(addingType, ptr);
 
       Value *res = BuilderM.CreateFAdd(LI, dif);
-      res = SanitizeDerivatives(externalContext(), orig, res, BuilderM);
+      res = SanitizeDerivatives(this, orig, res, BuilderM);
       StoreInst *st = BuilderM.CreateStore(res, ptr);
 
       SmallVector<Metadata *, 1> scopeMD = {
@@ -1289,7 +1284,7 @@ void DiffeGradientUtils::addToInvertedPtrDiffe(Instruction *orig,
                         Constant::getNullValue(dif->getType())};
       Value *LI = BuilderM.CreateCall(LF, largs);
       Value *res = BuilderM.CreateFAdd(LI, dif);
-      res = SanitizeDerivatives(externalContext(), orig, res, BuilderM, mask);
+      res = SanitizeDerivatives(this, orig, res, BuilderM, mask);
       Value *sargs[] = {res, ptr, alignv, mask};
       BuilderM.CreateCall(SF, sargs);
     };

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -2777,8 +2777,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
               tapeType);
       if (size != 0) {
         RetTypes[returnMapping.find(AugmentedStruct::Tape)->second] =
-            getDefaultAnonymousTapeType(externalContext(),
-                                        gutils->newFunc->getContext());
+            getDefaultAnonymousTapeType(gutils->newFunc->getContext());
       }
     }
   }
@@ -2938,7 +2937,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
         memory = malloccall;
       } else {
         memory = ConstantPointerNull::get(
-            getDefaultAnonymousTapeType(externalContext(), NewF->getContext()));
+            getDefaultAnonymousTapeType(NewF->getContext()));
       }
       Value *Idxs[] = {
           ib.getInt32(0),
@@ -2952,7 +2951,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
         cast<GetElementPtrInst>(gep)->setIsInBounds(true);
       }
       auto storeinst = ib.CreateStore(memory, gep);
-      PostCacheStore(externalContext(), storeinst, ib);
+      PostCacheStore(storeinst, ib);
     } else if (omp) {
       j->setName("tape");
       tapeMemory = j;
@@ -2971,7 +2970,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
         cast<GetElementPtrInst>(tapeMemory)->setIsInBounds(true);
       }
       if (EnzymeZeroCache) {
-        ZeroMemory(externalContext(), ib, tapeType, tapeMemory,
+        ZeroMemory(ib, tapeType, tapeMemory,
                    /*isTape*/ true);
       }
     }
@@ -2994,7 +2993,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
           cast<GetElementPtrInst>(gep)->setIsInBounds(true);
         }
         auto storeinst = ib.CreateStore(VMap[v], gep);
-        PostCacheStore(externalContext(), storeinst, ib);
+        PostCacheStore(storeinst, ib);
       }
       ++i;
     }
@@ -3045,7 +3044,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
         actualrv = unwrap(
             EnzymeFixupReturn(externalContext(), wrap(&ib), wrap(actualrv)));
       auto storeinst = ib.CreateStore(actualrv, gep);
-      PostCacheStore(externalContext(), storeinst, ib);
+      PostCacheStore(storeinst, ib);
     }
 
     if (shadowReturnUsed) {
@@ -3075,7 +3074,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
           shadowRV = unwrap(
               EnzymeFixupReturn(externalContext(), wrap(&ib), wrap(shadowRV)));
         auto storeinst = ib.CreateStore(shadowRV, gep);
-        PostCacheStore(externalContext(), storeinst, ib);
+        PostCacheStore(storeinst, ib);
       }
     }
     if (noReturn)
@@ -3842,7 +3841,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
           auto size = NewF->getParent()->getDataLayout().getTypeAllocSizeInBits(
               aug.tapeType);
           if (size != 0) {
-            CreateDealloc(externalContext(), bb, tape);
+            CreateDealloc(bb, tape);
           }
         }
         tape = truetape;
@@ -4017,9 +4016,9 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
       }
       size_t pa = 0;
       if (nextRetType != key.retType) {
-        revargs.push_back(getUndefinedValueForType(
-            externalContext(), *revfn->getParent(), key.todiff->getReturnType(),
-            /*forceZero*/ true));
+        revargs.push_back(getUndefinedValueForType(*revfn->getParent(),
+                                                   key.todiff->getReturnType(),
+                                                   /*forceZero*/ true));
       }
       while (arg != NewF->arg_end()) {
         revargs.push_back(arg);
@@ -4378,12 +4377,12 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
                               MDNode::get(truetape->getContext(), {}));
 
         if (!omp && gutils->FreeMemory) {
-          CreateDealloc(externalContext(), BuilderZ, additionalValue);
+          CreateDealloc(BuilderZ, additionalValue);
         }
         additionalValue = truetape;
       } else {
         if (gutils->FreeMemory) {
-          CreateDealloc(externalContext(), BuilderZ, additionalValue);
+          CreateDealloc(BuilderZ, additionalValue);
         }
         additionalValue = UndefValue::get(augmenteddata->tapeType);
       }
@@ -5054,7 +5053,7 @@ Function *EnzymeLogic::CreateForwardDiff(
                                 MDNode::get(truetape->getContext(), {}));
 
           if (!omp && gutils->FreeMemory) {
-            CreateDealloc(externalContext(), BuilderZ, additionalValue);
+            CreateDealloc(BuilderZ, additionalValue);
           }
           additionalValue = truetape;
         } else {
@@ -5063,7 +5062,7 @@ Function *EnzymeLogic::CreateForwardDiff(
                             ->getDataLayout()
                             .getTypeAllocSizeInBits(augmenteddata->tapeType);
             if (size != 0) {
-              CreateDealloc(externalContext(), BuilderZ, additionalValue);
+              CreateDealloc(BuilderZ, additionalValue);
             }
           }
           additionalValue = UndefValue::get(augmenteddata->tapeType);

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -122,7 +122,8 @@ cl::opt<bool> EnzymeAssumeUnknownNoFree(
     "enzyme-assume-unknown-nofree", cl::init(false), cl::Hidden,
     cl::desc("Assume unknown instructions are nofree as needed"));
 
-LLVMValueRef (*EnzymeFixupReturn)(LLVMBuilderRef, LLVMValueRef) = nullptr;
+LLVMValueRef (*EnzymeFixupReturn)(EnzymeContextRef, LLVMBuilderRef,
+                                  LLVMValueRef) = nullptr;
 }
 
 struct CacheAnalysis {
@@ -2045,7 +2046,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
     } else {
       ss << *todiff << "\n";
     }
-    if (EmitNoDerivativeError(ss.str(), todiff, context)) {
+    if (EmitNoDerivativeError(externalContext(), ss.str(), todiff, context)) {
       auto newFunc = todiff;
       std::map<AugmentedStruct, int> returnMapping;
       returnMapping[AugmentedStruct::Return] = -1;
@@ -2450,12 +2451,12 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
     (IRBuilder<>(gutils->inversionAllocs)).CreateUnreachable();
     DeleteDeadBlock(gutils->inversionAllocs);
     clearFunctionAttributes(gutils->newFunc);
-    if (EmitNoDerivativeError(ss.str(), todiff, context)) {
+    if (EmitNoDerivativeError(externalContext(), ss.str(), todiff, context)) {
       auto newFunc = gutils->newFunc;
       delete gutils;
       IRBuilder<> b(&*newFunc->getEntryBlock().begin());
       RequestContext context2{nullptr, &b};
-      EmitNoDerivativeError(ss.str(), todiff, context2);
+      EmitNoDerivativeError(externalContext(), ss.str(), todiff, context2);
       return insert_or_assign<AugmentedCacheKey, AugmentedReturn>(
                  AugmentedCachedFunctions, tup,
                  AugmentedReturn(newFunc, nullptr, {}, returnMapping, {}, {},
@@ -2649,8 +2650,9 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
                    << " const val: " << *orig_oldval;
                 if (CustomErrorHandler)
                   invertri = unwrap(CustomErrorHandler(
-                      str.c_str(), wrap(ri), ErrorType::MixedActivityError,
-                      gutils, wrap(orig_oldval), wrap(&BuilderZ)));
+                      externalContext(), str.c_str(), wrap(ri),
+                      ErrorType::MixedActivityError, gutils, wrap(orig_oldval),
+                      wrap(&BuilderZ)));
                 else
                   EmitWarningAlways("MixedActivityError", *ri, ss.str(),
                                     MixedActivityHint);
@@ -2775,7 +2777,8 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
               tapeType);
       if (size != 0) {
         RetTypes[returnMapping.find(AugmentedStruct::Tape)->second] =
-            getDefaultAnonymousTapeType(gutils->newFunc->getContext());
+            getDefaultAnonymousTapeType(externalContext(),
+                                        gutils->newFunc->getContext());
       }
     }
   }
@@ -2929,12 +2932,13 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
         CallInst *malloccall = nullptr;
         Instruction *zero = nullptr;
         tapeMemory = CreateAllocation(
-            ib, tapeType, ConstantInt::get(i64, 1), "tapemem", &malloccall,
-            EnzymeZeroCache ? &zero : nullptr, /*isDefault*/ true);
+            externalContext(), ib, tapeType, ConstantInt::get(i64, 1),
+            "tapemem", &malloccall, EnzymeZeroCache ? &zero : nullptr,
+            /*isDefault*/ true);
         memory = malloccall;
       } else {
         memory = ConstantPointerNull::get(
-            getDefaultAnonymousTapeType(NewF->getContext()));
+            getDefaultAnonymousTapeType(externalContext(), NewF->getContext()));
       }
       Value *Idxs[] = {
           ib.getInt32(0),
@@ -2948,7 +2952,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
         cast<GetElementPtrInst>(gep)->setIsInBounds(true);
       }
       auto storeinst = ib.CreateStore(memory, gep);
-      PostCacheStore(storeinst, ib);
+      PostCacheStore(externalContext(), storeinst, ib);
     } else if (omp) {
       j->setName("tape");
       tapeMemory = j;
@@ -2967,7 +2971,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
         cast<GetElementPtrInst>(tapeMemory)->setIsInBounds(true);
       }
       if (EnzymeZeroCache) {
-        ZeroMemory(ib, tapeType, tapeMemory,
+        ZeroMemory(externalContext(), ib, tapeType, tapeMemory,
                    /*isTape*/ true);
       }
     }
@@ -2990,7 +2994,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
           cast<GetElementPtrInst>(gep)->setIsInBounds(true);
         }
         auto storeinst = ib.CreateStore(VMap[v], gep);
-        PostCacheStore(storeinst, ib);
+        PostCacheStore(externalContext(), storeinst, ib);
       }
       ++i;
     }
@@ -3038,9 +3042,10 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
         ggep->setIsInBounds(true);
       }
       if (EnzymeFixupReturn)
-        actualrv = unwrap(EnzymeFixupReturn(wrap(&ib), wrap(actualrv)));
+        actualrv = unwrap(
+            EnzymeFixupReturn(externalContext(), wrap(&ib), wrap(actualrv)));
       auto storeinst = ib.CreateStore(actualrv, gep);
-      PostCacheStore(storeinst, ib);
+      PostCacheStore(externalContext(), storeinst, ib);
     }
 
     if (shadowReturnUsed) {
@@ -3067,9 +3072,10 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
           shadowRV = found->second;
         }
         if (EnzymeFixupReturn)
-          shadowRV = unwrap(EnzymeFixupReturn(wrap(&ib), wrap(shadowRV)));
+          shadowRV = unwrap(
+              EnzymeFixupReturn(externalContext(), wrap(&ib), wrap(shadowRV)));
         auto storeinst = ib.CreateStore(shadowRV, gep);
-        PostCacheStore(storeinst, ib);
+        PostCacheStore(externalContext(), storeinst, ib);
       }
     }
     if (noReturn)
@@ -3235,9 +3241,10 @@ void createTerminator(DiffeGradientUtils *gutils, BasicBlock *oBB,
             ss << "Mismatched activity for: " << *inst
                << " const val: " << *ret;
             if (CustomErrorHandler)
-              invertedPtr = unwrap(CustomErrorHandler(
-                  str.c_str(), wrap(inst), ErrorType::MixedActivityError,
-                  gutils, wrap(ret), wrap(&nBuilder)));
+              invertedPtr = unwrap(
+                  CustomErrorHandler(gutils->externalContext(), str.c_str(),
+                                     wrap(inst), ErrorType::MixedActivityError,
+                                     gutils, wrap(ret), wrap(&nBuilder)));
             else
               EmitWarningAlways("MixedActivityError", *inst, ss.str(),
                                 MixedActivityHint);
@@ -3764,7 +3771,8 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
       if (context.req) {
         ss << " at context: " << *context.req;
       }
-      if (EmitNoDerivativeError(ss.str(), key.todiff, context)) {
+      if (EmitNoDerivativeError(externalContext(), ss.str(), key.todiff,
+                                context)) {
         return nullptr;
       }
     }
@@ -3834,7 +3842,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
           auto size = NewF->getParent()->getDataLayout().getTypeAllocSizeInBits(
               aug.tapeType);
           if (size != 0) {
-            CreateDealloc(bb, tape);
+            CreateDealloc(externalContext(), bb, tape);
           }
         }
         tape = truetape;
@@ -4009,9 +4017,9 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
       }
       size_t pa = 0;
       if (nextRetType != key.retType) {
-        revargs.push_back(getUndefinedValueForType(*revfn->getParent(),
-                                                   key.todiff->getReturnType(),
-                                                   /*forceZero*/ true));
+        revargs.push_back(getUndefinedValueForType(
+            externalContext(), *revfn->getParent(), key.todiff->getReturnType(),
+            /*forceZero*/ true));
       }
       while (arg != NewF->arg_end()) {
         revargs.push_back(arg);
@@ -4109,7 +4117,8 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
         auto context2 = context;
         if (!context2.ip)
           context2.ip = &bb;
-        if (!EmitNoDerivativeError(ss.str(), key.todiff, context2)) {
+        if (!EmitNoDerivativeError(externalContext(), ss.str(), key.todiff,
+                                   context2)) {
           assert(0 && "bad type for custom gradient");
           llvm_unreachable("bad type for custom gradient");
         }
@@ -4265,12 +4274,13 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
     BasicBlock *entry = &gutils->newFunc->getEntryBlock();
     cleanupInversionAllocs(gutils, entry);
     clearFunctionAttributes(gutils->newFunc);
-    if (EmitNoDerivativeError(ss.str(), key.todiff, context)) {
+    if (EmitNoDerivativeError(externalContext(), ss.str(), key.todiff,
+                              context)) {
       auto newFunc = gutils->newFunc;
       delete gutils;
       IRBuilder<> b(&*newFunc->getEntryBlock().begin());
       RequestContext context2{nullptr, &b};
-      EmitNoDerivativeError(ss.str(), key.todiff, context2);
+      EmitNoDerivativeError(externalContext(), ss.str(), key.todiff, context2);
       return newFunc;
     }
     llvm::errs() << "mod: " << *key.todiff->getParent() << "\n";
@@ -4368,12 +4378,12 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
                               MDNode::get(truetape->getContext(), {}));
 
         if (!omp && gutils->FreeMemory) {
-          CreateDealloc(BuilderZ, additionalValue);
+          CreateDealloc(externalContext(), BuilderZ, additionalValue);
         }
         additionalValue = truetape;
       } else {
         if (gutils->FreeMemory) {
-          CreateDealloc(BuilderZ, additionalValue);
+          CreateDealloc(externalContext(), BuilderZ, additionalValue);
         }
         additionalValue = UndefValue::get(augmenteddata->tapeType);
       }
@@ -4946,7 +4956,7 @@ Function *EnzymeLogic::CreateForwardDiff(
     BasicBlock *entry = &gutils->newFunc->getEntryBlock();
     cleanupInversionAllocs(gutils, entry);
     clearFunctionAttributes(gutils->newFunc);
-    if (EmitNoDerivativeError(ss.str(), todiff, context)) {
+    if (EmitNoDerivativeError(externalContext(), ss.str(), todiff, context)) {
       auto newFunc = gutils->newFunc;
       delete gutils;
       return newFunc;
@@ -5044,7 +5054,7 @@ Function *EnzymeLogic::CreateForwardDiff(
                                 MDNode::get(truetape->getContext(), {}));
 
           if (!omp && gutils->FreeMemory) {
-            CreateDealloc(BuilderZ, additionalValue);
+            CreateDealloc(externalContext(), BuilderZ, additionalValue);
           }
           additionalValue = truetape;
         } else {
@@ -5053,7 +5063,7 @@ Function *EnzymeLogic::CreateForwardDiff(
                             ->getDataLayout()
                             .getTypeAllocSizeInBits(augmenteddata->tapeType);
             if (size != 0) {
-              CreateDealloc(BuilderZ, additionalValue);
+              CreateDealloc(externalContext(), BuilderZ, additionalValue);
             }
           }
           additionalValue = UndefValue::get(augmenteddata->tapeType);
@@ -5395,8 +5405,8 @@ public:
     ss << "cannot handle unknown instruction\n" << I;
     if (CustomErrorHandler) {
       IRBuilder<> Builder2(getNewFromOriginal(&I));
-      CustomErrorHandler(ss.str().c_str(), wrap(&I), ErrorType::NoTruncate,
-                         this, nullptr, wrap(&Builder2));
+      CustomErrorHandler(Logic.externalContext(), ss.str().c_str(), wrap(&I),
+                         ErrorType::NoTruncate, this, nullptr, wrap(&Builder2));
       return;
     } else {
       EmitFailure("NoTruncate", I.getDebugLoc(), &I, ss.str());
@@ -5778,7 +5788,7 @@ llvm::Function *EnzymeLogic::CreateTruncateFunc(RequestContext context,
       ss << *totrunc << "\n";
     }
     if (CustomErrorHandler) {
-      CustomErrorHandler(ss.str().c_str(), wrap(toshow),
+      CustomErrorHandler(externalContext(), ss.str().c_str(), wrap(toshow),
                          ErrorType::NoDerivative, nullptr, wrap(totrunc),
                          wrap(context.ip));
       return NewF;
@@ -5867,7 +5877,7 @@ llvm::Function *EnzymeLogic::CreateBatch(RequestContext context,
       ss << *tobatch << "\n";
     }
     if (CustomErrorHandler) {
-      CustomErrorHandler(ss.str().c_str(), wrap(toshow),
+      CustomErrorHandler(externalContext(), ss.str().c_str(), wrap(toshow),
                          ErrorType::NoDerivative, nullptr, wrap(tobatch),
                          wrap(context.ip));
       return NewF;
@@ -6162,7 +6172,7 @@ EnzymeLogic::CreateTrace(RequestContext context, llvm::Function *totrace,
       ss << *totrace << "\n";
     }
     if (CustomErrorHandler) {
-      CustomErrorHandler(ss.str().c_str(), wrap(toshow),
+      CustomErrorHandler(externalContext(), ss.str().c_str(), wrap(toshow),
                          ErrorType::NoDerivative, nullptr, wrap(totrace),
                          wrap(context.ip));
       auto newFunc = tutils->newFunc;
@@ -6406,7 +6416,7 @@ llvm::Value *EnzymeLogic::CreateNoFree(RequestContext context,
     }
     ss << " within func " << fname << " (" << demangledName << ")\n";
   }
-  if (EmitNoDerivativeError(ss.str(), todiff, context)) {
+  if (EmitNoDerivativeError(externalContext(), ss.str(), todiff, context)) {
     return todiff;
   }
 
@@ -6727,7 +6737,7 @@ llvm::Function *EnzymeLogic::CreateNoFree(RequestContext context, Function *F) {
     } else {
       ss << *F << "\n";
     }
-    if (EmitNoDerivativeError(ss.str(), F, context)) {
+    if (EmitNoDerivativeError(externalContext(), ss.str(), F, context)) {
       return F;
     }
     llvm::errs() << " unhandled, create no free of empty function: " << *F

--- a/enzyme/Enzyme/EnzymeLogic.h
+++ b/enzyme/Enzyme/EnzymeLogic.h
@@ -457,7 +457,15 @@ public:
   /// Provided through the frontend and only used from it.
   void *ExternalContext;
 
-  EnzymeLogic(bool PostOpt) : PostOpt(PostOpt), ExternalContext(nullptr) {}
+  /// The frontend state that requests served by this logic belong to. Handed
+  /// back unchanged to every frontend callback.
+  EnzymeContextRef externalContext() const { return ExternalContext; }
+
+  EnzymeLogic(bool PostOpt) : PostOpt(PostOpt), ExternalContext(nullptr) {
+    // The preprocessing cache reaches frontend callbacks of its own and has no
+    // other way back to the logic that owns it.
+    PPC.Logic = this;
+  }
 
   struct AugmentedCacheKey {
     llvm::Function *fn;

--- a/enzyme/Enzyme/EnzymeLogic.h
+++ b/enzyme/Enzyme/EnzymeLogic.h
@@ -458,7 +458,7 @@ public:
   void *ExternalContext;
 
   /// The frontend state that requests served by this logic belong to. Handed
-  /// back unchanged to every frontend callback.
+  /// back unchanged to the frontend callbacks that take it.
   EnzymeContextRef externalContext() const { return ExternalContext; }
 
   EnzymeLogic(bool PostOpt)

--- a/enzyme/Enzyme/EnzymeLogic.h
+++ b/enzyme/Enzyme/EnzymeLogic.h
@@ -461,11 +461,8 @@ public:
   /// back unchanged to every frontend callback.
   EnzymeContextRef externalContext() const { return ExternalContext; }
 
-  EnzymeLogic(bool PostOpt) : PostOpt(PostOpt), ExternalContext(nullptr) {
-    // The preprocessing cache reaches frontend callbacks of its own and has no
-    // other way back to the logic that owns it.
-    PPC.Logic = this;
-  }
+  EnzymeLogic(bool PostOpt)
+      : PPC(*this), PostOpt(PostOpt), ExternalContext(nullptr) {}
 
   struct AugmentedCacheKey {
     llvm::Function *fn;

--- a/enzyme/Enzyme/FixupJuliaCallingConvention.cpp
+++ b/enzyme/Enzyme/FixupJuliaCallingConvention.cpp
@@ -1602,12 +1602,10 @@ class FixupJuliaCallingConventionNewPM
     : public PassInfoMixin<FixupJuliaCallingConventionNewPM> {
 #endif
   bool sret_jlvalue;
-  EnzymeContextRef ExternalContext;
 
 public:
-  FixupJuliaCallingConventionNewPM(bool sret_jlvalue,
-                                   EnzymeContextRef ExternalContext = nullptr)
-      : sret_jlvalue(sret_jlvalue), ExternalContext(ExternalContext) {}
+  FixupJuliaCallingConventionNewPM(bool sret_jlvalue)
+      : sret_jlvalue(sret_jlvalue) {}
 
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM) {
     bool changed = false;
@@ -1618,7 +1616,9 @@ public:
       Functions.push_back(&F);
     }
     for (auto *F : Functions) {
-      EnzymeFixupJuliaCallingConvention(ExternalContext, F, sret_jlvalue);
+      // A named pass has no frontend to hand a context to.
+      EnzymeFixupJuliaCallingConvention(/*ExternalContext=*/nullptr, F,
+                                        sret_jlvalue);
       changed = true;
     }
     return changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
@@ -1632,12 +1632,6 @@ class FixupBatchedJuliaCallingConventionNewPM
     : public PassInfoMixin<FixupBatchedJuliaCallingConventionNewPM> {
 #endif
 public:
-  EnzymeContextRef ExternalContext;
-
-  FixupBatchedJuliaCallingConventionNewPM(
-      EnzymeContextRef ExternalContext = nullptr)
-      : ExternalContext(ExternalContext) {}
-
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM) {
     bool changed = false;
     SmallVector<llvm::Function *, 16> Functions;
@@ -1647,7 +1641,7 @@ public:
       Functions.push_back(&F);
     }
     for (auto *F : Functions) {
-      EnzymeFixupBatchedJuliaCallingConvention(ExternalContext, F);
+      EnzymeFixupBatchedJuliaCallingConvention(/*ExternalContext=*/nullptr, F);
       changed = true;
     }
     return changed ? PreservedAnalyses::none() : PreservedAnalyses::all();

--- a/enzyme/Enzyme/FixupJuliaCallingConvention.cpp
+++ b/enzyme/Enzyme/FixupJuliaCallingConvention.cpp
@@ -910,9 +910,9 @@ void EnzymeFixupJuliaCallingConvention(EnzymeContextRef ExternalContext,
         B.CreateStore(rval, gep);
 
         if (roots) {
-          moveSRetToFromRoots(
-              ExternalContext, B, rval->getType(), rval, roots_AT, roots,
-              /*rootOffset*/ 0, SRetRootMovement::SRetValueToRootPointer);
+          moveSRetToFromRoots(B, rval->getType(), rval, roots_AT, roots,
+                              /*rootOffset*/ 0,
+                              SRetRootMovement::SRetValueToRootPointer);
         }
 
         auto NR = B.CreateRetVoid();
@@ -960,8 +960,8 @@ void EnzymeFixupJuliaCallingConvention(EnzymeContextRef ExternalContext,
                                                            i + curOffset));
               }
             } else {
-              moveSRetToFromRoots(ExternalContext, B, Types[sretCount], gep,
-                                  roots_AT, roots, curOffset,
+              moveSRetToFromRoots(B, Types[sretCount], gep, roots_AT, roots,
+                                  curOffset,
                                   SRetRootMovement::SRetPointerToRootPointer);
             }
           }
@@ -1274,8 +1274,7 @@ void EnzymeFixupJuliaCallingConvention(EnzymeContextRef ExternalContext,
     // TODO we can optimize this further and avoid the copy in the primal and/or
     // forward mode as the copy is _only_ needed for the adjoint.
     for (auto &&[val, gep, ty] : preCallReplacements) {
-      copyNonJLValueInto(ExternalContext, B, ty, ty, gep, {}, ty, val, {},
-                         /*shouldZero*/ true);
+      copyNonJLValueInto(B, ty, ty, gep, {}, ty, val, {}, /*shouldZero*/ true);
     }
 
     // Actually perform the call, copying over relevant information.
@@ -1328,9 +1327,9 @@ void EnzymeFixupJuliaCallingConvention(EnzymeContextRef ExternalContext,
         auto ld = B.CreateLoad(ty, gep);
         auto SI = B.CreateStore(ld, val);
         if (val->getType()->getPointerAddressSpace() == 10)
-          PostCacheStore(ExternalContext, SI, B);
+          PostCacheStore(SI, B);
       } else {
-        copyNonJLValueInto(ExternalContext, B, ty, ty, val, {}, ty, gep, {},
+        copyNonJLValueInto(B, ty, ty, val, {}, ty, gep, {},
                            /*shouldZero*/ false);
       }
     }
@@ -1355,8 +1354,7 @@ void EnzymeFixupJuliaCallingConvention(EnzymeContextRef ExternalContext,
 
 using namespace llvm;
 
-void EnzymeFixupBatchedJuliaCallingConvention(EnzymeContextRef ExternalContext,
-                                              Function *F) {
+void EnzymeFixupBatchedJuliaCallingConvention(Function *F) {
   if (F->empty())
     return;
   auto RT = F->getReturnType();
@@ -1641,7 +1639,7 @@ public:
       Functions.push_back(&F);
     }
     for (auto *F : Functions) {
-      EnzymeFixupBatchedJuliaCallingConvention(/*ExternalContext=*/nullptr, F);
+      EnzymeFixupBatchedJuliaCallingConvention(F);
       changed = true;
     }
     return changed ? PreservedAnalyses::none() : PreservedAnalyses::all();

--- a/enzyme/Enzyme/FixupJuliaCallingConvention.cpp
+++ b/enzyme/Enzyme/FixupJuliaCallingConvention.cpp
@@ -27,8 +27,8 @@ extern bool
 DetectPointerArgOfFn(llvm::Function &F,
                      llvm::SmallPtrSetImpl<llvm::Function *> &calls_todo);
 
-bool needsReRooting(llvm::Argument *arg, bool &anyJLStore,
-                    llvm::Type *SRetType = nullptr) {
+bool needsReRooting(EnzymeContextRef ExternalContext, llvm::Argument *arg,
+                    bool &anyJLStore, llvm::Type *SRetType = nullptr) {
   auto Attrs = arg->getParent()->getAttributes();
 
   if (!SRetType)
@@ -176,8 +176,8 @@ bool needsReRooting(llvm::Argument *arg, bool &anyJLStore,
     std::string s;
     llvm::raw_string_ostream ss(s);
     ss << "Unknown user of sret-like argument\n";
-    CustomErrorHandler(ss.str().c_str(), wrap(I), ErrorType::GCRewrite,
-                       wrap(cur), wrap(arg), nullptr);
+    CustomErrorHandler(ExternalContext, ss.str().c_str(), wrap(I),
+                       ErrorType::GCRewrite, wrap(cur), wrap(arg), nullptr);
     legal = false;
     anyJLStore = true;
     break;
@@ -373,8 +373,8 @@ bool needsReRooting(llvm::Argument *arg, bool &anyJLStore,
           llvm::raw_string_ostream ss(s);
           ss << "Could not find use of stored value\n";
           ss << " sv: " << *sv << "\n";
-          CustomErrorHandler(ss.str().c_str(), wrap(sv), ErrorType::GCRewrite,
-                             nullptr, wrap(arg), nullptr);
+          CustomErrorHandler(ExternalContext, ss.str().c_str(), wrap(sv),
+                             ErrorType::GCRewrite, nullptr, wrap(arg), nullptr);
         }
         legal = false;
         break;
@@ -541,7 +541,8 @@ static bool isGuaranteedToFullyWrite(Function *F, unsigned argNo, Type *T) {
 
 // TODO, for sret/sret_v check if it actually stores the jlvalue_t's into the
 // sret If so, confirm that those values are saved elsewhere in a returnroot
-void EnzymeFixupJuliaCallingConvention(Function *F, bool sret_jlvalue) {
+void EnzymeFixupJuliaCallingConvention(EnzymeContextRef ExternalContext,
+                                       Function *F, bool sret_jlvalue) {
   if (F->empty())
     return;
 
@@ -572,7 +573,7 @@ void EnzymeFixupJuliaCallingConvention(Function *F, bool sret_jlvalue) {
     if (Attrs.hasAttribute(AttributeList::FirstArgIndex + i, "enzyme_sret")) {
       bool anyJLStore = false;
       enzyme_srets.insert(i);
-      if (needsReRooting(F->getArg(i), anyJLStore)) {
+      if (needsReRooting(ExternalContext, F->getArg(i), anyJLStore)) {
         // Case 1: jlvalue_t's were stored into the sret, but were not stored
         // into an existing rooted argument.
         reroot_enzyme_srets.insert(i);
@@ -622,7 +623,8 @@ void EnzymeFixupJuliaCallingConvention(Function *F, bool sret_jlvalue) {
     }
 
     bool anyJLStore = false;
-    bool rerooting = needsReRooting(F->getArg(0), anyJLStore, SRetType);
+    bool rerooting =
+        needsReRooting(ExternalContext, F->getArg(0), anyJLStore, SRetType);
 
     // We now assume we have an sret.
     // If it is properly rooted, we don't have any work to do
@@ -637,8 +639,8 @@ void EnzymeFixupJuliaCallingConvention(Function *F, bool sret_jlvalue) {
         llvm::raw_string_ostream ss(s);
         ss << "Illegal GC setup in which rerooting is required\n";
         ss << " + F: " << *F << "\n";
-        CustomErrorHandler(s.c_str(), wrap(F), ErrorType::InternalError,
-                           nullptr, nullptr, nullptr);
+        CustomErrorHandler(ExternalContext, s.c_str(), wrap(F),
+                           ErrorType::InternalError, nullptr, nullptr, nullptr);
       }
       assert(!rerooting);
 #endif
@@ -795,8 +797,8 @@ void EnzymeFixupJuliaCallingConvention(Function *F, bool sret_jlvalue) {
           ss << "    + Types[" << i << "] = " << *Types[i] << "\n";
         }
         ss << " F: " << *F << "\n";
-        CustomErrorHandler(s.c_str(), wrap(F), ErrorType::InternalError,
-                           nullptr, nullptr, nullptr);
+        CustomErrorHandler(ExternalContext, s.c_str(), wrap(F),
+                           ErrorType::InternalError, nullptr, nullptr, nullptr);
       }
       assert(numRooting == countF.count);
     }
@@ -908,9 +910,9 @@ void EnzymeFixupJuliaCallingConvention(Function *F, bool sret_jlvalue) {
         B.CreateStore(rval, gep);
 
         if (roots) {
-          moveSRetToFromRoots(B, rval->getType(), rval, roots_AT, roots,
-                              /*rootOffset*/ 0,
-                              SRetRootMovement::SRetValueToRootPointer);
+          moveSRetToFromRoots(
+              ExternalContext, B, rval->getType(), rval, roots_AT, roots,
+              /*rootOffset*/ 0, SRetRootMovement::SRetValueToRootPointer);
         }
 
         auto NR = B.CreateRetVoid();
@@ -958,8 +960,8 @@ void EnzymeFixupJuliaCallingConvention(Function *F, bool sret_jlvalue) {
                                                            i + curOffset));
               }
             } else {
-              moveSRetToFromRoots(B, Types[sretCount], gep, roots_AT, roots,
-                                  curOffset,
+              moveSRetToFromRoots(ExternalContext, B, Types[sretCount], gep,
+                                  roots_AT, roots, curOffset,
                                   SRetRootMovement::SRetPointerToRootPointer);
             }
           }
@@ -1021,8 +1023,9 @@ void EnzymeFixupJuliaCallingConvention(Function *F, bool sret_jlvalue) {
                   "sret ("
                << *sret << "), but no rereturned roots at index i=" << i
                << "\n";
-            CustomErrorHandler(s.c_str(), wrap(gep), ErrorType::InternalError,
-                               nullptr, nullptr, nullptr);
+            CustomErrorHandler(ExternalContext, s.c_str(), wrap(gep),
+                               ErrorType::InternalError, nullptr, nullptr,
+                               nullptr);
           }
 
           sretCount++;
@@ -1107,8 +1110,9 @@ void EnzymeFixupJuliaCallingConvention(Function *F, bool sret_jlvalue) {
             ss << " + Function containing CI: "
                << CI->getParent()->getParent()->getName() << "\n";
             if (CustomErrorHandler) {
-              CustomErrorHandler(s.c_str(), wrap(CI), ErrorType::InternalError,
-                                 nullptr, nullptr, nullptr);
+              CustomErrorHandler(ExternalContext, s.c_str(), wrap(CI),
+                                 ErrorType::InternalError, nullptr, nullptr,
+                                 nullptr);
             } else {
               EmitFailure("UnsupportedArgument", CI->getDebugLoc(), CI,
                           ss.str());
@@ -1187,8 +1191,9 @@ void EnzymeFixupJuliaCallingConvention(Function *F, bool sret_jlvalue) {
             ss << " + Function containing CI: "
                << CI->getParent()->getParent()->getName() << "\n";
             if (CustomErrorHandler) {
-              CustomErrorHandler(s.c_str(), wrap(CI), ErrorType::InternalError,
-                                 nullptr, nullptr, nullptr);
+              CustomErrorHandler(ExternalContext, s.c_str(), wrap(CI),
+                                 ErrorType::InternalError, nullptr, nullptr,
+                                 nullptr);
             } else {
               EmitFailure("UnsupportedArgument", CI->getDebugLoc(), CI,
                           ss.str());
@@ -1269,7 +1274,8 @@ void EnzymeFixupJuliaCallingConvention(Function *F, bool sret_jlvalue) {
     // TODO we can optimize this further and avoid the copy in the primal and/or
     // forward mode as the copy is _only_ needed for the adjoint.
     for (auto &&[val, gep, ty] : preCallReplacements) {
-      copyNonJLValueInto(B, ty, ty, gep, {}, ty, val, {}, /*shouldZero*/ true);
+      copyNonJLValueInto(ExternalContext, B, ty, ty, gep, {}, ty, val, {},
+                         /*shouldZero*/ true);
     }
 
     // Actually perform the call, copying over relevant information.
@@ -1322,9 +1328,9 @@ void EnzymeFixupJuliaCallingConvention(Function *F, bool sret_jlvalue) {
         auto ld = B.CreateLoad(ty, gep);
         auto SI = B.CreateStore(ld, val);
         if (val->getType()->getPointerAddressSpace() == 10)
-          PostCacheStore(SI, B);
+          PostCacheStore(ExternalContext, SI, B);
       } else {
-        copyNonJLValueInto(B, ty, ty, val, {}, ty, gep, {},
+        copyNonJLValueInto(ExternalContext, B, ty, ty, val, {}, ty, gep, {},
                            /*shouldZero*/ false);
       }
     }
@@ -1349,7 +1355,8 @@ void EnzymeFixupJuliaCallingConvention(Function *F, bool sret_jlvalue) {
 
 using namespace llvm;
 
-void EnzymeFixupBatchedJuliaCallingConvention(Function *F) {
+void EnzymeFixupBatchedJuliaCallingConvention(EnzymeContextRef ExternalContext,
+                                              Function *F) {
   if (F->empty())
     return;
   auto RT = F->getReturnType();
@@ -1595,10 +1602,12 @@ class FixupJuliaCallingConventionNewPM
     : public PassInfoMixin<FixupJuliaCallingConventionNewPM> {
 #endif
   bool sret_jlvalue;
+  EnzymeContextRef ExternalContext;
 
 public:
-  FixupJuliaCallingConventionNewPM(bool sret_jlvalue)
-      : sret_jlvalue(sret_jlvalue) {}
+  FixupJuliaCallingConventionNewPM(bool sret_jlvalue,
+                                   EnzymeContextRef ExternalContext = nullptr)
+      : sret_jlvalue(sret_jlvalue), ExternalContext(ExternalContext) {}
 
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM) {
     bool changed = false;
@@ -1609,7 +1618,7 @@ public:
       Functions.push_back(&F);
     }
     for (auto *F : Functions) {
-      EnzymeFixupJuliaCallingConvention(F, sret_jlvalue);
+      EnzymeFixupJuliaCallingConvention(ExternalContext, F, sret_jlvalue);
       changed = true;
     }
     return changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
@@ -1623,6 +1632,12 @@ class FixupBatchedJuliaCallingConventionNewPM
     : public PassInfoMixin<FixupBatchedJuliaCallingConventionNewPM> {
 #endif
 public:
+  EnzymeContextRef ExternalContext;
+
+  FixupBatchedJuliaCallingConventionNewPM(
+      EnzymeContextRef ExternalContext = nullptr)
+      : ExternalContext(ExternalContext) {}
+
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM) {
     bool changed = false;
     SmallVector<llvm::Function *, 16> Functions;
@@ -1632,7 +1647,7 @@ public:
       Functions.push_back(&F);
     }
     for (auto *F : Functions) {
-      EnzymeFixupBatchedJuliaCallingConvention(F);
+      EnzymeFixupBatchedJuliaCallingConvention(ExternalContext, F);
       changed = true;
     }
     return changed ? PreservedAnalyses::none() : PreservedAnalyses::all();

--- a/enzyme/Enzyme/FunctionUtils.cpp
+++ b/enzyme/Enzyme/FunctionUtils.cpp
@@ -1565,10 +1565,10 @@ void RemoveRedundantPHI(Function *F, FunctionAnalysisManager &FAM) {
 }
 
 EnzymeContextRef PreProcessCache::externalContext() const {
-  return Logic ? Logic->externalContext() : nullptr;
+  return Logic.externalContext();
 }
 
-PreProcessCache::PreProcessCache() {
+PreProcessCache::PreProcessCache(EnzymeLogic &Logic) : Logic(Logic) {
   // Explicitly chose AA passes that are stateless
   // and will not be invalidated
   FAM.registerPass([] { return TypeBasedAA(); });

--- a/enzyme/Enzyme/FunctionUtils.cpp
+++ b/enzyme/Enzyme/FunctionUtils.cpp
@@ -287,6 +287,7 @@ static inline bool OnlyUsedInOMP(AllocaInst *AI) {
 }
 
 void RecursivelyReplaceAddressSpace(
+    EnzymeContextRef ExternalContext,
     SmallVector<std::tuple<Value *, Value *, Instruction *>, 1> &Todo,
     SmallVector<Instruction *, 1> &toErase, bool legal) {
   SmallVector<StoreInst *, 1> toPostCache;
@@ -603,8 +604,8 @@ void RecursivelyReplaceAddressSpace(
     ss << " + inst: " << *inst << "\n";
 
     if (CustomErrorHandler) {
-      CustomErrorHandler(s.c_str(), wrap(inst), ErrorType::InternalError,
-                         nullptr, nullptr, nullptr);
+      CustomErrorHandler(ExternalContext, s.c_str(), wrap(inst),
+                         ErrorType::InternalError, nullptr, nullptr, nullptr);
     } else {
       auto instI = cast<Instruction>(inst);
       ss << *instI->getParent()->getParent() << "\n";
@@ -640,11 +641,12 @@ void RecursivelyReplaceAddressSpace(
   }
   for (auto SI : toPostCache) {
     IRBuilder<> B(SI->getNextNode());
-    PostCacheStore(SI, B);
+    PostCacheStore(ExternalContext, SI, B);
   }
 }
 
-void RecursivelyReplaceAddressSpace(Value *AI, Value *rep, bool legal) {
+void RecursivelyReplaceAddressSpace(EnzymeContextRef ExternalContext, Value *AI,
+                                    Value *rep, bool legal) {
   SmallVector<std::tuple<Value *, Value *, Instruction *>, 1> Todo;
   for (auto U : AI->users()) {
     Todo.push_back(
@@ -655,7 +657,7 @@ void RecursivelyReplaceAddressSpace(Value *AI, Value *rep, bool legal) {
     assert(I);
     toErase.push_back(I);
   }
-  RecursivelyReplaceAddressSpace(Todo, toErase, legal);
+  RecursivelyReplaceAddressSpace(ExternalContext, Todo, toErase, legal);
 }
 
 /// Convert necessary stack allocations into mallocs for use in the reverse
@@ -663,7 +665,8 @@ void RecursivelyReplaceAddressSpace(Value *AI, Value *rep, bool legal) {
 /// Even if topLevel any allocations that aren't in the entry block (and
 /// therefore may not be reachable in the reverse pass) must be upgraded.
 static inline void
-UpgradeAllocasToMallocs(Function *NewF, DerivativeMode mode,
+UpgradeAllocasToMallocs(EnzymeContextRef ExternalContext, Function *NewF,
+                        DerivativeMode mode,
                         SmallPtrSetImpl<llvm::BasicBlock *> &Unreachable) {
   SmallVector<AllocaInst *, 4> ToConvert;
 
@@ -754,9 +757,10 @@ UpgradeAllocasToMallocs(Function *NewF, DerivativeMode mode,
     IRBuilder<> B(insertBefore);
     CallInst *CI = nullptr;
     Instruction *ZeroInst = nullptr;
-    auto rep = CreateAllocation(
-        B, AI->getAllocatedType(), B.CreateZExtOrTrunc(AI->getArraySize(), i64),
-        nam, &CI, /*ZeroMem*/ EnzymeZeroCache ? &ZeroInst : nullptr);
+    auto rep =
+        CreateAllocation(ExternalContext, B, AI->getAllocatedType(),
+                         B.CreateZExtOrTrunc(AI->getArraySize(), i64), nam, &CI,
+                         /*ZeroMem*/ EnzymeZeroCache ? &ZeroInst : nullptr);
     auto align = AI->getAlign().value();
     CI->setMetadata(
         "enzyme_fromstack",
@@ -801,7 +805,8 @@ UpgradeAllocasToMallocs(Function *NewF, DerivativeMode mode,
       AI->eraseFromParent();
     }
   }
-  RecursivelyReplaceAddressSpace(Todo, toErase, /*legal*/ false);
+  RecursivelyReplaceAddressSpace(ExternalContext, Todo, toErase,
+                                 /*legal*/ false);
 }
 
 // Create a stack variable containing the size of the allocation
@@ -1113,7 +1118,8 @@ void PreProcessCache::LowerAllocAddr(Function *NewF) {
       toErase.push_back(I);
     }
   }
-  RecursivelyReplaceAddressSpace(Todo, toErase, /*legal*/ true);
+  RecursivelyReplaceAddressSpace(externalContext(), Todo, toErase,
+                                 /*legal*/ true);
 
 #if LLVM_VERSION_MAJOR >= 22
   {
@@ -1556,6 +1562,10 @@ void RemoveRedundantPHI(Function *F, FunctionAnalysisManager &FAM) {
       }
     }
   }
+}
+
+EnzymeContextRef PreProcessCache::externalContext() const {
+  return Logic ? Logic->externalContext() : nullptr;
 }
 
 PreProcessCache::PreProcessCache() {
@@ -2778,7 +2788,7 @@ Function *PreProcessCache::preprocessForClone(Function *F,
     // For subfunction calls upgrade stack allocations to mallocs
     // to ensure availability in the reverse pass
     auto unreachable = getGuaranteedUnreachable(NewF);
-    UpgradeAllocasToMallocs(NewF, mode, unreachable);
+    UpgradeAllocasToMallocs(externalContext(), NewF, mode, unreachable);
   }
 
   CanonicalizeLoops(NewF, FAM);
@@ -2975,7 +2985,8 @@ Function *PreProcessCache::preprocessForClone(Function *F,
   return NewF;
 }
 
-FunctionType *getFunctionTypeForClone(llvm::FunctionType *FTy,
+FunctionType *getFunctionTypeForClone(EnzymeContextRef ExternalContext,
+                                      llvm::FunctionType *FTy,
                                       DerivativeMode mode, unsigned width,
                                       llvm::Type *additionalArg,
                                       llvm::ArrayRef<DIFFE_TYPE> constant_args,
@@ -3014,8 +3025,8 @@ FunctionType *getFunctionTypeForClone(llvm::FunctionType *FTy,
   }
   Type *RetType = StructType::get(FTy->getContext(), RetTypes);
   if (returnTape) {
-    RetTypes.insert(RetTypes.begin(),
-                    getDefaultAnonymousTapeType(FTy->getContext()));
+    RetTypes.insert(RetTypes.begin(), getDefaultAnonymousTapeType(
+                                          ExternalContext, FTy->getContext()));
   }
 
   if (RetTypes.size() == 0)
@@ -3046,8 +3057,8 @@ Function *PreProcessCache::CloneFunctionWithReturns(
     F = preprocessForClone(F, mode);
   llvm::ValueToValueMapTy VMap;
   llvm::FunctionType *FTy = getFunctionTypeForClone(
-      F->getFunctionType(), mode, width, additionalArg, constant_args,
-      diffeReturnArg, returnTape, returnPrimal, returnShadow);
+      externalContext(), F->getFunctionType(), mode, width, additionalArg,
+      constant_args, diffeReturnArg, returnTape, returnPrimal, returnShadow);
 
   for (BasicBlock &BB : *F) {
     if (auto ri = dyn_cast<ReturnInst>(BB.getTerminator())) {

--- a/enzyme/Enzyme/FunctionUtils.cpp
+++ b/enzyme/Enzyme/FunctionUtils.cpp
@@ -641,7 +641,7 @@ void RecursivelyReplaceAddressSpace(
   }
   for (auto SI : toPostCache) {
     IRBuilder<> B(SI->getNextNode());
-    PostCacheStore(ExternalContext, SI, B);
+    PostCacheStore(SI, B);
   }
 }
 
@@ -2985,8 +2985,7 @@ Function *PreProcessCache::preprocessForClone(Function *F,
   return NewF;
 }
 
-FunctionType *getFunctionTypeForClone(EnzymeContextRef ExternalContext,
-                                      llvm::FunctionType *FTy,
+FunctionType *getFunctionTypeForClone(llvm::FunctionType *FTy,
                                       DerivativeMode mode, unsigned width,
                                       llvm::Type *additionalArg,
                                       llvm::ArrayRef<DIFFE_TYPE> constant_args,
@@ -3025,8 +3024,8 @@ FunctionType *getFunctionTypeForClone(EnzymeContextRef ExternalContext,
   }
   Type *RetType = StructType::get(FTy->getContext(), RetTypes);
   if (returnTape) {
-    RetTypes.insert(RetTypes.begin(), getDefaultAnonymousTapeType(
-                                          ExternalContext, FTy->getContext()));
+    RetTypes.insert(RetTypes.begin(),
+                    getDefaultAnonymousTapeType(FTy->getContext()));
   }
 
   if (RetTypes.size() == 0)
@@ -3057,8 +3056,8 @@ Function *PreProcessCache::CloneFunctionWithReturns(
     F = preprocessForClone(F, mode);
   llvm::ValueToValueMapTy VMap;
   llvm::FunctionType *FTy = getFunctionTypeForClone(
-      externalContext(), F->getFunctionType(), mode, width, additionalArg,
-      constant_args, diffeReturnArg, returnTape, returnPrimal, returnShadow);
+      F->getFunctionType(), mode, width, additionalArg, constant_args,
+      diffeReturnArg, returnTape, returnPrimal, returnShadow);
 
   for (BasicBlock &BB : *F) {
     if (auto ri = dyn_cast<ReturnInst>(BB.getTerminator())) {

--- a/enzyme/Enzyme/FunctionUtils.h
+++ b/enzyme/Enzyme/FunctionUtils.h
@@ -425,10 +425,9 @@ void ReplaceFunctionImplementation(llvm::Module &M);
 bool couldFunctionArgumentCapture(llvm::CallInst *CI, llvm::Value *val);
 
 llvm::FunctionType *getFunctionTypeForClone(
-    EnzymeContextRef ExternalContext, llvm::FunctionType *FTy,
-    DerivativeMode mode, unsigned width, llvm::Type *additionalArg,
-    llvm::ArrayRef<DIFFE_TYPE> constant_args, bool diffeReturnArg,
-    bool returnTape, bool returnPrimal, bool returnShadow);
+    llvm::FunctionType *FTy, DerivativeMode mode, unsigned width,
+    llvm::Type *additionalArg, llvm::ArrayRef<DIFFE_TYPE> constant_args,
+    bool diffeReturnArg, bool returnTape, bool returnPrimal, bool returnShadow);
 
 /// Lower __enzyme_todense, returning if changed.
 bool LowerSparsification(llvm::Function *F, bool replaceAll = true);

--- a/enzyme/Enzyme/FunctionUtils.h
+++ b/enzyme/Enzyme/FunctionUtils.h
@@ -75,9 +75,20 @@ extern llvm::cl::opt<bool> EnzymeAlwaysInlineDiff;
 // an error, or write to inaccesible memory.
 bool DetectReadonlyOrThrow(llvm::Module &M);
 
+class EnzymeLogic;
+
 class PreProcessCache {
 public:
   PreProcessCache();
+
+  /// The logic that owns this cache, set by its constructor. Preprocessing
+  /// runs before any GradientUtils exists, so this is the only route from here
+  /// back to the frontend state of the request being served.
+  EnzymeLogic *Logic = nullptr;
+
+  /// The frontend state of the request being preprocessed, if known.
+  EnzymeContextRef externalContext() const;
+
   PreProcessCache(PreProcessCache &) = delete;
   // Using the default move constructor will botch the FAM/MAM proxy passes
   // since now the new location of FAM/MAM will not be used. Therefore, use a
@@ -86,6 +97,7 @@ public:
   PreProcessCache(PreProcessCache &&prev) : PreProcessCache() {
     cache = std::move(prev.cache);
     CloneOrigin = std::move(prev.CloneOrigin);
+    Logic = prev.Logic;
   };
 
   llvm::LoopAnalysisManager LAM;
@@ -404,7 +416,8 @@ static inline void calculateUnusedStores(
   }
 }
 
-void RecursivelyReplaceAddressSpace(llvm::Value *AI, llvm::Value *rep,
+void RecursivelyReplaceAddressSpace(EnzymeContextRef ExternalContext,
+                                    llvm::Value *AI, llvm::Value *rep,
                                     bool legal);
 
 void ReplaceFunctionImplementation(llvm::Module &M);
@@ -413,9 +426,10 @@ void ReplaceFunctionImplementation(llvm::Module &M);
 bool couldFunctionArgumentCapture(llvm::CallInst *CI, llvm::Value *val);
 
 llvm::FunctionType *getFunctionTypeForClone(
-    llvm::FunctionType *FTy, DerivativeMode mode, unsigned width,
-    llvm::Type *additionalArg, llvm::ArrayRef<DIFFE_TYPE> constant_args,
-    bool diffeReturnArg, bool returnTape, bool returnPrimal, bool returnShadow);
+    EnzymeContextRef ExternalContext, llvm::FunctionType *FTy,
+    DerivativeMode mode, unsigned width, llvm::Type *additionalArg,
+    llvm::ArrayRef<DIFFE_TYPE> constant_args, bool diffeReturnArg,
+    bool returnTape, bool returnPrimal, bool returnShadow);
 
 /// Lower __enzyme_todense, returning if changed.
 bool LowerSparsification(llvm::Function *F, bool replaceAll = true);

--- a/enzyme/Enzyme/FunctionUtils.h
+++ b/enzyme/Enzyme/FunctionUtils.h
@@ -79,14 +79,14 @@ class EnzymeLogic;
 
 class PreProcessCache {
 public:
-  PreProcessCache();
+  /// The logic that owns this cache. Preprocessing runs before any
+  /// GradientUtils exists, so this is its route to the frontend state of the
+  /// request being served.
+  EnzymeLogic &Logic;
 
-  /// The logic that owns this cache, set by its constructor. Preprocessing
-  /// runs before any GradientUtils exists, so this is the only route from here
-  /// back to the frontend state of the request being served.
-  EnzymeLogic *Logic = nullptr;
+  PreProcessCache(EnzymeLogic &Logic);
 
-  /// The frontend state of the request being preprocessed, if known.
+  /// The frontend state of the request being preprocessed, taken from Logic.
   EnzymeContextRef externalContext() const;
 
   PreProcessCache(PreProcessCache &) = delete;
@@ -94,10 +94,9 @@ public:
   // since now the new location of FAM/MAM will not be used. Therefore, use a
   // custom move constructor and default initialize these, and move the
   // cache/origin maps.
-  PreProcessCache(PreProcessCache &&prev) : PreProcessCache() {
+  PreProcessCache(PreProcessCache &&prev) : PreProcessCache(prev.Logic) {
     cache = std::move(prev.cache);
     CloneOrigin = std::move(prev.CloneOrigin);
-    Logic = prev.Logic;
   };
 
   llvm::LoopAnalysisManager LAM;

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -7522,7 +7522,7 @@ Value *GradientUtils::lookupM(Value *val, IRBuilder<> &BuilderM,
                       st->setAlignment(Align(bsize));
                     }
                     scopeInstructions[cache].push_back(st);
-                    for (auto post : PostCacheStore(externalContext(), st, v)) {
+                    for (auto post : PostCacheStore(st, v)) {
                       scopeInstructions[cache].push_back(post);
                     }
                   }
@@ -8871,8 +8871,8 @@ bool GradientUtils::isOriginalBlock(const BasicBlock &BB) const {
 void GradientUtils::eraseFictiousPHIs() {
   {
     for (auto P : rematerializedPrimalOrShadowAllocations) {
-      Value *replacement = getUndefinedValueForType(
-          externalContext(), *oldFunc->getParent(), P->getType());
+      Value *replacement =
+          getUndefinedValueForType(*oldFunc->getParent(), P->getType());
       P->replaceAllUsesWith(replacement);
       erase(P);
     }
@@ -8909,8 +8909,8 @@ void GradientUtils::eraseFictiousPHIs() {
           EmitFailure("IllegalReplacePHI", I->getDebugLoc(), I, str);
         }
       }
-      Value *replacement = getUndefinedValueForType(
-          externalContext(), *oldFunc->getParent(), pp->getType());
+      Value *replacement =
+          getUndefinedValueForType(*oldFunc->getParent(), pp->getType());
       pp->replaceAllUsesWith(replacement);
     }
     erase(pp);

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -164,8 +164,8 @@ GradientUtils::GradientUtils(
     llvm::ValueMap<const llvm::Value *, AssertingReplacingVH> &originalToNewFn_,
     DerivativeMode mode, bool runtimeActivity, bool strongZero, unsigned width,
     bool omp)
-    : CacheUtility(TLI_, newFunc_), Logic(Logic), mode(mode), oldFunc(oldFunc_),
-      invertedPointers(),
+    : CacheUtility(TLI_, newFunc_, Logic.ExternalContext), Logic(Logic),
+      mode(mode), oldFunc(oldFunc_), invertedPointers(),
       OrigDT(oldFunc_->empty()
                  ? ((DominatorTree *)nullptr)
                  : &Logic.PPC.FAM.getResult<llvm::DominatorTreeAnalysis>(
@@ -462,8 +462,9 @@ Value *GradientUtils::getOrInsertTotalMultiplicativeProduct(Value *val,
         ss << " fn: " << *lc.header->getParent() << "\n";
 
         if (CustomErrorHandler) {
-          CustomErrorHandler(str.c_str(), wrap(PN), ErrorType::InternalError,
-                             nullptr, nullptr, nullptr);
+          CustomErrorHandler(externalContext(), str.c_str(), wrap(PN),
+                             ErrorType::InternalError, nullptr, nullptr,
+                             nullptr);
         } else {
           EmitFailure("GetIndexError", PN->getDebugLoc(), PN, ss.str());
         }
@@ -2862,7 +2863,7 @@ Value *GradientUtils::cacheForReverse(IRBuilder<> &BuilderQ, Value *malloc,
           ss << "ret: " << *ret << " - " << *ret->getType() << "\n";
           ss << "malloc: " << *malloc << "\n";
           if (CustomErrorHandler) {
-            CustomErrorHandler(str.c_str(), wrap(malloc),
+            CustomErrorHandler(externalContext(), str.c_str(), wrap(malloc),
                                ErrorType::InternalError, nullptr, nullptr,
                                nullptr);
           } else {
@@ -3110,8 +3111,8 @@ Value *GradientUtils::cacheForReverse(IRBuilder<> &BuilderQ, Value *malloc,
         IRBuilder<> entryBuilder(inversionAllocs);
 
         auto firstallocation =
-            CreateAllocation(entryBuilder, malloc->getType(), numThreads,
-                             malloc->getName() + "_malloccache");
+            CreateAllocation(externalContext(), entryBuilder, malloc->getType(),
+                             numThreads, malloc->getName() + "_malloccache");
         Value *tPtr = entryBuilder.CreateInBoundsGEP(
             malloc->getType(), firstallocation, ArrayRef<Value *>(tid));
         if (auto inst = dyn_cast<Instruction>(malloc)) {
@@ -4002,8 +4003,8 @@ bool GradientUtils::legalRecompute(const Value *val,
       ss << "phi: " << *phi << "\n";
       ss << "Invalid legalRecompute query on ficticious phi\n";
       if (CustomErrorHandler) {
-        CustomErrorHandler(str.c_str(), wrap(phi), ErrorType::InternalError,
-                           nullptr, nullptr, nullptr);
+        CustomErrorHandler(externalContext(), str.c_str(), wrap(phi),
+                           ErrorType::InternalError, nullptr, nullptr, nullptr);
       } else {
         EmitFailure("InvalidLegalRecompute", phi->getDebugLoc(), phi, ss.str());
       }
@@ -5857,9 +5858,9 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
             "shadow global\n";
       ss << *arg << "\n";
       if (CustomErrorHandler) {
-        return unwrap(CustomErrorHandler(ss.str().c_str(), wrap(arg),
-                                         ErrorType::NoShadow, this, nullptr,
-                                         wrap(&BuilderM)));
+        return unwrap(CustomErrorHandler(externalContext(), ss.str().c_str(),
+                                         wrap(arg), ErrorType::NoShadow, this,
+                                         nullptr, wrap(&BuilderM)));
       } else {
         EmitFailure("InvertGlobal", BuilderM.getCurrentDebugLocation(), oldFunc,
                     ss.str());
@@ -5877,9 +5878,9 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
       ss << *arg << "\n";
       ss << " md: " << *md << "\n";
       if (CustomErrorHandler) {
-        return unwrap(CustomErrorHandler(ss.str().c_str(), wrap(arg),
-                                         ErrorType::NoShadow, this, nullptr,
-                                         wrap(&BuilderM)));
+        return unwrap(CustomErrorHandler(externalContext(), ss.str().c_str(),
+                                         wrap(arg), ErrorType::NoShadow, this,
+                                         nullptr, wrap(&BuilderM)));
       } else {
         EmitFailure("InvertGlobal", BuilderM.getCurrentDebugLocation(), oldFunc,
                     ss.str());
@@ -6129,8 +6130,8 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
                  << " const val: " << *op;
               if (CustomErrorHandler)
                 ivops[i] = unwrap(CustomErrorHandler(
-                    str.c_str(), wrap(arg), ErrorType::MixedActivityError, this,
-                    wrap(op), wrap(&bb)));
+                    externalContext(), str.c_str(), wrap(arg),
+                    ErrorType::MixedActivityError, this, wrap(op), wrap(&bb)));
               else
                 EmitWarningAlways("MixedActivityError", *arg, ss.str(),
                                   MixedActivityHint);
@@ -6243,9 +6244,9 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
         raw_string_ostream ss(str);
         ss << "Mismatched activity for: " << *arg << " const val: " << *tval;
         if (CustomErrorHandler)
-          itval = unwrap(CustomErrorHandler(str.c_str(), wrap(arg),
-                                            ErrorType::MixedActivityError, this,
-                                            wrap(tval), wrap(&bb)));
+          itval = unwrap(CustomErrorHandler(
+              externalContext(), str.c_str(), wrap(arg),
+              ErrorType::MixedActivityError, this, wrap(tval), wrap(&bb)));
         else
           EmitWarningAlways("MixedActivityError", *arg, ss.str(),
                             MixedActivityHint);
@@ -6264,9 +6265,9 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
         raw_string_ostream ss(str);
         ss << "Mismatched activity for: " << *arg << " const val: " << *fval;
         if (CustomErrorHandler)
-          ifval = unwrap(CustomErrorHandler(str.c_str(), wrap(arg),
-                                            ErrorType::MixedActivityError, this,
-                                            wrap(fval), wrap(&bb)));
+          ifval = unwrap(CustomErrorHandler(
+              externalContext(), str.c_str(), wrap(arg),
+              ErrorType::MixedActivityError, this, wrap(fval), wrap(&bb)));
         else
           EmitWarningAlways("MixedActivityError", *arg, ss.str(),
                             MixedActivityHint);
@@ -6617,7 +6618,8 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
             ss << "Mismatched activity for: " << *phi
                << " const val: " << *preval;
             if (CustomErrorHandler)
-              val = unwrap(CustomErrorHandler(str.c_str(), wrap(phi),
+              val = unwrap(CustomErrorHandler(externalContext(), str.c_str(),
+                                              wrap(phi),
                                               ErrorType::MixedActivityError,
                                               this, wrap(preval), wrap(&pre)));
             else
@@ -6691,7 +6693,8 @@ Value *GradientUtils::invertPointerM(Value *const oval, IRBuilder<> &BuilderM,
             ss << "Mismatched activity for: " << *phi
                << " const val: " << *preval;
             if (CustomErrorHandler)
-              val = unwrap(CustomErrorHandler(str.c_str(), wrap(phi),
+              val = unwrap(CustomErrorHandler(externalContext(), str.c_str(),
+                                              wrap(phi),
                                               ErrorType::MixedActivityError,
                                               this, wrap(preval), wrap(&pre)));
             else
@@ -6755,9 +6758,9 @@ end:;
     std::string str;
     raw_string_ostream ss(str);
     ss << "cannot find shadow for " << *oval;
-    auto iv =
-        unwrap(CustomErrorHandler(str.c_str(), wrap(oval), ErrorType::NoShadow,
-                                  this, nullptr, wrap(&BuilderM)));
+    auto iv = unwrap(CustomErrorHandler(externalContext(), str.c_str(),
+                                        wrap(oval), ErrorType::NoShadow, this,
+                                        nullptr, wrap(&BuilderM)));
     if (iv) {
       invertedPointers.insert(
           std::make_pair((const Value *)oval, InvertedPointerVH(this, iv)));
@@ -7519,7 +7522,7 @@ Value *GradientUtils::lookupM(Value *val, IRBuilder<> &BuilderM,
                       st->setAlignment(Align(bsize));
                     }
                     scopeInstructions[cache].push_back(st);
-                    for (auto post : PostCacheStore(st, v)) {
+                    for (auto post : PostCacheStore(externalContext(), st, v)) {
                       scopeInstructions[cache].push_back(post);
                     }
                   }
@@ -7635,9 +7638,9 @@ Value *GradientUtils::lookupM(Value *val, IRBuilder<> &BuilderM,
                        << ") during unwrap of SCEV: " << *ar1->getStart()
                        << "\n";
                     if (CustomErrorHandler) {
-                      CustomErrorHandler(str.c_str(), wrap(li),
-                                         ErrorType::InternalError, nullptr,
-                                         nullptr, nullptr);
+                      CustomErrorHandler(externalContext(), str.c_str(),
+                                         wrap(li), ErrorType::InternalError,
+                                         nullptr, nullptr, nullptr);
                     } else {
                       EmitFailure("InsertedPHISCEV", li->getDebugLoc(), li,
                                   ss.str());
@@ -8816,7 +8819,7 @@ void GradientUtils::computeMinCache() {
           raw_string_ostream ss(str);
           ss << "Illegal cached pointer: " << *V << "\n";
           if (CustomErrorHandler) {
-            CustomErrorHandler(str.c_str(), wrap((Value *)V),
+            CustomErrorHandler(externalContext(), str.c_str(), wrap((Value *)V),
                                ErrorType::InternalError, nullptr, nullptr,
                                nullptr);
           } else {
@@ -8868,8 +8871,8 @@ bool GradientUtils::isOriginalBlock(const BasicBlock &BB) const {
 void GradientUtils::eraseFictiousPHIs() {
   {
     for (auto P : rematerializedPrimalOrShadowAllocations) {
-      Value *replacement =
-          getUndefinedValueForType(*oldFunc->getParent(), P->getType());
+      Value *replacement = getUndefinedValueForType(
+          externalContext(), *oldFunc->getParent(), P->getType());
       P->replaceAllUsesWith(replacement);
       erase(P);
     }
@@ -8898,15 +8901,16 @@ void GradientUtils::eraseFictiousPHIs() {
           ss << "  user: " << *U << "\n";
         }
         if (CustomErrorHandler) {
-          CustomErrorHandler(str.c_str(), wrap(pp), ErrorType::InternalError,
-                             nullptr, nullptr, nullptr);
+          CustomErrorHandler(externalContext(), str.c_str(), wrap(pp),
+                             ErrorType::InternalError, nullptr, nullptr,
+                             nullptr);
         } else {
           ss << " newFunc:\n" << *newFunc << "\n";
           EmitFailure("IllegalReplacePHI", I->getDebugLoc(), I, str);
         }
       }
-      Value *replacement =
-          getUndefinedValueForType(*oldFunc->getParent(), pp->getType());
+      Value *replacement = getUndefinedValueForType(
+          externalContext(), *oldFunc->getParent(), pp->getType());
       pp->replaceAllUsesWith(replacement);
     }
     erase(pp);
@@ -9699,8 +9703,9 @@ BasicBlock *GradientUtils::addReverseBlock(BasicBlock *currentBlock,
     ss << "currentBlock: " << *currentBlock << "\n";
     ss << "vec.back(): " << *vec.back() << "\n";
     if (CustomErrorHandler) {
-      CustomErrorHandler(str.c_str(), wrap((Value *)currentBlock),
-                         ErrorType::InternalError, nullptr, nullptr, nullptr);
+      CustomErrorHandler(externalContext(), str.c_str(),
+                         wrap((Value *)currentBlock), ErrorType::InternalError,
+                         nullptr, nullptr, nullptr);
     } else {
       DebugLoc loc;
       if (hasTerminator(found->second)) {
@@ -9865,7 +9870,7 @@ int GradientUtils::getIndex(
     ss << "idx: " << *idx.first << ", " << idx.second << "\n";
     ss << " could not find index in mapping\n";
     if (CustomErrorHandler) {
-      CustomErrorHandler(ss.str().c_str(), wrap(idx.first),
+      CustomErrorHandler(externalContext(), ss.str().c_str(), wrap(idx.first),
                          ErrorType::GetIndexError, this, nullptr, wrap(&B));
     } else {
       EmitFailure("GetIndexError", idx.first->getDebugLoc(), idx.first,

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -164,8 +164,8 @@ GradientUtils::GradientUtils(
     llvm::ValueMap<const llvm::Value *, AssertingReplacingVH> &originalToNewFn_,
     DerivativeMode mode, bool runtimeActivity, bool strongZero, unsigned width,
     bool omp)
-    : CacheUtility(TLI_, newFunc_, Logic.ExternalContext), Logic(Logic),
-      mode(mode), oldFunc(oldFunc_), invertedPointers(),
+    : CacheUtility(Logic, TLI_, newFunc_), mode(mode), oldFunc(oldFunc_),
+      invertedPointers(),
       OrigDT(oldFunc_->empty()
                  ? ((DominatorTree *)nullptr)
                  : &Logic.PPC.FAM.getResult<llvm::DominatorTreeAnalysis>(

--- a/enzyme/Enzyme/GradientUtils.h
+++ b/enzyme/Enzyme/GradientUtils.h
@@ -136,7 +136,6 @@ public:
 enum class AugmentedStruct;
 class GradientUtils : public CacheUtility {
 public:
-  EnzymeLogic &Logic;
   bool AtomicAdd;
   DerivativeMode mode;
   llvm::Function *oldFunc;

--- a/enzyme/Enzyme/TraceInterface.cpp
+++ b/enzyme/Enzyme/TraceInterface.cpp
@@ -39,7 +39,7 @@ using namespace llvm;
 TraceInterface::TraceInterface(LLVMContext &C) : C(C){};
 
 PointerType *traceType(LLVMContext &C) {
-  return getDefaultAnonymousTapeType(/*ExternalContext=*/nullptr, C);
+  return getDefaultAnonymousTapeType(C);
 }
 
 Type *addressType(LLVMContext &C) { return getInt8PtrTy(C); }

--- a/enzyme/Enzyme/TraceInterface.cpp
+++ b/enzyme/Enzyme/TraceInterface.cpp
@@ -39,7 +39,7 @@ using namespace llvm;
 TraceInterface::TraceInterface(LLVMContext &C) : C(C){};
 
 PointerType *traceType(LLVMContext &C) {
-  return getDefaultAnonymousTapeType(C);
+  return getDefaultAnonymousTapeType(/*ExternalContext=*/nullptr, C);
 }
 
 Type *addressType(LLVMContext &C) { return getInt8PtrTy(C); }

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -259,6 +259,10 @@ bool dontAnalyze(StringRef str) {
   return false;
 }
 
+EnzymeContextRef TypeAnalyzer::externalContext() const {
+  return interprocedural.Logic.externalContext();
+}
+
 TypeAnalyzer::TypeAnalyzer(const FnTypeInfo &fn, TypeAnalysis &TA,
                            uint8_t direction)
     : MST(EnzymePrintType ? new ModuleSlotTracker(fn.Function->getParent())
@@ -1269,8 +1273,9 @@ void TypeAnalyzer::updateAnalysis(Value *Val, TypeTree Data, Value *Origin) {
       ss << " origin=" << *Origin;
 
     if (CustomErrorHandler) {
-      CustomErrorHandler(str.c_str(), wrap(Val), ErrorType::IllegalTypeAnalysis,
-                         (void *)this, wrap(Origin), nullptr);
+      CustomErrorHandler(externalContext(), str.c_str(), wrap(Val),
+                         ErrorType::IllegalTypeAnalysis, (void *)this,
+                         wrap(Origin), nullptr);
     }
     if (auto I = dyn_cast<Instruction>(Val)) {
       EmitFailure("IllegalUpdateAnalysis", I->getDebugLoc(), I, ss.str());
@@ -2137,9 +2142,9 @@ void TypeAnalyzer::visitGEPOperator(GEPOperator &gep) {
     auto keepMinus = pointerAnalysis.KeepMinusOne(legal);
     if (!legal) {
       if (CustomErrorHandler)
-        CustomErrorHandler("Could not keep minus one", wrap(&gep),
-                           ErrorType::IllegalTypeAnalysis, this, nullptr,
-                           nullptr);
+        CustomErrorHandler(externalContext(), "Could not keep minus one",
+                           wrap(&gep), ErrorType::IllegalTypeAnalysis, this,
+                           nullptr, nullptr);
       else {
         dump();
         llvm::errs() << " could not perform minus one for gep'd: " << gep
@@ -2417,7 +2422,7 @@ void TypeAnalyzer::visitPHINode(PHINode &phi) {
                    << " lhs: " << PhiTypes.str()
                    << " rhs: " << getAnalysis(BO->getOperand(0)).str() << "\n";
                 if (CustomErrorHandler) {
-                  CustomErrorHandler(str.c_str(), wrap(BO),
+                  CustomErrorHandler(externalContext(), str.c_str(), wrap(BO),
                                      ErrorType::IllegalTypeAnalysis,
                                      (void *)this, wrap(BO), nullptr);
                 }
@@ -2444,7 +2449,7 @@ void TypeAnalyzer::visitPHINode(PHINode &phi) {
                    << " lhs: " << PhiTypes.str() << " rhs: " << otherData.str()
                    << "\n";
                 if (CustomErrorHandler) {
-                  CustomErrorHandler(str.c_str(), wrap(BO),
+                  CustomErrorHandler(externalContext(), str.c_str(), wrap(BO),
                                      ErrorType::IllegalTypeAnalysis,
                                      (void *)this, wrap(BO), nullptr);
                 }
@@ -2513,7 +2518,7 @@ void TypeAnalyzer::visitPHINode(PHINode &phi) {
         ss << "Illegal binopIn(consts): " << *bo << " lhs: " << vd1.str()
            << " rhs: " << vd2.str() << "\n";
         if (CustomErrorHandler) {
-          CustomErrorHandler(str.c_str(), wrap(bo),
+          CustomErrorHandler(externalContext(), str.c_str(), wrap(bo),
                              ErrorType::IllegalTypeAnalysis, (void *)this,
                              wrap(bo), nullptr);
         }
@@ -3126,7 +3131,7 @@ void TypeAnalyzer::visitBinaryOperation(const DataLayout &dl, llvm::Type *T,
            << " new: " << Data.str() << "\n";
         ss << "val: " << *Args[0];
         ss << "origin: " << *origin;
-        CustomErrorHandler(str.c_str(), wrap(Args[0]),
+        CustomErrorHandler(externalContext(), str.c_str(), wrap(Args[0]),
                            ErrorType::IllegalTypeAnalysis, (void *)this,
                            wrap(origin), nullptr);
       }
@@ -3138,7 +3143,7 @@ void TypeAnalyzer::visitBinaryOperation(const DataLayout &dl, llvm::Type *T,
            << " new: " << Data.str() << "\n";
         ss << "val: " << *Args[1];
         ss << "origin: " << *origin;
-        CustomErrorHandler(str.c_str(), wrap(Args[1]),
+        CustomErrorHandler(externalContext(), str.c_str(), wrap(Args[1]),
                            ErrorType::IllegalTypeAnalysis, (void *)this,
                            wrap(origin), nullptr);
       }
@@ -3210,7 +3215,7 @@ void TypeAnalyzer::visitBinaryOperation(const DataLayout &dl, llvm::Type *T,
                  << ((i == 0) ? RHS : LHS).str() << " FT from ret: " << *FT
                  << "\n";
               if (CustomErrorHandler) {
-                CustomErrorHandler(str.c_str(), wrap(origin),
+                CustomErrorHandler(externalContext(), str.c_str(), wrap(origin),
                                    ErrorType::IllegalTypeAnalysis, (void *)this,
                                    wrap(origin), nullptr);
               }
@@ -3366,7 +3371,7 @@ void TypeAnalyzer::visitBinaryOperation(const DataLayout &dl, llvm::Type *T,
         ss << "Illegal binopIn(down): " << Opcode << " lhs: " << Result.str()
            << " rhs: " << AnalysisRHS.str() << "\n";
         if (CustomErrorHandler) {
-          CustomErrorHandler(str.c_str(), wrap(origin),
+          CustomErrorHandler(externalContext(), str.c_str(), wrap(origin),
                              ErrorType::IllegalTypeAnalysis, (void *)this,
                              wrap(origin), nullptr);
         }
@@ -3654,7 +3659,7 @@ void TypeAnalyzer::visitMemTransferCommon(llvm::CallBase &MTI) {
        << getAnalysis(MTI.getArgOperand(1)).str() << "\n";
 
     if (CustomErrorHandler) {
-      CustomErrorHandler(str.c_str(), wrap(&MTI),
+      CustomErrorHandler(externalContext(), str.c_str(), wrap(&MTI),
                          ErrorType::IllegalTypeAnalysis, (void *)this,
                          wrap(&MTI), nullptr);
     }
@@ -4275,7 +4280,7 @@ void TypeAnalyzer::visitIntrinsicInst(llvm::IntrinsicInst &I) {
       ss << "Illegal binopIn(intr): " << I << " lhs: " << vd.str()
          << " rhs: " << getAnalysis(I.getOperand(1)).str() << "\n";
       if (CustomErrorHandler) {
-        CustomErrorHandler(str.c_str(), wrap(&I),
+        CustomErrorHandler(externalContext(), str.c_str(), wrap(&I),
                            ErrorType::IllegalTypeAnalysis, (void *)this,
                            wrap(&I), nullptr);
       }
@@ -4541,9 +4546,9 @@ void analyzeIntelSubscriptIntrinsic(IntrinsicInst &II, TypeAnalyzer &TA) {
     auto keepMinus = pointerAnalysis.KeepMinusOne(legal);
     if (!legal) {
       if (CustomErrorHandler)
-        CustomErrorHandler("Could not keep minus one", wrap(&II),
-                           ErrorType::IllegalTypeAnalysis, &TA, nullptr,
-                           nullptr);
+        CustomErrorHandler(TA.externalContext(), "Could not keep minus one",
+                           wrap(&II), ErrorType::IllegalTypeAnalysis, &TA,
+                           nullptr, nullptr);
       else {
         TA.dump();
         llvm::errs()
@@ -6419,8 +6424,9 @@ ConcreteType TypeResults::firstPointer(size_t num, Value *val, Instruction *I,
       ss << "Illegal firstPointer, num: " << num << " q: " << q.str() << "\n";
       ss << " at " << *val << " from " << *I << "\n";
       if (CustomErrorHandler) {
-        CustomErrorHandler(str.c_str(), wrap(I), ErrorType::IllegalFirstPointer,
-                           &analyzer, nullptr, nullptr);
+        CustomErrorHandler(analyzer->externalContext(), str.c_str(), wrap(I),
+                           ErrorType::IllegalFirstPointer, &analyzer, nullptr,
+                           nullptr);
       }
       llvm::errs() << ss.str() << "\n";
       llvm_unreachable("Illegal firstPointer");

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.h
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.h
@@ -274,6 +274,9 @@ public:
   /// functions
   TypeAnalysis &interprocedural;
 
+  /// The frontend state of the request this analysis is part of.
+  EnzymeContextRef externalContext() const;
+
   /// Directionality of checks
   uint8_t direction;
 

--- a/enzyme/Enzyme/TypeAnalysis/TypeTree.h
+++ b/enzyme/Enzyme/TypeAnalysis/TypeTree.h
@@ -239,9 +239,9 @@ public:
     if (SeqSize > EnzymeMaxTypeDepth) {
       if (EnzymeTypeWarning) {
         if (CustomErrorHandler) {
-          CustomErrorHandler("TypeAnalysisDepthLimit", nullptr,
-                             ErrorType::TypeDepthExceeded, this, nullptr,
-                             nullptr);
+          CustomErrorHandler(
+              /*ExternalContext=*/nullptr, "TypeAnalysisDepthLimit", nullptr,
+              ErrorType::TypeDepthExceeded, this, nullptr, nullptr);
         } else
           llvm::errs() << "not handling more than " << EnzymeMaxTypeDepth
                        << " pointer lookups deep dt:" << str()
@@ -481,9 +481,9 @@ public:
       Result.minIndices.pop_back();
       if (EnzymeTypeWarning) {
         if (CustomErrorHandler) {
-          CustomErrorHandler("TypeAnalysisDepthLimit", wrap(orig),
-                             ErrorType::TypeDepthExceeded, this, nullptr,
-                             nullptr);
+          CustomErrorHandler(
+              /*ExternalContext=*/nullptr, "TypeAnalysisDepthLimit", wrap(orig),
+              ErrorType::TypeDepthExceeded, this, nullptr, nullptr);
         } else if (orig) {
           EmitWarning("TypeAnalysisDepthLimit", *orig, *orig,
                       " not handling more than ", EnzymeMaxTypeDepth,

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -66,18 +66,16 @@ LLVMValueRef (*CustomAllocator)(EnzymeContextRef, LLVMBuilderRef, LLVMTypeRef,
                                 /*Count*/ LLVMValueRef,
                                 /*Align*/ LLVMValueRef, uint8_t,
                                 LLVMValueRef *) = nullptr;
-void (*CustomZero)(EnzymeContextRef, LLVMBuilderRef, LLVMTypeRef,
+void (*CustomZero)(LLVMBuilderRef, LLVMTypeRef,
                    /*Ptr*/ LLVMValueRef, uint8_t) = nullptr;
-LLVMValueRef (*CustomDeallocator)(EnzymeContextRef, LLVMBuilderRef,
-                                  LLVMValueRef) = nullptr;
-void (*CustomRuntimeInactiveError)(EnzymeContextRef, LLVMBuilderRef,
-                                   LLVMValueRef, LLVMValueRef) = nullptr;
-LLVMValueRef *(*EnzymePostCacheStore)(EnzymeContextRef, LLVMValueRef,
-                                      LLVMBuilderRef, uint64_t *size) = nullptr;
-LLVMTypeRef (*EnzymeDefaultTapeType)(EnzymeContextRef,
-                                     LLVMContextRef) = nullptr;
-LLVMValueRef (*EnzymeUndefinedValueForType)(EnzymeContextRef, LLVMModuleRef,
-                                            LLVMTypeRef, uint8_t) = nullptr;
+LLVMValueRef (*CustomDeallocator)(LLVMBuilderRef, LLVMValueRef) = nullptr;
+void (*CustomRuntimeInactiveError)(LLVMBuilderRef, LLVMValueRef,
+                                   LLVMValueRef) = nullptr;
+LLVMValueRef *(*EnzymePostCacheStore)(LLVMValueRef, LLVMBuilderRef,
+                                      uint64_t *size) = nullptr;
+LLVMTypeRef (*EnzymeDefaultTapeType)(LLVMContextRef) = nullptr;
+LLVMValueRef (*EnzymeUndefinedValueForType)(LLVMModuleRef, LLVMTypeRef,
+                                            uint8_t) = nullptr;
 
 LLVMValueRef (*EnzymeSanitizeDerivatives)(EnzymeContextRef, LLVMValueRef,
                                           LLVMValueRef toset, LLVMBuilderRef,
@@ -413,22 +411,21 @@ bool attributeKnownFunctions(llvm::Function &F) {
   return changed;
 }
 
-void ZeroMemory(EnzymeContextRef ExternalContext, llvm::IRBuilder<> &Builder,
-                llvm::Type *T, llvm::Value *obj, bool isTape) {
+void ZeroMemory(llvm::IRBuilder<> &Builder, llvm::Type *T, llvm::Value *obj,
+                bool isTape) {
   if (CustomZero) {
-    CustomZero(ExternalContext, wrap(&Builder), wrap(T), wrap(obj), isTape);
+    CustomZero(wrap(&Builder), wrap(T), wrap(obj), isTape);
   } else {
     Builder.CreateStore(Constant::getNullValue(T), obj);
   }
 }
 
-llvm::SmallVector<llvm::Instruction *, 2>
-PostCacheStore(EnzymeContextRef ExternalContext, llvm::StoreInst *SI,
-               llvm::IRBuilder<> &B) {
+llvm::SmallVector<llvm::Instruction *, 2> PostCacheStore(llvm::StoreInst *SI,
+                                                         llvm::IRBuilder<> &B) {
   SmallVector<llvm::Instruction *, 2> res;
   if (EnzymePostCacheStore) {
     uint64_t size = 0;
-    auto ptr = EnzymePostCacheStore(ExternalContext, wrap(SI), wrap(&B), &size);
+    auto ptr = EnzymePostCacheStore(wrap(SI), wrap(&B), &size);
     for (size_t i = 0; i < size; i++) {
       res.push_back(cast<Instruction>(unwrap(ptr[i])));
     }
@@ -437,11 +434,9 @@ PostCacheStore(EnzymeContextRef ExternalContext, llvm::StoreInst *SI,
   return res;
 }
 
-llvm::PointerType *getDefaultAnonymousTapeType(EnzymeContextRef ExternalContext,
-                                               llvm::LLVMContext &C) {
+llvm::PointerType *getDefaultAnonymousTapeType(llvm::LLVMContext &C) {
   if (EnzymeDefaultTapeType)
-    return cast<PointerType>(
-        unwrap(EnzymeDefaultTapeType(ExternalContext, wrap(&C))));
+    return cast<PointerType>(unwrap(EnzymeDefaultTapeType(wrap(&C))));
   return getInt8PtrTy(C);
 }
 
@@ -783,13 +778,12 @@ Value *CreateAllocation(EnzymeContextRef ExternalContext, IRBuilder<> &Builder,
   return res;
 }
 
-CallInst *CreateDealloc(EnzymeContextRef ExternalContext,
-                        llvm::IRBuilder<> &Builder, llvm::Value *ToFree) {
+CallInst *CreateDealloc(llvm::IRBuilder<> &Builder, llvm::Value *ToFree) {
   CallInst *res = nullptr;
 
   if (CustomDeallocator) {
-    res = dyn_cast_or_null<CallInst>(unwrap(
-        CustomDeallocator(ExternalContext, wrap(&Builder), wrap(ToFree))));
+    res = dyn_cast_or_null<CallInst>(
+        unwrap(CustomDeallocator(wrap(&Builder), wrap(ToFree))));
   } else {
 
     ToFree =
@@ -944,10 +938,9 @@ void emit_backtrace(llvm::Instruction *inst, llvm::raw_ostream &ss) {
   }
 }
 
-void ErrorIfRuntimeInactive(GradientUtils *gutils, llvm::IRBuilder<> &B,
-                            llvm::Value *primal, llvm::Value *shadow,
-                            const char *Message, llvm::DebugLoc &&loc,
-                            llvm::Instruction *orig) {
+void ErrorIfRuntimeInactive(llvm::IRBuilder<> &B, llvm::Value *primal,
+                            llvm::Value *shadow, const char *Message,
+                            llvm::DebugLoc &&loc, llvm::Instruction *orig) {
   Module &M = *B.GetInsertBlock()->getParent()->getParent();
   std::string name = "__enzyme_runtimeinactiveerr";
   if (CustomRuntimeInactiveError) {
@@ -986,8 +979,7 @@ void ErrorIfRuntimeInactive(GradientUtils *gutils, llvm::IRBuilder<> &B,
     EB.SetInsertPoint(error);
 
     if (CustomRuntimeInactiveError) {
-      CustomRuntimeInactiveError(gutils->externalContext(), wrap(&EB),
-                                 wrap(msg), wrap(orig));
+      CustomRuntimeInactiveError(wrap(&EB), wrap(msg), wrap(orig));
     } else {
       FunctionType *FT =
           FunctionType::get(Type::getInt32Ty(M.getContext()),
@@ -3783,12 +3775,11 @@ llvm::Optional<BlasInfo> extractBLAS(llvm::StringRef in)
   return {};
 }
 
-llvm::Constant *getUndefinedValueForType(EnzymeContextRef ExternalContext,
-                                         llvm::Module &M, llvm::Type *T,
+llvm::Constant *getUndefinedValueForType(llvm::Module &M, llvm::Type *T,
                                          bool forceZero) {
   if (EnzymeUndefinedValueForType)
-    return cast<Constant>(unwrap(EnzymeUndefinedValueForType(
-        ExternalContext, wrap(&M), wrap(T), forceZero)));
+    return cast<Constant>(
+        unwrap(EnzymeUndefinedValueForType(wrap(&M), wrap(T), forceZero)));
   else if (EnzymeZeroCache || forceZero)
     return Constant::getNullValue(T);
   else
@@ -4972,8 +4963,7 @@ static Value *constantInBoundsGEPHelper(llvm::IRBuilder<> &B, llvm::Type *type,
   return B.CreateInBoundsGEP(type, value, vals);
 }
 
-llvm::Value *moveSRetToFromRoots(EnzymeContextRef ExternalContext,
-                                 llvm::IRBuilder<> &B, llvm::Type *jltype,
+llvm::Value *moveSRetToFromRoots(llvm::IRBuilder<> &B, llvm::Type *jltype,
                                  llvm::Value *sret, llvm::Type *root_ty,
                                  llvm::Value *rootRet, size_t rootOffset,
                                  SRetRootMovement direction) {
@@ -5025,8 +5015,7 @@ llvm::Value *moveSRetToFromRoots(EnzymeContextRef ExternalContext,
       }
       case SRetRootMovement::NullifySRetValue: {
         loc = getUndefinedValueForType(
-            ExternalContext, *B.GetInsertBlock()->getParent()->getParent(), ty,
-            false);
+            *B.GetInsertBlock()->getParent()->getParent(), ty, false);
         val = B.CreateInsertValue(val, loc, path);
         break;
       }
@@ -5097,9 +5086,9 @@ llvm::Value *moveSRetToFromRoots(EnzymeContextRef ExternalContext,
   return val;
 }
 
-void copyNonJLValueInto(EnzymeContextRef ExternalContext, llvm::IRBuilder<> &B,
-                        llvm::Type *curType, llvm::Type *dstType,
-                        llvm::Value *dst, llvm::ArrayRef<unsigned> dstPrefix0,
+void copyNonJLValueInto(llvm::IRBuilder<> &B, llvm::Type *curType,
+                        llvm::Type *dstType, llvm::Value *dst,
+                        llvm::ArrayRef<unsigned> dstPrefix0,
                         llvm::Type *srcType, llvm::Value *src,
                         llvm::ArrayRef<unsigned> srcPrefix0, bool shouldZero) {
   std::deque<
@@ -5124,7 +5113,7 @@ void copyNonJLValueInto(EnzymeContextRef ExternalContext, llvm::IRBuilder<> &B,
           Value *out = dst;
           if (dstPrefix.size() > 0)
             out = constantInBoundsGEPHelper(B, dstType, out, dstPrefix);
-          B.CreateStore(getUndefinedValueForType(ExternalContext, M, ty), out);
+          B.CreateStore(getUndefinedValueForType(M, ty), out);
         }
       }
       // We don't actually need pointers either here

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -59,26 +59,28 @@
 using namespace llvm;
 
 extern "C" {
-LLVMValueRef (*CustomErrorHandler)(const char *, LLVMValueRef, ErrorType,
-                                   const void *, LLVMValueRef,
+LLVMValueRef (*CustomErrorHandler)(EnzymeContextRef, const char *, LLVMValueRef,
+                                   ErrorType, const void *, LLVMValueRef,
                                    LLVMBuilderRef) = nullptr;
-LLVMValueRef (*CustomAllocator)(LLVMBuilderRef, LLVMTypeRef,
+LLVMValueRef (*CustomAllocator)(EnzymeContextRef, LLVMBuilderRef, LLVMTypeRef,
                                 /*Count*/ LLVMValueRef,
                                 /*Align*/ LLVMValueRef, uint8_t,
                                 LLVMValueRef *) = nullptr;
-void (*CustomZero)(LLVMBuilderRef, LLVMTypeRef,
+void (*CustomZero)(EnzymeContextRef, LLVMBuilderRef, LLVMTypeRef,
                    /*Ptr*/ LLVMValueRef, uint8_t) = nullptr;
-LLVMValueRef (*CustomDeallocator)(LLVMBuilderRef, LLVMValueRef) = nullptr;
-void (*CustomRuntimeInactiveError)(LLVMBuilderRef, LLVMValueRef,
-                                   LLVMValueRef) = nullptr;
-LLVMValueRef *(*EnzymePostCacheStore)(LLVMValueRef, LLVMBuilderRef,
-                                      uint64_t *size) = nullptr;
-LLVMTypeRef (*EnzymeDefaultTapeType)(LLVMContextRef) = nullptr;
-LLVMValueRef (*EnzymeUndefinedValueForType)(LLVMModuleRef, LLVMTypeRef,
-                                            uint8_t) = nullptr;
+LLVMValueRef (*CustomDeallocator)(EnzymeContextRef, LLVMBuilderRef,
+                                  LLVMValueRef) = nullptr;
+void (*CustomRuntimeInactiveError)(EnzymeContextRef, LLVMBuilderRef,
+                                   LLVMValueRef, LLVMValueRef) = nullptr;
+LLVMValueRef *(*EnzymePostCacheStore)(EnzymeContextRef, LLVMValueRef,
+                                      LLVMBuilderRef, uint64_t *size) = nullptr;
+LLVMTypeRef (*EnzymeDefaultTapeType)(EnzymeContextRef,
+                                     LLVMContextRef) = nullptr;
+LLVMValueRef (*EnzymeUndefinedValueForType)(EnzymeContextRef, LLVMModuleRef,
+                                            LLVMTypeRef, uint8_t) = nullptr;
 
-LLVMValueRef (*EnzymeSanitizeDerivatives)(LLVMValueRef, LLVMValueRef toset,
-                                          LLVMBuilderRef,
+LLVMValueRef (*EnzymeSanitizeDerivatives)(EnzymeContextRef, LLVMValueRef,
+                                          LLVMValueRef toset, LLVMBuilderRef,
                                           LLVMValueRef) = nullptr;
 
 extern llvm::cl::opt<bool> EnzymeZeroCache;
@@ -411,21 +413,22 @@ bool attributeKnownFunctions(llvm::Function &F) {
   return changed;
 }
 
-void ZeroMemory(llvm::IRBuilder<> &Builder, llvm::Type *T, llvm::Value *obj,
-                bool isTape) {
+void ZeroMemory(EnzymeContextRef ExternalContext, llvm::IRBuilder<> &Builder,
+                llvm::Type *T, llvm::Value *obj, bool isTape) {
   if (CustomZero) {
-    CustomZero(wrap(&Builder), wrap(T), wrap(obj), isTape);
+    CustomZero(ExternalContext, wrap(&Builder), wrap(T), wrap(obj), isTape);
   } else {
     Builder.CreateStore(Constant::getNullValue(T), obj);
   }
 }
 
-llvm::SmallVector<llvm::Instruction *, 2> PostCacheStore(llvm::StoreInst *SI,
-                                                         llvm::IRBuilder<> &B) {
+llvm::SmallVector<llvm::Instruction *, 2>
+PostCacheStore(EnzymeContextRef ExternalContext, llvm::StoreInst *SI,
+               llvm::IRBuilder<> &B) {
   SmallVector<llvm::Instruction *, 2> res;
   if (EnzymePostCacheStore) {
     uint64_t size = 0;
-    auto ptr = EnzymePostCacheStore(wrap(SI), wrap(&B), &size);
+    auto ptr = EnzymePostCacheStore(ExternalContext, wrap(SI), wrap(&B), &size);
     for (size_t i = 0; i < size; i++) {
       res.push_back(cast<Instruction>(unwrap(ptr[i])));
     }
@@ -434,13 +437,16 @@ llvm::SmallVector<llvm::Instruction *, 2> PostCacheStore(llvm::StoreInst *SI,
   return res;
 }
 
-llvm::PointerType *getDefaultAnonymousTapeType(llvm::LLVMContext &C) {
+llvm::PointerType *getDefaultAnonymousTapeType(EnzymeContextRef ExternalContext,
+                                               llvm::LLVMContext &C) {
   if (EnzymeDefaultTapeType)
-    return cast<PointerType>(unwrap(EnzymeDefaultTapeType(wrap(&C))));
+    return cast<PointerType>(
+        unwrap(EnzymeDefaultTapeType(ExternalContext, wrap(&C))));
   return getInt8PtrTy(C);
 }
 
-Function *getOrInsertExponentialAllocator(Module &M, Function *newFunc,
+Function *getOrInsertExponentialAllocator(EnzymeContextRef ExternalContext,
+                                          Module &M, Function *newFunc,
                                           bool ZeroInit, llvm::Type *RT) {
   bool custom = true;
   llvm::PointerType *allocType;
@@ -451,7 +457,9 @@ Function *getOrInsertExponentialAllocator(Module &M, Function *newFunc,
     auto P = B.CreatePHI(i64, 1);
     CallInst *malloccall;
     Instruction *SubZero = nullptr;
-    CreateAllocation(B, RT, P, "tapemem", &malloccall, &SubZero)->getType();
+    CreateAllocation(ExternalContext, B, RT, P, "tapemem", &malloccall,
+                     &SubZero)
+        ->getType();
     if (auto F = getFunctionFromCall(malloccall)) {
       custom = F->getName() != "malloc";
     }
@@ -539,7 +547,8 @@ Function *getOrInsertExponentialAllocator(Module &M, Function *newFunc,
         newFunc->getParent()->getDataLayout().getTypeAllocSizeInBits(RT) / 8);
     auto elSize = B.CreateUDiv(next, tsize, "", /*isExact*/ true);
     Instruction *SubZero = nullptr;
-    gVal = CreateAllocation(B, RT, elSize, "", nullptr, &SubZero);
+    gVal =
+        CreateAllocation(ExternalContext, B, RT, elSize, "", nullptr, &SubZero);
 
     Type *bTy =
         getPointerType(Type::getInt8Ty(gVal->getContext()),
@@ -588,7 +597,8 @@ Function *getOrInsertExponentialAllocator(Module &M, Function *newFunc,
   return F;
 }
 
-llvm::Value *CreateReAllocation(llvm::IRBuilder<> &B, llvm::Value *prev,
+llvm::Value *CreateReAllocation(EnzymeContextRef ExternalContext,
+                                llvm::IRBuilder<> &B, llvm::Value *prev,
                                 llvm::Type *T, llvm::Value *OuterCount,
                                 llvm::Value *InnerCount,
                                 const llvm::Twine &Name,
@@ -608,18 +618,19 @@ llvm::Value *CreateReAllocation(llvm::IRBuilder<> &B, llvm::Value *prev,
       B.CreateMul(tsize, InnerCount, "", /*NUW*/ true,
                   /*NSW*/ true)};
 
-  auto realloccall =
-      B.CreateCall(getOrInsertExponentialAllocator(*newFunc->getParent(),
-                                                   newFunc, ZeroMem, T),
-                   idxs, Name);
+  auto realloccall = B.CreateCall(
+      getOrInsertExponentialAllocator(ExternalContext, *newFunc->getParent(),
+                                      newFunc, ZeroMem, T),
+      idxs, Name);
   if (caller)
     *caller = realloccall;
   return realloccall;
 }
 
-Value *CreateAllocation(IRBuilder<> &Builder, llvm::Type *T, Value *Count,
-                        const Twine &Name, CallInst **caller,
-                        Instruction **ZeroMem, bool isDefault) {
+Value *CreateAllocation(EnzymeContextRef ExternalContext, IRBuilder<> &Builder,
+                        llvm::Type *T, Value *Count, const Twine &Name,
+                        CallInst **caller, Instruction **ZeroMem,
+                        bool isDefault) {
   Value *res;
   auto &M = *Builder.GetInsertBlock()->getParent()->getParent();
   auto AlignI = M.getDataLayout().getTypeAllocSizeInBits(T) / 8;
@@ -650,8 +661,8 @@ Value *CreateAllocation(IRBuilder<> &Builder, llvm::Type *T, Value *Count,
   CallInst *malloccall = nullptr;
   if (CustomAllocator) {
     LLVMValueRef wzeromem = nullptr;
-    res = unwrap(CustomAllocator(wrap(&Builder), wrap(T), wrap(Count),
-                                 wrap(Align), isDefault,
+    res = unwrap(CustomAllocator(ExternalContext, wrap(&Builder), wrap(T),
+                                 wrap(Count), wrap(Align), isDefault,
                                  ZeroMem ? &wzeromem : nullptr));
     if (isa<UndefValue>(res))
       return res;
@@ -772,12 +783,13 @@ Value *CreateAllocation(IRBuilder<> &Builder, llvm::Type *T, Value *Count,
   return res;
 }
 
-CallInst *CreateDealloc(llvm::IRBuilder<> &Builder, llvm::Value *ToFree) {
+CallInst *CreateDealloc(EnzymeContextRef ExternalContext,
+                        llvm::IRBuilder<> &Builder, llvm::Value *ToFree) {
   CallInst *res = nullptr;
 
   if (CustomDeallocator) {
-    res = dyn_cast_or_null<CallInst>(
-        unwrap(CustomDeallocator(wrap(&Builder), wrap(ToFree))));
+    res = dyn_cast_or_null<CallInst>(unwrap(
+        CustomDeallocator(ExternalContext, wrap(&Builder), wrap(ToFree))));
   } else {
 
     ToFree =
@@ -932,7 +944,8 @@ void emit_backtrace(llvm::Instruction *inst, llvm::raw_ostream &ss) {
   }
 }
 
-void ErrorIfRuntimeInactive(llvm::IRBuilder<> &B, llvm::Value *primal,
+void ErrorIfRuntimeInactive(EnzymeContextRef ExternalContext,
+                            llvm::IRBuilder<> &B, llvm::Value *primal,
                             llvm::Value *shadow, const char *Message,
                             llvm::DebugLoc &&loc, llvm::Instruction *orig) {
   Module &M = *B.GetInsertBlock()->getParent()->getParent();
@@ -973,7 +986,8 @@ void ErrorIfRuntimeInactive(llvm::IRBuilder<> &B, llvm::Value *primal,
     EB.SetInsertPoint(error);
 
     if (CustomRuntimeInactiveError) {
-      CustomRuntimeInactiveError(wrap(&EB), wrap(msg), wrap(orig));
+      CustomRuntimeInactiveError(ExternalContext, wrap(&EB), wrap(msg),
+                                 wrap(orig));
     } else {
       FunctionType *FT =
           FunctionType::get(Type::getInt32Ty(M.getContext()),
@@ -2327,9 +2341,10 @@ llvm::Value *nextPowerOfTwo(llvm::IRBuilder<> &B, llvm::Value *V) {
   return V;
 }
 
-llvm::Function *getOrInsertDifferentialWaitallSave(llvm::Module &M,
-                                                   ArrayRef<llvm::Type *> T,
-                                                   PointerType *reqType) {
+llvm::Function *
+getOrInsertDifferentialWaitallSave(EnzymeContextRef ExternalContext,
+                                   llvm::Module &M, ArrayRef<llvm::Type *> T,
+                                   PointerType *reqType) {
   std::string name = "__enzyme_differential_waitall_save";
   FunctionType *FT = FunctionType::get(getUnqual(reqType), T, false);
   Function *F = cast<Function>(M.getOrInsertFunction(name, FT).getCallee());
@@ -2354,7 +2369,7 @@ llvm::Function *getOrInsertDifferentialWaitallSave(llvm::Module &M,
   IRBuilder<> B(entry);
   count = B.CreateZExtOrTrunc(count, Type::getInt64Ty(entry->getContext()));
 
-  auto ret = CreateAllocation(B, reqType, count);
+  auto ret = CreateAllocation(ExternalContext, B, reqType, count);
 
   BasicBlock *loopBlock = BasicBlock::Create(M.getContext(), "loop", F);
   BasicBlock *endBlock = BasicBlock::Create(M.getContext(), "end", F);
@@ -3768,18 +3783,20 @@ llvm::Optional<BlasInfo> extractBLAS(llvm::StringRef in)
   return {};
 }
 
-llvm::Constant *getUndefinedValueForType(llvm::Module &M, llvm::Type *T,
+llvm::Constant *getUndefinedValueForType(EnzymeContextRef ExternalContext,
+                                         llvm::Module &M, llvm::Type *T,
                                          bool forceZero) {
   if (EnzymeUndefinedValueForType)
-    return cast<Constant>(
-        unwrap(EnzymeUndefinedValueForType(wrap(&M), wrap(T), forceZero)));
+    return cast<Constant>(unwrap(EnzymeUndefinedValueForType(
+        ExternalContext, wrap(&M), wrap(T), forceZero)));
   else if (EnzymeZeroCache || forceZero)
     return Constant::getNullValue(T);
   else
     return UndefValue::get(T);
 }
 
-llvm::Value *SanitizeDerivatives(llvm::Value *val, llvm::Value *toset,
+llvm::Value *SanitizeDerivatives(EnzymeContextRef ExternalContext,
+                                 llvm::Value *val, llvm::Value *toset,
                                  llvm::IRBuilder<> &BuilderM,
                                  llvm::Value *mask) {
   if (EnzymeCheckDerivativeNaN && toset->getType()->isFPOrFPVectorTy()) {
@@ -3834,8 +3851,9 @@ llvm::Value *SanitizeDerivatives(llvm::Value *val, llvm::Value *toset,
 
       B.SetInsertPoint(bad);
       if (CustomErrorHandler) {
-        CustomErrorHandler("NaN Error", wrap(inp), ErrorType::NaNError, nullptr,
-                           wrap(msg_ptr), wrap(&B));
+        CustomErrorHandler(ExternalContext, "NaN Error", wrap(inp),
+                           ErrorType::NaNError, nullptr, wrap(msg_ptr),
+                           wrap(&B));
       } else {
         llvm::FunctionType *PutsFT = llvm::FunctionType::get(
             llvm::Type::getInt32Ty(Context), {getInt8PtrTy(Context)}, false);
@@ -3871,8 +3889,8 @@ llvm::Value *SanitizeDerivatives(llvm::Value *val, llvm::Value *toset,
   }
 
   if (EnzymeSanitizeDerivatives)
-    return unwrap(EnzymeSanitizeDerivatives(wrap(val), wrap(toset),
-                                            wrap(&BuilderM), wrap(mask)));
+    return unwrap(EnzymeSanitizeDerivatives(
+        ExternalContext, wrap(val), wrap(toset), wrap(&BuilderM), wrap(mask)));
   return toset;
 }
 
@@ -4092,8 +4110,8 @@ llvm::Value *is_left(IRBuilder<> &B, llvm::Value *side, bool byRef,
 // However, if we ask openBlas c ABI,
 // it is one of the following 32 bit integers values:
 // enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113};
-llvm::Value *transpose(std::string floatType, IRBuilder<> &B, llvm::Value *V,
-                       bool cublas) {
+llvm::Value *transpose(EnzymeContextRef ExternalContext, std::string floatType,
+                       IRBuilder<> &B, llvm::Value *V, bool cublas) {
   llvm::Type *T = V->getType();
   if (cublas) {
     auto isT1 = B.CreateICmpEQ(V, ConstantInt::get(T, 1));
@@ -4147,8 +4165,8 @@ llvm::Value *transpose(std::string floatType, IRBuilder<> &B, llvm::Value *V,
     llvm::raw_string_ostream ss(s);
     ss << "cannot handle unknown trans blas value\n" << V;
     if (CustomErrorHandler) {
-      CustomErrorHandler(ss.str().c_str(), nullptr, ErrorType::NoDerivative,
-                         nullptr, nullptr, nullptr);
+      CustomErrorHandler(ExternalContext, ss.str().c_str(), nullptr,
+                         ErrorType::NoDerivative, nullptr, nullptr, nullptr);
     } else {
       EmitFailure("unknown trans blas value", B.getCurrentDebugLocation(),
                   B.GetInsertBlock()->getParent(), ss.str());
@@ -4179,9 +4197,9 @@ llvm::Value *get_cached_mat_width(llvm::IRBuilder<> &B,
   return width;
 }
 
-llvm::Value *transpose(std::string floatType, llvm::IRBuilder<> &B,
-                       llvm::Value *V, bool byRef, bool cublas,
-                       llvm::IntegerType *julia_decl,
+llvm::Value *transpose(EnzymeContextRef ExternalContext, std::string floatType,
+                       llvm::IRBuilder<> &B, llvm::Value *V, bool byRef,
+                       bool cublas, llvm::IntegerType *julia_decl,
                        llvm::IRBuilder<> &entryBuilder,
                        const llvm::Twine &name) {
 
@@ -4214,7 +4232,7 @@ llvm::Value *transpose(std::string floatType, llvm::IRBuilder<> &B,
     V = B.CreateLoad(charType, V, "ld." + name);
   }
 
-  V = transpose(floatType, B, V, cublas);
+  V = transpose(ExternalContext, floatType, B, V, cublas);
 
   return to_blas_callconv(B, V, byRef, cublas, julia_decl, entryBuilder,
                           "transpose." + name);
@@ -4449,9 +4467,9 @@ llvm::Value *EmitNoDerivativeError(const std::string &message,
                                    llvm::IRBuilder<> &Builder2,
                                    llvm::Value *condition) {
   if (CustomErrorHandler) {
-    return unwrap(CustomErrorHandler(message.c_str(), wrap(&inst),
-                                     ErrorType::NoDerivative, gutils,
-                                     wrap(condition), wrap(&Builder2)));
+    return unwrap(CustomErrorHandler(gutils->externalContext(), message.c_str(),
+                                     wrap(&inst), ErrorType::NoDerivative,
+                                     gutils, wrap(condition), wrap(&Builder2)));
   } else if (EnzymeRuntimeError) {
     auto &M = *inst.getParent()->getParent()->getParent();
     FunctionType *FT = FunctionType::get(Type::getInt32Ty(M.getContext()),
@@ -4482,15 +4500,17 @@ llvm::Value *EmitNoDerivativeError(const std::string &message,
   }
 }
 
-bool EmitNoDerivativeError(const std::string &message, Value *todiff,
+bool EmitNoDerivativeError(EnzymeContextRef ExternalContext,
+                           const std::string &message, Value *todiff,
                            RequestContext &context) {
   Value *toshow = todiff;
   if (context.req) {
     toshow = context.req;
   }
   if (CustomErrorHandler) {
-    CustomErrorHandler(message.c_str(), wrap(toshow), ErrorType::NoDerivative,
-                       nullptr, wrap(todiff), wrap(context.ip));
+    CustomErrorHandler(ExternalContext, message.c_str(), wrap(toshow),
+                       ErrorType::NoDerivative, nullptr, wrap(todiff),
+                       wrap(context.ip));
     return true;
   } else if (context.ip && EnzymeRuntimeError) {
     auto &M = *context.ip->GetInsertBlock()->getParent()->getParent();
@@ -4528,8 +4548,9 @@ bool EmitNoDerivativeError(const std::string &message, Value *todiff,
 void EmitNoTypeError(const std::string &message, llvm::Instruction &inst,
                      GradientUtils *gutils, llvm::IRBuilder<> &Builder2) {
   if (CustomErrorHandler) {
-    CustomErrorHandler(message.c_str(), wrap(&inst), ErrorType::NoType,
-                       gutils->TR.analyzer, nullptr, wrap(&Builder2));
+    CustomErrorHandler(gutils->externalContext(), message.c_str(), wrap(&inst),
+                       ErrorType::NoType, gutils->TR.analyzer, nullptr,
+                       wrap(&Builder2));
   } else if (EnzymeRuntimeError) {
     auto &M = *inst.getParent()->getParent()->getParent();
     FunctionType *FT = FunctionType::get(Type::getInt32Ty(M.getContext()),
@@ -4950,7 +4971,8 @@ static Value *constantInBoundsGEPHelper(llvm::IRBuilder<> &B, llvm::Type *type,
   return B.CreateInBoundsGEP(type, value, vals);
 }
 
-llvm::Value *moveSRetToFromRoots(llvm::IRBuilder<> &B, llvm::Type *jltype,
+llvm::Value *moveSRetToFromRoots(EnzymeContextRef ExternalContext,
+                                 llvm::IRBuilder<> &B, llvm::Type *jltype,
                                  llvm::Value *sret, llvm::Type *root_ty,
                                  llvm::Value *rootRet, size_t rootOffset,
                                  SRetRootMovement direction) {
@@ -5002,7 +5024,8 @@ llvm::Value *moveSRetToFromRoots(llvm::IRBuilder<> &B, llvm::Type *jltype,
       }
       case SRetRootMovement::NullifySRetValue: {
         loc = getUndefinedValueForType(
-            *B.GetInsertBlock()->getParent()->getParent(), ty, false);
+            ExternalContext, *B.GetInsertBlock()->getParent()->getParent(), ty,
+            false);
         val = B.CreateInsertValue(val, loc, path);
         break;
       }
@@ -5073,9 +5096,9 @@ llvm::Value *moveSRetToFromRoots(llvm::IRBuilder<> &B, llvm::Type *jltype,
   return val;
 }
 
-void copyNonJLValueInto(llvm::IRBuilder<> &B, llvm::Type *curType,
-                        llvm::Type *dstType, llvm::Value *dst,
-                        llvm::ArrayRef<unsigned> dstPrefix0,
+void copyNonJLValueInto(EnzymeContextRef ExternalContext, llvm::IRBuilder<> &B,
+                        llvm::Type *curType, llvm::Type *dstType,
+                        llvm::Value *dst, llvm::ArrayRef<unsigned> dstPrefix0,
                         llvm::Type *srcType, llvm::Value *src,
                         llvm::ArrayRef<unsigned> srcPrefix0, bool shouldZero) {
   std::deque<
@@ -5100,7 +5123,7 @@ void copyNonJLValueInto(llvm::IRBuilder<> &B, llvm::Type *curType,
           Value *out = dst;
           if (dstPrefix.size() > 0)
             out = constantInBoundsGEPHelper(B, dstType, out, dstPrefix);
-          B.CreateStore(getUndefinedValueForType(M, ty), out);
+          B.CreateStore(getUndefinedValueForType(ExternalContext, M, ty), out);
         }
       }
       // We don't actually need pointers either here

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -944,10 +944,10 @@ void emit_backtrace(llvm::Instruction *inst, llvm::raw_ostream &ss) {
   }
 }
 
-void ErrorIfRuntimeInactive(EnzymeContextRef ExternalContext,
-                            llvm::IRBuilder<> &B, llvm::Value *primal,
-                            llvm::Value *shadow, const char *Message,
-                            llvm::DebugLoc &&loc, llvm::Instruction *orig) {
+void ErrorIfRuntimeInactive(GradientUtils *gutils, llvm::IRBuilder<> &B,
+                            llvm::Value *primal, llvm::Value *shadow,
+                            const char *Message, llvm::DebugLoc &&loc,
+                            llvm::Instruction *orig) {
   Module &M = *B.GetInsertBlock()->getParent()->getParent();
   std::string name = "__enzyme_runtimeinactiveerr";
   if (CustomRuntimeInactiveError) {
@@ -986,8 +986,8 @@ void ErrorIfRuntimeInactive(EnzymeContextRef ExternalContext,
     EB.SetInsertPoint(error);
 
     if (CustomRuntimeInactiveError) {
-      CustomRuntimeInactiveError(ExternalContext, wrap(&EB), wrap(msg),
-                                 wrap(orig));
+      CustomRuntimeInactiveError(gutils->externalContext(), wrap(&EB),
+                                 wrap(msg), wrap(orig));
     } else {
       FunctionType *FT =
           FunctionType::get(Type::getInt32Ty(M.getContext()),
@@ -2341,10 +2341,10 @@ llvm::Value *nextPowerOfTwo(llvm::IRBuilder<> &B, llvm::Value *V) {
   return V;
 }
 
-llvm::Function *
-getOrInsertDifferentialWaitallSave(EnzymeContextRef ExternalContext,
-                                   llvm::Module &M, ArrayRef<llvm::Type *> T,
-                                   PointerType *reqType) {
+llvm::Function *getOrInsertDifferentialWaitallSave(GradientUtils *gutils,
+                                                   llvm::Module &M,
+                                                   ArrayRef<llvm::Type *> T,
+                                                   PointerType *reqType) {
   std::string name = "__enzyme_differential_waitall_save";
   FunctionType *FT = FunctionType::get(getUnqual(reqType), T, false);
   Function *F = cast<Function>(M.getOrInsertFunction(name, FT).getCallee());
@@ -2369,7 +2369,7 @@ getOrInsertDifferentialWaitallSave(EnzymeContextRef ExternalContext,
   IRBuilder<> B(entry);
   count = B.CreateZExtOrTrunc(count, Type::getInt64Ty(entry->getContext()));
 
-  auto ret = CreateAllocation(ExternalContext, B, reqType, count);
+  auto ret = CreateAllocation(gutils->externalContext(), B, reqType, count);
 
   BasicBlock *loopBlock = BasicBlock::Create(M.getContext(), "loop", F);
   BasicBlock *endBlock = BasicBlock::Create(M.getContext(), "end", F);
@@ -3795,8 +3795,8 @@ llvm::Constant *getUndefinedValueForType(EnzymeContextRef ExternalContext,
     return UndefValue::get(T);
 }
 
-llvm::Value *SanitizeDerivatives(EnzymeContextRef ExternalContext,
-                                 llvm::Value *val, llvm::Value *toset,
+llvm::Value *SanitizeDerivatives(GradientUtils *gutils, llvm::Value *val,
+                                 llvm::Value *toset,
                                  llvm::IRBuilder<> &BuilderM,
                                  llvm::Value *mask) {
   if (EnzymeCheckDerivativeNaN && toset->getType()->isFPOrFPVectorTy()) {
@@ -3851,7 +3851,7 @@ llvm::Value *SanitizeDerivatives(EnzymeContextRef ExternalContext,
 
       B.SetInsertPoint(bad);
       if (CustomErrorHandler) {
-        CustomErrorHandler(ExternalContext, "NaN Error", wrap(inp),
+        CustomErrorHandler(gutils->externalContext(), "NaN Error", wrap(inp),
                            ErrorType::NaNError, nullptr, wrap(msg_ptr),
                            wrap(&B));
       } else {
@@ -3889,8 +3889,9 @@ llvm::Value *SanitizeDerivatives(EnzymeContextRef ExternalContext,
   }
 
   if (EnzymeSanitizeDerivatives)
-    return unwrap(EnzymeSanitizeDerivatives(
-        ExternalContext, wrap(val), wrap(toset), wrap(&BuilderM), wrap(mask)));
+    return unwrap(EnzymeSanitizeDerivatives(gutils->externalContext(),
+                                            wrap(val), wrap(toset),
+                                            wrap(&BuilderM), wrap(mask)));
   return toset;
 }
 
@@ -4110,7 +4111,7 @@ llvm::Value *is_left(IRBuilder<> &B, llvm::Value *side, bool byRef,
 // However, if we ask openBlas c ABI,
 // it is one of the following 32 bit integers values:
 // enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113};
-llvm::Value *transpose(EnzymeContextRef ExternalContext, std::string floatType,
+llvm::Value *transpose(GradientUtils *gutils, std::string floatType,
                        IRBuilder<> &B, llvm::Value *V, bool cublas) {
   llvm::Type *T = V->getType();
   if (cublas) {
@@ -4165,7 +4166,7 @@ llvm::Value *transpose(EnzymeContextRef ExternalContext, std::string floatType,
     llvm::raw_string_ostream ss(s);
     ss << "cannot handle unknown trans blas value\n" << V;
     if (CustomErrorHandler) {
-      CustomErrorHandler(ExternalContext, ss.str().c_str(), nullptr,
+      CustomErrorHandler(gutils->externalContext(), ss.str().c_str(), nullptr,
                          ErrorType::NoDerivative, nullptr, nullptr, nullptr);
     } else {
       EmitFailure("unknown trans blas value", B.getCurrentDebugLocation(),
@@ -4197,7 +4198,7 @@ llvm::Value *get_cached_mat_width(llvm::IRBuilder<> &B,
   return width;
 }
 
-llvm::Value *transpose(EnzymeContextRef ExternalContext, std::string floatType,
+llvm::Value *transpose(GradientUtils *gutils, std::string floatType,
                        llvm::IRBuilder<> &B, llvm::Value *V, bool byRef,
                        bool cublas, llvm::IntegerType *julia_decl,
                        llvm::IRBuilder<> &entryBuilder,
@@ -4232,7 +4233,7 @@ llvm::Value *transpose(EnzymeContextRef ExternalContext, std::string floatType,
     V = B.CreateLoad(charType, V, "ld." + name);
   }
 
-  V = transpose(ExternalContext, floatType, B, V, cublas);
+  V = transpose(gutils, floatType, B, V, cublas);
 
   return to_blas_callconv(B, V, byRef, cublas, julia_decl, entryBuilder,
                           "transpose." + name);

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -191,11 +191,12 @@ enum class ErrorType {
 /// An opaque handle on the frontend state that the differentiation request
 /// currently being served belongs to. Enzyme never inspects it: the frontend
 /// installs it on its EnzymeLogic with EnzymeLogicSetExternalContext, and
-/// Enzyme hands it back unchanged to every frontend callback it invokes. A
-/// callback can therefore recover the state of the request that reached it
-/// (for Enzyme.jl: the Julia world age the code is being compiled in, and the
-/// method instances of the functions in it) instead of consulting global or
-/// thread-local state. It is fixed for the lifetime of an EnzymeLogic.
+/// Enzyme hands it back unchanged to the frontend callbacks that need it (the
+/// error handler, the allocator, the return fixup and the derivative
+/// sanitizer). A callback can therefore recover the state of the request that
+/// reached it (for Enzyme.jl: the Julia world age the code is being compiled
+/// in) instead of consulting global or thread-local state. It is null when
+/// Enzyme has no way to reach a logic from the call site.
 typedef void *EnzymeContextRef;
 
 extern "C" {
@@ -210,9 +211,8 @@ extern LLVMValueRef (*CustomErrorHandler)(EnzymeContextRef, const char *,
                                           LLVMValueRef, LLVMBuilderRef);
 }
 
-llvm::SmallVector<llvm::Instruction *, 2>
-PostCacheStore(EnzymeContextRef ExternalContext, llvm::StoreInst *SI,
-               llvm::IRBuilder<> &B);
+llvm::SmallVector<llvm::Instruction *, 2> PostCacheStore(llvm::StoreInst *SI,
+                                                         llvm::IRBuilder<> &B);
 
 llvm::Value *CreateAllocation(EnzymeContextRef ExternalContext,
                               llvm::IRBuilder<> &B, llvm::Type *T,
@@ -220,10 +220,9 @@ llvm::Value *CreateAllocation(EnzymeContextRef ExternalContext,
                               llvm::CallInst **caller = nullptr,
                               llvm::Instruction **ZeroMem = nullptr,
                               bool isDefault = false);
-llvm::CallInst *CreateDealloc(EnzymeContextRef ExternalContext,
-                              llvm::IRBuilder<> &B, llvm::Value *ToFree);
-void ZeroMemory(EnzymeContextRef ExternalContext, llvm::IRBuilder<> &Builder,
-                llvm::Type *T, llvm::Value *obj, bool isTape);
+llvm::CallInst *CreateDealloc(llvm::IRBuilder<> &B, llvm::Value *ToFree);
+void ZeroMemory(llvm::IRBuilder<> &Builder, llvm::Type *T, llvm::Value *obj,
+                bool isTape);
 
 llvm::Value *
 CreateReAllocation(EnzymeContextRef ExternalContext, llvm::IRBuilder<> &B,
@@ -231,8 +230,7 @@ CreateReAllocation(EnzymeContextRef ExternalContext, llvm::IRBuilder<> &B,
                    llvm::Value *InnerCount, const llvm::Twine &Name = "",
                    llvm::CallInst **caller = nullptr, bool ZeroMem = false);
 
-llvm::PointerType *getDefaultAnonymousTapeType(EnzymeContextRef ExternalContext,
-                                               llvm::LLVMContext &C);
+llvm::PointerType *getDefaultAnonymousTapeType(llvm::LLVMContext &C);
 
 class GradientUtils;
 extern llvm::StringMap<std::function<llvm::Value *(
@@ -1597,10 +1595,9 @@ getOrInsertDifferentialWaitallSave(GradientUtils *gutils, llvm::Module &M,
                                    llvm::ArrayRef<llvm::Type *> T,
                                    llvm::PointerType *reqType);
 
-void ErrorIfRuntimeInactive(GradientUtils *gutils, llvm::IRBuilder<> &B,
-                            llvm::Value *primal, llvm::Value *shadow,
-                            const char *Message, llvm::DebugLoc &&loc,
-                            llvm::Instruction *orig);
+void ErrorIfRuntimeInactive(llvm::IRBuilder<> &B, llvm::Value *primal,
+                            llvm::Value *shadow, const char *Message,
+                            llvm::DebugLoc &&loc, llvm::Instruction *orig);
 
 llvm::Function *GetFunctionFromValue(llvm::Value *fn);
 
@@ -2239,8 +2236,7 @@ static inline bool isNoEscapingAllocation(const llvm::CallBase *call) {
 
 bool attributeKnownFunctions(llvm::Function &F);
 
-llvm::Constant *getUndefinedValueForType(EnzymeContextRef ExternalContext,
-                                         llvm::Module &M, llvm::Type *T,
+llvm::Constant *getUndefinedValueForType(llvm::Module &M, llvm::Type *T,
                                          bool forceZero = false);
 
 llvm::Value *SanitizeDerivatives(GradientUtils *gutils, llvm::Value *val,
@@ -2779,17 +2775,16 @@ enum class SRetRootMovement {
   NullifySRetValue = 4,
 };
 
-llvm::Value *moveSRetToFromRoots(EnzymeContextRef ExternalContext,
-                                 llvm::IRBuilder<> &B, llvm::Type *jltype,
+llvm::Value *moveSRetToFromRoots(llvm::IRBuilder<> &B, llvm::Type *jltype,
                                  llvm::Value *sret, llvm::Type *root_ty,
                                  llvm::Value *rootRet, size_t rootOffset,
                                  SRetRootMovement direction);
 
-void copyNonJLValueInto(EnzymeContextRef ExternalContext, llvm::IRBuilder<> &B,
-                        llvm::Type *curType, llvm::Type *dstType,
-                        llvm::Value *dst, llvm::ArrayRef<unsigned> dstPrefix,
-                        llvm::Type *srcType, llvm::Value *src,
-                        llvm::ArrayRef<unsigned> srcPrefix, bool shouldZero);
+void copyNonJLValueInto(llvm::IRBuilder<> &B, llvm::Type *curType,
+                        llvm::Type *dstType, llvm::Value *dst,
+                        llvm::ArrayRef<unsigned> dstPrefix, llvm::Type *srcType,
+                        llvm::Value *src, llvm::ArrayRef<unsigned> srcPrefix,
+                        bool shouldZero);
 
 static bool anyJuliaObjects(llvm::Type *T) {
   if (isSpecialPtr(T))

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -1592,14 +1592,15 @@ static inline std::vector<ssize_t> getDeallocationIndicesFromCall(T *op) {
   return vinds;
 }
 
-llvm::Function *getOrInsertDifferentialWaitallSave(
-    EnzymeContextRef ExternalContext, llvm::Module &M,
-    llvm::ArrayRef<llvm::Type *> T, llvm::PointerType *reqType);
+llvm::Function *
+getOrInsertDifferentialWaitallSave(GradientUtils *gutils, llvm::Module &M,
+                                   llvm::ArrayRef<llvm::Type *> T,
+                                   llvm::PointerType *reqType);
 
-void ErrorIfRuntimeInactive(EnzymeContextRef ExternalContext,
-                            llvm::IRBuilder<> &B, llvm::Value *primal,
-                            llvm::Value *shadow, const char *Message,
-                            llvm::DebugLoc &&loc, llvm::Instruction *orig);
+void ErrorIfRuntimeInactive(GradientUtils *gutils, llvm::IRBuilder<> &B,
+                            llvm::Value *primal, llvm::Value *shadow,
+                            const char *Message, llvm::DebugLoc &&loc,
+                            llvm::Instruction *orig);
 
 llvm::Function *GetFunctionFromValue(llvm::Value *fn);
 
@@ -2242,8 +2243,8 @@ llvm::Constant *getUndefinedValueForType(EnzymeContextRef ExternalContext,
                                          llvm::Module &M, llvm::Type *T,
                                          bool forceZero = false);
 
-llvm::Value *SanitizeDerivatives(EnzymeContextRef ExternalContext,
-                                 llvm::Value *val, llvm::Value *toset,
+llvm::Value *SanitizeDerivatives(GradientUtils *gutils, llvm::Value *val,
+                                 llvm::Value *toset,
                                  llvm::IRBuilder<> &BuilderM,
                                  llvm::Value *mask = nullptr);
 
@@ -2424,10 +2425,10 @@ llvm::Value *lookup_with_layout(llvm::IRBuilder<> &B, llvm::Type *fpType,
                                 llvm::Value *col);
 
 // first one assume V is an Integer
-llvm::Value *transpose(EnzymeContextRef ExternalContext, std::string floatType,
+llvm::Value *transpose(GradientUtils *gutils, std::string floatType,
                        llvm::IRBuilder<> &B, llvm::Value *V, bool cublas);
 // secon one assume V is an Integer or a ptr to an int (depends on byRef)
-llvm::Value *transpose(EnzymeContextRef ExternalContext, std::string floatType,
+llvm::Value *transpose(GradientUtils *gutils, std::string floatType,
                        llvm::IRBuilder<> &B, llvm::Value *V, bool byRef,
                        bool cublas, llvm::IntegerType *IT,
                        llvm::IRBuilder<> &entryBuilder,

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -188,6 +188,16 @@ enum class ErrorType {
   NoAccumulate = 13,
 };
 
+/// An opaque handle on the frontend state that the differentiation request
+/// currently being served belongs to. Enzyme never inspects it: the frontend
+/// installs it on its EnzymeLogic with EnzymeLogicSetExternalContext, and
+/// Enzyme hands it back unchanged to every frontend callback it invokes. A
+/// callback can therefore recover the state of the request that reached it
+/// (for Enzyme.jl: the Julia world age the code is being compiled in, and the
+/// method instances of the functions in it) instead of consulting global or
+/// thread-local state. It is fixed for the lifetime of an EnzymeLogic.
+typedef void *EnzymeContextRef;
+
 extern "C" {
 /// Print additional debug info relevant to performance
 extern llvm::cl::opt<bool> EnzymePrintPerf;
@@ -195,31 +205,34 @@ extern llvm::cl::opt<bool> EnzymeNonPower2Cache;
 extern llvm::cl::opt<bool> EnzymeBlasCopy;
 extern llvm::cl::opt<bool> EnzymeLapackCopy;
 extern llvm::cl::opt<bool> EnzymeJuliaAddrLoad;
-extern LLVMValueRef (*CustomErrorHandler)(const char *, LLVMValueRef, ErrorType,
-                                          const void *, LLVMValueRef,
-                                          LLVMBuilderRef);
+extern LLVMValueRef (*CustomErrorHandler)(EnzymeContextRef, const char *,
+                                          LLVMValueRef, ErrorType, const void *,
+                                          LLVMValueRef, LLVMBuilderRef);
 }
 
-llvm::SmallVector<llvm::Instruction *, 2> PostCacheStore(llvm::StoreInst *SI,
-                                                         llvm::IRBuilder<> &B);
+llvm::SmallVector<llvm::Instruction *, 2>
+PostCacheStore(EnzymeContextRef ExternalContext, llvm::StoreInst *SI,
+               llvm::IRBuilder<> &B);
 
-llvm::Value *CreateAllocation(llvm::IRBuilder<> &B, llvm::Type *T,
+llvm::Value *CreateAllocation(EnzymeContextRef ExternalContext,
+                              llvm::IRBuilder<> &B, llvm::Type *T,
                               llvm::Value *Count, const llvm::Twine &Name = "",
                               llvm::CallInst **caller = nullptr,
                               llvm::Instruction **ZeroMem = nullptr,
                               bool isDefault = false);
-llvm::CallInst *CreateDealloc(llvm::IRBuilder<> &B, llvm::Value *ToFree);
-void ZeroMemory(llvm::IRBuilder<> &Builder, llvm::Type *T, llvm::Value *obj,
-                bool isTape);
+llvm::CallInst *CreateDealloc(EnzymeContextRef ExternalContext,
+                              llvm::IRBuilder<> &B, llvm::Value *ToFree);
+void ZeroMemory(EnzymeContextRef ExternalContext, llvm::IRBuilder<> &Builder,
+                llvm::Type *T, llvm::Value *obj, bool isTape);
 
-llvm::Value *CreateReAllocation(llvm::IRBuilder<> &B, llvm::Value *prev,
-                                llvm::Type *T, llvm::Value *OuterCount,
-                                llvm::Value *InnerCount,
-                                const llvm::Twine &Name = "",
-                                llvm::CallInst **caller = nullptr,
-                                bool ZeroMem = false);
+llvm::Value *
+CreateReAllocation(EnzymeContextRef ExternalContext, llvm::IRBuilder<> &B,
+                   llvm::Value *prev, llvm::Type *T, llvm::Value *OuterCount,
+                   llvm::Value *InnerCount, const llvm::Twine &Name = "",
+                   llvm::CallInst **caller = nullptr, bool ZeroMem = false);
 
-llvm::PointerType *getDefaultAnonymousTapeType(llvm::LLVMContext &C);
+llvm::PointerType *getDefaultAnonymousTapeType(EnzymeContextRef ExternalContext,
+                                               llvm::LLVMContext &C);
 
 class GradientUtils;
 extern llvm::StringMap<std::function<llvm::Value *(
@@ -372,7 +385,8 @@ llvm::Value *EmitNoDerivativeError(const std::string &message,
                                    llvm::Instruction &inst,
                                    GradientUtils *gutils, llvm::IRBuilder<> &B,
                                    llvm::Value *condition = nullptr);
-bool EmitNoDerivativeError(const std::string &message, llvm::Value *todiff,
+bool EmitNoDerivativeError(EnzymeContextRef ExternalContext,
+                           const std::string &message, llvm::Value *todiff,
                            RequestContext &ctx);
 
 void EmitNoTypeError(const std::string &, llvm::Instruction &inst,
@@ -1578,12 +1592,12 @@ static inline std::vector<ssize_t> getDeallocationIndicesFromCall(T *op) {
   return vinds;
 }
 
-llvm::Function *
-getOrInsertDifferentialWaitallSave(llvm::Module &M,
-                                   llvm::ArrayRef<llvm::Type *> T,
-                                   llvm::PointerType *reqType);
+llvm::Function *getOrInsertDifferentialWaitallSave(
+    EnzymeContextRef ExternalContext, llvm::Module &M,
+    llvm::ArrayRef<llvm::Type *> T, llvm::PointerType *reqType);
 
-void ErrorIfRuntimeInactive(llvm::IRBuilder<> &B, llvm::Value *primal,
+void ErrorIfRuntimeInactive(EnzymeContextRef ExternalContext,
+                            llvm::IRBuilder<> &B, llvm::Value *primal,
                             llvm::Value *shadow, const char *Message,
                             llvm::DebugLoc &&loc, llvm::Instruction *orig);
 
@@ -2224,10 +2238,12 @@ static inline bool isNoEscapingAllocation(const llvm::CallBase *call) {
 
 bool attributeKnownFunctions(llvm::Function &F);
 
-llvm::Constant *getUndefinedValueForType(llvm::Module &M, llvm::Type *T,
+llvm::Constant *getUndefinedValueForType(EnzymeContextRef ExternalContext,
+                                         llvm::Module &M, llvm::Type *T,
                                          bool forceZero = false);
 
-llvm::Value *SanitizeDerivatives(llvm::Value *val, llvm::Value *toset,
+llvm::Value *SanitizeDerivatives(EnzymeContextRef ExternalContext,
+                                 llvm::Value *val, llvm::Value *toset,
                                  llvm::IRBuilder<> &BuilderM,
                                  llvm::Value *mask = nullptr);
 
@@ -2408,12 +2424,13 @@ llvm::Value *lookup_with_layout(llvm::IRBuilder<> &B, llvm::Type *fpType,
                                 llvm::Value *col);
 
 // first one assume V is an Integer
-llvm::Value *transpose(std::string floatType, llvm::IRBuilder<> &B,
-                       llvm::Value *V, bool cublas);
+llvm::Value *transpose(EnzymeContextRef ExternalContext, std::string floatType,
+                       llvm::IRBuilder<> &B, llvm::Value *V, bool cublas);
 // secon one assume V is an Integer or a ptr to an int (depends on byRef)
-llvm::Value *transpose(std::string floatType, llvm::IRBuilder<> &B,
-                       llvm::Value *V, bool byRef, bool cublas,
-                       llvm::IntegerType *IT, llvm::IRBuilder<> &entryBuilder,
+llvm::Value *transpose(EnzymeContextRef ExternalContext, std::string floatType,
+                       llvm::IRBuilder<> &B, llvm::Value *V, bool byRef,
+                       bool cublas, llvm::IntegerType *IT,
+                       llvm::IRBuilder<> &entryBuilder,
                        const llvm::Twine &name);
 llvm::SmallVector<llvm::Value *, 1>
 get_blas_row(llvm::IRBuilder<> &B, llvm::ArrayRef<llvm::Value *> trans,
@@ -2761,16 +2778,17 @@ enum class SRetRootMovement {
   NullifySRetValue = 4,
 };
 
-llvm::Value *moveSRetToFromRoots(llvm::IRBuilder<> &B, llvm::Type *jltype,
+llvm::Value *moveSRetToFromRoots(EnzymeContextRef ExternalContext,
+                                 llvm::IRBuilder<> &B, llvm::Type *jltype,
                                  llvm::Value *sret, llvm::Type *root_ty,
                                  llvm::Value *rootRet, size_t rootOffset,
                                  SRetRootMovement direction);
 
-void copyNonJLValueInto(llvm::IRBuilder<> &B, llvm::Type *curType,
-                        llvm::Type *dstType, llvm::Value *dst,
-                        llvm::ArrayRef<unsigned> dstPrefix, llvm::Type *srcType,
-                        llvm::Value *src, llvm::ArrayRef<unsigned> srcPrefix,
-                        bool shouldZero);
+void copyNonJLValueInto(EnzymeContextRef ExternalContext, llvm::IRBuilder<> &B,
+                        llvm::Type *curType, llvm::Type *dstType,
+                        llvm::Value *dst, llvm::ArrayRef<unsigned> dstPrefix,
+                        llvm::Type *srcType, llvm::Value *src,
+                        llvm::ArrayRef<unsigned> srcPrefix, bool shouldZero);
 
 static bool anyJuliaObjects(llvm::Type *T) {
   if (isSpecialPtr(T))

--- a/enzyme/tools/enzyme-tblgen/blas-tblgen.cpp
+++ b/enzyme/tools/enzyme-tblgen/blas-tblgen.cpp
@@ -211,7 +211,8 @@ void emit_free_and_ending(const TGPattern &pattern, raw_ostream &os) {
       auto name = nameVec[i];
       os << "      if (cache_" << name << ") {\n"
          << "        {\n"
-         << "          CallInst *freecall = CreateDealloc(Builder2, free_"
+         << "          CallInst *freecall = "
+            "CreateDealloc(gutils->externalContext(), Builder2, free_"
          << name << ");\n"
          << "          if (freecall) {\n"
          << "            auto ident = "
@@ -1401,8 +1402,9 @@ void rev_call_arg(bool forward, const DagInit *ruleDag,
       auto name = Def->getValueAsString("name");
       os << "{(arg_transposed_" << name << " = arg_transposed_" << name
          << " ? arg_transposed_" << name << " : "
-         << "transpose(blas.floatType, Builder2, arg_" << name
-         << ", byRef, cublas, charType, allocationBuilder, \"" << name
+         << "transpose(gutils->externalContext(), blas.floatType, Builder2, "
+            "arg_"
+         << name << ", byRef, cublas, charType, allocationBuilder, \"" << name
          << "\"))}";
     } else {
       errs() << Def->getName() << "\n";
@@ -1542,8 +1544,9 @@ void emit_tmp_free(const Record *Def, raw_ostream &os, StringRef builder) {
   const auto matName = args[0];
   const auto allocName = "mat_" + matName;
   os << "    {\n"
-     << "      CallInst *freecall = CreateDealloc(" << builder << ", true_"
-     << allocName << ");\n"
+     << "      CallInst *freecall = "
+        "CreateDealloc(gutils->externalContext(), "
+     << builder << ", true_" << allocName << ");\n"
      << "      if (freecall && ident_" << allocName << ") {\n"
      << "        freecall->setMetadata(\"enzyme_cache_free\", "
         "MDNode::get(freecall->getContext(), {ident_"
@@ -1621,7 +1624,8 @@ void emit_tmp_creation(const Record *Def, raw_ostream &os, StringRef builder) {
   const auto matName = args[0];
   const auto allocName = "mat_" + matName;
   os << "    CallInst * malloccall_" << allocName << " = nullptr;\n";
-  os << "    Value * true_" << allocName << " = CreateAllocation(" << builder
+  os << "    Value * true_" << allocName
+     << " = CreateAllocation(gutils->externalContext(), " << builder
      << ", fpType, size_" << matName << ", \"" << allocName
      << "\", &malloccall_" << allocName << ");\n";
   os << "    MDNode *ident_" << allocName << " = nullptr;\n"

--- a/enzyme/tools/enzyme-tblgen/blas-tblgen.cpp
+++ b/enzyme/tools/enzyme-tblgen/blas-tblgen.cpp
@@ -211,8 +211,7 @@ void emit_free_and_ending(const TGPattern &pattern, raw_ostream &os) {
       auto name = nameVec[i];
       os << "      if (cache_" << name << ") {\n"
          << "        {\n"
-         << "          CallInst *freecall = "
-            "CreateDealloc(gutils->externalContext(), Builder2, free_"
+         << "          CallInst *freecall = CreateDealloc(Builder2, free_"
          << name << ");\n"
          << "          if (freecall) {\n"
          << "            auto ident = "
@@ -1543,9 +1542,8 @@ void emit_tmp_free(const Record *Def, raw_ostream &os, StringRef builder) {
   const auto matName = args[0];
   const auto allocName = "mat_" + matName;
   os << "    {\n"
-     << "      CallInst *freecall = "
-        "CreateDealloc(gutils->externalContext(), "
-     << builder << ", true_" << allocName << ");\n"
+     << "      CallInst *freecall = CreateDealloc(" << builder << ", true_"
+     << allocName << ");\n"
      << "      if (freecall && ident_" << allocName << ") {\n"
      << "        freecall->setMetadata(\"enzyme_cache_free\", "
         "MDNode::get(freecall->getContext(), {ident_"

--- a/enzyme/tools/enzyme-tblgen/blas-tblgen.cpp
+++ b/enzyme/tools/enzyme-tblgen/blas-tblgen.cpp
@@ -1402,9 +1402,8 @@ void rev_call_arg(bool forward, const DagInit *ruleDag,
       auto name = Def->getValueAsString("name");
       os << "{(arg_transposed_" << name << " = arg_transposed_" << name
          << " ? arg_transposed_" << name << " : "
-         << "transpose(gutils->externalContext(), blas.floatType, Builder2, "
-            "arg_"
-         << name << ", byRef, cublas, charType, allocationBuilder, \"" << name
+         << "transpose(gutils, blas.floatType, Builder2, arg_" << name
+         << ", byRef, cublas, charType, allocationBuilder, \"" << name
          << "\"))}";
     } else {
       errs() << Def->getName() << "\n";

--- a/enzyme/tools/enzyme-tblgen/caching.cpp
+++ b/enzyme/tools/enzyme-tblgen/caching.cpp
@@ -171,7 +171,7 @@ void emit_vec_like_copy(const TGPattern &pattern, raw_ostream &os) {
 << "      arg_malloc_size = malloc_size;\n"
 << "      malloc_size = load_if_ref(BuilderZ, intType, malloc_size, byRef);\n"
 << "      CallInst *malloccall = nullptr;\n"
-<< "      auto malins = CreateAllocation(BuilderZ, fpType, malloc_size, \"cache." << name << "\", &malloccall);\n"
+<< "      auto malins = CreateAllocation(gutils->externalContext(), BuilderZ, fpType, malloc_size, \"cache." << name << "\", &malloccall);\n"
 << "      if (malloccall) {\n"
 << "        auto ident = MDNode::getDistinct(malloccall->getContext(), {ConstantAsMetadata::get(ConstantInt::getFalse(malloccall->getContext()))});\n"
 << "        malloccall->setMetadata(\"enzyme_cache_alloc\", MDNode::get(malloccall->getContext(), {ident}));\n"
@@ -212,7 +212,7 @@ os
 << "      malloc_size = load_if_ref(BuilderZ, intType, malloc_size, byRef);\n"
 << "      Instruction *SubZero = nullptr;\n"
 << "      CallInst *malloccall = nullptr;\n"
-<< "      auto malins = CreateAllocation(BuilderZ, fpType, malloc_size, \"cache." << vecName << "\", &malloccall";
+<< "      auto malins = CreateAllocation(gutils->externalContext(), BuilderZ, fpType, malloc_size, \"cache." << vecName << "\", &malloccall";
     if (pattern.getName() == "potrf") os << ", &SubZero";
     os << ");\n"
 << "      if (malloccall) {\n"
@@ -298,7 +298,7 @@ os
 << "      auto *matSize = BuilderZ.CreateMul(len1, len2);\n"
 << "      Instruction *SubZero = nullptr;\n"
 << "      CallInst *malloccall = nullptr;\n"
-<< "      auto malins = CreateAllocation(BuilderZ, fpType, matSize, \"cache." << matName << "\", &malloccall";
+<< "      auto malins = CreateAllocation(gutils->externalContext(), BuilderZ, fpType, matSize, \"cache." << matName << "\", &malloccall";
     if (pattern.getName() == "potrf") os << ", &SubZero";
     os << ");\n"
 << "      if (malloccall) {\n"

--- a/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
+++ b/enzyme/tools/enzyme-tblgen/enzyme-tblgen.cpp
@@ -2605,8 +2605,9 @@ static void emitDerivatives(const RecordKeeper &recordKeeper, raw_ostream &os,
       os << "            ss << \"orig: \" << " << origName << " << \"\\n\";\n";
       os << "            ss << \"found: \" << *found->second << \"\\n\";\n";
       os << "            if (CustomErrorHandler) {\n";
-      os << "              CustomErrorHandler(str.c_str(), wrap(&(" << origName
-         << ")), ErrorType::InternalError,\n";
+      os << "              CustomErrorHandler(gutils->externalContext(), "
+            "str.c_str(), wrap(&("
+         << origName << ")), ErrorType::InternalError,\n";
       os << "                                 nullptr, nullptr, nullptr);\n";
       os << "            } else {\n";
       os << "              EmitFailure(\"PHIError\", (" << origName
@@ -2636,8 +2637,9 @@ static void emitDerivatives(const RecordKeeper &recordKeeper, raw_ostream &os,
       os << "            ss << \"orig: \" << " << origName << " << \"\\n\";\n";
       os << "            ss << \"found: \" << *found->second << \"\\n\";\n";
       os << "            if (CustomErrorHandler) {\n";
-      os << "              CustomErrorHandler(str.c_str(), wrap(&(" << origName
-         << ")), ErrorType::InternalError,\n";
+      os << "              CustomErrorHandler(gutils->externalContext(), "
+            "str.c_str(), wrap(&("
+         << origName << ")), ErrorType::InternalError,\n";
       os << "                                 nullptr, nullptr, nullptr);\n";
       os << "            } else {\n";
       os << "              EmitFailure(\"PHIError\", (" << origName


### PR DESCRIPTION
Hands the frontend's per-request context to the four callbacks that need it, so Enzyme.jl can stop keeping that state on the side.

## The problem

Enzyme calls back into the frontend through global function pointers, and none of them is told which differentiation request it is serving. Enzyme.jl needs to know: turning an LLVM type back into a Julia one only has an answer in a world age. Its workarounds today are a task-local variable holding the world, published around every `EnzymeCreate*` call and read back inside the callbacks, and reporting "unknown world" from the error handler when it is invoked without a `GradientUtils`, which loses the source location in the resulting Julia exception. Task-local state is also wrong under a frontend that differentiates from several tasks against separate logics.

## The design

`EnzymeLogic` already carries an opaque `void *ExternalContext` for the frontend, installed with `EnzymeLogicSetExternalContext`. This PR gives it a name, `EnzymeContextRef`, and makes it the first parameter of the callbacks whose Enzyme.jl implementations consult the world (EnzymeAD/Enzyme.jl#2643):

| Callback | Why it needs the context |
| --- | --- |
| `CustomErrorHandler` | the paths that reach it with a null `data` (the `Create*` bodies, batching, truncation, tracing, the calling-convention fixup, internal errors) have nothing else to recover the world from |
| `CustomAllocator` | boxes the tape type |
| `EnzymeFixupReturn` | materializes `nothing` |
| `EnzymeSanitizeDerivatives` | raises a Julia error |

The other callbacks (zeroing, deallocation, runtime-inactive errors, cache stores, tape type, undefined values, shadow allocation rewriting) keep their signatures: their Enzyme.jl implementations never consult the world, and the last already receives the `GradientUtils`.

The work is in getting the context from the logic down to each call site, reaching it through the object that already owns it wherever one exists:

| Carrier | Reaches |
| --- | --- |
| `EnzymeLogic::externalContext()` | the `CreateAugmentedPrimal` / `CreatePrimalAndGradient` / `CreateForwardDiff` / `CreateBatch` / `CreateTruncateFunc` / `CreateTrace` bodies |
| `CacheUtility::externalContext()`, read from the `EnzymeLogic &Logic` it now holds (moved down from `GradientUtils`) | `GradientUtils`, `DiffeGradientUtils`, `AdjointGenerator`, the BLAS derivatives and the caching machinery |
| `PreProcessCache::Logic`, the owning logic taken by reference at construction | preprocessing, which runs before any `GradientUtils` exists and reaches the allocator and the error handler itself |
| `TypeAnalyzer::externalContext()`, through its `TypeAnalysis`'s logic | type analysis errors |
| a `GradientUtils *` first parameter | the free helpers only ever called with one in hand: `getOrInsertDifferentialWaitallSave`, `SanitizeDerivatives`, `transpose` |
| an explicit `EnzymeContextRef` first parameter | `CreateAllocation`, `CreateReAllocation`, `EmitNoDerivativeError(RequestContext)`, `RecursivelyReplaceAddressSpace`, and the calling-convention fixup |

No copy of the context is stored anywhere below the logic: every carrier reads `EnzymeLogic::externalContext()` at the time of the call.

Two sites have no route to a logic and pass a null context: the type-depth warnings in `TypeTree`, which is a value type not owned by an analyzer. Their `data` is the tree, as before.

The Julia calling-convention fixup is a module pass, so it has nowhere to take a context from either. `EnzymeFixupJuliaCallingConventionModule` runs it over a module with one supplied, calling the per-function fixup directly; the named passes (`enzyme-fixup-julia`, `enzyme-fixup-julia-sret`) keep working and pass null. The batched fixup reaches no callback and is untouched.

## Breaking change

The ABI of the four callbacks above changes: a frontend must add the leading context parameter to each of them. Nothing else about the callbacks changes, and the existing `data` argument of the error handler (the `GradientUtils` or `TypeAnalyzer`, where there is one) is untouched.

The Julia CI job here builds Enzyme.jl main against this branch, so it will fail until the companion Enzyme.jl PR lands. That companion PR adds the parameter to the four `@cfunction` signatures, deletes the task-local world and its accessor, and switches the calling-convention fixup from the named pass to the new entry point.

## Test

Built against LLVM 20. `lit` over `enzyme/test/Enzyme`: 346 passed, 703 failed, 10 expectedly failed, an identical set of failures to `origin/main` built and run the same way (they are opaque-pointer expectation mismatches in this local configuration, not regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZ9ygd17aLfCESakQx36ot
