### PR TITLE
TypeAnalysis: cache the Julia object shape of each type

### DIFF
--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -54,6 +54,7 @@
 #endif
 
 #include "llvm/Analysis/DependenceAnalysis.h"
+#include <chrono>
 #include <deque>
 
 #include "llvm/IR/BasicBlock.h"
@@ -105,6 +106,11 @@ llvm::cl::opt<bool>
     EnzymePrintUnnecessary("enzyme-print-unnecessary", cl::init(false),
                            cl::Hidden,
                            cl::desc("Print unnecessary values in function"));
+
+llvm::cl::opt<bool> EnzymePrintUnusedStats(
+    "enzyme-print-unused-stats", cl::init(false), cl::Hidden,
+    cl::desc("Print isNoNeed / differential-use cache statistics and timing "
+             "of calculateUnusedValuesInFunction"));
 
 cl::opt<bool> looseTypeAnalysis("enzyme-loose-types", cl::init(false),
                                 cl::Hidden,
@@ -756,8 +762,43 @@ void calculateUnusedValuesInFunction(
     }
   }
 
-  std::function<bool(const llvm::Value *)> isNoNeed = [&](const llvm::Value
-                                                              *v) {
+  // isNoNeed(v) walks every user of v's base object, and the callbacks below
+  // ask it once per (user, value) pair examined, so an allocation with U users
+  // costs O(U^2) per visit and is revisited every time one of its users is
+  // marked unnecessary: O(U^3), each step a differential-use query. Memoize it.
+  // The result depends only on unnecessaryValues / unnecessaryInstructions,
+  // which only grow, and every check against them can only turn a user from
+  // "blocking" into "benign": a `true` result is therefore final, and a `false`
+  // result stays valid until either set changes (the epoch below).
+  llvm::DenseMap<const llvm::Value *, std::pair<size_t, bool>> noNeedCache;
+  llvm::DenseMap<std::pair<const llvm::Value *, const llvm::Instruction *>,
+                 bool>
+      directUseCache;
+  size_t noNeedCalls = 0, noNeedHits = 0, directUseCalls = 0, directUseHits = 0;
+  auto noNeedEpoch = [&]() {
+    return unnecessaryValues.size() + unnecessaryInstructions.size();
+  };
+  // is_use_directly_needed_in_reverse depends on gutils, mode and
+  // oldUnreachable only, all fixed for this call, so its answer per (value,
+  // user) is constant.
+  auto cachedDirectUse = [&](const llvm::Value *cur,
+                             const llvm::Instruction *I) {
+    directUseCalls++;
+    auto key = std::make_pair(cur, I);
+    auto found = directUseCache.find(key);
+    if (found != directUseCache.end()) {
+      directUseHits++;
+      return found->second;
+    }
+    bool res = DifferentialUseAnalysis::is_use_directly_needed_in_reverse(
+        gutils, cur, mode, I, oldUnreachable, QueryType::Primal);
+    directUseCache[key] = res;
+    return res;
+  };
+  auto unusedStart = std::chrono::steady_clock::now();
+  std::function<bool(const llvm::Value *)> isNoNeed;
+  std::function<bool(const llvm::Value *)> isNoNeedImpl = [&](const llvm::Value
+                                                                  *v) {
     auto Obj = getBaseObject(v);
     if (Obj != v)
       return isNoNeed(Obj);
@@ -791,9 +832,7 @@ void calculateUnusedValuesInFunction(
             }
             if (auto I = dyn_cast<Instruction>(u)) {
               if (unnecessaryInstructions.count(I)) {
-                if (!DifferentialUseAnalysis::is_use_directly_needed_in_reverse(
-                        gutils, cur, mode, I, oldUnreachable,
-                        QueryType::Primal)) {
+                if (!cachedDirectUse(cur, I)) {
                   continue;
                 }
               }
@@ -854,6 +893,19 @@ void calculateUnusedValuesInFunction(
       return isNoNeed(II->getOperand(ptrArgIdx));
     }
     return false;
+  };
+  isNoNeed = [&](const llvm::Value *v) {
+    noNeedCalls++;
+    size_t epoch = noNeedEpoch();
+    auto found = noNeedCache.find(v);
+    if (found != noNeedCache.end() &&
+        (found->second.second || found->second.first == epoch)) {
+      noNeedHits++;
+      return found->second.second;
+    }
+    bool res = isNoNeedImpl(v);
+    noNeedCache[v] = std::make_pair(epoch, res);
+    return res;
   };
 
   calculateUnusedValues(
@@ -1130,6 +1182,20 @@ void calculateUnusedValuesInFunction(
         }
         return true;
       });
+  if (EnzymePrintUnusedStats) {
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                  std::chrono::steady_clock::now() - unusedStart)
+                  .count();
+    llvm::errs() << "calculateUnusedValuesInFunction " << func.getName()
+                 << " mode=" << to_string(mode)
+                 << " insts=" << func.getInstructionCount()
+                 << " unnecessaryValues=" << unnecessaryValues.size()
+                 << " unnecessaryInstructions="
+                 << unnecessaryInstructions.size()
+                 << " isNoNeed calls=" << noNeedCalls << " hits=" << noNeedHits
+                 << " directUse calls=" << directUseCalls
+                 << " hits=" << directUseHits << " time=" << ms << "ms\n";
+  }
   if (EnzymePrintUnnecessary) {
     llvm::errs() << " val use analysis of " << func.getName()
                  << ": mode=" << to_string(mode) << "\n";

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -937,98 +937,92 @@ void getConstantAnalysis(Constant *Val, TypeAnalyzer &TA,
   return;
 }
 
-static bool AllJuliaTypes(Type *T) {
+static bool isJuliaTrackedPointer(Type *T) {
   if (auto PT = dyn_cast<PointerType>(T)) {
     unsigned AS = PT->getPointerAddressSpace();
-    if (AS == 10 || AS == 11 || AS == 13) {
-      return true;
-    }
+    return AS == 10 || AS == 11 || AS == 13;
   }
-  if (auto AT = dyn_cast<ArrayType>(T)) {
-    return AllJuliaTypes(AT->getElementType());
-  }
-  if (auto ST = dyn_cast<StructType>(T)) {
-    auto len = ST->getNumElements();
-    if (len != 0) {
-      for (size_t i = 0; i < len; i++) {
-        if (!AllJuliaTypes(ST->getElementType(i)))
-          return false;
+  return false;
+}
+
+const TypeAnalysis::JuliaObjectShape &
+TypeAnalysis::getJuliaObjectShape(Type *T, const DataLayout &DL) {
+  auto found = JuliaObjectShapes.find(T);
+  if (found != JuliaObjectShapes.end())
+    return found->second;
+
+  // Build into a local: the recursive calls below may grow the map and
+  // invalidate any reference into it.
+  JuliaObjectShape Shape;
+  if (isJuliaTrackedPointer(T)) {
+    Shape.All = true;
+    Shape.Any = true;
+    Shape.PointerOffsets.push_back(0);
+  } else if (auto AT = dyn_cast<ArrayType>(T)) {
+    // Copy, since the recursive call may reallocate the map.
+    JuliaObjectShape Elem = getJuliaObjectShape(AT->getElementType(), DL);
+    Shape.All = Elem.All;
+    Shape.Any = Elem.Any;
+    // Record offsets even when All is set: an enclosing mixed aggregate needs
+    // them.
+    if (Shape.Any) {
+      // Array elements are laid out at successive multiples of the element's
+      // alloc size, which is what a gep [0, 1] into the array would compute.
+      // Walk from the last element down to match the worklist order the
+      // offsets were historically inserted in.
+      size_t stride = DL.getTypeAllocSize(AT->getElementType());
+      for (size_t i = AT->getNumElements(); i-- > 0;) {
+        for (int off : Elem.PointerOffsets)
+          Shape.PointerOffsets.push_back((int)(i * stride) + off);
       }
-      return true;
     }
-  }
-  return false;
-}
-
-static bool AnyJuliaTypes(Type *T) {
-  if (auto PT = dyn_cast<PointerType>(T)) {
-    unsigned AS = PT->getPointerAddressSpace();
-    if (AS == 10 || AS == 11 || AS == 13) {
-      return true;
-    }
-  }
-  if (auto AT = dyn_cast<ArrayType>(T)) {
-    return AnyJuliaTypes(AT->getElementType());
-  }
-  if (auto ST = dyn_cast<StructType>(T)) {
+  } else if (auto ST = dyn_cast<StructType>(T)) {
     auto len = ST->getNumElements();
+    // An empty struct holds no pointers, so it is neither All nor Any.
+    Shape.All = len != 0;
     for (size_t i = 0; i < len; i++) {
-      if (AnyJuliaTypes(ST->getElementType(i)))
-        return true;
+      // Copy, since the recursive call may reallocate the map.
+      JuliaObjectShape Elem = getJuliaObjectShape(ST->getElementType(i), DL);
+      Shape.All &= Elem.All;
+      Shape.Any |= Elem.Any;
+    }
+    if (Shape.Any) {
+      // The struct layout already records each field's offset, which is what a
+      // gep [0, i] into the struct would compute. Walk from the last field down
+      // to match the worklist order the offsets were historically inserted in.
+      auto SL = DL.getStructLayout(ST);
+      for (size_t i = len; i-- > 0;) {
+        // Every field was cached by the loop above, so this cannot grow the
+        // map.
+        const auto &Elem =
+            JuliaObjectShapes.find(ST->getElementType(i))->second;
+        int base = (int)SL->getElementOffset(i);
+        for (int off : Elem.PointerOffsets)
+          Shape.PointerOffsets.push_back(base + off);
+      }
     }
   }
-  return false;
+  return JuliaObjectShapes[T] = std::move(Shape);
 }
 
-static void AugmentWithJuliaObjectType(TypeTree &TT, Type *T,
+static void AugmentWithJuliaObjectType(TypeTree &TT, Type *T, TypeAnalysis &TA,
                                        const DataLayout &DL) {
-  if (AllJuliaTypes(T)) {
+  const auto &Shape = TA.getJuliaObjectShape(T, DL);
+  if (Shape.All) {
     TT.remove({-1});
     TT.remove({0});
     TT.insert({-1}, BaseType::Pointer);
     return;
   }
-  if (!AnyJuliaTypes(T))
+  if (!Shape.Any)
     return;
   auto outAll = TT[{-1}];
   if (outAll != BaseType::Unknown)
     return;
 
-  std::vector<std::pair<Type *, size_t>> todo;
-  todo.emplace_back(T, 0);
-  while (!todo.empty()) {
-    auto cur = todo.back();
-    todo.pop_back();
-    T = cur.first;
-    auto offset = cur.second;
-    if (!AnyJuliaTypes(T))
-      continue;
-    if (isa<PointerType>(T)) {
-      TT.remove(std::vector<int>{(int)offset});
-      TT.insert(std::vector<int>{(int)offset}, BaseType::Pointer);
-      continue;
-    }
-    if (auto AT = dyn_cast<ArrayType>(T)) {
-      // Array elements are laid out at successive multiples of the element's
-      // alloc size, which is what a gep [0, 1] into the array would compute.
-      size_t stride = DL.getTypeAllocSize(AT->getElementType());
-      for (size_t i = 0; i < AT->getNumElements(); i++) {
-        todo.emplace_back(AT->getElementType(), offset + i * stride);
-      }
-
-      continue;
-    }
-    if (auto ST = dyn_cast<StructType>(T)) {
-      // The struct layout already records each field's offset, which is what a
-      // gep [0, i] into the struct would compute.
-      auto SL = DL.getStructLayout(ST);
-      for (size_t i = 0; i < ST->getNumElements(); i++) {
-        todo.emplace_back(ST->getElementType(i),
-                          offset + (size_t)SL->getElementOffset(i));
-      }
-
-      continue;
-    }
+  for (int offset : Shape.PointerOffsets) {
+    TT.remove(std::vector<int>{offset});
+    TT.insert(std::vector<int>{offset}, BaseType::Pointer);
   }
 }
 
@@ -1045,7 +1039,7 @@ const TypeTree &TypeAnalyzer::getAnalysis(Value *Val) {
     getConstantAnalysis(C, *this, analysis);
     if (EnzymeJuliaAddrLoad)
       AugmentWithJuliaObjectType(
-          analysis[Val], Val->getType(),
+          analysis[Val], Val->getType(), interprocedural,
           fntypeinfo.Function->getParent()->getDataLayout());
     return analysis[Val];
   }
@@ -1070,7 +1064,7 @@ const TypeTree &TypeAnalyzer::getAnalysis(Value *Val) {
 
   if (EnzymeJuliaAddrLoad)
     AugmentWithJuliaObjectType(
-        analysis[Val], Val->getType(),
+        analysis[Val], Val->getType(), interprocedural,
         fntypeinfo.Function->getParent()->getDataLayout());
 
   // Return current results
@@ -6526,7 +6520,10 @@ std::set<int64_t> TypeAnalyzer::knownIntegralValues(Value *val) {
   return fntypeinfo.knownIntegralValues(val, DT, intseen, SE);
 }
 
-void TypeAnalysis::clear() { analyzedFunctions.clear(); }
+void TypeAnalysis::clear() {
+  analyzedFunctions.clear();
+  JuliaObjectShapes.clear();
+}
 
 FnTypeInfo preventTypeAnalysisLoops(const FnTypeInfo &oldTypeInfo_,
                                     llvm::Function *todiff) {

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.h
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.h
@@ -30,7 +30,9 @@
 
 #include <llvm/Config/llvm-config.h>
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 
 #include "llvm/Analysis/TargetLibraryInfo.h"
@@ -435,6 +437,29 @@ public:
   /// Map of possible query states to TypeAnalyzer intermediate results
   std::map<FnTypeInfo, std::shared_ptr<TypeAnalyzer>> analyzedFunctions;
 
+  /// Where a type holds Julia tracked pointers (address spaces 10, 11, 13).
+  struct JuliaObjectShape {
+    /// Every leaf of the type is a tracked pointer (and there is at least
+    /// one leaf), so the whole value is a pointer.
+    bool All = false;
+    /// Some leaf of the type is a tracked pointer.
+    bool Any = false;
+    /// Byte offsets of the tracked pointers, in the order the type walk
+    /// visits them. Populated whenever Any is set.
+    llvm::SmallVector<int, 4> PointerOffsets;
+  };
+
+  /// Cache of JuliaObjectShape per type. Types are uniqued per LLVMContext,
+  /// so a Type* is a stable key for the lifetime of the context, which
+  /// outlives this object. The returned reference is only valid until the
+  /// next call, since a later lookup may grow the map.
+  const JuliaObjectShape &getJuliaObjectShape(llvm::Type *T,
+                                              const llvm::DataLayout &DL);
+
+private:
+  llvm::DenseMap<llvm::Type *, JuliaObjectShape> JuliaObjectShapes;
+
+public:
   /// Analyze a particular function, returning the results
   TypeResults analyzeFunction(const FnTypeInfo &fn);
 

--- a/enzyme/test/TypeAnalysis/juliaobject.ll
+++ b/enzyme/test/TypeAnalysis/juliaobject.ll
@@ -1,0 +1,34 @@
+; RUN: %opt < %s %newLoadEnzyme -passes="print-type-analysis" -enzyme-julia-addr-load -type-analysis-func=caller -S -o /dev/null | FileCheck %s
+
+; With -enzyme-julia-addr-load, every value whose type contains Julia tracked
+; pointers (address spaces 10, 11, 13) is augmented: a type made only of tracked
+; pointers is a pointer everywhere, and a mixed aggregate gets a Pointer at each
+; tracked pointer's byte offset.
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128-ni:10:11:12:13"
+
+%all = type { ptr addrspace(10), [2 x ptr addrspace(10)] }
+%mixed = type { i64, ptr addrspace(10), { double, [2 x ptr addrspace(11)] }, ptr addrspace(13) }
+%none = type { i64, ptr, [2 x double] }
+
+define void @caller(%all %a, %mixed %m, %none %n, ptr addrspace(10) %p, [3 x ptr addrspace(13)] %arr, i64 %i) {
+entry:
+  %a1 = insertvalue %all %a, ptr addrspace(10) %p, 0
+  %m1 = insertvalue %mixed %m, i64 %i, 0
+  %n1 = insertvalue %none %n, i64 %i, 0
+  %e = extractvalue [3 x ptr addrspace(13)] %arr, 1
+  ret void
+}
+
+; CHECK: %all %a: {[-1]:Pointer}
+; CHECK-NEXT: %mixed %m: {[8]:Pointer, [24]:Pointer, [32]:Pointer, [40]:Pointer}
+; CHECK-NEXT: %none %n: {}
+; CHECK-NEXT: ptr addrspace(10) %p: {[-1]:Pointer}
+; CHECK-NEXT: [3 x ptr addrspace(13)] %arr: {[-1]:Pointer}
+; CHECK-NEXT: i64 %i: {[-1]:Integer}
+; CHECK-NEXT: entry
+; CHECK-NEXT:   %a1 = insertvalue %all %a, ptr addrspace(10) %p, 0: {[-1]:Pointer}
+; CHECK-NEXT:   %m1 = insertvalue %mixed %m, i64 %i, 0: {[0]:Integer, [1]:Integer, [2]:Integer, [3]:Integer, [4]:Integer, [5]:Integer, [6]:Integer, [7]:Integer, [8]:Pointer, [24]:Pointer, [32]:Pointer, [40]:Pointer}
+; CHECK-NEXT:   %n1 = insertvalue %none %n, i64 %i, 0: {[0]:Integer, [1]:Integer, [2]:Integer, [3]:Integer, [4]:Integer, [5]:Integer, [6]:Integer, [7]:Integer}
+; CHECK-NEXT:   %e = extractvalue [3 x ptr addrspace(13)] %arr, 1: {[-1]:Pointer}
+; CHECK-NEXT:   ret void: {}


### PR DESCRIPTION
Stacked on #3195.

With `-enzyme-julia-addr-load`, `AugmentWithJuliaObjectType` runs on every `getAnalysis` call. It recursed through the value's type twice (`AllJuliaTypes` and `AnyJuliaTypes`) and then walked it a third time with a heap-allocated worklist to find the byte offsets of tracked pointers, querying the struct layout for every nested struct. None of that depends on the value, only on its type.

This memoizes the result per `llvm::Type` in `TypeAnalysis` as a `JuliaObjectShape`: the all/any flags plus the flat list of tracked-pointer offsets. Nested types are memoized on the way down, so filling the cache costs one visit per distinct type. `AugmentWithJuliaObjectType` is now a hash lookup followed by a loop over precomputed offsets.

Offsets are recorded in the order the old worklist visited them (last field first, depth first), so the sequence of `TypeTree` inserts is unchanged. The cache is cleared alongside `analyzedFunctions` in `TypeAnalysis::clear`.

Verification: built the base branch and this branch against LLVM 22 and diffed the raw `print-type-analysis` output with `-enzyme-julia-addr-load` forced on across all 90 TypeAnalysis tests plus the Julia-flag ReverseMode tests. All outputs are byte-identical. Adds `test/TypeAnalysis/juliaobject.ll` covering an all-pointer struct, a mixed struct with nested arrays, a Julia-free struct, and a bare array of tracked pointers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqaVYvJBrBx6amXGyPVLuw