### PR TITLE
TypeAnalysis: do not sign-extend and-masks wider than 64 bits

### DIFF
--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -570,7 +570,8 @@ FnTypeInfo::knownIntegralValues(llvm::Value *val, const DominatorTree &DT,
                 if (auto Val = dyn_cast<SCEVConstant>(S->evaluateAtIteration(
                         SE.getConstant(Iters->getType(), i, /*signed*/ false),
                         SE))) {
-                  insert(Val->getAPInt().getSExtValue());
+                  if (Val->getAPInt().getSignificantBits() <= 64)
+                    insert(Val->getAPInt().getSExtValue());
                 }
               }
               return intseen[val];
@@ -3383,10 +3384,14 @@ void TypeAnalyzer::visitBinaryOperation(const DataLayout &dl, llvm::Type *T,
           bool isNegMask = false;
           if (Args[i]) {
             if (auto CI = dyn_cast<ConstantInt>(Args[i])) {
-              int64_t andval = CI->getSExtValue();
-              if (andval < 0 && andval >= -64) {
-                Result = (i == 0 ? AnalysisRHS : AnalysisLHS);
-                isNegMask = true;
+              // Masks wider than 64 bits (e.g. on i128) cannot be a small
+              // negative number, and getSExtValue would assert on them.
+              if (CI->getValue().getSignificantBits() <= 64) {
+                int64_t andval = CI->getSExtValue();
+                if (andval < 0 && andval >= -64) {
+                  Result = (i == 0 ? AnalysisRHS : AnalysisLHS);
+                  isNegMask = true;
+                }
               }
             }
             if (!isNegMask) {

--- a/enzyme/test/TypeAnalysis/andmask128.ll
+++ b/enzyme/test/TypeAnalysis/andmask128.ll
@@ -1,0 +1,26 @@
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -print-type-analysis -type-analysis-func=caller -o /dev/null | FileCheck %s; fi
+; RUN: %opt < %s %newLoadEnzyme -passes="print-type-analysis" -type-analysis-func=caller -S -o /dev/null | FileCheck %s
+
+; An `and` with a mask wider than 64 bits (here the UUIDv4 version/variant
+; mask on an i128) must not be treated as a small negative mask.
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare void @f(i128 %x)
+
+define void @caller(i128 %n) {
+entry:
+  %m = and i128 %n, -1133381790946770133450753
+  %v = or i128 %m, 302240678275694148452352
+  call void @f(i128 %v)
+  ret void
+}
+
+; CHECK: caller - {} |{[-1]:Integer}:{}
+; CHECK-NEXT: i128 %n: {[-1]:Integer}
+; CHECK-NEXT: entry
+; CHECK-NEXT:   %m = and i128 %n, -1133381790946770133450753: {[-1]:Anything}
+; CHECK-NEXT:   %v = or i128 %m, 302240678275694148452352: {[-1]:Anything}
+; CHECK-NEXT:   call void @f(i128 %v): {}
+; CHECK-NEXT:   ret void: {}


### PR DESCRIPTION
`visitBinaryOperation` calls `getSExtValue()` on the constant operand of every `and` to detect small negative masks. On an `i128` operand whose value does not fit in 64 bits this trips the `APInt::getSExtValue` assertion (`getSignificantBits() <= 64`) and aborts the host process.

Julia reaches this through `UUIDs.uuid4()`, which masks a `UInt128` with the RFC 4122 version/variant mask `0xffffffffffff0fff3fffffffffffffff`. AbstractMCMC's progress logger calls `uuid4()` on every `sample`, so differentiating through any Turing `sample` call crashes Julia (EnzymeAD/Enzyme.jl#2464).

Only consult the value when it fits in 64 bits: a wider mask can never be a small negative number, so the existing logic is unchanged for every case that did not assert. The SCEV-derived induction values in `knownIntegralValues` get the same guard.

The new lit test `TypeAnalysis/andmask128.ll` aborts `opt` on the current library and passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcTbLNBXz7VEHFHMXHcFdp