### PR TITLE
Cache a loopy reduction PHI's start value when it cannot be recomputed

### DIFF
--- a/enzyme/Enzyme/DifferentialUseAnalysis.cpp
+++ b/enzyme/Enzyme/DifferentialUseAnalysis.cpp
@@ -1285,9 +1285,13 @@ bool checkLoopyReductionPHI(const GradientUtils *gutils,
   return true;
 }
 
-void pushLoopyPHIPreheader(const GradientUtils *gutils, llvm::Value *V,
-                           llvm::SetVector<llvm::Value *> &Intermediates,
-                           std::deque<llvm::Value *> &todo) {
+void pushLoopyPHIPreheader(
+    const GradientUtils *gutils, llvm::Value *V,
+    llvm::SetVector<llvm::Value *> &Intermediates,
+    std::deque<llvm::Value *> &todo,
+    llvm::function_ref<bool(llvm::Value *)> legalRecompute,
+    llvm::SetVector<llvm::Value *> &MinReq,
+    llvm::SmallPtrSetImpl<llvm::Value *> &NeedGraph) {
   using namespace llvm;
   if (auto P0 = dyn_cast<PHINode>(V)) {
     if (!gutils->OrigLI)
@@ -1349,6 +1353,15 @@ void pushLoopyPHIPreheader(const GradientUtils *gutils, llvm::Value *V,
       if (!isa<Instruction>(Pstart))
         break;
       Intermediates.insert(Pstart);
+      if (!legalRecompute(Pstart)) {
+        // The start value cannot be rebuilt in the reverse pass (for example
+        // a preheader PHI merging another loop's exit value). It lies outside
+        // the min-cut graph, so require its cache directly. As with every
+        // cached value, nothing it is computed from is needed on its behalf.
+        MinReq.insert(Pstart);
+        NeedGraph.insert(Pstart);
+        break;
+      }
       todo.push_back(Pstart);
       if (auto phi = dyn_cast<PHINode>(Pstart)) {
         if (phi->getNumIncomingValues() == 1)

--- a/enzyme/Enzyme/DifferentialUseAnalysis.h
+++ b/enzyme/Enzyme/DifferentialUseAnalysis.h
@@ -84,9 +84,18 @@ bool checkLoopyReductionPHI(const GradientUtils *gutils,
                             const llvm::PHINode *P0,
                             const llvm::Value *incomingVal);
 
-void pushLoopyPHIPreheader(const GradientUtils *gutils, llvm::Value *V,
-                           llvm::SetVector<llvm::Value *> &Intermediates,
-                           std::deque<llvm::Value *> &todo);
+/// Provide the start value that the reverse pass of a loopy reduction PHI V
+/// reads from its preheader. The start value, and any single-incoming PHI it
+/// passes through, joins the recompute graph when legalRecompute admits it.
+/// Otherwise it is recorded in MinReq and NeedGraph: it lies outside the
+/// min-cut graph and cannot be rebuilt in the reverse pass, so it is cached.
+void pushLoopyPHIPreheader(
+    const GradientUtils *gutils, llvm::Value *V,
+    llvm::SetVector<llvm::Value *> &Intermediates,
+    std::deque<llvm::Value *> &todo,
+    llvm::function_ref<bool(llvm::Value *)> legalRecompute,
+    llvm::SetVector<llvm::Value *> &MinReq,
+    llvm::SmallPtrSetImpl<llvm::Value *> &NeedGraph);
 
 template <QueryType VT, bool OneLevel = false>
 inline bool is_value_needed_in_reverse(

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -8713,6 +8713,21 @@ void GradientUtils::computeMinCache() {
       }
     }
 
+    // Whether V may be rebuilt in the reverse pass, given the allocations and
+    // the induction variables of the loops enclosing its definition.
+    auto legalToRecompute = [&](Value *V) {
+      ValueToValueMapTy Available2;
+      for (auto a : Available)
+        Available2[a.first] = a.second;
+      for (Loop *L = OrigLI->getLoopFor(cast<Instruction>(V)->getParent());
+           L != nullptr; L = L->getParentLoop()) {
+        for (auto v : LoopAvail[L]) {
+          Available2[v] = v;
+        }
+      }
+      return legalRecompute(V, Available2, nullptr);
+    };
+
     SetVector<Value *> Intermediates;
     SetVector<Value *> Required;
     std::deque<Value *> todo(Recomputes.begin(), Recomputes.end());
@@ -8728,16 +8743,7 @@ void GradientUtils::computeMinCache() {
         continue;
       }
       if (!Recomputes.count(V)) {
-        ValueToValueMapTy Available2;
-        for (auto a : Available)
-          Available2[a.first] = a.second;
-        for (Loop *L = OrigLI->getLoopFor(cast<Instruction>(V)->getParent());
-             L != nullptr; L = L->getParentLoop()) {
-          for (auto v : LoopAvail[L]) {
-            Available2[v] = v;
-          }
-        }
-        if (!legalRecompute(V, Available2, nullptr)) {
+        if (!legalToRecompute(V)) {
           // if not legal to recompute, we would've already explicitly marked
           // this for caching if it was needed in reverse pass
           continue;
@@ -8763,8 +8769,12 @@ void GradientUtils::computeMinCache() {
 
     for (Value *V : MinReq) {
       NeedGraph.insert(V);
-      DifferentialUseAnalysis::pushLoopyPHIPreheader(this, V, Intermediates,
-                                                     todo);
+    }
+    // A cached loopy reduction PHI still reads its start value in the reverse
+    // pass. The helper may add that start value to MinReq, so walk a copy.
+    for (Value *V : SmallVector<Value *, 8>(MinReq.begin(), MinReq.end())) {
+      DifferentialUseAnalysis::pushLoopyPHIPreheader(
+          this, V, Intermediates, todo, legalToRecompute, MinReq, NeedGraph);
     }
     for (Value *V : Required) {
       todo.push_back(V);
@@ -8775,8 +8785,8 @@ void GradientUtils::computeMinCache() {
       if (NeedGraph.count(V))
         continue;
       NeedGraph.insert(V);
-      DifferentialUseAnalysis::pushLoopyPHIPreheader(this, V, Intermediates,
-                                                     todo);
+      DifferentialUseAnalysis::pushLoopyPHIPreheader(
+          this, V, Intermediates, todo, legalToRecompute, MinReq, NeedGraph);
       auto I = dyn_cast<Instruction>(V);
       if (!I)
         continue;
@@ -8804,16 +8814,7 @@ void GradientUtils::computeMinCache() {
           if (getFuncNameFromCall(CI) == "julia.call")
             assert(0);
 
-        ValueToValueMapTy Available2;
-        for (auto a : Available)
-          Available2[a.first] = a.second;
-        for (Loop *L = OrigLI->getLoopFor(cast<Instruction>(V)->getParent());
-             L != nullptr; L = L->getParentLoop()) {
-          for (auto v : LoopAvail[L]) {
-            Available2[v] = v;
-          }
-        }
-        assert(legalRecompute(V, Available2, nullptr));
+        assert(legalToRecompute(V));
       }
       if (!NeedGraph.count(V)) {
         assert(!MinReq.count(V));

--- a/enzyme/test/Enzyme/ReverseMode/mincache-loopy-preheader-phi.ll
+++ b/enzyme/test/Enzyme/ReverseMode/mincache-loopy-preheader-phi.ll
@@ -1,0 +1,56 @@
+; RUN: %opt < %s %newLoadEnzyme -passes="enzyme,function(mem2reg,instsimplify,%simplifycfg)" -enzyme-preopt=false -S | FileCheck %s
+
+; The clamp loop's header PHI %current is a loopy select reduction whose
+; condition is needed in the reverse pass, so the min-cut cache planner keeps
+; %current and then provides its start value %current.ph. That preheader PHI
+; merges the argument with the scale loop's exit value %acc.next; it cannot be
+; recomputed in the reverse pass, so the planner must cache it rather than
+; mark it recomputable.
+
+define double @clamp(double %x, i64 %n, i64 %m, i1 %above) {
+entry:
+  %skip = icmp eq i64 %n, 0
+  br i1 %skip, label %clamp.preheader, label %scale
+
+scale:
+  %i = phi i64 [ 0, %entry ], [ %i.next, %scale ]
+  %acc = phi double [ %x, %entry ], [ %acc.next, %scale ]
+  %acc.next = fmul double %acc, %x
+  %i.next = add i64 %i, 1
+  %scaled = icmp eq i64 %i.next, %n
+  br i1 %scaled, label %clamp.preheader, label %scale
+
+clamp.preheader:
+  %current.ph = phi double [ %x, %entry ], [ %acc.next, %scale ]
+  br label %clamp
+
+clamp:
+  %j = phi i64 [ 0, %clamp.preheader ], [ %j.next, %clamp ]
+  %current = phi double [ %current.ph, %clamp.preheader ], [ %next, %clamp ]
+  %less = fcmp olt double %current, 0.000000e+00
+  %greater = fcmp ogt double %current, 0.000000e+00
+  %outside = select i1 %above, i1 %greater, i1 %less
+  %next = select i1 %outside, double 0.000000e+00, double %current
+  %j.next = add i64 %j, 1
+  %clamped = icmp eq i64 %j.next, %m
+  br i1 %clamped, label %exit, label %clamp
+
+exit:
+  ret double %next
+}
+
+define double @dclamp(double %x, i64 %n, i64 %m, i1 %above) {
+  %r = call double (...) @__enzyme_autodiff(ptr @clamp, double %x, i64 %n, i64 %m, i1 %above)
+  ret double %r
+}
+
+declare double @__enzyme_autodiff(...)
+
+; The start value stays a preheader PHI of the primal, and the reverse of the
+; clamp loop carries its adjoint back to the scale loop and the argument.
+
+; CHECK: define internal { double } @diffeclamp(double %x, i64 %n, i64 %m, i1 %above, double %differeturn)
+; CHECK: clamp.preheader:
+; CHECK:   %current.ph = phi double [ %x, %entry ], [ %acc.next, %scale{{.*}} ]
+; CHECK: invertclamp:
+; CHECK:   %"current.ph'de.0" = phi double


### PR DESCRIPTION
`pushLoopyPHIPreheader` (added by #2937) provides the preheader start value of a loop-header PHI whose single active use is a select or fdiv reduction, because the reverse pass reads that value. It inserts that value into the recompute graph after `minCut` has run, so `computeMinCache` always marks it recomputable, overwriting the caching decision its own first pass had already made. In the reproducer the start value is `%current.ph`, a preheader PHI merging `%x` with the main loop's exit value. `legalRecompute` refuses it because that incoming is another loop's last-iteration value, hence the assertion. Upstream's own regression test passes only because preprocessing folds its single-incoming LCSSA PHIs away, leaving a recomputable `fmul`. Without assertions, the planner would try to recompute a value the reverse pass cannot form.

Fix: the helper now takes the planner's legality test plus `MinReq` and `NeedGraph`. A start value that cannot be recomputed is recorded as cached and the single-incoming PHI chain stops there. The cut is walked over a copy because the helper may extend it, and the four copies of the Available2 construction became one lambda.

Tested on LLVM 23.1.2, with x64 and CUDA 13.3. The .ll regression test was written with the help of Claude Opus 5.