### PR TITLE
Mark jl_world_counter as an inactive integral global

### DIFF
--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -117,6 +117,8 @@ cl::list<std::string> EnzymeLoadInactiveFiles(
 static const StringSet<> InactiveGlobals = {
     "small_typeof",
     "jl_small_typeof",
+    "jl_world_counter",
+    "ijl_world_counter",
     "ompi_request_null",
     "ompi_mpi_double",
     "ompi_mpi_comm_world",

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -886,6 +886,16 @@ void getConstantAnalysis(Constant *Val, TypeAnalyzer &TA,
       return;
     }
 
+    // from julia code, the world age counter is an integer
+    if (GV->getName() == "jl_world_counter" ||
+        GV->getName() == "ijl_world_counter") {
+      TypeTree T;
+      T.insert({-1}, BaseType::Pointer);
+      T.insert({-1, -1}, BaseType::Integer);
+      analysis[Val] = T;
+      return;
+    }
+
     if (startsWith(GV->getName(), getInstrProfCountersVarPrefix())) {
       TypeTree T;
       T.insert({-1}, BaseType::Pointer);


### PR DESCRIPTION
Julia's world age counter is an external `i64` global with no initializer, so Enzyme could neither deduce its inner type nor create a shadow for it. Differentiating a Julia model that reaches a generated function (here, a Wren model calling `logpdf` through `RuntimeGeneratedFunctions`) failed with:

```
ERROR: EnzymeNoShadowError: Enzyme could not find shadow for value
cannot compute with global variable that doesn't have marked shadow global
@jl_world_counter = external local_unnamed_addr global i64
```

This seeds its type as a pointer to integer data in type analysis, and lists it (along with the `ijl_` variant) among the known inactive globals in activity analysis, next to the existing `jl_small_typeof` handling. With the global known inactive, `invertPointerM` is never asked for a shadow of it.

No lit test: a minimal module that just loads the global is already killed as "const as integral" before reaching the shadow path, so such a test would pass with or without the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JS9YgwAvq8YuPtRgkauuMu