### PR TITLE
Only attach enzyme_type to cache reloads when the tree is in range

### DIFF
--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -7913,7 +7913,16 @@ Value *GradientUtils::lookupM(Value *val, IRBuilder<> &BuilderM,
       origInst = isOriginal(prelcssaInst);
     if (origInst) {
       TypeTree TT = TR.query(origInst);
-      if (TT.isKnown())
+      // considerTBAA rejects a tree with an offset past the register size of
+      // the instruction it is attached to with a fatal error, so drop those
+      // rather than emitting metadata a later type analysis run will reject.
+      auto &DL = newFunc->getParent()->getDataLayout();
+      auto RegSize = (DL.getTypeSizeInBits(resultInst->getType()) + 7) / 8;
+      bool legal = TT.isKnown();
+      for (const auto &pair : TT.getMapping())
+        if (pair.first[0] != -1 && (size_t)pair.first[0] >= RegSize)
+          legal = false;
+      if (legal)
         resultInst->setMetadata("enzyme_type",
                                 TT.toMD(resultInst->getContext()));
     }


### PR DESCRIPTION
Follow-up to #3156, which superseded this PR's original contents.

#3156 records the original `TypeTree` as `!enzyme_type` on values restored from reverse caches, but attaches whatever `TR.query` returns without checking it against the reload's register size.

`TypeAnalyzer::considerTBAA` does check, and treats a violation as fatal:

```cpp
if ((size_t)pair.first[0] >= RegSize) {
  llvm::errs() << " bad enzyme_type " << TT.str() << ...;
  llvm::report_fatal_error("Canonicalization failed");
}
```

So a tree with an offset past the register size doesn't degrade the analysis — it aborts the next type analysis run over the generated function, which is exactly the nested-differentiation case (forward-over-reverse) the metadata was added to serve.

This applies the same range check before setting the metadata, and drops the tree when it doesn't hold. Dropping only returns that reload to the pre-#3156 behaviour of an untyped load, which is the conservative direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RD6pJCuKKB1n9L8k2orUua