### PR TITLE
Remove Enzyme call markers from Clang's CUDA RDC retention lists

### DIFF
--- a/enzyme/Enzyme/PreserveNVVM.cpp
+++ b/enzyme/Enzyme/PreserveNVVM.cpp
@@ -42,9 +42,11 @@
 #include "llvm/Pass.h"
 
 #include "llvm/Transforms/Utils.h"
+#include "llvm/Transforms/Utils/ModuleUtils.h"
 
 #include <map>
 
+#include "EnzymeCallMarkers.h"
 #include "PreserveNVVM.h"
 #include "Utils.h"
 
@@ -348,9 +350,57 @@ handleCustomDerivative(llvm::Module &M, llvm::GlobalVariable &g,
   globalsToErase.push_back(&g);
 }
 
+// Clang's RDC retention lists describe device symbols referenced from host
+// code, including references in host/device functions. Enzyme call markers
+// are compile-time metadata, not runtime device variables. Their presence in
+// these lists would keep an undefined device symbol alive after AD consumed
+// every call. Remove only the markers; genuine host-only device references
+// must still extract their definitions from device archives.
+static bool removeCudaMarkerRetention(Module &M) {
+  SmallVector<GlobalVariable *, 4> Lists;
+  for (auto &G : M.globals())
+    if (startsWith(G.getName(), "__clang_gpu_used_external") &&
+        G.hasInternalLinkage() && G.hasInitializer() &&
+        isa<ConstantArray>(G.getInitializer()))
+      Lists.push_back(&G);
+
+  bool Changed = false;
+  for (auto *G : Lists) {
+    auto *Initial = cast<ConstantArray>(G->getInitializer());
+    SmallVector<Constant *, 4> Keep;
+    for (auto &Op : Initial->operands()) {
+      auto *Entry = cast<Constant>(Op.get());
+      auto *Variable = dyn_cast<GlobalVariable>(Entry->stripPointerCasts());
+      if (!Variable || !enzyme_markers::lookupEnzymeMarker(Variable->getName()))
+        Keep.push_back(Entry);
+    }
+    if (Keep.size() == Initial->getNumOperands())
+      continue;
+    Changed = true;
+    if (Keep.empty()) {
+      removeFromUsedLists(
+          M, [G](Constant *C) { return C->stripPointerCasts() == G; });
+      G->eraseFromParent();
+    } else {
+      auto *A = ConstantArray::get(
+          ArrayType::get(Initial->getType()->getElementType(), Keep.size()),
+          Keep);
+      auto *Replacement = new GlobalVariable(
+          M, A->getType(), G->isConstant(), G->getLinkage(), A, "", nullptr,
+          G->getThreadLocalMode(), G->getAddressSpace());
+      Replacement->copyAttributesFrom(G);
+      Replacement->copyMetadata(G, 0);
+      Replacement->takeName(G);
+      G->replaceAllUsesWith(Replacement);
+      G->eraseFromParent();
+    }
+  }
+  return Changed;
+}
+
 bool preserveNVVM(bool Begin, Module &M,
                   bool PreserveCustomRuleLinkage = true) {
-  bool changed = false;
+  bool changed = removeCudaMarkerRetention(M);
   constexpr static const char gradient_handler_name[] =
       "__enzyme_register_gradient";
   constexpr static const char derivative_handler_name[] =

--- a/enzyme/test/Enzyme/ReverseMode/cuda-marker-retention.ll
+++ b/enzyme/test/Enzyme/ReverseMode/cuda-marker-retention.ll
@@ -1,0 +1,28 @@
+; RUN: %opt < %s %newLoadEnzyme -passes="preserve-nvvm" -S | FileCheck %s
+; RUN: %opt < %s %newLoadEnzyme -passes="preserve-nvvm-end" -S | FileCheck %s
+;
+; An RDC list can contain only compile-time markers, a mixture of markers
+; and genuine device symbols, or no markers. Retain the real symbols and
+; unknown enzyme-prefixed names. A real use of a marker is not rewritten.
+
+@enzyme_dup = external addrspace(1) global i32
+@enzyme_width = external addrspace(1) global i32
+@real_device_state = external addrspace(1) global i32
+@enzyme_application_state = external addrspace(1) global i32
+
+@__clang_gpu_used_external = internal global [2 x ptr] [ptr addrspacecast (ptr addrspace(1) @enzyme_dup to ptr), ptr addrspacecast (ptr addrspace(1) @enzyme_width to ptr)]
+@__clang_gpu_used_external.1 = internal global [2 x ptr] [ptr addrspacecast (ptr addrspace(1) @enzyme_dup to ptr), ptr addrspacecast (ptr addrspace(1) @real_device_state to ptr)]
+@__clang_gpu_used_external.2 = internal global [1 x ptr] [ptr addrspacecast (ptr addrspace(1) @enzyme_application_state to ptr)]
+@llvm.compiler.used = appending global [3 x ptr] [ptr @__clang_gpu_used_external, ptr @__clang_gpu_used_external.1, ptr @__clang_gpu_used_external.2], section "llvm.metadata"
+
+define i32 @unconsumed_marker() {
+  %marker = load i32, ptr addrspace(1) @enzyme_dup
+  ret i32 %marker
+}
+
+; CHECK-NOT: @__clang_gpu_used_external =
+; CHECK-DAG: @__clang_gpu_used_external.1 = internal global [1 x ptr] [ptr addrspacecast (ptr addrspace(1) @real_device_state to ptr)]
+; CHECK-DAG: @__clang_gpu_used_external.2 = internal global [1 x ptr] [ptr addrspacecast (ptr addrspace(1) @enzyme_application_state to ptr)]
+; CHECK-DAG: @llvm.compiler.used = appending global [2 x ptr] [ptr @__clang_gpu_used_external.1, ptr @__clang_gpu_used_external.2], section "llvm.metadata"
+; CHECK: define i32 @unconsumed_marker()
+; CHECK: load i32, ptr addrspace(1) @enzyme_dup


### PR DESCRIPTION
Clang records external device declarations referenced from host/device functions in __clang_gpu_used_external under RDC. Enzyme's activity markers land there too, so after differentiation nvlink still wants a definition of enzyme_dup. Drop only recognised markers from those lists, keeping real device symbols, unknown enzyme-prefixed names and genuine marker uses.

Tested on LLVM 23.1.2. Machine uses an Intel x64-v3 CPU and an Ada (SM89) GPU on CUDA 13.3 and Nvidia HPC SDK 26.5.