### PR TITLE
Classify an aggregate whose type tree begins with Anything without a null type

### DIFF
--- a/enzyme/Enzyme/TypeAnalysis/TypeTree.h
+++ b/enzyme/Enzyme/TypeAnalysis/TypeTree.h
@@ -829,30 +829,34 @@ public:
     auto m0 = TypeTree::operator[]({0});
 
     llvm::Type *flt = m0.isFloat();
+    if (!flt && !(anythingIsFloat && m0 == BaseType::Anything))
+      return nullptr;
+
     if (!flt) {
-      if (!(anythingIsFloat && m0 == BaseType::Anything)) {
-        return nullptr;
+      // A leading Anything leaves the floating type, and with it the chunk
+      // size, to the first floating entry at a later byte.
+      for (size_t i = 1; i < size && !flt; ++i)
+        flt = TypeTree::operator[]({(int)i}).isFloat();
+      if (!flt) {
+        // There is no floating entry at all. Without a chunk size the only
+        // claim available is that every byte is Anything.
+        for (size_t i = 1; i < size; ++i)
+          if (TypeTree::operator[]({(int)i}) != BaseType::Anything)
+            return nullptr;
+        return (llvm::Type *)0x123;
       }
     }
+
     size_t chunk = dl.getTypeSizeInBits(flt) / 8;
-    for (size_t i = chunk; i < size; i += chunk) {
+    for (size_t i = 0; i < size; i += chunk) {
       auto mx = TypeTree::operator[]({(int)i});
       if (auto f2 = mx.isFloat()) {
-        if (f2 != flt) {
-          if (anythingIsFloat && !flt) {
-            flt = f2;
-            continue;
-          }
+        if (f2 != flt)
           return nullptr;
-        }
       } else if (anythingIsFloat && mx == BaseType::Anything) {
         continue;
       } else
         return nullptr;
-    }
-
-    if (!flt && anythingIsFloat) {
-      return (llvm::Type *)0x123;
     }
     return flt;
   }

--- a/enzyme/test/Enzyme/ForwardMode/insertvalue-leading-anything.ll
+++ b/enzyme/test/Enzyme/ForwardMode/insertvalue-leading-anything.ll
@@ -1,0 +1,34 @@
+; RUN: if [ %llvmver -lt 16 ]; then %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -instsimplify -S | FileCheck %s; fi
+; RUN: %opt < %s %newLoadEnzyme -passes="enzyme,function(instsimplify)" -enzyme-preopt=false -S | FileCheck %s
+
+; The inactive aggregate %base never has its first element written, so its
+; type tree is Anything at bytes 0 to 7 and Float@double at bytes 8 to 15, and
+; so is the tree of the active insertvalue %p over it. Nulling the shadow of
+; %base with that tree must classify the aggregate as all float from its
+; later floating entry rather than dereference a null leading type.
+
+define double @f(double %x, double %y, double %z, i1 %c) {
+  %by = insertvalue { double, double } undef, double %y, 1
+  %bz = insertvalue { double, double } undef, double %z, 1
+  %base = select i1 %c, { double, double } %by, { double, double } %bz
+  %xx = fmul double %x, %x
+  %p = insertvalue { double, double } %base, double %xx, 1
+  %e1 = extractvalue { double, double } %p, 1
+  ret double %e1
+}
+
+define double @df(double %x, double %y, double %z, i1 %c) {
+  %r = call double (...) @__enzyme_fwddiff(ptr @f, metadata !"enzyme_dup", double %x, double 1.0, metadata !"enzyme_const", double %y, metadata !"enzyme_const", double %z, metadata !"enzyme_const", i1 %c)
+  ret double %r
+}
+
+declare double @__enzyme_fwddiff(...)
+
+; The shadow of %base is null, and the tangent of the returned element is
+; that of %xx alone.
+
+; CHECK: define internal double @fwddiffef(double %x, double %"x'", double %y, double %z, i1 %c)
+; CHECK-NEXT:   %[[a:.+]] = fmul fast double %"x'", %x
+; CHECK-NEXT:   %[[b:.+]] = fmul fast double %"x'", %x
+; CHECK-NEXT:   %[[s:.+]] = fadd fast double %[[a]], %[[b]]
+; CHECK-NEXT:   ret double %[[s]]


### PR DESCRIPTION
TypeTree::allFloat with anythingIsFloat accepted a leading Anything and then took the chunk size from the null type it yields. Take the floating type from the first floating entry at a later byte, and require every byte to be Anything when there is none; invertPointerM reaches this when it nulls the shadow of an inactive aggregate whose first element is never written.

Tested on LLVM 23.1.2, x64/CUDA 13.3