### PR TITLE
Fortran test: custom derivative rule registered from a C translation unit

### DIFF
--- a/enzyme/test/CMakeLists.txt
+++ b/enzyme/test/CMakeLists.txt
@@ -4,6 +4,15 @@ else()
   set(ENZYME_FLANG_ENABLED 0)
 endif()
 
+# Tests that need to compile a C translation unit alongside the main input
+# (e.g. enzyme/test/Fortran/ReverseMode/custom_rule_from_c.f90) are gated on
+# the `clang` lit feature.
+if (${Clang_FOUND})
+  set(ENZYME_CLANG_ENABLED 1)
+else()
+  set(ENZYME_CLANG_ENABLED 0)
+endif()
+
 # Locate an MPI implementation for the Fortran MPI regression tests
 # (enzyme/test/Fortran/mpi); the tests are marked unsupported if none is
 # found. The include and link flags are serialized into lit substitutions

--- a/enzyme/test/Fortran/ReverseMode/Inputs/custom_square_primal.f90
+++ b/enzyme/test/Fortran/ReverseMode/Inputs/custom_square_primal.f90
@@ -1,0 +1,20 @@
+! Primal for custom_rule_from_c.f90, whose derivative is overridden by a rule
+! registered from a C translation unit.
+!
+! It lives in its own translation unit on purpose: Enzyme matches a custom rule
+! against the *call* to fsquare, so if flang were free to inline the body into
+! the caller the rule would never fire and Enzyme would silently differentiate
+! the inlined body instead.  Keeping it external also mirrors the realistic
+! case, where the routine being overridden comes from another file or library.
+!
+! bind(C) gives the routine a stable, unmangled symbol for the C side to name.
+! Without `value` the arguments are passed by reference as usual, so the C
+! signature is `void fsquare(const double *x, double *y)`.
+
+subroutine fsquare(x, y) bind(C, name="fsquare")
+  use iso_c_binding, only: c_double
+  implicit none
+  real(c_double), intent(in) :: x
+  real(c_double), intent(out) :: y
+  y = x * x
+end subroutine fsquare

--- a/enzyme/test/Fortran/ReverseMode/Inputs/custom_square_rule.c
+++ b/enzyme/test/Fortran/ReverseMode/Inputs/custom_square_rule.c
@@ -1,0 +1,49 @@
+/* Enzyme custom reverse-mode rule for the Fortran subroutine `fsquare`.
+ *
+ * This is the C-translation-unit workaround for the fact that flang has no way
+ * to spell a custom rule in Fortran source: flang plugins run after semantics
+ * and replace codegen rather than augmenting it, so they cannot introduce a
+ * directive that survives into IR, and the registration global below needs a
+ * *constant* array of function addresses, which Fortran cannot express
+ * (C_FUNLOC is not a constant expression, so it cannot initialize a module
+ * variable).  So the registration is written in C and llvm-linked in.
+ *
+ * fsquare is `bind(C)` and takes its arguments by reference, hence the pointer
+ * signature.  This file is an input to custom_rule_from_c.f90, not a test.
+ */
+
+extern void fsquare(const double *x, double *y);
+
+/* Counters, so the test can assert each half of the rule ran exactly once. */
+int augment_calls = 0;
+int gradient_calls = 0;
+
+/* Augmented forward pass: run the primal and zero the shadow of the output.
+ * The tape is unused here, so return null. */
+void *augment_fsquare(const double *x, const double *dx, double *y,
+                      double *dy) {
+  augment_calls++;
+  *y = *x * *x;
+  *dy = 0.0;
+  return (void *)0;
+}
+
+/* Reverse pass.  Deliberately *not* 2*x: the bogus factor is what lets the test
+ * distinguish this rule from the derivative Enzyme would have synthesized. */
+void gradient_fsquare(const double *x, double *dx, const double *y,
+                      const double *dy, void *tape) {
+  gradient_calls++;
+  *dx += 13.0 * *dy;
+}
+
+/* Enzyme's registration ABI for reverse mode: {primal, augmented, gradient}.
+ * The -passes=preserve-nvvm run turns this global into enzyme_augment and
+ * enzyme_gradient metadata on fsquare before the enzyme pass looks at it. */
+void *__enzyme_register_gradient_fsquare[] = {
+    (void *)fsquare,
+    (void *)augment_fsquare,
+    (void *)gradient_fsquare,
+};
+
+int enzyme_augment_calls(void) { return augment_calls; }
+int enzyme_gradient_calls(void) { return gradient_calls; }

--- a/enzyme/test/Fortran/ReverseMode/custom_rule_from_c.f90
+++ b/enzyme/test/Fortran/ReverseMode/custom_rule_from_c.f90
@@ -1,0 +1,86 @@
+! REQUIRES: fortran
+! REQUIRES: clang
+! UNSUPPORTED: ifx
+
+! A custom derivative rule for a Fortran routine, registered from a C
+! translation unit and linked in at the IR level.
+!
+! Each translation unit is compiled to bitcode separately, llvm-link merges
+! them, and only then is Enzyme run -- the registration global has to be in the
+! same module as the primal for preserve-nvvm to attach the rule to it.  This
+! is why the %loadFlangEnzyme route is not exercised here: -fpass-plugin runs
+! Enzyme inside flang, per translation unit, where the C registration is not
+! yet visible.
+
+! RUN: %clang -flto -O0 -c %S/Inputs/custom_square_rule.c -o %t.rule.bc
+! RUN: %fc -flto -O0 -c %S/Inputs/custom_square_primal.f90 -o %t.primal.bc
+! RUN: %fc -flto -O0 -c %loadFortran %s -o %t.main.bc
+! RUN: llvm-link %t.main.bc %t.primal.bc %t.rule.bc -o %t.linked.bc
+! RUN: %opt %newLoadEnzyme -passes="preserve-nvvm,enzyme" %t.linked.bc -o %t.ll
+! RUN: %fc -flto -O0 %t.ll -o %t1 && %t1 | FileCheck %s
+
+! RUN: %clang -flto -O2 -c %S/Inputs/custom_square_rule.c -o %t2.rule.bc
+! RUN: %fc -flto -O2 -c %S/Inputs/custom_square_primal.f90 -o %t2.primal.bc
+! RUN: %fc -flto -O2 -c %loadFortran %s -o %t2.main.bc
+! RUN: llvm-link %t2.main.bc %t2.primal.bc %t2.rule.bc -o %t2.linked.bc
+! RUN: %opt %newLoadEnzyme -passes="preserve-nvvm,enzyme" %t2.linked.bc -o %t2.ll
+! RUN: %fc -flto -O2 %t2.ll -o %t3 && %t3 | FileCheck %s
+
+module custom_rule_driver
+  use iso_c_binding, only: c_double, c_int
+  implicit none
+
+  interface
+    ! The routine whose derivative is overridden; defined in
+    ! Inputs/custom_square_primal.f90.
+    subroutine fsquare(x, y) bind(C, name="fsquare")
+      import :: c_double
+      real(c_double), intent(in) :: x
+      real(c_double), intent(out) :: y
+    end subroutine fsquare
+
+    ! Call counters owned by Inputs/custom_square_rule.c.
+    function augment_calls() bind(C, name="enzyme_augment_calls")
+      import :: c_int
+      integer(c_int) :: augment_calls
+    end function augment_calls
+
+    function gradient_calls() bind(C, name="enzyme_gradient_calls")
+      import :: c_int
+      integer(c_int) :: gradient_calls
+    end function gradient_calls
+  end interface
+
+contains
+
+  ! Enzyme differentiates this.  The call to fsquare is where the registered
+  ! rule takes over.
+  function wrapper(x) result(y)
+    real(c_double), intent(in) :: x
+    real(c_double) :: y
+    call fsquare(x, y)
+  end function wrapper
+
+end module custom_rule_driver
+
+program main
+  use custom_rule_driver, only: wrapper, augment_calls, gradient_calls
+  use enzyme, only: enzyme_autodiff
+  use iso_c_binding, only: c_double
+  implicit none
+  real(c_double) :: x, dx
+
+  x = 3.0_c_double
+  dx = 0.0_c_double
+  call enzyme_autodiff(wrapper, x, dx)
+
+  ! The true derivative of x**2 at x = 3 is 6.  Seeing 13 instead is what
+  ! proves the rule registered from the C translation unit was the one used.
+  write(*,"(a,f0.3)") "dx = ", dx
+  write(*,"(a,i0)") "augment calls = ", augment_calls()
+  write(*,"(a,i0)") "gradient calls = ", gradient_calls()
+end program main
+
+! CHECK: dx = 13.000
+! CHECK-NEXT: augment calls = 1
+! CHECK-NEXT: gradient calls = 1

--- a/enzyme/test/lit.site.cfg.py.in
+++ b/enzyme/test/lit.site.cfg.py.in
@@ -69,6 +69,8 @@ config.substitutions.append(('%eopt', emopt))
 config.substitutions.append(('%llvmver', config.llvm_ver))
 config.substitutions.append(('%FileCheck', config.llvm_tools_dir + "/FileCheck"))
 config.substitutions.append(('%clang', eclang))
+if "@ENZYME_CLANG_ENABLED@" == "1":
+    config.available_features.add('clang')
 config.substitutions.append(('%O0TBAA', "-O1 -Xclang -disable-llvm-passes"))
 
 oldPM = ((" --enable-new-pm=0" if int(config.llvm_ver) >= 13 else "")


### PR DESCRIPTION
## Why

There is no way to spell an Enzyme custom rule in Fortran source, and flang plugins do not provide one:

- Flang plugins are `PluginParseTreeAction`s (`flang/include/flang/Frontend/FrontendActions.h`) that run *after* semantics and **replace** codegen — `-plugin <name>` sets `programAction = PluginAction`, one arm of the single-action switch in `ExecuteCompilerInvocation.cpp`. There is no analogue of clang's `PluginASTAction::AddBeforeMainAction`, which is the mode `Clang/EnzymeClang.cpp` relies on, and no `ParsedAttrInfoRegistry`/`PragmaHandler` equivalent, so a plugin cannot add syntax either.
- `!DIR$ <name>[=<int>]` already parses for any name into `CompilerDirective::NameValue`, but nothing in Semantics or Lower consumes it and `resolve-names.cpp` warns "Unrecognized compiler directive was ignored". The payload never reaches FIR.
- The registration global needs a *constant* array of function addresses. `C_FUNLOC` is not a constant expression, so no Fortran module variable can be initialized with it.

So the only route that works today is to keep the registration in a C translation unit and merge at the IR level. This adds a regression test pinning that down.

## What

`enzyme/test/Fortran/ReverseMode/custom_rule_from_c.f90` differentiates a Fortran `wrapper(x)` that calls `fsquare`; the rule registered from C takes over that call.

- `Inputs/custom_square_primal.f90` — the primal, `bind(C, name="fsquare")` for a stable unmangled symbol. By-reference args give the C signature `void fsquare(const double*, double*)`.
- `Inputs/custom_square_rule.c` — `augment_fsquare`/`gradient_fsquare` plus `__enzyme_register_gradient_fsquare = {primal, augment, gradient}`, modelled on `test/Integration/ReverseMode/customcombined.c`.

Pipeline: each TU to bitcode → `llvm-link` → `opt -passes="preserve-nvvm,enzyme"` → link. Run at `-O0` and `-O2`.

The gradient returns `13.0 * dy` rather than `2*x`, so `dx = 13.000` in the checked output proves the registered rule fired rather than a derivative Enzyme synthesized; two call counters exposed via `bind(C)` assert each half ran exactly once.

## Three details worth review

1. **`preserve-nvvm` has to be explicit.** `EnzymeNewPM` does not call `preserveNVVM` itself, so the usual `%loadEnzyme %enzyme` would leave the registration global untouched and the rule would silently never attach. The test uses `%newLoadEnzyme -passes="preserve-nvvm,enzyme"` instead — unlike every other Fortran test.
2. **`%loadFlangEnzyme` is deliberately not exercised.** `-fpass-plugin` runs Enzyme inside flang per TU, where the C registration is not yet visible. Noted in the test header so nobody "fixes" it later.
3. **The primal needs its own TU.** Enzyme matches the rule against the call, so an inlined primal is differentiated normally with no diagnostic. Keeping it external is what lets the test run at `-O2`; with the primal in the driver TU it would pass at `-O0` and silently report `6.0` at `-O2`.

Also adds a `clang` lit feature (`Clang_FOUND` → `ENZYME_CLANG_ENABLED`), since no Fortran test has needed `%clang` before and it would otherwise point at a nonexistent binary in a clang-less build.

## Not yet verified

⚠️ Draft because **this has not been run** — no flang available on the machine it was written on. The IR-level mechanics were checked against the Enzyme and flang sources, but the Fortran side was not executed. Most likely to need adjusting: the `write(*,"(a,f0.3)")` formatting against the `CHECK` lines.

## Follow-up

The principled fix is a directive in flang proper, following the existing `FORCEINLINE`/`IVDEP` path: parse-tree node → grammar → `resolve-names.cpp` → `Bridge.cpp` attaching an attribute to the lowered entity. Ideally a *generic* facility that binds a name to an opaque string attribute on a procedure, so the Enzyme-specific meaning stays in the out-of-tree pass plugin, which already reads exactly that (`PreserveNVVM.cpp` annotation handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016h9wdNQZVYd7D6VCm1WkWz