### PR TITLE
Allow a cached value to be an argument, constant or global

### DIFF
--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -2975,22 +2975,24 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
     unsigned i = 0;
     for (auto v : gutils->getTapeValues()) {
       if (!isa<UndefValue>(v)) {
-        if (!isa<Instruction>(VMap[v])) {
-          llvm::errs() << " non constant for vmap[v=" << *v
-                       << " ]= " << *VMap[v] << "\n";
+        Value *nv = VMap[v];
+        // An instruction has to be stored right after it is defined, whereas an
+        // argument, constant or global is available from the start of the
+        // function and can be stored alongside the tape allocation itself.
+        IRBuilder<> tb(ib.GetInsertBlock(), ib.GetInsertPoint());
+        if (auto inst = dyn_cast<Instruction>(nv)) {
+          tb.SetInsertPoint(inst->getNextNode());
+          if (isa<PHINode>(inst))
+            tb.SetInsertPoint(getFirstNonPHI(inst->getParent()));
         }
-        auto inst = cast<Instruction>(VMap[v]);
-        IRBuilder<> ib(inst->getNextNode());
-        if (isa<PHINode>(inst))
-          ib.SetInsertPoint(getFirstNonPHI(inst->getParent()));
-        Value *Idxs[] = {ib.getInt32(0), ib.getInt32(i)};
+        Value *Idxs[] = {tb.getInt32(0), tb.getInt32(i)};
         Value *gep = tapeMemory;
         if (!removeTapeStruct) {
-          gep = ib.CreateGEP(tapeType, tapeMemory, Idxs, "");
+          gep = tb.CreateGEP(tapeType, tapeMemory, Idxs, "");
           cast<GetElementPtrInst>(gep)->setIsInBounds(true);
         }
-        auto storeinst = ib.CreateStore(VMap[v], gep);
-        PostCacheStore(storeinst, ib);
+        auto storeinst = tb.CreateStore(nv, gep);
+        PostCacheStore(storeinst, tb);
       }
       ++i;
     }

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -3094,7 +3094,12 @@ Value *GradientUtils::cacheForReverse(IRBuilder<> &BuilderQ, Value *malloc,
 
     bool inLoop;
 
-    if (ctx.ForceSingleIteration) {
+    if (!isa<Instruction>(malloc)) {
+      // An argument, constant or global is available for the whole function and
+      // cannot vary between loop iterations, so it never needs to be cached per
+      // iteration.
+      inLoop = false;
+    } else if (ctx.ForceSingleIteration) {
       inLoop = true;
       ctx.ForceSingleIteration = false;
     } else {


### PR DESCRIPTION
## Problem

`GradientUtils::cacheForReverse` takes an arbitrary `Value *`, and its `!inLoop` path happily pushes one onto `addedTapeVals`. `CreateAugmentedPrimal` then assumed every taped value was an `Instruction`, because it needs the defining instruction to pick the insertion point for the store into the tape:

```cpp
if (!isa<Instruction>(VMap[v])) {
  llvm::errs() << " non constant for vmap[v=" << *v << " ]= " << *VMap[v] << "\n";
}
auto inst = cast<Instruction>(VMap[v]);
IRBuilder<> ib(inst->getNextNode());
```

So a custom augmented-forward handler (`EnzymeRegisterCallHandler`) that hands back one of its shadow *arguments* as the call's shadow return aborts:

```
non constant for vmap[v={} addrspace(10)* %"'1" ]= {} addrspace(10)* %"'1"
Casting.h:573: decltype(auto) llvm::cast(From&) ... Assertion `isa<To>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
```

That is a real limitation rather than a corner case: every Julia custom augmented-forward rule that wants to return the shadow of one of the call's operands has to route it through a dummy `jl_apply_generic` call today just to have an `Instruction` in hand.

The same assumption appears one level down: a non-`Instruction` gets a `LimitContext` from `BuilderQ.GetInsertBlock()`, so if the call sits in a loop, `inLoop` comes out true and `ensureLookupCached(cast<Instruction>(malloc), ...)` asserts as well.

## Fix

An argument, constant or global is available from the entry of the function and cannot vary between iterations:

* `EnzymeLogic.cpp` — store such a value into the tape alongside the tape allocation itself (the builder already positioned in the entry block just after `tapeMemory` is set up) instead of after a defining instruction. For an `Instruction` the insertion point, including the `PHINode` special case and the debug location taken from `inst->getNextNode()`, is exactly what it was.
* `GradientUtils.cpp` — treat a non-`Instruction` as loop invariant, so `cacheForReverse` takes the plain `addedTapeVals.push_back` path rather than trying to build a per-iteration cache.

## Testing

`ninja check-enzyme`: 1049 passed, 10 expectedly failed, 0 failed — unchanged, as expected since the `Instruction` path is untouched.

The new path is only reachable through a custom call handler, so it is not expressible as a lit test; it is exercised by EnzymeAD/Enzyme.jl#3556, where the forward and augmented-forward rules for `jl_f_setfield` need to return the shadow of the stored value (`setfield!(obj, fld, val)` returns `val`). With this change the reverse-mode rule can return that shadow directly even when it is the caller's shadow argument, which fixes a silently dropped derivative in EnzymeAD/Enzyme.jl#3555:

```julia
g(v) = sum(setit!(b, :u, v))   # exact [1, 1]; Enzyme.Reverse gave [0, 0]
```

Verified against Julia 1.11 with a local build of this branch: `Enzyme.Reverse` and batched `BatchDuplicated` reverse now give the correct gradients, and the Enzyme.jl test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RAaewsVwF5wyRBfErBEEr