### PR TITLE
Assemble a batched call's vector operands instead of passing undef (#3003)

### DIFF
--- a/enzyme/Enzyme/InstructionBatcher.cpp
+++ b/enzyme/Enzyme/InstructionBatcher.cpp
@@ -254,7 +254,7 @@ void InstructionBatcher::visitCallInst(llvm::CallInst &call) {
         auto found = vectorizedValues.find(op);
         assert(found != vectorizedValues.end());
         Value *new_op = found->second[i];
-        Builder2.CreateInsertValue(agg, new_op, {i});
+        agg = Builder2.CreateInsertValue(agg, new_op, {i});
       }
       args.push_back(agg);
       arg_types.push_back(BATCH_TYPE::VECTOR);

--- a/enzyme/test/Enzyme/BatchMode/vector-call.ll
+++ b/enzyme/test/Enzyme/BatchMode/vector-call.ll
@@ -35,10 +35,10 @@ entry:
 ; CHECK-NEXT:   %mul2 = fmul double %unwrap.x2, %unwrap.x2
 ; CHECK-NEXT:   %mul3 = fmul double %unwrap.x3, %unwrap.x3
 ; CHECK-NEXT:   %0 = insertvalue [4 x double] undef, double %mul0, 0
-; CHECK-NEXT:   %1 = insertvalue [4 x double] undef, double %mul1, 1
-; CHECK-NEXT:   %2 = insertvalue [4 x double] undef, double %mul2, 2
-; CHECK-NEXT:   %3 = insertvalue [4 x double] undef, double %mul3, 3
-; CHECK-NEXT:   %call = call [4 x double] @batch_add3([4 x double] undef, double %a)
+; CHECK-NEXT:   %1 = insertvalue [4 x double] %0, double %mul1, 1
+; CHECK-NEXT:   %2 = insertvalue [4 x double] %1, double %mul2, 2
+; CHECK-NEXT:   %3 = insertvalue [4 x double] %2, double %mul3, 3
+; CHECK-NEXT:   %call = call [4 x double] @batch_add3([4 x double] %3, double %a)
 ; CHECK-NEXT:   %unwrap.call0 = extractvalue [4 x double] %call, 0
 ; CHECK-NEXT:   %unwrap.call1 = extractvalue [4 x double] %call, 1
 ; CHECK-NEXT:   %unwrap.call2 = extractvalue [4 x double] %call, 2

--- a/enzyme/test/Integration/BatchMode/fwddiff-call.cpp
+++ b/enzyme/test/Integration/BatchMode/fwddiff-call.cpp
@@ -1,0 +1,56 @@
+// RUN: %clang -O0 %s -S -emit-llvm -o - | %opt - %OPloadEnzyme %enzyme -S | %lli -
+// RUN: %clang -O1 %s -S -emit-llvm -o - | %opt - %OPloadEnzyme %enzyme -S | %lli -
+// RUN: %clang -O1 -g %s -S -emit-llvm -o - | %opt - %OPloadEnzyme %enzyme -S | %lli -
+// RUN: %clang -O2 %s -S -emit-llvm -o - | %opt - %OPloadEnzyme %enzyme -S | %lli -
+// RUN: %clang -O3 %s -S -emit-llvm -o - | %opt - %OPloadEnzyme %enzyme -S | %lli -
+// RUN: %clang -O0 %s -S -emit-llvm -o - | %opt - %OPloadEnzyme %enzyme -enzyme-inline=1 -S | %lli -
+// RUN: %clang -O1 %s -S -emit-llvm -o - | %opt - %OPloadEnzyme %enzyme -enzyme-inline=1 -S | %lli -
+// RUN: %clang -O2 %s -S -emit-llvm -o - | %opt - %OPloadEnzyme %enzyme -enzyme-inline=1 -S | %lli -
+// RUN: %clang -O3 %s -S -emit-llvm -o - | %opt - %OPloadEnzyme %enzyme -enzyme-inline=1 -S | %lli -
+
+// Batching a function that itself calls a defined function: here the callee
+// is the forward-mode derivative Enzyme generates inside the batched
+// function. Every vector operand of the inner call must reach the batched
+// callee lane by lane.
+
+#include "../test_utils.h"
+#include <stdio.h>
+
+struct Batch2 {
+  double a, b;
+};
+
+extern Batch2 __enzyme_batch(...);
+extern double __enzyme_fwddiff(void *, ...);
+extern int enzyme_width;
+extern int enzyme_vector;
+extern int enzyme_scalar;
+
+double f(double g, double x) { return g * x * x * x; }
+
+// df/dx = 3 g x^2
+double dfdx(double g, double x) {
+  return __enzyme_fwddiff((void *)f, g, 0.0, x, 1.0);
+}
+
+int main() {
+  const double g = 2.0, x0 = 1.0, x1 = 3.0;
+
+  Batch2 p = __enzyme_batch((void *)f, enzyme_width, 2, enzyme_scalar, g,
+                            enzyme_vector, x0, x1);
+  Batch2 dv = __enzyme_batch((void *)dfdx, enzyme_width, 2, enzyme_vector, g, g,
+                             enzyme_vector, x0, x1);
+  Batch2 ds = __enzyme_batch((void *)dfdx, enzyme_width, 2, enzyme_scalar, g,
+                             enzyme_vector, x0, x1);
+
+  printf("primal (%g, %g) all-vector (%g, %g) scalar-g (%g, %g)\n", p.a, p.b,
+         dv.a, dv.b, ds.a, ds.b);
+
+  APPROX_EQ(p.a, g * x0 * x0 * x0, 1e-10);
+  APPROX_EQ(p.b, g * x1 * x1 * x1, 1e-10);
+  APPROX_EQ(dv.a, 3 * g * x0 * x0, 1e-10);
+  APPROX_EQ(dv.b, 3 * g * x1 * x1, 1e-10);
+  APPROX_EQ(ds.a, 3 * g * x0 * x0, 1e-10);
+  APPROX_EQ(ds.b, 3 * g * x1 * x1, 1e-10);
+  return 0;
+}


### PR DESCRIPTION
In `InstructionBatcher::visitCallInst`, the loop that assembles a vector operand for a call to a defined callee does
`Builder2.CreateInsertValue(agg, new_op, {i});` and then discards the result. This means `agg` stays undef and the batched callee is called with [N x double] undef for every vector operand. The lanes were never kept apart because they were never passed. Under opt the pass first lowers dfdx, leaving a call to the generated `fwddiffe_f` inside it, and batching dfdx then goes through that call path. Under the clang plugin at -O1 and above, the inner call has been inlined into dfdx before Enzyme runs, so no call is batched; at -O0 the undef survives to execution as nan. Any batched function calling any defined function with a vector argument was affected, derivative or not. 

The existing vector-call.ll test encoded the wrong output in its CHECK lines, expecting call `@batch_add3([4 x double] undef, ...).` Closes #3003.

Tested on LLVM 23.1.2, x64/CUDA 13.3.