### PR TITLE
Mark inactive Fortran calls

### DIFF
--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -227,8 +227,7 @@ bool isInactiveCall(CallBase &CI) {
   // clang-format off
 const char *KnownInactiveFunctionsStartingWith[] = {
     "f90io",
-    // LLVM flang's I/O runtime, the modern equivalent of f90io above.
-    "_FortranAio",
+    "_FortranAio", // LLVM flang's I/O runtime (modern equivalent of f90io)
     "$ss5print",
     "strcpy",
     "_ZTv0_n24_NSoD", //"1Ev, 0Ev
@@ -242,12 +241,8 @@ const char *KnownInactiveFunctionsContains[] = {
     "__enzyme_pointer", "__enzyme_ignore_derivatives"};
 
 const StringSet<> KnownInactiveFunctions = {
-    // Fortran runtime queries and character handling. Neither moves floating
-    // point data, so neither can carry a derivative. Note _FortranAAssign is
-    // deliberately absent: it copies data which may include reals, so it needs
-    // a real rule rather than being declared inactive.
-    "_FortranAClassIs",
-    "_FortranATrim",
+    "_FortranAClassIs", // Fortran runtime queries
+    "_FortranATrim", // Fortran character handling
     "mpfr_greater_p",
     "__nv_isnand",
     "__nv_isnanf",

--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -227,6 +227,8 @@ bool isInactiveCall(CallBase &CI) {
   // clang-format off
 const char *KnownInactiveFunctionsStartingWith[] = {
     "f90io",
+    // LLVM flang's I/O runtime, the modern equivalent of f90io above.
+    "_FortranAio",
     "$ss5print",
     "strcpy",
     "_ZTv0_n24_NSoD", //"1Ev, 0Ev
@@ -240,6 +242,12 @@ const char *KnownInactiveFunctionsContains[] = {
     "__enzyme_pointer", "__enzyme_ignore_derivatives"};
 
 const StringSet<> KnownInactiveFunctions = {
+    // Fortran runtime queries and character handling. Neither moves floating
+    // point data, so neither can carry a derivative. Note _FortranAAssign is
+    // deliberately absent: it copies data which may include reals, so it needs
+    // a real rule rather than being declared inactive.
+    "_FortranAClassIs",
+    "_FortranATrim",
     "mpfr_greater_p",
     "__nv_isnand",
     "__nv_isnanf",

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -3628,9 +3628,15 @@ public:
                   minInt = pair.first[0];
                   mv = pair.second;
                 }
-                assert(mv != BaseType::Unknown);
-                vd.insert({0}, mv);
-                goto known;
+                // Note the comparison above is unsigned, so an entry at the
+                // any-offset index -1 is skipped and mv is left unknown. That
+                // is the common shape for a tree such as {[]:Pointer,
+                // [-1]:Anything}, so fall through to the diagnostics below
+                // rather than assuming a type was found.
+                if (mv != BaseType::Unknown) {
+                  vd.insert({0}, mv);
+                  goto known;
+                }
               }
             }
           }


### PR DESCRIPTION
Refinement of #3168

This PR marks a few Fortran-related things as inactive in the activity analysis.