### PR TITLE
Defer differentiation from an LTO pre-link pipeline to the post-link run

### DIFF
--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -101,6 +101,11 @@ using namespace llvm;
 llvm::cl::opt<bool> EnzymeEnable("enzyme-enable", cl::init(true), cl::Hidden,
                                  cl::desc("Run the Enzyme pass"));
 
+llvm::cl::opt<bool> EnzymeLTOPreLink(
+    "enzyme-lto-prelink", cl::init(false), cl::Hidden,
+    cl::desc("Run Enzyme in an LTO pre-link pipeline, rather than deferring "
+             "differentiation to the post-link run"));
+
 llvm::cl::opt<bool>
     EnzymePostOpt("enzyme-postopt", cl::init(false), cl::Hidden,
                   cl::desc("Run enzymepostprocessing optimizations"));
@@ -3151,7 +3156,7 @@ void augmentPassBuilder(llvm::PassBuilder &PB) {
 
 #if LLVM_VERSION_MAJOR >= 20
   auto loadPass = [prePass](ModulePassManager &MPM, OptimizationLevel Level,
-                            ThinOrFullLTOPhase)
+                            ThinOrFullLTOPhase Phase)
 #else
   auto loadPass = [prePass](ModulePassManager &MPM, OptimizationLevel Level)
 #endif
@@ -3160,6 +3165,23 @@ void augmentPassBuilder(llvm::PassBuilder &PB) {
 
     if (!EnzymeEnable)
       return;
+
+#if LLVM_VERSION_MAJOR >= 20
+    // An LTO pre-link pipeline only ever sees one translation unit, so a
+    // __enzyme_autodiff call here may name a function whose body lives in
+    // another object file. Differentiating now fails on exactly those calls,
+    // while the post-link run sees the whole program: for full LTO that is the
+    // FullLinkTimeOptimizationEarly callback below, for ThinLTO this same
+    // callback re-entered with ThinLTOPostLink. Defer to it -- the
+    // PreserveNVVM run above keeps the relevant functions alive until then.
+    //
+    // This requires the plugin to be loaded by the linker as well, e.g.
+    // -Wl,--load-pass-plugin=LLDEnzyme-<N>.so. Pass -enzyme-lto-prelink=1 to
+    // restore the old behaviour when that is not possible.
+    if (!EnzymeLTOPreLink && (Phase == ThinOrFullLTOPhase::FullLTOPreLink ||
+                              Phase == ThinOrFullLTOPhase::ThinLTOPreLink))
+      return;
+#endif
 
     if (Level != OptimizationLevel::O0)
       prePass(MPM, Level);

--- a/enzyme/test/Integration/ForwardMode/lto_prelink.c
+++ b/enzyme/test/Integration/ForwardMode/lto_prelink.c
@@ -1,0 +1,36 @@
+// An LTO pre-link pipeline only ever sees one translation unit, so the function
+// named by __enzyme_fwddiff may still be a bare declaration. Enzyme defers to
+// the post-link run instead of failing here; `square` below stands in for a
+// callee whose body lives in another object file.
+
+// RUN: if [ %llvmver -ge 20 ]; then %clang -std=c11 -O2 -flto %loadClangEnzyme -c %s -o /dev/null; fi
+// RUN: if [ %llvmver -ge 20 ]; then %clang -std=c11 -O2 -flto=thin %loadClangEnzyme -c %s -o /dev/null; fi
+// RUN: if [ %llvmver -ge 20 ]; then %clang -std=c11 -O0 -flto %loadClangEnzyme -c %s -o /dev/null; fi
+
+// Once the definition is linked in, the post-link pipeline differentiates the
+// call that the pre-link run left alone: d/dx x*x == 2*x.
+// RUN: if [ %llvmver -ge 20 ]; then %clang -std=c11 -O2 -flto %loadClangEnzyme -c %s -emit-llvm -o %t.caller.bc && %clang -std=c11 -O2 -flto -DDEFINITION -c %s -emit-llvm -o %t.callee.bc && llvm-link %t.caller.bc %t.callee.bc -o %t.bc && %opt %optLoadClangEnzyme -passes="lto<O2>" %t.bc -S -o - | FileCheck %s; fi
+
+// CHECK-LABEL: @dsquare(
+// CHECK-NOT: __enzyme_fwddiff
+// CHECK: fmul {{.*}}double %{{.*}}, 2.000000e+00
+
+// -enzyme-lto-prelink=1 restores the old behaviour, which cannot resolve the
+// callee from this translation unit alone.
+// RUN: if [ %llvmver -ge 20 ]; then not %clang -std=c11 -O2 -flto %loadClangEnzyme -mllvm -enzyme-lto-prelink=1 -c %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=UNRESOLVED; fi
+
+// Without LTO nothing changes: Enzyme still runs per translation unit, and the
+// declaration is still an error there.
+// RUN: not %clang -std=c11 -O2 %loadClangEnzyme -c %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=UNRESOLVED
+
+// UNRESOLVED: Enzyme: failed to find fn to differentiate
+
+#ifdef DEFINITION
+double square(double x) { return x * x; }
+#else
+extern double square(double x);
+
+double __enzyme_fwddiff(void *, double, double);
+
+double dsquare(double x) { return __enzyme_fwddiff((void *)square, x, 1.0); }
+#endif

--- a/enzyme/test/lit.site.cfg.py.in
+++ b/enzyme/test/lit.site.cfg.py.in
@@ -116,6 +116,15 @@ if len("@ENZYME_BINARY_DIR@") == 0:
 config.substitutions.append(('%loadClangEnzyme', oldPM if int(config.llvm_ver) < 15 else newPM))
 config.substitutions.append(('%newLoadClangEnzyme', newPM))
 
+# ClangEnzyme, loaded into opt rather than clang. Unlike LLVMEnzyme it is built
+# with ENZYME_RUNPASS, so it registers the pass builder extension points and can
+# be used to run the pipelines a linker would (e.g. -passes='lto<O2>').
+optLoadClangEnzyme = ''
+if len("@ENZYME_BINARY_DIR@") != 0:
+  optLoadClangEnzyme = (' -load-pass-plugin=@ENZYME_BINARY_DIR@/Enzyme/ClangEnzyme-'
+                        + config.llvm_ver + config.llvm_shlib_ext)
+config.substitutions.append(('%optLoadClangEnzyme', optLoadClangEnzyme))
+
 config.substitutions.append(('%hasMPFR', has_mpfr))
 
 # Fortran-specific configuration


### PR DESCRIPTION
`augmentPassBuilder` registers Enzyme on two extension points: `OptimizerEarly`, which runs per translation unit, and `FullLinkTimeOptimizationEarly`, which runs inside the linker. With `-flto` **both** fire, and the pre-link one fires first — on a module that is only one translation unit. So a `__enzyme_autodiff` call naming a function defined in another object dies with `Enzyme: failed to find fn to differentiate` before the link-time run ever gets to see the whole program.

That forces an either/or on users: load the plugin in the compiler (`-fpass-plugin=`) or in the linker (`-Wl,--load-pass-plugin=`), but not both — even though on LLVM ≥ 16 `FlangEnzyme`/`ClangEnzyme`/`LLDEnzyme` are the same library behind the same `llvmGetPassPluginInfo`, and `LLDEnzymeFlags` already hands out `-flto` as a *compile* option next to the linker plugin.

Since LLVM 20 the `OptimizerEarly` callback receives the `ThinOrFullLTOPhase`, which Enzyme discarded:

```c++
auto loadPass = [prePass](ModulePassManager &MPM, OptimizationLevel Level,
                          ThinOrFullLTOPhase)
```

This PR uses it: skip the body at `FullLTOPreLink` and `ThinLTOPreLink` and let the post-link run do the work — `FullLinkTimeOptimizationEarly` for full LTO, this same callback re-entered with `ThinLTOPostLink` for ThinLTO. `PreserveNVVM(/*Begin=*/true)` still runs at pre-link, so the functions involved stay alive until then, and `loadLTO` already calls `loadPass` with an explicit `ThinOrFullLTOPhase::None`, so the link-time path is unaffected.

The effect is that "plugin loaded in both the compiler and the linker" becomes the correct default: compile-time Enzyme is a no-op exactly when a link-time run is going to see more.

### Caveats

* This requires the plugin to be loaded by the linker as well. Where that is not possible, `-mllvm -enzyme-lto-prelink=1` restores the old behaviour. Forgetting it is a loud failure (`undefined reference to __enzyme_autodiff...`), not silently wrong derivatives.
* Non-LTO builds are unchanged, and LLVM < 20 is untouched — the phase is not available on that callback there.

### Testing

Verified against LLVM 22 (`opt` standing in for the linker, which is where the post-link pipelines actually run):

| pipeline | before | after |
| --- | --- | --- |
| `default<O2>` | differentiates | differentiates |
| `lto-pre-link<O2>` | `failed to find fn to differentiate` | deferred |
| `thinlto-pre-link<O2>` | `failed to find fn to differentiate` | deferred |
| `lto<O2>` | differentiates | differentiates |
| `thinlto<O2>` | differentiates | differentiates |

End to end, `d/dx square(x)` across two translation units now folds to `fmul double %0, 2.000000e+00` in the post-link module instead of failing at compile time.

`enzyme/test/Integration/ForwardMode/lto_prelink.c` covers all of the above. It needs a new lit substitution, `%optLoadClangEnzyme`, to load a plugin that actually registers the extension points — `%loadEnzyme` points at `LLVMEnzyme`, which is built without `ENZYME_RUNPASS` and so never calls `augmentPassBuilder`.

`check-enzyme`, `check-enzyme-activity` and `check-enzyme-typeanalysis` show identical results with and without the patch (unsurprising: they all run through `LLVMEnzyme`, which does not reach this code).

### Context

Came out of https://github.com/EnzymeAD/flang-test-case, where the flang and lld routes had to be separate fpm profiles for exactly this reason. With this change they compose into one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TC5oeSdtsztrJspe4tFCJx
