### PR TITLE
cacheForReverse: don't cache an argument, rebuild it in the reverse

### DIFF
--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -3163,6 +3163,8 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
     PPC.ReplaceReallocs(NewF, /*mem2reg*/ true);
 
   AugmentedCachedFunctions.find(tup)->second.fn = NewF;
+  AugmentedCachedFunctions.find(tup)->second.uncachedTapeArgs =
+      gutils->getUncachedTapeArgs();
   if ((recursive && nonRecursiveUse) || (omp && !noTape))
     AugmentedCachedFunctions.find(tup)->second.tapeType = tapeType;
   AugmentedCachedFunctions.find(tup)->second.isComplete = true;
@@ -4318,8 +4320,10 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
   gutils->can_modref_map = &can_modref_map;
 
   std::map<std::pair<Instruction *, CacheType>, int> mapping;
-  if (augmenteddata)
+  if (augmenteddata) {
     mapping = augmenteddata->tapeIndices;
+    gutils->setUncachedTapeArgs(augmenteddata->uncachedTapeArgs);
+  }
 
   auto getIndex = [&](Instruction *I, CacheType u, IRBuilder<> &B) -> unsigned {
     return gutils->getIndex(std::make_pair(I, u), mapping, B);

--- a/enzyme/Enzyme/EnzymeLogic.h
+++ b/enzyme/Enzyme/EnzymeLogic.h
@@ -105,6 +105,10 @@ public:
 
   std::map<std::pair<llvm::Instruction *, CacheType>, int> tapeIndices;
 
+  //! Tape indices which hold no data because the value is an argument; maps to
+  //! the original argument index and whether its primal or shadow is wanted
+  std::map<unsigned, std::pair<unsigned, bool>> uncachedTapeArgs;
+
   //! Map from original call to sub augmentation data
   std::map<const llvm::CallInst *, const AugmentedReturn *> subaugmentations;
 

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -2719,6 +2719,22 @@ Value *GradientUtils::cacheForReverse(IRBuilder<> &BuilderQ, Value *malloc,
       assert(malloc);
       return UndefValue::get(malloc->getType());
     }
+    // The augmented pass stored nothing at this index because the value is an
+    // argument, so take it from this function's arguments rather than loading
+    // the (empty) slot.
+    auto uncached = uncachedTapeArgs.find((unsigned)idx);
+    if (uncached != uncachedTapeArgs.end()) {
+      Value *ret = argFromOriginal(uncached->second);
+      assert(ret->getType() == malloc->getType());
+      if (replace)
+        if (auto malloci = dyn_cast<Instruction>(malloc)) {
+          malloci->replaceAllUsesWith(ret);
+          if (malloci == &*BuilderQ.GetInsertPoint())
+            BuilderQ.SetInsertPoint(malloci->getNextNode());
+          erase(malloci);
+        }
+      return ret;
+    }
     if (idx >= 0 && !tape->getType()->isStructTy()) {
       llvm::errs() << "cacheForReverse incorrect tape type: " << *tape
                    << " idx: " << idx << "\n";
@@ -3080,6 +3096,16 @@ Value *GradientUtils::cacheForReverse(IRBuilder<> &BuilderQ, Value *malloc,
 
     if (isa<UndefValue>(malloc)) {
       addedTapeVals.push_back(malloc);
+      return malloc;
+    }
+
+    // An argument is available unchanged in the reverse pass, so there is
+    // nothing to cache. Record which argument is wanted against this index and
+    // store nothing -- the slot is left undef, so no store (and no builder) is
+    // materialized for it, and the split reverse rebuilds the value instead.
+    if (auto uncached = originalArgOf(malloc)) {
+      uncachedTapeArgs[(unsigned)idx] = *uncached;
+      addedTapeVals.push_back(UndefValue::get(malloc->getType()));
       return malloc;
     }
 
@@ -9827,6 +9853,34 @@ void GradientUtils::eraseWithPlaceholder(Instruction *I, Instruction *orig,
   if (erase) {
     this->erase(I);
   }
+}
+
+std::optional<std::pair<unsigned, bool>>
+GradientUtils::originalArgOf(Value *val) {
+  if (!isa<Argument>(val))
+    return std::nullopt;
+  auto found = newToOriginalFn.find(val);
+  if (found != newToOriginalFn.end()) {
+    Value *orig = found->second;
+    if (auto oarg = dyn_cast_or_null<Argument>(orig))
+      return std::make_pair(oarg->getArgNo(), false);
+  }
+  for (auto &oarg : oldFunc->args()) {
+    auto ifound = invertedPointers.find(&oarg);
+    if (ifound != invertedPointers.end() && &*ifound->second == val)
+      return std::make_pair(oarg.getArgNo(), true);
+  }
+  return std::nullopt;
+}
+
+Value *GradientUtils::argFromOriginal(std::pair<unsigned, bool> arg) {
+  assert(arg.first < oldFunc->arg_size());
+  auto oarg = oldFunc->getArg(arg.first);
+  if (!arg.second)
+    return getNewFromOriginal((Value *)oarg);
+  auto found = invertedPointers.find(oarg);
+  assert(found != invertedPointers.end());
+  return &*found->second;
 }
 
 void GradientUtils::setTape(Value *newtape) {

--- a/enzyme/Enzyme/GradientUtils.h
+++ b/enzyme/Enzyme/GradientUtils.h
@@ -31,6 +31,7 @@
 #include <functional>
 #include <map>
 #include <string>
+#include <optional>
 
 #include <llvm/Config/llvm-config.h>
 
@@ -315,6 +316,11 @@ public:
 
 private:
   llvm::SmallVector<llvm::WeakTrackingVH, 4> addedTapeVals;
+  /// Tape indices which hold no data because the value is an argument, and so
+  /// is available unchanged in the reverse pass. Maps to the index of the
+  /// argument in the original function, and whether it is the primal or the
+  /// shadow of it which is wanted.
+  std::map<unsigned, std::pair<unsigned, bool>> uncachedTapeArgs;
   unsigned tapeidx;
   llvm::Value *tape;
 
@@ -388,6 +394,24 @@ public:
   llvm::ArrayRef<llvm::WeakTrackingVH> getTapeValues() const {
     return addedTapeVals;
   }
+
+  const std::map<unsigned, std::pair<unsigned, bool>> &
+  getUncachedTapeArgs() const {
+    return uncachedTapeArgs;
+  }
+
+  void setUncachedTapeArgs(
+      const std::map<unsigned, std::pair<unsigned, bool>> &args) {
+    uncachedTapeArgs = args;
+  }
+
+  /// If \p val is an argument of the function being generated, which argument
+  /// of the original function it corresponds to, and whether it is the primal
+  /// or the shadow of it.
+  std::optional<std::pair<unsigned, bool>> originalArgOf(llvm::Value *val);
+
+  /// The counterpart of originalArgOf, in the function being generated now.
+  llvm::Value *argFromOriginal(std::pair<unsigned, bool> arg);
 
 public:
   llvm::AAResults *OrigAA;


### PR DESCRIPTION
## Problem

`cacheForReverse` takes an arbitrary `Value *`, and a custom augmented forward handler (`EnzymeRegisterCallHandler`) may legitimately hand back one of the call's own shadow operands as the call's shadow return. `visitCallInst` tapes whatever the handler returns, because the split gradient pass never re-runs it and loads the shadow back out of the tape instead.

When the operand is an argument that is the wrong thing to do twice over. It is available unchanged in the reverse pass, so the slot is pointless; and it did not merely waste space, it aborted, because the augmented primal needs a defining instruction to place the store into the tape:

```cpp
auto inst = cast<Instruction>(VMap[v]);   // Assertion `isa<To>(Val)' failed
IRBuilder<> ib(inst->getNextNode());
```

```
non constant for vmap[v={} addrspace(10)* %"'1" ]= {} addrspace(10)* %"'1"
```

## Fix

Handle it in `cacheForReverse`, so passing an argument is legal and simply produces no cache:

* **augmented pass** — record, against the tape index, which argument of the *original* function is wanted and whether it is the primal or the shadow of it, and store nothing. The slot is left `undef`, so no store and no `IRBuilder` are materialized for it, exactly as for an explicit `UndefValue`.
* **split reverse** — find the index in that record and rebuild the value from this function's own arguments instead of loading the slot.

Rebuilding goes through the original function (`newToOriginalFn` / `invertedPointers` one way, `getNewFromOriginal` / `invertedPointers` the other), so it does not assume the augmented and gradient clones share an argument layout. The record rides on `AugmentedReturn` beside `tapeIndices`.

Only arguments are special-cased; anything else, constants included, still takes the ordinary caching path. `AdjointGenerator.h` is untouched — the call site stays unconditional.

The index keeps its slot in the tape struct, since `tapeIndices` indexes struct fields directly; nothing is written to it. Dropping the field entirely would mean decoupling the index from the field position.

## Testing

`check-enzyme`: 1049 passed, 10 expectedly failed, 0 failed.

Exercised by EnzymeAD/Enzyme.jl#3556: `setfield!(obj, fld, val)` returns `val`, so the shadow of that call is the shadow of its 3rd operand, which inside a callee is that callee's own shadow argument. With this the augmented forward rule can return it directly, fixing a silently dropped derivative (EnzymeAD/Enzyme.jl#3555):

```julia
f(v) = sum(setit!(b, :u, v)) + sum(b.u)   # exact [2, 2];  was [1, 1]
g(v) = sum(setit!(b, :u, v))              # exact [1, 1];  was [0, 0]
```

Verified on Julia 1.11 with a local build of this branch: forward (widths 1-3), reverse, batched reverse, and the case where the shadow is consumed inside the same callee all give correct gradients, and the Enzyme.jl test suite passes (all 58 files). At width >= 2 the shadow of an argument is an `insertvalue` aggregate rather than an argument, so batched mode keeps taking the ordinary caching path.

Since the path is only reachable through `EnzymeRegisterCallHandler`, and nothing in this repo registers a custom call handler (nor is there a gtest harness -- the installed LLVM ships no gtest), there is no lit test that can reach it; the regression coverage is the Enzyme.jl tests in #3556, which crash outright without this. Happy to add a small lit-driver tool that registers a handler over the C API if you want it gated here too.

Pairs with #3207, which reverts #3201 -- that was the wrong fix for the same crash, teaching the tape to store an argument rather than not caching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RAaewsVwF5wyRBfErBEEr