### PR TITLE
Revert "Allow a cached value to be an argument, constant or global (#3201)"

### DIFF
--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -2975,24 +2975,22 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
     unsigned i = 0;
     for (auto v : gutils->getTapeValues()) {
       if (!isa<UndefValue>(v)) {
-        Value *nv = VMap[v];
-        // An instruction has to be stored right after it is defined, whereas an
-        // argument, constant or global is available from the start of the
-        // function and can be stored alongside the tape allocation itself.
-        IRBuilder<> tb(ib.GetInsertBlock(), ib.GetInsertPoint());
-        if (auto inst = dyn_cast<Instruction>(nv)) {
-          tb.SetInsertPoint(inst->getNextNode());
-          if (isa<PHINode>(inst))
-            tb.SetInsertPoint(getFirstNonPHI(inst->getParent()));
+        if (!isa<Instruction>(VMap[v])) {
+          llvm::errs() << " non constant for vmap[v=" << *v
+                       << " ]= " << *VMap[v] << "\n";
         }
-        Value *Idxs[] = {tb.getInt32(0), tb.getInt32(i)};
+        auto inst = cast<Instruction>(VMap[v]);
+        IRBuilder<> ib(inst->getNextNode());
+        if (isa<PHINode>(inst))
+          ib.SetInsertPoint(getFirstNonPHI(inst->getParent()));
+        Value *Idxs[] = {ib.getInt32(0), ib.getInt32(i)};
         Value *gep = tapeMemory;
         if (!removeTapeStruct) {
-          gep = tb.CreateGEP(tapeType, tapeMemory, Idxs, "");
+          gep = ib.CreateGEP(tapeType, tapeMemory, Idxs, "");
           cast<GetElementPtrInst>(gep)->setIsInBounds(true);
         }
-        auto storeinst = tb.CreateStore(nv, gep);
-        PostCacheStore(storeinst, tb);
+        auto storeinst = ib.CreateStore(VMap[v], gep);
+        PostCacheStore(storeinst, ib);
       }
       ++i;
     }

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -3094,12 +3094,7 @@ Value *GradientUtils::cacheForReverse(IRBuilder<> &BuilderQ, Value *malloc,
 
     bool inLoop;
 
-    if (!isa<Instruction>(malloc)) {
-      // An argument, constant or global is available for the whole function and
-      // cannot vary between loop iterations, so it never needs to be cached per
-      // iteration.
-      inLoop = false;
-    } else if (ctx.ForceSingleIteration) {
+    if (ctx.ForceSingleIteration) {
       inLoop = true;
       ctx.ForceSingleIteration = false;
     } else {


### PR DESCRIPTION
Reverts #3201 (`4336efa3`).

That change taught `CreateAugmentedPrimal` to store an argument into the tape, so that a custom augmented forward handler could return one of the call's own shadow operands as the call's shadow return without hitting `cast<Instruction>(VMap[v])`.

It fixed the crash but treated the symptom. Nothing decided that argument *should* be cached — `visitCallInst` tapes whatever a custom handler hands back, unconditionally, and an argument is available unchanged in the reverse pass, so the tape slot was never needed. #3206 makes `cacheForReverse` hand such a value straight back instead, which is the fix this was standing in for.

#3206 is currently based on `main` as of before this landed; it applies cleanly either way, but it should go in alongside or after this revert, not instead of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RAaewsVwF5wyRBfErBEEr