### PR TITLE
Bump enzyme-benchmarks past the lit 23 config break

### DIFF
--- a/enzyme/CMakeLists.txt
+++ b/enzyme/CMakeLists.txt
@@ -311,7 +311,7 @@ if (ENZYME_ENABLE_PLUGINS AND ENZYME_ENABLE_BENCHMARKS)
 	include (FetchContent)
 	FetchContent_Declare(cpu_benchmarks
 	    GIT_REPOSITORY https://github.com/EnzymeAD/enzyme-benchmarks
-	    GIT_TAG        "9fa1579296b28d9642f8b69a6fffb753211c3f88"
+	    GIT_TAG        "aa5297d24bbae76f0e0d0eb7872717158ef59f25"
 	)
 
 	if(NOT cpu_benchmarks_POPULATED)

--- a/enzyme/CMakeLists.txt
+++ b/enzyme/CMakeLists.txt
@@ -311,7 +311,7 @@ if (ENZYME_ENABLE_PLUGINS AND ENZYME_ENABLE_BENCHMARKS)
 	include (FetchContent)
 	FetchContent_Declare(cpu_benchmarks
 	    GIT_REPOSITORY https://github.com/EnzymeAD/enzyme-benchmarks
-	    GIT_TAG        "aa5297d24bbae76f0e0d0eb7872717158ef59f25"
+	    GIT_TAG        "ba60574cfb85ff48c56ae0d576740f4ab3ce1043"
 	)
 
 	if(NOT cpu_benchmarks_POPULATED)


### PR DESCRIPTION
The `Benchmarking` workflow has been failing on `main` on every run for at least three days. It is not a benchmark regression — `make bench-enzyme` never runs a benchmark, because lit cannot parse the fetched suite's config:

```
lit: TestingConfig.py:164: fatal: unable to parse config file '.../cpu_benchmarks-src/lit.cfg.py'
  File ".../cpu_benchmarks-src/lit.cfg.py", line 22, in <module>
    config.test_format = lit.formats.ShTest(execute_external)
ValueError: execute_external=True is deprected as of LLVM-23 and the option will be
removed in LLVM-24. Please move to using the internal shell (execute_external=False).
If you still need to force external execution to allow time for migration, set
force_execute_external=True
```

As of lit 23, `ShTest.__init__` raises unless `execute_external=True` is accompanied by `force_execute_external=True`. `enzyme/test/lit.cfg.py` here already handles this (added in #3160); the benchmark suite lives in EnzymeAD/enzyme-benchmarks and never got the same treatment. Only the benchmark job breaks because its container has a lit 23 build, while the LLVM 15/16 jobs still run older lit.

EnzymeAD/enzyme-benchmarks#1 applied the identical guard there and is now merged. This PR moves the `FetchContent` pin onto its merge commit, `ba60574`.

Verified locally against both lit 22.1.8 and lit 23.1.1: the old config raises the `ValueError` under 23, the merged one constructs `ShTest` with `execute_external=True` under both.

This gets the job past config parsing. Whether the benchmarks themselves then pass is a separate question — nothing has run them in days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KizJorTNfqA9Q6kVwARLVV