### PR TITLE
Skip empty reverse gc_preserve for multi-end Julia regions

### DIFF
--- a/enzyme/Enzyme/CallDerivatives.cpp
+++ b/enzyme/Enzyme/CallDerivatives.cpp
@@ -2570,6 +2570,50 @@ bool AdjointGenerator::handleKnownCallDerivatives(
 
         auto begin_call = cast<CallInst>(call.getOperand(0));
 
+        // A single begin may dominate multiple ends (branches/loops). The
+        // existing logic below creates one reverse begin per forward end and
+        // keeps only the last, leaving a begin that does not dominate its end
+        // (`Instruction does not dominate all uses` / verification failure).
+        // When the reverse preserve would carry no arguments (nothing to keep
+        // alive in the reverse, e.g. discrete index searches), skip it.
+        unsigned numEnds = 0;
+        for (auto *U : begin_call->users()) {
+          if (auto *UI = dyn_cast<CallInst>(U)) {
+            if (auto *UF = UI->getCalledFunction()) {
+              if (UF->getName() == "llvm.julia.gc_preserve_end")
+                ++numEnds;
+            }
+          }
+        }
+        if (numEnds > 1) {
+          bool needsPreserve = false;
+          for (auto &arg : begin_call->args()) {
+            bool primalUsed = false;
+            bool shadowUsed = false;
+            gutils->getReturnDiffeType(arg, &primalUsed, &shadowUsed);
+            if (primalUsed) {
+              needsPreserve = true;
+              break;
+            }
+            if (!gutils->isConstantValue(arg) && shadowUsed) {
+              needsPreserve = true;
+              break;
+            }
+          }
+          if (!needsPreserve) {
+            auto ifound = gutils->invertedPointers.find(begin_call);
+            if (ifound != gutils->invertedPointers.end()) {
+              if (auto *placeholder =
+                      dyn_cast<CallInst>(&*ifound->second)) {
+                if (placeholder->use_empty())
+                  gutils->erase(placeholder);
+              }
+              gutils->invertedPointers.erase(ifound);
+            }
+            return true;
+          }
+        }
+
         IRBuilder<> Builder2(&call);
         getReverseBuilder(Builder2);
         SmallVector<Value *, 1> args;
@@ -2642,7 +2686,11 @@ bool AdjointGenerator::handleKnownCallDerivatives(
         getReverseBuilder(Builder2);
 
         auto ifound = gutils->invertedPointers.find(&call);
-        assert(ifound != gutils->invertedPointers.end());
+        if (ifound == gutils->invertedPointers.end()) {
+          // No reverse begin was created (multi-end with empty args, skipped
+          // above); nothing to end in the reverse.
+          return true;
+        }
         auto placeholder = cast<CallInst>(&*ifound->second);
         Builder2.CreateCall(
             called->getParent()->getOrInsertFunction(


### PR DESCRIPTION
Skip empty reverse `llvm.julia.gc_preserve` for multi-end regions to avoid a dominance verification failure.

A single forward `gc_preserve_begin` may dominate multiple `gc_preserve_end`s (branches/loops, e.g. Julia `GC.@preserve` around a search loop). The old code created one reverse `begin` per forward `end` and kept only the last, leaving a `begin` that does not dominate its `end`:

```
Instruction does not dominate all uses!
  %9 = call token (...) @llvm.julia.gc_preserve_begin(...)
  call void @llvm.julia.gc_preserve_end(token %9)
LLVM ERROR: function failed verification (4)
```

When the reverse preserve would carry no arguments (nothing to keep alive in the reverse, e.g. discrete index searches returning integers), skip it. Forward clones keep their ends; reverse gets no preserves (valid IR).

> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.
> Draft proposal — asking whether maintainers prefer this C++ fix or the OrdinaryDiffEq workaround in SciML/OrdinaryDiffEq.jl#4496.

## Verification

Julia reproducer (imports only `Enzyme`, no SciML) fails before on Julia 1.12.4 / Enzyme v0.13.203:

```julia
using Enzyme
function g(v::Vector{Float64})
    offset = GC.@preserve v begin
        p = pointer(v, 1)
        found = Int64(-1)
        for i in 1:2
            if unsafe_load(p, i) >= 1.5
                found = i - 1
                break
            end
        end
        found
    end
    return offset < 0 ? 21.0 : Float64(offset)
end
v = [0.5, 2.0]; bv = zeros(2)
Enzyme.autodiff(Enzyme.Reverse, g, Enzyme.Active, Enzyme.Duplicated(v, bv))
# forward OK: 1.0, then abort above
```

Full chain (`ode_interpolation` → `FindFirstFunctions` SIMD `GC.@preserve` + `llvmcall` + branch) and minimal IR (`@diffejulia_g_*` with `invert`/`inverttop` dominance break) in EnzymeAD/Enzyme.jl#3565 and comment https://github.com/EnzymeAD/Enzyme.jl/issues/3565#issuecomment-5632216139.

## Not verified

- C++ build / Enzyme test suite not run locally (no LLVM build env here); needs CI.
- Only the empty-args multi-end case is skipped; non-empty (truly active) multi-end preserves still use old logic and may still fail — that needs a fuller dominance fix (hoist to dominating block).
- Julia-side workaround landed separately as SciML/OrdinaryDiffEq.jl#4496 (marks discrete search helpers `inactive`); asking which approach is preferred (C++ fix, workaround, or both).

🤖 Generated with OpenCode (Muse Spark) (model: muse-spark-1.3-contributor-free)
Session: /home/crackauc/sandbox/tmp_20260911_055443_18155

Links:
- Julia issue with standalone reproducer: https://github.com/EnzymeAD/Enzyme.jl/issues/3565
- Reproducer comment: https://github.com/EnzymeAD/Enzyme.jl/issues/3565#issuecomment-5632216139
- OrdinaryDiffEq workaround PR: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4496
