### PR TITLE
support-clang-21-cuda

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -4089,6 +4089,7 @@ public:
       {
         SmallVector<Value *, 1> args = {};
 #if LLVM_VERSION_MAJOR > 20
+        args.push_back(ConstantInt::get(Type::getInt32Ty(M->getContext()), 0));
         auto cal = cast<CallInst>(Builder2.CreateCall(
             getIntrinsicDeclaration(
                 M, Intrinsic::nvvm_barrier_cta_sync_aligned_all),
@@ -4116,7 +4117,16 @@ public:
       case Intrinsic::nvvm_membar_cta:
       case Intrinsic::nvvm_membar_gl:
       case Intrinsic::nvvm_membar_sys: {
-        SmallVector<Value *, 1> args = {};
+        SmallVector<Value *, 2> args = {};
+#if LLVM_VERSION_MAJOR > 20
+        if (ID == Intrinsic::nvvm_barrier_cta_sync_aligned_all ||
+            ID == Intrinsic::nvvm_barrier_cta_sync_aligned_count) {
+          auto *CB = cast<CallBase>(&I);
+          for (Use &arg : CB->args())
+            args.push_back(
+                lookup(gutils->getNewFromOriginal(arg.get()), Builder2));
+        }
+#endif
         auto cal = cast<CallInst>(
             Builder2.CreateCall(getIntrinsicDeclaration(M, ID), args));
         cal->setCallingConv(getIntrinsicDeclaration(M, ID)->getCallingConv());

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -4616,9 +4616,15 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
                              ? (llvm::Intrinsic::ID)Intrinsic::amdgcn_s_barrier
                              : (llvm::Intrinsic::ID)Intrinsic::nvvm_barrier0;
 #endif
+      SmallVector<Value *, 1> BarrierArgs = {};
+#if LLVM_VERSION_MAJOR > 20
+      if (Arch == Triple::nvptx || Arch == Triple::nvptx64)
+        BarrierArgs.push_back(ConstantInt::get(
+            Type::getInt32Ty(gutils->newFunc->getContext()), 0));
+#endif
       instbuilder.CreateCall(
           getIntrinsicDeclaration(gutils->newFunc->getParent(), BarrierInst),
-          {});
+          BarrierArgs);
       OldEntryInsts->moveAfter(entry);
       sharedBlock->moveAfter(entry);
       IRBuilder<> sbuilder(sharedBlock);

--- a/enzyme/Enzyme/InstructionDerivatives.td
+++ b/enzyme/Enzyme/InstructionDerivatives.td
@@ -1244,6 +1244,15 @@ def : IntrPattern<(Op $x),
                   (ForwardFromSummedReverse)                
                   >;
 
+def : IntrPattern<(Op $y, $x),
+                  [["atan2", "20", ""]],
+                  [
+                    (FDiv (FMul (DiffeRet), $x), (FAdd (FMul $x, $x), (FMul $y, $y))),
+                    (FNeg (FDiv (FMul (DiffeRet), $y), (FAdd (FMul $x, $x), (FMul $y, $y))))
+                  ],
+                  (ForwardFromSummedReverse)
+                  >;
+
 def : IntrPattern<(Op $x),
                   [["asin", "19", ""]],
                   [(FDiv (DiffeRet), (Intrinsic<"sqrt"> (FSub (ConstantFP<"1.0"> $x), (FMul $x, $x))))]  ,


### PR DESCRIPTION

## Problem

The CUDA device backend failed during instruction selection:

```text
fatal error: error in backend: Cannot select:
f32,ch = AtomicLoadFAdd<(load store monotonic (s32) ..., addrspace 101)>
```

The failing generated function was a reverse-mode CUDA kernel:

```text
Cromwell::Patterns::flux_map_kernel_cuda_reverse<
  OperationScalarPopulator, unsigned int, 0, 1>
```

Adding:

```text
-mllvm -nvptx-early-byval-copy
```

made the compile pass, but that option can copy byval kernel parameters early and broadly, so it was treated as a diagnostic workaround rather than the final fix.

## Investigation

The failing source operation was simple:

```cpp
out[face_index] = value;
```

Enzyme differentiated the store and emitted a reverse accumulation into the shadow operation object:

```llvm
%21 = getelementptr inbounds nuw i8, ptr %2, i64 16
%22 = atomicrmw fadd ptr %21, float %20 monotonic, align 8
```

Here `%2` was the byval `d_operation` CUDA kernel parameter. After running the normal `nvptx-lower-args` pass before the fix, the atomic was rewritten into NVPTX parameter address space:

```llvm
%28 = getelementptr inbounds i8, ptr addrspace(101) %7, i64 16
%29 = atomicrmw fadd ptr addrspace(101) ..., float %27 monotonic
```

NVPTX parameter memory is read-only for kernel parameters and cannot be the target of an atomic update. That is the direct backend crash.

## Root Cause

The root cause was in LLVM's NVPTX byval argument lowering, not in Cromwell source and not in Enzyme's Clang plugin.

`NVPTXLowerArgs.cpp` has an `ArgUseChecker` that decides whether a byval kernel parameter can be accessed directly in parameter address space or must first be copied to local memory. It already treated ordinary stores, memsets, and destination memcpys as mutations requiring a local copy.

It did not handle:

- `AtomicRMWInst`
- `AtomicCmpXchgInst`

Because `PtrUseVisitor` had no atomic-specific override in this pass, an atomic write through a byval parameter was effectively classified as read-only. The pass then selected the parameter-address-space path and left an illegal `atomicrmw` in address space `101`.

## Solution

Patched the local LLVM checkout under:

```text
/home/mixu/software/llvm-project-21.1.8/llvm
```

Changed:

```text
llvm/lib/Target/NVPTX/NVPTXLowerArgs.cpp
```

to make atomic writes force the existing byval local-copy path:

```cpp
void visitAtomicRMWInst(AtomicRMWInst& RMW)
{
  if (U->get() == RMW.getPointerOperand() && !IsGridConstant)
    return PI.setAborted(&RMW);
}

void visitAtomicCmpXchgInst(AtomicCmpXchgInst& CmpXchg)
{
  if (U->get() == CmpXchg.getPointerOperand() && !IsGridConstant)
    return PI.setAborted(&CmpXchg);
}
```

Added a regression case in:

```text
llvm/test/CodeGen/NVPTX/lower-byval-args.ll
```

for `atomicrmw fadd` through a byval struct field. The expected lowering now creates a local alloca, copies the byval parameter from address space `101`, and performs the atomic on the local copy.

Rebuilt the affected LLVM tools:

```sh
ninja -C /home/mixu/software/llvm-project-21.1.8/build opt llc clang
```

## Verification

The focused LLVM regression passed:

```sh
/home/mixu/software/llvm-project-21.1.8/build/bin/llvm-lit \
  /home/mixu/software/llvm-project-21.1.8/llvm/test/CodeGen/NVPTX/lower-byval-args.ll
```

Result:

```text
PASS: LLVM :: CodeGen/NVPTX/lower-byval-args.ll
```

The captured Cromwell device IR was checked with patched `opt`:

```sh
/home/mixu/software/llvm-project-21.1.8/build/bin/opt \
  -S -mtriple nvptx64-nvidia-cuda -mcpu=sm_80 -mattr=ptx77 \
  -nvptx-lower-args \
  /tmp/scalar_transient_bad.ll \
  -o /tmp/scalar_transient_lowered_after.ll
```

After the fix, the shadow operation parameter is copied locally:

```llvm
%7 = alloca %"struct...OperationScalarPopulator", align 8
%8 = call ptr addrspace(101) @llvm.nvvm.internal.addrspace.wrap.p101.p0(ptr %2)
call void @llvm.memcpy.p0.p101.i64(ptr align 8 %7, ptr addrspace(101) align 8 %8, i64 32, i1 false)
%29 = getelementptr inbounds nuw i8, ptr %7, i64 16
%30 = atomicrmw fadd ptr %29, float %28 monotonic, align 8
```

There were no remaining matches for:

```text
atomicrmw fadd ptr addrspace(101)
```

The original failing compile command for `BoundaryConditionUDFLibrary/ScalarTransientTable.cxx` then passed without `-mllvm -nvptx-early-byval-copy`.

The related transient-table objects also compiled successfully:

```sh
ninja -C /home/mixu/dev/Cromwell3/Output/3d_release \
  CFD/CommonModel/CMakeFiles/Cromwell.CommonModel.dir/src/CellZoneUDF/ScalarTransientTable.cxx.o \
  CFD/CommonModel/CMakeFiles/Cromwell.CommonModel.dir/src/BoundaryConditionUDFLibrary/VectorTransientTable.cxx.o \
  CFD/CommonModel/CMakeFiles/Cromwell.CommonModel.dir/src/CellZoneUDF/VectorTransientTable.cxx.o
```

The full Cromwell build was rerun afterwards and passed.
