### PR TITLE
TypeAnalysis: skip redundant remove/insert in AugmentWithJuliaObjectType

### DIFF
--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -983,6 +983,15 @@ static bool AnyJuliaTypes(Type *T) {
 static void AugmentWithJuliaObjectType(TypeTree &TT, Type *T,
                                        const DataLayout &DL) {
   if (AllJuliaTypes(T)) {
+    // Fast path: already augmented (exact-key checks are O(log n); the
+    // remove/insert below each walk the whole map).
+    {
+      const auto &M = TT.getMapping();
+      auto it = M.find(std::vector<int>{-1});
+      if (it != M.end() && it->second == BaseType::Pointer &&
+          M.find(std::vector<int>{0}) == M.end())
+        return;
+    }
     TT.remove({-1});
     TT.remove({0});
     TT.insert({-1}, BaseType::Pointer);
@@ -1004,6 +1013,12 @@ static void AugmentWithJuliaObjectType(TypeTree &TT, Type *T,
     if (!AnyJuliaTypes(T))
       continue;
     if (isa<PointerType>(T)) {
+      {
+        const auto &M = TT.getMapping();
+        auto it = M.find(std::vector<int>{(int)offset});
+        if (it != M.end() && it->second == BaseType::Pointer)
+          continue; // already augmented at this offset
+      }
       TT.remove(std::vector<int>{(int)offset});
       TT.insert(std::vector<int>{(int)offset}, BaseType::Pointer);
       continue;


### PR DESCRIPTION
This is something that Fable found when analysing compile times of SpeedyWeather gradients in Julia 1.12. I chatted with @vchuravy about this. 

Claude summary: 

# TypeAnalysis: skip redundant remove/insert in `AugmentWithJuliaObjectType`

## What

`AugmentWithJuliaObjectType` (`enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp`) is called from
`TypeAnalyzer::getAnalysis`, i.e. on every type query, when `EnzymeJuliaAddrLoad` is set. It marks Julia object
pointers in the `TypeTree`:

- for a tracked pointer type: `remove({-1}); remove({0}); insert({-1}, Pointer)`,
- for each Julia pointer field of a struct/array type: `remove({off}); insert({off}, Pointer)`.

It does this unconditionally, although after the first call the tree already carries exactly that result.
`TypeTree::insert` iterates over the whole offset map ("check if there is an existing match"), so every later query
on a large tree — a pointer to a big Julia struct has one entry per field offset — pays O(map size) for nothing.

This PR checks the exact keys first (an O(log n) `map::find`) and returns early when the post-condition already
holds:

- tracked pointer: `{-1}` is `Pointer` and there is no `{0}` entry,
- struct field: `{off}` is already `Pointer`.

The resulting tree is identical to what the unconditional remove/insert produces; only the redundant work is skipped.
About 15 added lines, no new state.

## Why

With #3186/#3187/#3188 in place, profiling reverse-mode compilation of a Julia atmospheric model
(SpeedyWeather.jl, Julia 1.12, LLVM 18) shows activity analysis dominated by

```
forceActiveDetection → isConstantValue → isValueInactiveFromUsers → TypeAnalyzer::getAnalysis (66 %)
  → AugmentWithJuliaObjectType (53 %) → TypeTree::insert (49 %)
```

i.e. half of the activity-analysis time is this redundant re-augmentation.

## Measured

SpeedyWeather.jl `BarotropicModel` `time_step!`, reverse mode, Julia 1.12.6, Apple M3, Enzyme core v0.0.292 +
#3186/#3187/#3188 as the baseline:

| | compile time | gradient |
|---|---|---|
| baseline | 123.5 s | `sum|g| = 36.89456`, `max|g| = 1.4142135` |
| with this change | **111.0 s** | bit-identical |

On the same model's larger `PrimitiveWetModel` step the change is one of two needed to get through activity analysis
at all (the other being a memoised `isNoNeed` in `calculateUnusedValuesInFunction`, sent separately).

## Testing

- Gradients bit-identical on the two SpeedyWeather test cases above.
- lit suite: not yet run by me — please run in CI.